### PR TITLE
feat: Phase 2 world graph, movement, TUI scrollback

### DIFF
--- a/data/parish.json
+++ b/data/parish.json
@@ -1,0 +1,188 @@
+{
+    "locations": [
+        {
+            "id": 1,
+            "name": "The Crossroads",
+            "description_template": "A quiet crossroads where four narrow roads meet. A weathered stone wall lines the eastern side, half-hidden by brambles. The {weather} sky stretches over the flat midlands. It is {time}.",
+            "indoor": false,
+            "public": true,
+            "connections": [
+                {"target": 2, "traversal_minutes": 3, "path_description": "a short lane past a row of cottages"},
+                {"target": 3, "traversal_minutes": 5, "path_description": "a winding boreen lined with hawthorn"},
+                {"target": 4, "traversal_minutes": 2, "path_description": "the road past a hand-painted sign"},
+                {"target": 6, "traversal_minutes": 4, "path_description": "a gravel path along the school wall"},
+                {"target": 9, "traversal_minutes": 8, "path_description": "a narrow road between stone walls"},
+                {"target": 13, "traversal_minutes": 3, "path_description": "a few steps across the road"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": "Crossroads hold power in Irish folklore — a place between places, where the veil is thin."
+        },
+        {
+            "id": 2,
+            "name": "Darcy's Pub",
+            "description_template": "The warm interior of Darcy's Pub. Turf smoke hangs in the air. Old photographs of GAA teams line the walls. A fiddle sits propped in the corner. It is {time} and the weather outside is {weather}.",
+            "indoor": true,
+            "public": true,
+            "connections": [
+                {"target": 1, "traversal_minutes": 3, "path_description": "the lane back to the crossroads"}
+            ],
+            "associated_npcs": [1],
+            "mythological_significance": null
+        },
+        {
+            "id": 3,
+            "name": "St. Brigid's Church",
+            "description_template": "A small stone church with a slate roof, its stained-glass windows catching the {time} light. The graveyard behind is thick with Celtic crosses and lichen-covered headstones. The sky is {weather}.",
+            "indoor": false,
+            "public": true,
+            "connections": [
+                {"target": 1, "traversal_minutes": 5, "path_description": "the boreen back to the crossroads"},
+                {"target": 12, "traversal_minutes": 6, "path_description": "a muddy track past the graveyard wall"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": "Built on the site of an older holy well dedicated to Brigid, the goddess-turned-saint."
+        },
+        {
+            "id": 4,
+            "name": "The Post Office",
+            "description_template": "A small stone building with a red An Post sign above the door. Notices flutter on the community board outside. It is {time}. The weather is {weather}.",
+            "indoor": true,
+            "public": true,
+            "connections": [
+                {"target": 1, "traversal_minutes": 2, "path_description": "back across to the crossroads"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": null
+        },
+        {
+            "id": 5,
+            "name": "The GAA Pitch",
+            "description_template": "A well-kept GAA pitch with white goalposts standing against the {weather} sky. The Kiltoom-Cam clubhouse sits at one end, its green and gold paint peeling slightly. It is {time}.",
+            "indoor": false,
+            "public": true,
+            "connections": [
+                {"target": 6, "traversal_minutes": 3, "path_description": "a tarmac path back past the school"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": null
+        },
+        {
+            "id": 6,
+            "name": "The National School",
+            "description_template": "Kiltoom National School — a single-storey building with a playground behind a green railing. Children's artwork fills the windows. It is {time}. The sky is {weather}.",
+            "indoor": false,
+            "public": true,
+            "connections": [
+                {"target": 1, "traversal_minutes": 4, "path_description": "the gravel path back to the crossroads"},
+                {"target": 5, "traversal_minutes": 3, "path_description": "a tarmac path down to the pitch"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": null
+        },
+        {
+            "id": 7,
+            "name": "Lough Ree Shore",
+            "description_template": "The stony shore of Lough Ree stretches out before you. The great lake shimmers under the {weather} sky. Small islands dot the water in the distance. It is {time}.",
+            "indoor": false,
+            "public": true,
+            "connections": [
+                {"target": 8, "traversal_minutes": 6, "path_description": "a lakeside path through reeds and willow"},
+                {"target": 11, "traversal_minutes": 10, "path_description": "a rough track climbing away from the shore"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": "Lough Ree is said to be home to a monster — the Lough Ree wurm, Ireland's lesser-known cousin of Nessie."
+        },
+        {
+            "id": 8,
+            "name": "Hodson Bay",
+            "description_template": "A sheltered bay on Lough Ree. Boats bob at their moorings. The old boathouse leans into the wind. It is {time} and the sky is {weather}.",
+            "indoor": false,
+            "public": true,
+            "connections": [
+                {"target": 7, "traversal_minutes": 6, "path_description": "the lakeside path back along the shore"},
+                {"target": 9, "traversal_minutes": 7, "path_description": "a lane winding uphill from the bay"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": null
+        },
+        {
+            "id": 9,
+            "name": "Murphy's Farm",
+            "description_template": "A working farm with a whitewashed house and rusted corrugated sheds. Cattle graze in the near field. A sheepdog watches from the gate. It is {time}. The sky is {weather}.",
+            "indoor": false,
+            "public": false,
+            "connections": [
+                {"target": 1, "traversal_minutes": 8, "path_description": "the narrow road back between stone walls"},
+                {"target": 8, "traversal_minutes": 7, "path_description": "a lane winding down toward the bay"},
+                {"target": 10, "traversal_minutes": 5, "path_description": "a boreen through a gap in the hedge"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": null
+        },
+        {
+            "id": 10,
+            "name": "O'Brien's Farm",
+            "description_template": "A tidy farm with stone outbuildings and a well-kept garden. Hens scratch in the yard. A tractor idles by the barn. It is {time}. Weather: {weather}.",
+            "indoor": false,
+            "public": false,
+            "connections": [
+                {"target": 9, "traversal_minutes": 5, "path_description": "a boreen back through the hedge to Murphy's"},
+                {"target": 14, "traversal_minutes": 6, "path_description": "a soggy track across the lower field"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": null
+        },
+        {
+            "id": 11,
+            "name": "The Fairy Fort",
+            "description_template": "An ancient ring fort — a raised circular mound ringed by hawthorn and elder. The air feels different here, heavy and watchful. It is {time}. The sky is {weather}.",
+            "indoor": false,
+            "public": true,
+            "connections": [
+                {"target": 7, "traversal_minutes": 10, "path_description": "the rough track back down to the shore"},
+                {"target": 12, "traversal_minutes": 8, "path_description": "a barely visible path through gorse and bracken"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": "A rath said to be home to the sídhe. No farmer has ever ploughed within twenty yards of it. Those who disturb fairy forts are said to suffer terrible misfortune."
+        },
+        {
+            "id": 12,
+            "name": "The Bog Road",
+            "description_template": "A rough track cutting through blanket bog. Turf banks stand in neat rows, drying in the wind. The {weather} sky presses down. Pools of dark water gleam between the heather. It is {time}.",
+            "indoor": false,
+            "public": true,
+            "connections": [
+                {"target": 3, "traversal_minutes": 6, "path_description": "the muddy track back toward the church"},
+                {"target": 11, "traversal_minutes": 8, "path_description": "a barely visible path through gorse to the fort"},
+                {"target": 14, "traversal_minutes": 7, "path_description": "a squelching path along the bog's edge"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": "Bogs preserve everything — bodies, butter, memories. People say you can hear voices in the wind here on certain nights."
+        },
+        {
+            "id": 13,
+            "name": "Connolly's Shop",
+            "description_template": "A small general shop crammed with everything from Wellington boots to Holy Communion cards. The bell above the door jangles. It is {time}. Outside, the weather is {weather}.",
+            "indoor": true,
+            "public": true,
+            "connections": [
+                {"target": 1, "traversal_minutes": 3, "path_description": "a few steps back across the road to the crossroads"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": null
+        },
+        {
+            "id": 14,
+            "name": "The Creamery",
+            "description_template": "The old creamery building, partly converted to a community hall. The original weighbridge still sits outside. It is {time}. The weather is {weather}.",
+            "indoor": false,
+            "public": true,
+            "connections": [
+                {"target": 10, "traversal_minutes": 6, "path_description": "the soggy track back up to O'Brien's"},
+                {"target": 12, "traversal_minutes": 7, "path_description": "a path along the bog's edge back to the road"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": null
+        }
+    ]
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -80,4 +80,5 @@ Detailed, implementation-ready plans for each development phase.
 | [DESIGN.md](../DESIGN.md) | Original monolithic design document (archival) |
 | [CLAUDE.md](../CLAUDE.md) | Build commands, code style, gotchas, dependencies |
 | [Development Journal](journal.md) | Cross-session notes, observations, recommendations |
+| [Known Issues](known-issues.md) | Active bugs and UX issues |
 | [README.md](../README.md) | Project overview, quick start |

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -6,6 +6,38 @@ Notes, observations, and recommendations carried between sessions.
 
 ---
 
+## 2026-03-19 — Phase 2: World Graph Implementation
+
+### Changes this session
+
+- **World graph system**: New `src/world/graph.rs` module with `WorldGraph`, `Connection`, and `LocationData` types. Graph supports BFS pathfinding, fuzzy name search (with article stripping), neighbor queries, and path travel time calculation.
+- **Parish data file**: `data/parish.json` with 14 hand-authored Kiltoom locations: The Crossroads (hub), Darcy's Pub, St. Brigid's Church, The Post Office, The GAA Pitch, The National School, Lough Ree Shore, Hodson Bay, Murphy's Farm, O'Brien's Farm, The Fairy Fort, The Bog Road, Connolly's Shop, and The Creamery.
+- **Graph validation**: On load, validates all connection targets exist, connections are bidirectional, and no orphan nodes.
+- **Movement system**: New `src/world/movement.rs` with `resolve_movement()` — resolves "go to X" intents to destinations via fuzzy matching, computes shortest path via BFS, and generates travel narration text.
+- **Encounter system**: New `src/world/encounter.rs` — probability-based random encounters during travel. Base ~20% chance, modified by time of day (higher in morning, lower at night/midnight).
+- **Dynamic descriptions**: New `src/world/description.rs` — renders location description templates by interpolating `{time}`, `{weather}`, and `{npcs_present}` placeholders with current game state.
+- **WorldState integration**: `WorldState::from_parish_file()` loads the world graph and populates both the new graph and legacy locations map. New `current_location_data()` accessor.
+- **Serde support**: Added `Serialize`/`Deserialize` to `LocationId` and `NpcId` with `#[serde(transparent)]`.
+- **New error variant**: `WorldGraph(String)` in `ParishError`.
+- **Test count**: 160 tests passing (up from 90), 1 ignored. Added 21 integration tests in `tests/world_graph_integration.rs`.
+- **Mythological significance**: Crossroads, St. Brigid's Church, The Fairy Fort, The Bog Road, and Lough Ree Shore all have mythological flavor text.
+
+### Technical notes
+
+- `find_by_name()` fuzzy matching strips common articles ("the", "a", "an") and checks both directions (query in name, name in query).
+- All 14 locations are reachable from the crossroads. Traversal times range from 2-10 minutes.
+- The encounter system uses an explicit `roll` parameter for deterministic testing.
+- Description templates use simple string replacement; LLM enrichment deferred to Phase 6.
+
+### Recommendations for next session
+
+1. **Wire movement into game loop**: The movement resolution, time advancement, encounter checks, and description rendering are all implemented but not yet connected to the main game loop (`main.rs`, `headless.rs`). Next step is to handle `IntentKind::Move` in the game loop by calling `resolve_movement()`, advancing the clock, checking encounters, and rendering the new location.
+2. **Wire `from_parish_file` into startup**: Replace `WorldState::new()` with `WorldState::from_parish_file()` in `main.rs` so the full parish loads on game start.
+3. **Add `/look` command**: Now that dynamic descriptions exist, wire up `IntentKind::Look` to render the current location description.
+4. **OSM extraction tool**: Deferred — hand-authored data is sufficient for now.
+
+---
+
 ## 2026-03-19 — Robust Ollama Integration & Headless Mode
 
 ### Changes this session

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,0 +1,19 @@
+# Known Issues
+
+> [Docs Index](index.md)
+
+## Active
+
+(none currently)
+
+## Resolved
+
+### 1. TUI does not scroll back
+**Severity:** High — **Fixed 2026-03-20**
+**Description:** When the main text panel fills up with content, there was no way to scroll back to see earlier output.
+**Fix:** Added `ScrollState` to App. Page Up/Down scroll by 10 lines, Up/Down by 1, Home/End jump to top/bottom. Auto-scroll follows new output unless the user scrolls up. Scroll position indicator shown in top-right corner.
+
+### 2. LLM fallback fails for unusual movement verbs
+**Severity:** Medium — **Fixed 2026-03-20**
+**Description:** Unusual verbs like "saunter", "mosey", "wander" fell through to the LLM which returned `Unknown`.
+**Fix:** Expanded `parse_intent_local()` with 36 multi-word "verb to" phrases and 27 single-verb prefixes including saunter, mosey, wander, stroll, amble, trek, hike, sprint, march, creep, sneak, and multi-word phrases like "make my way to", "pop over to", "nip to".

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -4,9 +4,17 @@
 
 ## Active
 
-(none currently)
+### 4. NPCs have no conversation memory
+**Severity:** Medium
+**Description:** Each NPC interaction is stateless — Padraig has no context about what has already been said in the conversation. Previous exchanges are not included in the LLM prompt.
+**Expected:** NPCs should remember at least the current session's dialogue. Planned for Phase 3 (short-term memory system).
 
 ## Resolved
+
+### 3. Inline separator metadata leaks into NPC dialogue
+**Severity:** Medium — **Fixed 2026-03-20**
+**Description:** When the LLM puts `---` inline with dialogue instead of on its own line (e.g., `(smiles) --- {"action":...}`), the separator filter failed to detect it, causing JSON metadata to display to the player.
+**Fix:** Extended `find_response_separator()` to detect `" --- "` and `" ---\n"` inline patterns in addition to `---` on its own line. Increased `SEPARATOR_HOLDBACK` from 16 to 24 bytes.
 
 ### 1. TUI does not scroll back
 **Severity:** High — **Fixed 2026-03-20**

--- a/docs/requirements/roadmap.md
+++ b/docs/requirements/roadmap.md
@@ -2,8 +2,8 @@
 
 > [Docs Index](../index.md)
 
-> Last updated: 2026-03-18
-> Current phase: **Phase 1 — Core Loop**
+> Last updated: 2026-03-19
+> Current phase: **Phase 2 — World Graph** (in progress)
 
 ## Status Legend
 
@@ -37,14 +37,14 @@
 
 > [Detailed plan](../plans/phase-2-world-graph.md) | [Design: World & Geography](../design/world-geography.md)
 
-- [ ] Full `Location` struct with connections and properties
-- [ ] `WorldGraph` struct (adjacency list)
-- [ ] Hand-authored test parish JSON (~10-15 locations)
-- [ ] OSM data extraction tool
-- [ ] Movement command handling ("go to X", traversal time)
-- [ ] Time advancement during traversal
-- [ ] En-route encounter system
-- [ ] Dynamic location descriptions (LLM-enriched templates)
+- [x] Full `Location` struct with connections and properties
+- [x] `WorldGraph` struct (adjacency list with BFS pathfinding)
+- [x] Hand-authored test parish JSON (14 Kiltoom locations)
+- [ ] OSM data extraction tool (stretch goal)
+- [x] Movement command handling ("go to X", fuzzy matching, traversal time)
+- [x] Time advancement during traversal
+- [x] En-route encounter system (probability-based, time-of-day weighted)
+- [x] Dynamic location descriptions (template interpolation with time/weather/NPCs)
 
 ## Phase 3 — Multiple NPCs & Simulation
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,9 @@ pub enum ParishError {
     #[error("setup error: {0}")]
     Setup(String),
 
+    #[error("world graph error: {0}")]
+    WorldGraph(String),
+
     #[error("model not available: {0}")]
     ModelNotAvailable(String),
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -13,8 +13,11 @@ use crate::npc::{
     parse_npc_stream_response,
 };
 use crate::tui::App;
+use crate::world::description::{format_exits, render_description};
+use crate::world::movement::{self, MovementResult};
 use anyhow::Result;
 use std::io::{BufRead, Write};
+use std::path::Path;
 use tokio::sync::mpsc;
 
 /// Runs the game in headless mode with a plain stdin/stdout REPL.
@@ -41,25 +44,20 @@ pub async fn run_headless(setup: OllamaSetup) -> Result<()> {
     let _worker = inference::spawn_inference_worker(client.clone(), rx);
     let queue = InferenceQueue::new(tx);
 
-    // Initialize app state
+    // Initialize app state — load parish data if available
     let mut app = App::new();
+    let parish_path = Path::new("data/parish.json");
+    if parish_path.exists() {
+        match crate::world::WorldState::from_parish_file(parish_path, crate::world::LocationId(1)) {
+            Ok(world) => app.world = world,
+            Err(e) => eprintln!("Warning: Failed to load parish data: {}", e),
+        }
+    }
     app.inference_queue = Some(queue);
     app.npcs.push(Npc::new_test_npc());
 
     // Show initial location
-    let loc_name = app.world.current_location().name.clone();
-    let loc_desc = app.world.current_location().description.clone();
-    println!("--- {} ---", loc_name);
-    println!("{}", loc_desc);
-    println!();
-
-    // Show NPC presence
-    for npc in &app.npcs {
-        if npc.location == app.world.player_location {
-            println!("{} is here.", npc.name);
-        }
-    }
-    println!();
+    print_location_arrival(&app);
 
     let mut request_id: u64 = 0;
     let stdin = std::io::stdin();
@@ -158,129 +156,129 @@ async fn handle_headless_game_input(
     text: &str,
     request_id: &mut u64,
 ) -> Result<()> {
-    let npc = app
-        .npcs
-        .iter()
-        .find(|n| n.location == app.world.player_location)
-        .cloned();
+    // Always parse intent first so Move/Look work even with NPCs present
+    let intent = parse_intent(client, text, model).await?;
 
-    if let Some(npc) = npc {
-        let system_prompt = npc::build_tier1_system_prompt(&npc);
-        let context = npc::build_tier1_context(&npc, &app.world, text);
+    match intent.intent {
+        crate::input::IntentKind::Move => {
+            if let Some(target) = &intent.target {
+                handle_headless_movement(app, target);
+            } else {
+                println!("Go where?");
+            }
+        }
+        crate::input::IntentKind::Look => {
+            print_location_description(app);
+        }
+        _ => {
+            // Route to NPC conversation if one is present
+            let npc = app
+                .npcs
+                .iter()
+                .find(|n| n.location == app.world.player_location)
+                .cloned();
 
-        if let Some(queue) = &app.inference_queue {
-            *request_id += 1;
+            if let Some(npc) = npc {
+                let system_prompt = npc::build_tier1_system_prompt(&npc);
+                let context = npc::build_tier1_context(&npc, &app.world, text);
 
-            // Create streaming channel
-            let (token_tx, mut token_rx) = mpsc::unbounded_channel::<String>();
+                if let Some(queue) = &app.inference_queue {
+                    *request_id += 1;
 
-            // Print NPC name prefix, then stream tokens inline
-            print!("{}: ", npc.name);
-            std::io::stdout().flush().ok();
+                    let (token_tx, mut token_rx) = mpsc::unbounded_channel::<String>();
 
-            match queue
-                .send(
-                    *request_id,
-                    model.to_string(),
-                    context,
-                    Some(system_prompt),
-                    Some(token_tx),
-                )
-                .await
-            {
-                Ok(rx) => {
-                    // Stream tokens with separator-aware filtering.
-                    // Hold back SEP_LEN chars to detect the separator
-                    // before it reaches the display.
-                    let stream_handle = tokio::spawn(async move {
-                        let mut accumulated = String::new();
-                        let mut displayed_len: usize = 0;
-                        let mut separator_found = false;
+                    print!("{}: ", npc.name);
+                    std::io::stdout().flush().ok();
 
-                        while let Some(token) = token_rx.recv().await {
-                            accumulated.push_str(&token);
+                    match queue
+                        .send(
+                            *request_id,
+                            model.to_string(),
+                            context,
+                            Some(system_prompt),
+                            Some(token_tx),
+                        )
+                        .await
+                    {
+                        Ok(rx) => {
+                            let stream_handle = tokio::spawn(async move {
+                                let mut accumulated = String::new();
+                                let mut displayed_len: usize = 0;
+                                let mut separator_found = false;
 
-                            if separator_found {
-                                continue;
-                            }
+                                while let Some(token) = token_rx.recv().await {
+                                    accumulated.push_str(&token);
 
-                            // Check for separator (--- on its own line, flexible whitespace)
-                            if let Some((dialogue_end, _meta_start)) =
-                                find_response_separator(&accumulated)
-                            {
-                                // Display any remaining dialogue before separator
-                                if dialogue_end > displayed_len {
-                                    let new_text = &accumulated[displayed_len..dialogue_end];
-                                    print!("{}", new_text);
+                                    if separator_found {
+                                        continue;
+                                    }
+
+                                    if let Some((dialogue_end, _meta_start)) =
+                                        find_response_separator(&accumulated)
+                                    {
+                                        if dialogue_end > displayed_len {
+                                            let new_text =
+                                                &accumulated[displayed_len..dialogue_end];
+                                            print!("{}", new_text);
+                                            std::io::stdout().flush().ok();
+                                        }
+                                        separator_found = true;
+                                        continue;
+                                    }
+
+                                    let raw_end =
+                                        accumulated.len().saturating_sub(SEPARATOR_HOLDBACK);
+                                    let safe_end = floor_char_boundary(&accumulated, raw_end);
+                                    if safe_end > displayed_len {
+                                        let new_text = &accumulated[displayed_len..safe_end];
+                                        print!("{}", new_text);
+                                        std::io::stdout().flush().ok();
+                                        displayed_len = safe_end;
+                                    }
+                                }
+
+                                if !separator_found && displayed_len < accumulated.len() {
+                                    let remaining = &accumulated[displayed_len..];
+                                    print!("{}", remaining);
                                     std::io::stdout().flush().ok();
                                 }
-                                separator_found = true;
-                                continue;
-                            }
 
-                            // Display tokens, holding back enough to detect separator
-                            let raw_end = accumulated.len().saturating_sub(SEPARATOR_HOLDBACK);
-                            let safe_end = floor_char_boundary(&accumulated, raw_end);
-                            if safe_end > displayed_len {
-                                let new_text = &accumulated[displayed_len..safe_end];
-                                print!("{}", new_text);
-                                std::io::stdout().flush().ok();
-                                displayed_len = safe_end;
-                            }
-                        }
+                                println!();
+                                accumulated
+                            });
 
-                        // Stream ended — flush remaining if no separator found
-                        if !separator_found && displayed_len < accumulated.len() {
-                            let remaining = &accumulated[displayed_len..];
-                            print!("{}", remaining);
-                            std::io::stdout().flush().ok();
-                        }
+                            match rx.await {
+                                Ok(response) => {
+                                    let _streamed = stream_handle.await.unwrap_or_default();
 
-                        println!();
-                        accumulated
-                    });
-
-                    // Wait for the full response
-                    match rx.await {
-                        Ok(response) => {
-                            let _streamed = stream_handle.await.unwrap_or_default();
-
-                            if let Some(err) = &response.error {
-                                println!("[Ollama error: {}]", err);
-                            } else {
-                                // Parse metadata silently (dialogue already displayed)
-                                let parsed = parse_npc_stream_response(&response.text);
-                                if let Some(meta) = &parsed.metadata {
-                                    tracing::debug!(
-                                        "NPC metadata: action={}, mood={}",
-                                        meta.action,
-                                        meta.mood
-                                    );
+                                    if let Some(err) = &response.error {
+                                        println!("[Ollama error: {}]", err);
+                                    } else {
+                                        let parsed = parse_npc_stream_response(&response.text);
+                                        if let Some(meta) = &parsed.metadata {
+                                            tracing::debug!(
+                                                "NPC metadata: action={}, mood={}",
+                                                meta.action,
+                                                meta.mood
+                                            );
+                                        }
+                                    }
+                                }
+                                Err(_) => {
+                                    let _ = stream_handle.await;
+                                    println!("[Inference channel closed]");
                                 }
                             }
                         }
-                        Err(_) => {
-                            let _ = stream_handle.await;
-                            println!("[Inference channel closed]");
+                        Err(e) => {
+                            println!();
+                            println!("[Failed to send request: {}]", e);
                         }
                     }
+                } else {
+                    println!("[No inference engine available]");
                 }
-                Err(e) => {
-                    println!();
-                    println!("[Failed to send request: {}]", e);
-                }
-            }
-        } else {
-            println!("[No inference engine available]");
-        }
-    } else {
-        let intent = parse_intent(client, text, model).await?;
-        match intent.intent {
-            crate::input::IntentKind::Look => {
-                let loc = app.world.current_location();
-                println!("{}", loc.description);
-            }
-            _ => {
+            } else {
                 println!("Nothing happens.");
             }
         }
@@ -288,6 +286,99 @@ async fn handle_headless_game_input(
 
     println!();
     Ok(())
+}
+
+/// Prints the current location with description, NPCs, and exits (headless).
+fn print_location_arrival(app: &App) {
+    let loc_name = app.world.current_location().name.clone();
+    println!("--- {} ---", loc_name);
+
+    if let Some(loc_data) = app.world.current_location_data() {
+        let tod = app.world.clock.time_of_day();
+        let npc_names: Vec<&str> = app
+            .npcs
+            .iter()
+            .filter(|n| n.location == app.world.player_location)
+            .map(|n| n.name.as_str())
+            .collect();
+        let desc = render_description(loc_data, tod, &app.world.weather, &npc_names);
+        println!("{}", desc);
+    } else {
+        println!("{}", app.world.current_location().description);
+    }
+
+    for npc in &app.npcs {
+        if npc.location == app.world.player_location {
+            println!("{} is here.", npc.name);
+        }
+    }
+
+    let exits = format_exits(app.world.player_location, &app.world.graph);
+    println!("{}", exits);
+    println!();
+}
+
+/// Prints current location description and exits (headless /look).
+fn print_location_description(app: &App) {
+    if let Some(loc_data) = app.world.current_location_data() {
+        let tod = app.world.clock.time_of_day();
+        let npc_names: Vec<&str> = app
+            .npcs
+            .iter()
+            .filter(|n| n.location == app.world.player_location)
+            .map(|n| n.name.as_str())
+            .collect();
+        let desc = render_description(loc_data, tod, &app.world.weather, &npc_names);
+        println!("{}", desc);
+    } else {
+        println!("{}", app.world.current_location().description);
+    }
+
+    let exits = format_exits(app.world.player_location, &app.world.graph);
+    println!("{}", exits);
+}
+
+/// Handles movement in headless mode.
+fn handle_headless_movement(app: &mut App, target: &str) {
+    let result = movement::resolve_movement(target, &app.world.graph, app.world.player_location);
+
+    match result {
+        MovementResult::Arrived {
+            destination,
+            minutes,
+            narration,
+            ..
+        } => {
+            println!("{}", narration);
+            println!();
+
+            app.world.clock.advance(minutes as i64);
+            app.world.player_location = destination;
+
+            if let Some(data) = app.world.graph.get(destination) {
+                app.world
+                    .locations
+                    .entry(destination)
+                    .or_insert_with(|| crate::world::Location {
+                        id: destination,
+                        name: data.name.clone(),
+                        description: data.description_template.clone(),
+                        indoor: data.indoor,
+                        public: data.public,
+                    });
+            }
+
+            print_location_arrival(app);
+        }
+        MovementResult::AlreadyHere => {
+            println!("You are already here.");
+        }
+        MovementResult::NotFound(name) => {
+            println!("You don't know how to get to \"{}\".", name);
+            let exits = format_exits(app.world.player_location, &app.world.graph);
+            println!("{}", exits);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -165,15 +165,144 @@ Input: \"pick up the stone\" → {\"intent\": \"interact\", \"target\": \"the st
 \n\
 Respond ONLY with valid JSON. No explanation.";
 
-/// Parses natural language input into a structured `PlayerIntent` via LLM.
+/// Attempts to parse intent locally using keyword matching.
 ///
-/// Sends the player's input to Ollama for intent classification. Falls back
-/// to `IntentKind::Unknown` if the LLM response cannot be parsed.
+/// Catches common movement and look phrases without requiring an LLM call.
+/// Returns `None` if the input doesn't match any known pattern.
+pub fn parse_intent_local(raw_input: &str) -> Option<PlayerIntent> {
+    let lower = raw_input.trim().to_lowercase();
+
+    // Movement patterns — multi-word phrases checked first (longest match wins),
+    // then single-verb prefixes. Covers common, colloquial, and unusual verbs.
+    let move_phrases = [
+        "make my way to ",
+        "make my way ",
+        "head over to ",
+        "head over ",
+        "pop over to ",
+        "pop over ",
+        "nip to ",
+        "swing by ",
+        "go to ",
+        "walk to ",
+        "head to ",
+        "move to ",
+        "travel to ",
+        "run to ",
+        "jog to ",
+        "dash to ",
+        "hurry to ",
+        "rush to ",
+        "stroll to ",
+        "saunter to ",
+        "mosey to ",
+        "wander to ",
+        "amble to ",
+        "trek to ",
+        "hike to ",
+        "proceed to ",
+        "sprint to ",
+        "march to ",
+        "traipse to ",
+        "meander to ",
+        "trot to ",
+        "stride to ",
+        "creep to ",
+        "sneak to ",
+        "bolt to ",
+        "scramble to ",
+    ];
+
+    // Single-verb prefixes (without "to") — "saunter pub", "go pub", etc.
+    let move_verbs = [
+        "go ",
+        "walk ",
+        "head ",
+        "visit ",
+        "run ",
+        "jog ",
+        "dash ",
+        "hurry ",
+        "rush ",
+        "stroll ",
+        "saunter ",
+        "mosey ",
+        "wander ",
+        "amble ",
+        "trek ",
+        "hike ",
+        "proceed ",
+        "sprint ",
+        "march ",
+        "traipse ",
+        "meander ",
+        "trot ",
+        "stride ",
+        "creep ",
+        "sneak ",
+        "bolt ",
+        "scramble ",
+    ];
+
+    // Try multi-word phrases first for longest-match semantics
+    for prefix in &move_phrases {
+        if let Some(target) = lower.strip_prefix(prefix) {
+            let target = target.trim();
+            if !target.is_empty() {
+                return Some(PlayerIntent {
+                    intent: IntentKind::Move,
+                    target: Some(target.to_string()),
+                    dialogue: None,
+                    raw: raw_input.to_string(),
+                });
+            }
+        }
+    }
+
+    // Then try bare verb + destination
+    for prefix in &move_verbs {
+        if let Some(target) = lower.strip_prefix(prefix) {
+            let target = target.trim();
+            if !target.is_empty() {
+                return Some(PlayerIntent {
+                    intent: IntentKind::Move,
+                    target: Some(target.to_string()),
+                    dialogue: None,
+                    raw: raw_input.to_string(),
+                });
+            }
+        }
+    }
+
+    // Look patterns
+    let look_phrases = ["look", "look around", "l", "examine room", "where am i"];
+    if look_phrases.contains(&lower.as_str()) {
+        return Some(PlayerIntent {
+            intent: IntentKind::Look,
+            target: None,
+            dialogue: None,
+            raw: raw_input.to_string(),
+        });
+    }
+
+    None
+}
+
+/// Parses natural language input into a structured `PlayerIntent`.
+///
+/// First tries local keyword matching for common commands (movement, look).
+/// Falls back to Ollama LLM for ambiguous input. If the LLM call fails,
+/// returns `IntentKind::Unknown`.
 pub async fn parse_intent(
     client: &OllamaClient,
     raw_input: &str,
     model: &str,
 ) -> Result<PlayerIntent, ParishError> {
+    // Try local parsing first — no LLM needed for obvious commands
+    if let Some(intent) = parse_intent_local(raw_input) {
+        return Ok(intent);
+    }
+
     let result = client
         .generate_json::<IntentResponse>(model, raw_input, Some(INTENT_SYSTEM_PROMPT))
         .await;
@@ -325,5 +454,305 @@ mod tests {
             classify_input("  hello  "),
             InputResult::GameInput("hello".to_string())
         );
+    }
+
+    #[test]
+    fn test_local_parse_go_to() {
+        let intent = parse_intent_local("go to the pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the pub".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_walk_to() {
+        let intent = parse_intent_local("walk to the church").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the church".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_go_shorthand() {
+        let intent = parse_intent_local("go pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("pub".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_head_to() {
+        let intent = parse_intent_local("head to Murphy's Farm").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("murphy's farm".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_visit() {
+        let intent = parse_intent_local("visit the fairy fort").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the fairy fort".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_look() {
+        let intent = parse_intent_local("look").unwrap();
+        assert_eq!(intent.intent, IntentKind::Look);
+
+        let intent = parse_intent_local("look around").unwrap();
+        assert_eq!(intent.intent, IntentKind::Look);
+
+        let intent = parse_intent_local("l").unwrap();
+        assert_eq!(intent.intent, IntentKind::Look);
+    }
+
+    #[test]
+    fn test_local_parse_case_insensitive() {
+        let intent = parse_intent_local("GO TO THE PUB").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the pub".to_string()));
+
+        let intent = parse_intent_local("LOOK").unwrap();
+        assert_eq!(intent.intent, IntentKind::Look);
+    }
+
+    #[test]
+    fn test_local_parse_no_match() {
+        assert!(parse_intent_local("tell Mary hello").is_none());
+        assert!(parse_intent_local("pick up the stone").is_none());
+        assert!(parse_intent_local("hello there").is_none());
+    }
+
+    #[test]
+    fn test_local_parse_empty_target() {
+        // "go to " with nothing after should match "go " prefix with target "to",
+        // which is fine — the world graph won't find "to" and will say not found.
+        // But bare "go" or "walk" with no target should not match.
+        assert!(parse_intent_local("go").is_none());
+        assert!(parse_intent_local("walk").is_none());
+    }
+
+    #[test]
+    fn test_local_parse_saunter() {
+        let intent = parse_intent_local("saunter to the pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the pub".to_string()));
+
+        let intent = parse_intent_local("saunter pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("pub".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_mosey() {
+        let intent = parse_intent_local("mosey to the church").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the church".to_string()));
+
+        let intent = parse_intent_local("mosey church").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("church".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_wander() {
+        let intent = parse_intent_local("wander to the crossroads").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the crossroads".to_string()));
+
+        let intent = parse_intent_local("wander crossroads").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("crossroads".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_stroll() {
+        let intent = parse_intent_local("stroll to the fairy fort").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the fairy fort".to_string()));
+
+        let intent = parse_intent_local("stroll fairy fort").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("fairy fort".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_amble() {
+        let intent = parse_intent_local("amble to the village green").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the village green".to_string()));
+
+        let intent = parse_intent_local("amble village green").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("village green".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_trek_and_hike() {
+        let intent = parse_intent_local("trek to the bog").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the bog".to_string()));
+
+        let intent = parse_intent_local("hike to the hill").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the hill".to_string()));
+
+        let intent = parse_intent_local("trek bog").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("bog".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_run_jog_dash() {
+        let intent = parse_intent_local("run to the pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the pub".to_string()));
+
+        let intent = parse_intent_local("jog to the church").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the church".to_string()));
+
+        let intent = parse_intent_local("dash to the crossroads").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the crossroads".to_string()));
+
+        // Without "to"
+        let intent = parse_intent_local("run pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("pub".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_hurry_rush() {
+        let intent = parse_intent_local("hurry to the pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the pub".to_string()));
+
+        let intent = parse_intent_local("rush to the church").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the church".to_string()));
+
+        let intent = parse_intent_local("hurry pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("pub".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_proceed() {
+        let intent = parse_intent_local("proceed to the town square").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the town square".to_string()));
+
+        let intent = parse_intent_local("proceed town square").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("town square".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_multi_word_phrases() {
+        let intent = parse_intent_local("make my way to the pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the pub".to_string()));
+
+        let intent = parse_intent_local("make my way pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("pub".to_string()));
+
+        let intent = parse_intent_local("head over to the church").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the church".to_string()));
+
+        let intent = parse_intent_local("head over church").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("church".to_string()));
+
+        let intent = parse_intent_local("pop over to the shop").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the shop".to_string()));
+
+        let intent = parse_intent_local("pop over shop").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("shop".to_string()));
+
+        let intent = parse_intent_local("nip to the pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the pub".to_string()));
+
+        let intent = parse_intent_local("swing by the pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the pub".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_sprint_march_traipse() {
+        let intent = parse_intent_local("sprint to the pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the pub".to_string()));
+
+        let intent = parse_intent_local("march to the church").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the church".to_string()));
+
+        let intent = parse_intent_local("traipse to the bog").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the bog".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_meander_trot_stride() {
+        let intent = parse_intent_local("meander to the river").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the river".to_string()));
+
+        let intent = parse_intent_local("trot to the farm").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the farm".to_string()));
+
+        let intent = parse_intent_local("stride to the hill").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the hill".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_creep_sneak_bolt_scramble() {
+        let intent = parse_intent_local("creep to the graveyard").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the graveyard".to_string()));
+
+        let intent = parse_intent_local("sneak to the pub").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the pub".to_string()));
+
+        let intent = parse_intent_local("bolt to the church").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the church".to_string()));
+
+        let intent = parse_intent_local("scramble to the hill").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the hill".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_unusual_verbs_case_insensitive() {
+        let intent = parse_intent_local("SAUNTER TO THE PUB").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the pub".to_string()));
+
+        let intent = parse_intent_local("Mosey To The Church").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("the church".to_string()));
+
+        let intent = parse_intent_local("WANDER crossroads").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target, Some("crossroads".to_string()));
+    }
+
+    #[test]
+    fn test_local_parse_bare_unusual_verbs_no_target() {
+        // Bare verbs without a target should not match
+        assert!(parse_intent_local("saunter").is_none());
+        assert!(parse_intent_local("mosey").is_none());
+        assert!(parse_intent_local("wander").is_none());
+        assert!(parse_intent_local("stroll").is_none());
+        assert!(parse_intent_local("amble").is_none());
+        assert!(parse_intent_local("run").is_none());
+        assert!(parse_intent_local("dash").is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,9 @@ use parish::npc::{
     parse_npc_stream_response,
 };
 use parish::tui::{self, App};
+use parish::world::description::{format_exits, render_description};
+use parish::world::movement::{self, MovementResult};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
@@ -62,25 +65,21 @@ async fn main() -> Result<()> {
     let _worker = inference::spawn_inference_worker(client.clone(), rx);
     let queue = InferenceQueue::new(tx);
 
-    // Initialize app
+    // Initialize app — load parish data if available
     let mut app = App::new();
+    let parish_path = Path::new("data/parish.json");
+    if parish_path.exists() {
+        match parish::world::WorldState::from_parish_file(parish_path, parish::world::LocationId(1))
+        {
+            Ok(world) => app.world = world,
+            Err(e) => tracing::warn!("Failed to load parish data: {}", e),
+        }
+    }
     app.inference_queue = Some(queue);
     app.npcs.push(Npc::new_test_npc());
 
     // Show initial location description
-    let loc_name = app.world.current_location().name.clone();
-    let loc_desc = app.world.current_location().description.clone();
-    app.world.log(format!("— {} —", loc_name));
-    app.world.log(loc_desc);
-    app.world.log(String::new());
-
-    // Show NPC presence
-    for npc in &app.npcs {
-        if npc.location == app.world.player_location {
-            app.world.log(format!("{} is here.", npc.name));
-        }
-    }
-    app.world.log(String::new());
+    show_location_arrival(&mut app);
 
     // Initialize terminal
     let mut terminal = tui::init_terminal()?;
@@ -108,7 +107,7 @@ async fn main() -> Result<()> {
         }
 
         // Draw frame
-        terminal.draw(|frame| tui::draw(frame, &app))?;
+        terminal.draw(|frame| tui::draw(frame, &mut app))?;
 
         // Check for quit
         if app.should_quit {
@@ -124,173 +123,183 @@ async fn main() -> Result<()> {
                     handle_system_command(&mut app, cmd);
                 }
                 InputResult::GameInput(text) => {
-                    // Find NPC at player's location
-                    let npc = app
-                        .npcs
-                        .iter()
-                        .find(|n| n.location == app.world.player_location)
-                        .cloned();
+                    // Always parse intent first so Move/Look work even with NPCs present
+                    let intent = parse_intent(&client, &text, &model).await?;
 
-                    if let Some(npc) = npc {
-                        // Build context and send inference request
-                        let system_prompt = npc::build_tier1_system_prompt(&npc);
-                        let context = npc::build_tier1_context(&npc, &app.world, &text);
+                    match intent.intent {
+                        parish::input::IntentKind::Move => {
+                            if let Some(target) = &intent.target {
+                                handle_movement(&mut app, target);
+                            } else {
+                                app.world.log("Go where?".to_string());
+                            }
+                        }
+                        parish::input::IntentKind::Look => {
+                            show_location_description(&mut app);
+                        }
+                        _ => {
+                            // Route to NPC conversation if one is present
+                            let npc = app
+                                .npcs
+                                .iter()
+                                .find(|n| n.location == app.world.player_location)
+                                .cloned();
 
-                        if let Some(queue) = &app.inference_queue {
-                            request_id += 1;
+                            if let Some(npc) = npc {
+                                let system_prompt = npc::build_tier1_system_prompt(&npc);
+                                let context = npc::build_tier1_context(&npc, &app.world, &text);
 
-                            // Create streaming channel
-                            let (token_tx, mut token_rx) = mpsc::unbounded_channel::<String>();
+                                if let Some(queue) = &app.inference_queue {
+                                    request_id += 1;
 
-                            // Start a streaming log line with NPC name prefix
-                            app.world.log(format!("{}: ", npc.name));
+                                    let (token_tx, mut token_rx) =
+                                        mpsc::unbounded_channel::<String>();
 
-                            // Mark streaming as active
-                            *streaming_active.lock().unwrap() = true;
+                                    app.world.log(format!("{}: ", npc.name));
+                                    *streaming_active.lock().unwrap() = true;
 
-                            // Spawn separator-aware buffering task.
-                            // Only puts dialogue text (before ---) into the shared buffer.
-                            let buf_clone = Arc::clone(&streaming_buf);
-                            let active_clone = Arc::clone(&streaming_active);
-                            let stream_handle = tokio::spawn(async move {
-                                let mut accumulated = String::new();
-                                let mut displayed_len: usize = 0;
-                                let mut separator_found = false;
+                                    let buf_clone = Arc::clone(&streaming_buf);
+                                    let active_clone = Arc::clone(&streaming_active);
+                                    let stream_handle = tokio::spawn(async move {
+                                        let mut accumulated = String::new();
+                                        let mut displayed_len: usize = 0;
+                                        let mut separator_found = false;
 
-                                while let Some(token) = token_rx.recv().await {
-                                    accumulated.push_str(&token);
+                                        while let Some(token) = token_rx.recv().await {
+                                            accumulated.push_str(&token);
 
-                                    if separator_found {
-                                        continue;
-                                    }
-
-                                    // Check for separator (--- on its own line)
-                                    if let Some((dialogue_end, _meta_start)) =
-                                        find_response_separator(&accumulated)
-                                    {
-                                        if dialogue_end > displayed_len {
-                                            let new_text = accumulated[displayed_len..dialogue_end]
-                                                .to_string();
-                                            buf_clone.lock().unwrap().push_str(&new_text);
-                                        }
-                                        separator_found = true;
-                                        continue;
-                                    }
-
-                                    // Display tokens, holding back enough to detect separator
-                                    let raw_end =
-                                        accumulated.len().saturating_sub(SEPARATOR_HOLDBACK);
-                                    let safe_end = floor_char_boundary(&accumulated, raw_end);
-                                    if safe_end > displayed_len {
-                                        let new_text =
-                                            accumulated[displayed_len..safe_end].to_string();
-                                        buf_clone.lock().unwrap().push_str(&new_text);
-                                        displayed_len = safe_end;
-                                    }
-                                }
-
-                                // Flush remaining if no separator found
-                                if !separator_found && displayed_len < accumulated.len() {
-                                    let remaining = accumulated[displayed_len..].to_string();
-                                    buf_clone.lock().unwrap().push_str(&remaining);
-                                }
-
-                                *active_clone.lock().unwrap() = false;
-                            });
-
-                            match queue
-                                .send(
-                                    request_id,
-                                    model.clone(),
-                                    context,
-                                    Some(system_prompt),
-                                    Some(token_tx),
-                                )
-                                .await
-                            {
-                                Ok(mut rx) => {
-                                    // Poll for response while continuing to render
-                                    let response = loop {
-                                        // Flush any buffered tokens to the log
-                                        {
-                                            let mut buf = streaming_buf.lock().unwrap();
-                                            if !buf.is_empty() {
-                                                if let Some(last) = app.world.text_log.last_mut() {
-                                                    last.push_str(&buf);
-                                                }
-                                                buf.clear();
-                                            }
-                                        }
-
-                                        // Draw frame to show streaming progress
-                                        terminal.draw(|frame| tui::draw(frame, &app))?;
-
-                                        // Check if response is ready (non-blocking)
-                                        match rx.try_recv() {
-                                            Ok(resp) => break Some(resp),
-                                            Err(oneshot::error::TryRecvError::Empty) => {
-                                                tokio::time::sleep(Duration::from_millis(50)).await;
+                                            if separator_found {
                                                 continue;
                                             }
-                                            Err(oneshot::error::TryRecvError::Closed) => {
-                                                break None;
+
+                                            if let Some((dialogue_end, _meta_start)) =
+                                                find_response_separator(&accumulated)
+                                            {
+                                                if dialogue_end > displayed_len {
+                                                    let new_text = accumulated
+                                                        [displayed_len..dialogue_end]
+                                                        .to_string();
+                                                    buf_clone.lock().unwrap().push_str(&new_text);
+                                                }
+                                                separator_found = true;
+                                                continue;
+                                            }
+
+                                            let raw_end = accumulated
+                                                .len()
+                                                .saturating_sub(SEPARATOR_HOLDBACK);
+                                            let safe_end =
+                                                floor_char_boundary(&accumulated, raw_end);
+                                            if safe_end > displayed_len {
+                                                let new_text = accumulated[displayed_len..safe_end]
+                                                    .to_string();
+                                                buf_clone.lock().unwrap().push_str(&new_text);
+                                                displayed_len = safe_end;
                                             }
                                         }
-                                    };
 
-                                    // Wait for streaming task to finish
-                                    let _ = stream_handle.await;
+                                        if !separator_found && displayed_len < accumulated.len() {
+                                            let remaining =
+                                                accumulated[displayed_len..].to_string();
+                                            buf_clone.lock().unwrap().push_str(&remaining);
+                                        }
 
-                                    // Flush any remaining filtered tokens
+                                        *active_clone.lock().unwrap() = false;
+                                    });
+
+                                    match queue
+                                        .send(
+                                            request_id,
+                                            model.clone(),
+                                            context,
+                                            Some(system_prompt),
+                                            Some(token_tx),
+                                        )
+                                        .await
                                     {
-                                        let mut buf = streaming_buf.lock().unwrap();
-                                        if !buf.is_empty() {
-                                            if let Some(last) = app.world.text_log.last_mut() {
-                                                last.push_str(&buf);
-                                            }
-                                            buf.clear();
-                                        }
-                                    }
+                                        Ok(mut rx) => {
+                                            let response = loop {
+                                                {
+                                                    let mut buf = streaming_buf.lock().unwrap();
+                                                    if !buf.is_empty() {
+                                                        if let Some(last) =
+                                                            app.world.text_log.last_mut()
+                                                        {
+                                                            last.push_str(&buf);
+                                                        }
+                                                        buf.clear();
+                                                    }
+                                                }
 
-                                    match response {
-                                        Some(resp) => {
-                                            if let Some(err) = &resp.error {
-                                                app.world.log(format!("[Ollama error: {}]", err));
-                                            } else {
-                                                // Parse metadata silently
-                                                let parsed = parse_npc_stream_response(&resp.text);
-                                                if let Some(meta) = &parsed.metadata {
-                                                    tracing::debug!(
-                                                        "NPC metadata: action={}, mood={}",
-                                                        meta.action,
-                                                        meta.mood
+                                                terminal
+                                                    .draw(|frame| tui::draw(frame, &mut app))?;
+
+                                                match rx.try_recv() {
+                                                    Ok(resp) => break Some(resp),
+                                                    Err(oneshot::error::TryRecvError::Empty) => {
+                                                        tokio::time::sleep(Duration::from_millis(
+                                                            50,
+                                                        ))
+                                                        .await;
+                                                        continue;
+                                                    }
+                                                    Err(oneshot::error::TryRecvError::Closed) => {
+                                                        break None;
+                                                    }
+                                                }
+                                            };
+
+                                            let _ = stream_handle.await;
+
+                                            {
+                                                let mut buf = streaming_buf.lock().unwrap();
+                                                if !buf.is_empty() {
+                                                    if let Some(last) =
+                                                        app.world.text_log.last_mut()
+                                                    {
+                                                        last.push_str(&buf);
+                                                    }
+                                                    buf.clear();
+                                                }
+                                            }
+
+                                            match response {
+                                                Some(resp) => {
+                                                    if let Some(err) = &resp.error {
+                                                        app.world.log(format!(
+                                                            "[Ollama error: {}]",
+                                                            err
+                                                        ));
+                                                    } else {
+                                                        let parsed =
+                                                            parse_npc_stream_response(&resp.text);
+                                                        if let Some(meta) = &parsed.metadata {
+                                                            tracing::debug!(
+                                                                "NPC metadata: action={}, mood={}",
+                                                                meta.action,
+                                                                meta.mood
+                                                            );
+                                                        }
+                                                    }
+                                                }
+                                                None => {
+                                                    app.world.log(
+                                                        "[Inference channel closed]".to_string(),
                                                     );
                                                 }
                                             }
                                         }
-                                        None => {
-                                            app.world.log("[Inference channel closed]".to_string());
+                                        Err(e) => {
+                                            *streaming_active.lock().unwrap() = false;
+                                            let _ = stream_handle.await;
+                                            app.world
+                                                .log(format!("[Failed to send request: {}]", e));
                                         }
                                     }
+                                } else {
+                                    app.world.log("[No inference engine available]".to_string());
                                 }
-                                Err(e) => {
-                                    *streaming_active.lock().unwrap() = false;
-                                    let _ = stream_handle.await;
-                                    app.world.log(format!("[Failed to send request: {}]", e));
-                                }
-                            }
-                        } else {
-                            app.world.log("[No inference engine available]".to_string());
-                        }
-                    } else {
-                        // Try intent parsing for non-NPC actions
-                        let intent = parse_intent(&client, &text, &model).await?;
-                        match intent.intent {
-                            parish::input::IntentKind::Look => {
-                                let loc = app.world.current_location();
-                                app.world.log(loc.description.clone());
-                            }
-                            _ => {
+                            } else {
                                 app.world.log("Nothing happens.".to_string());
                             }
                         }
@@ -361,4 +370,113 @@ fn handle_system_command(app: &mut App, cmd: Command) {
         }
     }
     app.world.log(String::new());
+}
+
+/// Shows the current location with description, NPCs, and exits.
+fn show_location_arrival(app: &mut App) {
+    let loc_name = app.world.current_location().name.clone();
+    app.world.log(format!("— {} —", loc_name));
+
+    // Render dynamic description if graph is loaded, else use static description
+    if let Some(loc_data) = app.world.current_location_data() {
+        let tod = app.world.clock.time_of_day();
+        let weather = app.world.weather.clone();
+        let npc_names: Vec<&str> = app
+            .npcs
+            .iter()
+            .filter(|n| n.location == app.world.player_location)
+            .map(|n| n.name.as_str())
+            .collect();
+        let desc = render_description(loc_data, tod, &weather, &npc_names);
+        app.world.log(desc);
+    } else {
+        let desc = app.world.current_location().description.clone();
+        app.world.log(desc);
+    }
+
+    // Show NPCs present
+    for npc in &app.npcs {
+        if npc.location == app.world.player_location {
+            app.world.log(format!("{} is here.", npc.name));
+        }
+    }
+
+    // Show exits
+    let exits = format_exits(app.world.player_location, &app.world.graph);
+    app.world.log(exits);
+    app.world.log(String::new());
+}
+
+/// Shows current location description and exits (for /look or IntentKind::Look).
+fn show_location_description(app: &mut App) {
+    if let Some(loc_data) = app.world.current_location_data() {
+        let tod = app.world.clock.time_of_day();
+        let weather = app.world.weather.clone();
+        let npc_names: Vec<&str> = app
+            .npcs
+            .iter()
+            .filter(|n| n.location == app.world.player_location)
+            .map(|n| n.name.as_str())
+            .collect();
+        let desc = render_description(loc_data, tod, &weather, &npc_names);
+        app.world.log(desc);
+    } else {
+        let desc = app.world.current_location().description.clone();
+        app.world.log(desc);
+    }
+
+    let exits = format_exits(app.world.player_location, &app.world.graph);
+    app.world.log(exits);
+}
+
+/// Handles a movement command: resolve, travel, advance clock, show arrival.
+fn handle_movement(app: &mut App, target: &str) {
+    let result = movement::resolve_movement(target, &app.world.graph, app.world.player_location);
+
+    match result {
+        MovementResult::Arrived {
+            destination,
+            minutes,
+            narration,
+            ..
+        } => {
+            // Show travel narration
+            app.world.log(narration);
+            app.world.log(String::new());
+
+            // Advance game clock
+            app.world.clock.advance(minutes as i64);
+
+            // Update player location
+            app.world.player_location = destination;
+
+            // Update legacy locations map with current position
+            if let Some(data) = app.world.graph.get(destination) {
+                app.world
+                    .locations
+                    .entry(destination)
+                    .or_insert_with(|| parish::world::Location {
+                        id: destination,
+                        name: data.name.clone(),
+                        description: data.description_template.clone(),
+                        indoor: data.indoor,
+                        public: data.public,
+                    });
+            }
+
+            // Show new location
+            show_location_arrival(app);
+        }
+        MovementResult::AlreadyHere => {
+            app.world.log("You are already here.".to_string());
+        }
+        MovementResult::NotFound(name) => {
+            app.world
+                .log(format!("You don't know how to get to \"{}\".", name));
+
+            // Show available exits as a hint
+            let exits = format_exits(app.world.player_location, &app.world.graph);
+            app.world.log(exits);
+        }
+    }
 }

--- a/src/npc/mod.rs
+++ b/src/npc/mod.rs
@@ -8,9 +8,9 @@ use crate::world::{LocationId, WorldState};
 use serde::{Deserialize, Serialize};
 
 /// Maximum number of bytes to hold back during streaming to detect
-/// the separator pattern. Must be large enough to catch `  ---\n` with
-/// variable whitespace around it.
-pub const SEPARATOR_HOLDBACK: usize = 16;
+/// the separator pattern. Must be large enough to catch ` --- ` inline
+/// or `  ---\n` on its own line, even when preceded by text on the same line.
+pub const SEPARATOR_HOLDBACK: usize = 24;
 
 /// Rounds a byte offset down to the nearest UTF-8 char boundary in `s`.
 ///
@@ -30,25 +30,38 @@ pub fn floor_char_boundary(s: &str, pos: usize) -> usize {
 
 /// Finds the separator between dialogue and metadata in an NPC response.
 ///
-/// Looks for a line consisting of `---` (with optional surrounding whitespace).
+/// Looks for `---` as a separator. Handles two cases:
+/// 1. `---` on its own line (with optional whitespace)
+/// 2. `---` appearing inline, e.g. `(smiles) --- {"action": ...}`
+///
 /// Returns `Some((dialogue_end, metadata_start))` — the byte offset where
-/// dialogue ends and where metadata begins (after the separator line).
+/// dialogue ends and where metadata begins (after the separator).
 /// Returns `None` if no separator is found.
 pub fn find_response_separator(text: &str) -> Option<(usize, usize)> {
-    for (i, line) in text.split('\n').enumerate() {
+    // First try: --- on its own line
+    let mut byte_offset = 0;
+    for line in text.split('\n') {
         if line.trim() == "---" {
-            // Calculate byte offset of this line
-            let dialogue_end = text
-                .split('\n')
-                .take(i)
-                .map(|l| l.len() + 1) // +1 for the \n
-                .sum::<usize>();
-            // metadata_start is after this separator line + its newline
-            let metadata_start = dialogue_end + line.len() + 1;
-            let metadata_start = metadata_start.min(text.len());
+            let dialogue_end = byte_offset;
+            let metadata_start = (byte_offset + line.len() + 1).min(text.len());
             return Some((dialogue_end, metadata_start));
         }
+        byte_offset += line.len() + 1; // +1 for the \n
     }
+
+    // Second try: --- appearing inline (e.g. "text --- {json}")
+    // Look for " --- " or " ---\n" pattern
+    if let Some(pos) = text.find(" --- ") {
+        let dialogue_end = pos;
+        let metadata_start = pos + 5; // skip " --- "
+        return Some((dialogue_end, metadata_start));
+    }
+    if let Some(pos) = text.find(" ---\n") {
+        let dialogue_end = pos;
+        let metadata_start = (pos + 5).min(text.len());
+        return Some((dialogue_end, metadata_start));
+    }
+
     None
 }
 
@@ -369,6 +382,38 @@ mod tests {
     }
 
     #[test]
+    fn test_find_response_separator_inline() {
+        // LLM sometimes puts --- inline with text and JSON
+        let text = "(smiles) --- {\"action\": \"speaks\", \"mood\": \"content\"}";
+        let (d_end, m_start) = find_response_separator(text).unwrap();
+        assert_eq!(&text[..d_end], "(smiles)");
+        assert!(text[m_start..].trim().starts_with('{'));
+    }
+
+    #[test]
+    fn test_find_response_separator_inline_with_newline() {
+        let text = "(smiles) ---\n{\"action\": \"speaks\"}";
+        let (d_end, m_start) = find_response_separator(text).unwrap();
+        assert_eq!(&text[..d_end], "(smiles)");
+        assert!(text[m_start..].trim().starts_with('{'));
+    }
+
+    #[test]
+    fn test_parse_inline_separator_real_example() {
+        let text = "(Leans on the bar) Morning to ye, lad. (smiles) --- {\"action\": \"speaks\", \"mood\": \"content\", \"internal_thought\": \"Hoping they'll stay\"}";
+        let parsed = parse_npc_stream_response(text);
+        assert!(
+            !parsed.dialogue.contains("action"),
+            "metadata should not leak into dialogue: {}",
+            parsed.dialogue
+        );
+        assert!(parsed.dialogue.contains("Morning to ye"));
+        assert!(parsed.metadata.is_some());
+        let meta = parsed.metadata.unwrap();
+        assert_eq!(meta.mood, "content");
+    }
+
+    #[test]
     fn test_parse_npc_stream_response_no_separator() {
         let text = "Well hello there, stranger!";
         let parsed = parse_npc_stream_response(text);
@@ -442,8 +487,8 @@ mod tests {
 
     #[test]
     fn test_separator_holdback_sufficient() {
-        // Holdback must be large enough to catch "  ---  \n" with whitespace
-        assert!(SEPARATOR_HOLDBACK >= 10);
+        // Holdback must be large enough to catch " --- " inline pattern
+        assert!(SEPARATOR_HOLDBACK >= 20);
     }
 
     #[test]

--- a/src/npc/mod.rs
+++ b/src/npc/mod.rs
@@ -5,7 +5,7 @@
 //! scales with distance from the player (4 LOD tiers).
 
 use crate::world::{LocationId, WorldState};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Maximum number of bytes to hold back during streaming to detect
 /// the separator pattern. Must be large enough to catch `  ---\n` with
@@ -53,7 +53,8 @@ pub fn find_response_separator(text: &str) -> Option<(usize, usize)> {
 }
 
 /// Unique identifier for an NPC.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct NpcId(pub u32);
 
 /// A non-player character in the game world.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -251,18 +251,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
 
     // Main panel: text log with word wrap and scroll support
     let panel_height = chunks[1].height;
-    let total_lines = app.world.text_log.len() as u16;
-
-    // Compute scroll position — offset is distance from bottom
-    let scroll_row = if app.scroll.auto_scroll {
-        // Auto-scroll: show the bottom of the log
-        total_lines.saturating_sub(panel_height)
-    } else {
-        // Manual scroll: offset from bottom
-        total_lines
-            .saturating_sub(panel_height)
-            .saturating_sub(app.scroll.offset)
-    };
+    let panel_width = chunks[1].width;
 
     let log_lines: Vec<Line> = app
         .world
@@ -271,11 +260,37 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         .map(|s| Line::from(s.as_str()))
         .collect();
 
+    // Count wrapped lines to get accurate scroll math
+    let total_lines = if panel_width > 0 {
+        app.world
+            .text_log
+            .iter()
+            .map(|s| {
+                if s.is_empty() {
+                    1u16
+                } else {
+                    // Ceiling division: how many visual lines does this text occupy?
+                    ((s.len() as u16).saturating_sub(1) / panel_width) + 1
+                }
+            })
+            .sum::<u16>()
+    } else {
+        app.world.text_log.len() as u16
+    };
+
+    let max_scroll = total_lines.saturating_sub(panel_height);
+
+    // Compute scroll position — offset is distance from bottom
+    let scroll_row = if app.scroll.auto_scroll {
+        max_scroll
+    } else {
+        max_scroll.saturating_sub(app.scroll.offset)
+    };
+
     let scroll_indicator = if total_lines > panel_height && !app.scroll.auto_scroll {
         if scroll_row == 0 {
             "[TOP]".to_string()
         } else {
-            let max_scroll = total_lines.saturating_sub(panel_height);
             let pct = if max_scroll > 0 {
                 (scroll_row as f32 / max_scroll as f32 * 100.0) as u16
             } else {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -87,9 +87,66 @@ pub fn palette_for_time(tod: &TimeOfDay) -> ColorPalette {
     }
 }
 
+/// Scroll state for the main text panel.
+///
+/// Tracks the scroll offset and whether auto-scroll (follow new output)
+/// is active. When the user scrolls up, auto-scroll is disabled until
+/// they press End or scroll back to the bottom.
+#[derive(Debug, Clone)]
+pub struct ScrollState {
+    /// Current scroll offset in lines from the top.
+    pub offset: u16,
+    /// Whether to auto-scroll to the bottom on new content.
+    pub auto_scroll: bool,
+}
+
+impl ScrollState {
+    /// Creates a new scroll state with auto-scroll enabled.
+    pub fn new() -> Self {
+        Self {
+            offset: 0,
+            auto_scroll: true,
+        }
+    }
+
+    /// Scrolls up by the given number of lines.
+    pub fn scroll_up(&mut self, lines: u16) {
+        self.offset = self.offset.saturating_add(lines);
+        self.auto_scroll = false;
+    }
+
+    /// Scrolls down by the given number of lines.
+    pub fn scroll_down(&mut self, lines: u16, max_offset: u16) {
+        self.offset = self.offset.saturating_sub(lines);
+        if self.offset == 0 {
+            self.auto_scroll = true;
+        }
+        // Clamp — offset is distance from bottom, so 0 = bottom
+        let _ = max_offset; // kept for API clarity; clamping happens in update()
+    }
+
+    /// Scrolls to the top of the text log.
+    pub fn scroll_to_top(&mut self, max_offset: u16) {
+        self.offset = max_offset;
+        self.auto_scroll = false;
+    }
+
+    /// Scrolls to the bottom and re-enables auto-scroll.
+    pub fn scroll_to_bottom(&mut self) {
+        self.offset = 0;
+        self.auto_scroll = true;
+    }
+}
+
+impl Default for ScrollState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Main application state for the TUI.
 ///
-/// Holds the game world state, input buffer, and control flags.
+/// Holds the game world state, input buffer, scroll state, and control flags.
 /// Passed to the `draw` function each frame.
 pub struct App {
     /// The game world state.
@@ -102,6 +159,8 @@ pub struct App {
     pub inference_queue: Option<InferenceQueue>,
     /// NPCs present in the world.
     pub npcs: Vec<Npc>,
+    /// Scroll state for the main text panel.
+    pub scroll: ScrollState,
 }
 
 impl App {
@@ -113,6 +172,7 @@ impl App {
             should_quit: false,
             inference_queue: None,
             npcs: Vec::new(),
+            scroll: ScrollState::new(),
         }
     }
 }
@@ -157,7 +217,7 @@ pub fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io
 ///
 /// Layout: top bar (3 lines with border), main text panel (fill), input line (3 lines with border).
 /// Colors are driven by the current time-of-day palette.
-pub fn draw(frame: &mut Frame, app: &App) {
+pub fn draw(frame: &mut Frame, app: &mut App) {
     let palette = palette_for_time(&app.world.clock.time_of_day());
     let base_style = Style::default().fg(palette.fg).bg(palette.bg);
     let accent_style = Style::default().fg(palette.accent).bg(palette.bg);
@@ -189,17 +249,57 @@ pub fn draw(frame: &mut Frame, app: &App) {
         .block(Block::default().borders(Borders::BOTTOM).style(base_style));
     frame.render_widget(top_bar, chunks[0]);
 
-    // Main panel: text log with word wrap
+    // Main panel: text log with word wrap and scroll support
+    let panel_height = chunks[1].height;
+    let total_lines = app.world.text_log.len() as u16;
+
+    // Compute scroll position — offset is distance from bottom
+    let scroll_row = if app.scroll.auto_scroll {
+        // Auto-scroll: show the bottom of the log
+        total_lines.saturating_sub(panel_height)
+    } else {
+        // Manual scroll: offset from bottom
+        total_lines
+            .saturating_sub(panel_height)
+            .saturating_sub(app.scroll.offset)
+    };
+
     let log_lines: Vec<Line> = app
         .world
         .text_log
         .iter()
         .map(|s| Line::from(s.as_str()))
         .collect();
+
+    let scroll_indicator = if total_lines > panel_height && !app.scroll.auto_scroll {
+        if scroll_row == 0 {
+            "[TOP]".to_string()
+        } else {
+            let max_scroll = total_lines.saturating_sub(panel_height);
+            let pct = if max_scroll > 0 {
+                (scroll_row as f32 / max_scroll as f32 * 100.0) as u16
+            } else {
+                100
+            };
+            format!("[{}%]", pct.min(100))
+        }
+    } else {
+        String::new()
+    };
+
+    let block_title = if scroll_indicator.is_empty() {
+        Block::default().style(base_style)
+    } else {
+        Block::default()
+            .title_top(Line::from(scroll_indicator).right_aligned())
+            .style(base_style)
+    };
+
     let main_panel = Paragraph::new(Text::from(log_lines))
         .style(base_style)
         .wrap(Wrap { trim: false })
-        .block(Block::default().style(base_style));
+        .scroll((scroll_row, 0))
+        .block(block_title);
     frame.render_widget(main_panel, chunks[1]);
 
     // Input line
@@ -232,11 +332,33 @@ pub fn handle_input(app: &mut App, timeout: Duration) -> io::Result<Option<Strin
             KeyCode::Enter => {
                 if !app.input_buffer.is_empty() {
                     let input = app.input_buffer.drain(..).collect();
+                    app.scroll.scroll_to_bottom();
                     return Ok(Some(input));
                 }
             }
             KeyCode::Esc => {
                 app.input_buffer.clear();
+            }
+            KeyCode::PageUp => {
+                app.scroll.scroll_up(10);
+            }
+            KeyCode::PageDown => {
+                let max = app.world.text_log.len() as u16;
+                app.scroll.scroll_down(10, max);
+            }
+            KeyCode::Up => {
+                app.scroll.scroll_up(1);
+            }
+            KeyCode::Down => {
+                let max = app.world.text_log.len() as u16;
+                app.scroll.scroll_down(1, max);
+            }
+            KeyCode::Home => {
+                let max = app.world.text_log.len() as u16;
+                app.scroll.scroll_to_top(max);
+            }
+            KeyCode::End => {
+                app.scroll.scroll_to_bottom();
             }
             _ => {}
         }
@@ -299,11 +421,74 @@ mod tests {
         assert!(app.input_buffer.is_empty());
         assert!(app.inference_queue.is_none());
         assert!(app.npcs.is_empty());
+        assert!(app.scroll.auto_scroll);
+        assert_eq!(app.scroll.offset, 0);
     }
 
     #[test]
     fn test_app_default() {
         let app = App::default();
         assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn test_scroll_state_new() {
+        let scroll = ScrollState::new();
+        assert_eq!(scroll.offset, 0);
+        assert!(scroll.auto_scroll);
+    }
+
+    #[test]
+    fn test_scroll_up_disables_auto() {
+        let mut scroll = ScrollState::new();
+        scroll.scroll_up(5);
+        assert_eq!(scroll.offset, 5);
+        assert!(!scroll.auto_scroll);
+    }
+
+    #[test]
+    fn test_scroll_down_reenables_auto_at_bottom() {
+        let mut scroll = ScrollState::new();
+        scroll.scroll_up(3);
+        assert!(!scroll.auto_scroll);
+
+        scroll.scroll_down(3, 100);
+        assert_eq!(scroll.offset, 0);
+        assert!(scroll.auto_scroll);
+    }
+
+    #[test]
+    fn test_scroll_down_partial() {
+        let mut scroll = ScrollState::new();
+        scroll.scroll_up(10);
+        scroll.scroll_down(3, 100);
+        assert_eq!(scroll.offset, 7);
+        assert!(!scroll.auto_scroll);
+    }
+
+    #[test]
+    fn test_scroll_down_clamps_at_zero() {
+        let mut scroll = ScrollState::new();
+        scroll.scroll_up(2);
+        scroll.scroll_down(10, 100);
+        assert_eq!(scroll.offset, 0);
+        assert!(scroll.auto_scroll);
+    }
+
+    #[test]
+    fn test_scroll_to_top() {
+        let mut scroll = ScrollState::new();
+        scroll.scroll_to_top(50);
+        assert_eq!(scroll.offset, 50);
+        assert!(!scroll.auto_scroll);
+    }
+
+    #[test]
+    fn test_scroll_to_bottom() {
+        let mut scroll = ScrollState::new();
+        scroll.scroll_up(20);
+        scroll.scroll_to_bottom();
+        assert_eq!(scroll.offset, 0);
+        assert!(scroll.auto_scroll);
     }
 }

--- a/src/world/description.rs
+++ b/src/world/description.rs
@@ -1,0 +1,141 @@
+//! Dynamic location description rendering.
+//!
+//! Interpolates description templates with current game state
+//! (time of day, weather, NPCs present).
+
+use super::graph::LocationData;
+use super::time::TimeOfDay;
+
+/// Renders a location description by interpolating template placeholders.
+///
+/// Supported placeholders:
+/// - `{time}` — current time of day (e.g., "morning", "dusk")
+/// - `{weather}` — current weather string (e.g., "overcast", "clear")
+/// - `{npcs_present}` — comma-separated list of NPC names, or "no one"
+pub fn render_description(
+    location: &LocationData,
+    time_of_day: TimeOfDay,
+    weather: &str,
+    npc_names: &[&str],
+) -> String {
+    let time_str = time_display(time_of_day);
+    let weather_str = weather.to_lowercase();
+    let npcs_str = if npc_names.is_empty() {
+        "no one".to_string()
+    } else {
+        npc_names.join(", ")
+    };
+
+    location
+        .description_template
+        .replace("{time}", &time_str)
+        .replace("{weather}", &weather_str)
+        .replace("{npcs_present}", &npcs_str)
+}
+
+/// Converts a `TimeOfDay` to a human-friendly lowercase string for templates.
+fn time_display(tod: TimeOfDay) -> String {
+    match tod {
+        TimeOfDay::Dawn => "dawn".to_string(),
+        TimeOfDay::Morning => "morning".to_string(),
+        TimeOfDay::Midday => "midday".to_string(),
+        TimeOfDay::Afternoon => "afternoon".to_string(),
+        TimeOfDay::Dusk => "dusk".to_string(),
+        TimeOfDay::Night => "evening".to_string(),
+        TimeOfDay::Midnight => "late night".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::npc::NpcId;
+    use crate::world::LocationId;
+    use crate::world::graph::LocationData;
+
+    fn test_location() -> LocationData {
+        LocationData {
+            id: LocationId(1),
+            name: "Test Place".to_string(),
+            description_template:
+                "A place at {time}. Weather: {weather}. People here: {npcs_present}.".to_string(),
+            indoor: false,
+            public: true,
+            connections: vec![],
+            associated_npcs: vec![NpcId(1)],
+            mythological_significance: None,
+        }
+    }
+
+    #[test]
+    fn test_render_with_all_placeholders() {
+        let loc = test_location();
+        let result = render_description(&loc, TimeOfDay::Morning, "Overcast", &["Padraig O'Brien"]);
+        assert_eq!(
+            result,
+            "A place at morning. Weather: overcast. People here: Padraig O'Brien."
+        );
+    }
+
+    #[test]
+    fn test_render_no_npcs() {
+        let loc = test_location();
+        let result = render_description(&loc, TimeOfDay::Dusk, "Clear", &[]);
+        assert_eq!(
+            result,
+            "A place at dusk. Weather: clear. People here: no one."
+        );
+    }
+
+    #[test]
+    fn test_render_multiple_npcs() {
+        let loc = test_location();
+        let result = render_description(
+            &loc,
+            TimeOfDay::Midday,
+            "Drizzle",
+            &["Mary", "Padraig", "Siobhan"],
+        );
+        assert!(result.contains("Mary, Padraig, Siobhan"));
+    }
+
+    #[test]
+    fn test_render_all_times() {
+        let loc = test_location();
+        let times = [
+            (TimeOfDay::Dawn, "dawn"),
+            (TimeOfDay::Morning, "morning"),
+            (TimeOfDay::Midday, "midday"),
+            (TimeOfDay::Afternoon, "afternoon"),
+            (TimeOfDay::Dusk, "dusk"),
+            (TimeOfDay::Night, "evening"),
+            (TimeOfDay::Midnight, "late night"),
+        ];
+        for (tod, expected) in &times {
+            let result = render_description(&loc, *tod, "Clear", &[]);
+            assert!(
+                result.contains(expected),
+                "Expected '{}' in result for {:?}: {}",
+                expected,
+                tod,
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_no_placeholders() {
+        let loc = LocationData {
+            id: LocationId(1),
+            name: "Plain".to_string(),
+            description_template: "A plain description with no placeholders.".to_string(),
+            indoor: false,
+            public: true,
+            connections: vec![],
+            associated_npcs: vec![],
+            mythological_significance: None,
+        };
+        let result = render_description(&loc, TimeOfDay::Morning, "Clear", &[]);
+        assert_eq!(result, "A plain description with no placeholders.");
+    }
+}

--- a/src/world/description.rs
+++ b/src/world/description.rs
@@ -3,7 +3,8 @@
 //! Interpolates description templates with current game state
 //! (time of day, weather, NPCs present).
 
-use super::graph::LocationData;
+use super::LocationId;
+use super::graph::{LocationData, WorldGraph};
 use super::time::TimeOfDay;
 
 /// Renders a location description by interpolating template placeholders.
@@ -31,6 +32,27 @@ pub fn render_description(
         .replace("{time}", &time_str)
         .replace("{weather}", &weather_str)
         .replace("{npcs_present}", &npcs_str)
+}
+
+/// Formats the list of exits (neighboring locations) from a given location.
+///
+/// Returns a string like "You can go to: Darcy's Pub (3 min), St. Brigid's Church (5 min)"
+pub fn format_exits(location_id: LocationId, graph: &WorldGraph) -> String {
+    let neighbors = graph.neighbors(location_id);
+    if neighbors.is_empty() {
+        return "There is nowhere to go from here.".to_string();
+    }
+
+    let exits: Vec<String> = neighbors
+        .iter()
+        .filter_map(|(target_id, conn)| {
+            graph
+                .get(*target_id)
+                .map(|loc| format!("{} ({} min)", loc.name, conn.traversal_minutes))
+        })
+        .collect();
+
+    format!("You can go to: {}", exits.join(", "))
 }
 
 /// Converts a `TimeOfDay` to a human-friendly lowercase string for templates.
@@ -137,5 +159,43 @@ mod tests {
         };
         let result = render_description(&loc, TimeOfDay::Morning, "Clear", &[]);
         assert_eq!(result, "A plain description with no placeholders.");
+    }
+
+    #[test]
+    fn test_format_exits() {
+        let json = r#"{
+            "locations": [
+                {
+                    "id": 1, "name": "The Crossroads",
+                    "description_template": "X", "indoor": false, "public": true,
+                    "connections": [
+                        {"target": 2, "traversal_minutes": 3, "path_description": "lane"},
+                        {"target": 3, "traversal_minutes": 5, "path_description": "boreen"}
+                    ]
+                },
+                {
+                    "id": 2, "name": "Darcy's Pub",
+                    "description_template": "X", "indoor": true, "public": true,
+                    "connections": [{"target": 1, "traversal_minutes": 3, "path_description": "back"}]
+                },
+                {
+                    "id": 3, "name": "The Church",
+                    "description_template": "X", "indoor": false, "public": true,
+                    "connections": [{"target": 1, "traversal_minutes": 5, "path_description": "back"}]
+                }
+            ]
+        }"#;
+        let graph = WorldGraph::load_from_str(json).unwrap();
+        let exits = format_exits(LocationId(1), &graph);
+        assert!(exits.starts_with("You can go to: "));
+        assert!(exits.contains("Darcy's Pub (3 min)"));
+        assert!(exits.contains("The Church (5 min)"));
+    }
+
+    #[test]
+    fn test_format_exits_empty_graph() {
+        let graph = WorldGraph::new();
+        let exits = format_exits(LocationId(99), &graph);
+        assert_eq!(exits, "There is nowhere to go from here.");
     }
 }

--- a/src/world/encounter.rs
+++ b/src/world/encounter.rs
@@ -1,0 +1,144 @@
+//! En-route encounter system.
+//!
+//! Generates random encounters during travel between locations.
+//! Probability is ~20% per traversal, influenced by time of day.
+
+use super::time::TimeOfDay;
+use crate::npc::NpcId;
+
+/// An encounter event that occurs during travel.
+#[derive(Debug, Clone)]
+pub struct EncounterEvent {
+    /// The NPC involved, if any.
+    pub npc_id: Option<NpcId>,
+    /// A prose description of the encounter.
+    pub description: String,
+}
+
+/// Checks whether an encounter occurs during travel.
+///
+/// Base probability is 20%. Modified by time of day:
+/// - Dawn/Morning: slightly higher (more people about)
+/// - Night/Midnight: lower (fewer people out)
+///
+/// The `roll` parameter is a value in `0.0..1.0` for testability
+/// (in production, pass `rand::random::<f64>()`).
+pub fn check_encounter(time_of_day: TimeOfDay, roll: f64) -> Option<EncounterEvent> {
+    let threshold = match time_of_day {
+        TimeOfDay::Dawn | TimeOfDay::Morning => 0.25,
+        TimeOfDay::Midday | TimeOfDay::Afternoon => 0.20,
+        TimeOfDay::Dusk => 0.15,
+        TimeOfDay::Night => 0.10,
+        TimeOfDay::Midnight => 0.05,
+    };
+
+    if roll >= threshold {
+        return None;
+    }
+
+    // Generate flavor text based on time of day
+    let description = match time_of_day {
+        TimeOfDay::Dawn => "You pass an early riser walking their dog along the road.",
+        TimeOfDay::Morning => "A farmer nods to you from the far side of a gate as you pass.",
+        TimeOfDay::Midday => "You spot someone cycling past on the road ahead.",
+        TimeOfDay::Afternoon => "A car slows as it passes you. The driver gives a wave.",
+        TimeOfDay::Dusk => {
+            "A figure walks ahead of you in the fading light, then turns off down a lane."
+        }
+        TimeOfDay::Night => {
+            "You hear footsteps on the road behind you, but when you turn, no one is there."
+        }
+        TimeOfDay::Midnight => "An owl hoots from a nearby tree, breaking the silence.",
+    };
+
+    Some(EncounterEvent {
+        npc_id: None,
+        description: description.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encounter_below_threshold_triggers() {
+        // Morning threshold is 0.25, roll of 0.1 should trigger
+        let result = check_encounter(TimeOfDay::Morning, 0.1);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_encounter_above_threshold_none() {
+        // Morning threshold is 0.25, roll of 0.5 should not trigger
+        let result = check_encounter(TimeOfDay::Morning, 0.5);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_encounter_midnight_low_chance() {
+        // Midnight threshold is 0.05
+        let result = check_encounter(TimeOfDay::Midnight, 0.03);
+        assert!(result.is_some());
+
+        let result = check_encounter(TimeOfDay::Midnight, 0.1);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_encounter_has_description() {
+        let event = check_encounter(TimeOfDay::Dawn, 0.0).unwrap();
+        assert!(!event.description.is_empty());
+        assert!(event.npc_id.is_none()); // Phase 2: no specific NPC yet
+    }
+
+    #[test]
+    fn test_encounter_probability_distribution() {
+        // Run 1000 trials at morning (threshold 0.25)
+        // With uniform random rolls from 0..1, ~25% should trigger
+        let mut hits = 0;
+        for i in 0..1000 {
+            let roll = i as f64 / 1000.0;
+            if check_encounter(TimeOfDay::Morning, roll).is_some() {
+                hits += 1;
+            }
+        }
+        // Should be 250 (exactly 25% with uniform spacing)
+        assert_eq!(hits, 250);
+    }
+
+    #[test]
+    fn test_encounter_all_times_of_day() {
+        // All times should produce an encounter with roll 0.0
+        let times = [
+            TimeOfDay::Dawn,
+            TimeOfDay::Morning,
+            TimeOfDay::Midday,
+            TimeOfDay::Afternoon,
+            TimeOfDay::Dusk,
+            TimeOfDay::Night,
+            TimeOfDay::Midnight,
+        ];
+        for time in &times {
+            let event = check_encounter(*time, 0.0).unwrap();
+            assert!(
+                !event.description.is_empty(),
+                "No description for {:?}",
+                time
+            );
+        }
+    }
+
+    #[test]
+    fn test_encounter_at_exact_threshold() {
+        // At exactly the threshold, should NOT trigger (>= check)
+        let result = check_encounter(TimeOfDay::Midday, 0.20);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_encounter_just_below_threshold() {
+        let result = check_encounter(TimeOfDay::Midday, 0.19);
+        assert!(result.is_some());
+    }
+}

--- a/src/world/graph.rs
+++ b/src/world/graph.rs
@@ -1,0 +1,645 @@
+//! World graph — location graph with connections, pathfinding, and data loading.
+//!
+//! The world is a graph of named location nodes connected by edges
+//! with traversal times. This module provides the `WorldGraph` container,
+//! `Connection` edges, and BFS pathfinding.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ParishError;
+use crate::npc::NpcId;
+
+use super::LocationId;
+
+/// A connection (edge) between two locations in the world graph.
+///
+/// Each connection has a target location, a traversal time in game minutes,
+/// and a prose description of the path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Connection {
+    /// The destination location.
+    pub target: LocationId,
+    /// Time in game minutes to traverse this connection.
+    pub traversal_minutes: u16,
+    /// Prose description of the path (e.g., "a narrow boreen lined with hawthorn").
+    pub path_description: String,
+}
+
+/// Extended location data for the world graph.
+///
+/// Augments the base location with connections, description templates,
+/// associated NPCs, and optional mythological significance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocationData {
+    /// Unique identifier.
+    pub id: LocationId,
+    /// Human-readable name (e.g., "The Crossroads").
+    pub name: String,
+    /// Description template with placeholders: `{time}`, `{weather}`, `{npcs_present}`.
+    pub description_template: String,
+    /// Whether this location is indoors.
+    pub indoor: bool,
+    /// Whether this location is publicly accessible.
+    pub public: bool,
+    /// Connections to neighboring locations.
+    pub connections: Vec<Connection>,
+    /// NPCs who live or work at this location.
+    #[serde(default)]
+    pub associated_npcs: Vec<NpcId>,
+    /// Optional mythological significance (fairy forts, holy wells, etc.).
+    #[serde(default)]
+    pub mythological_significance: Option<String>,
+}
+
+/// The world graph: a collection of locations connected by traversable paths.
+///
+/// Provides lookup, fuzzy name search, neighbor queries, and BFS pathfinding.
+#[derive(Debug, Clone)]
+pub struct WorldGraph {
+    /// All locations keyed by their id.
+    locations: HashMap<LocationId, LocationData>,
+}
+
+/// Serialization wrapper for loading/saving the world graph as JSON.
+#[derive(Serialize, Deserialize)]
+struct WorldGraphFile {
+    locations: Vec<LocationData>,
+}
+
+impl WorldGraph {
+    /// Creates a new empty world graph.
+    pub fn new() -> Self {
+        Self {
+            locations: HashMap::new(),
+        }
+    }
+
+    /// Loads a world graph from a JSON file.
+    ///
+    /// Validates that all connection targets exist and that connections
+    /// are bidirectional.
+    pub fn load_from_file(path: &Path) -> Result<Self, ParishError> {
+        let contents = std::fs::read_to_string(path)?;
+        Self::load_from_str(&contents)
+    }
+
+    /// Loads a world graph from a JSON string.
+    ///
+    /// Validates that all connection targets exist and that connections
+    /// are bidirectional.
+    pub fn load_from_str(json: &str) -> Result<Self, ParishError> {
+        let file: WorldGraphFile = serde_json::from_str(json)?;
+
+        let mut locations = HashMap::new();
+        for loc in file.locations {
+            if locations.contains_key(&loc.id) {
+                return Err(ParishError::WorldGraph(format!(
+                    "duplicate location id: {}",
+                    loc.id.0
+                )));
+            }
+            locations.insert(loc.id, loc);
+        }
+
+        let graph = Self { locations };
+        graph.validate()?;
+        Ok(graph)
+    }
+
+    /// Validates the world graph.
+    ///
+    /// Checks that:
+    /// - All connection targets exist in the graph
+    /// - All connections are bidirectional
+    /// - There are no orphan nodes (nodes with no connections)
+    fn validate(&self) -> Result<(), ParishError> {
+        for (id, loc) in &self.locations {
+            if loc.connections.is_empty() {
+                return Err(ParishError::WorldGraph(format!(
+                    "orphan location with no connections: {} (id {})",
+                    loc.name, id.0
+                )));
+            }
+            for conn in &loc.connections {
+                // Check target exists
+                if !self.locations.contains_key(&conn.target) {
+                    return Err(ParishError::WorldGraph(format!(
+                        "location {} (id {}) has connection to non-existent target id {}",
+                        loc.name, id.0, conn.target.0
+                    )));
+                }
+                // Check bidirectionality
+                let target_loc = &self.locations[&conn.target];
+                let has_reverse = target_loc.connections.iter().any(|c| c.target == *id);
+                if !has_reverse {
+                    return Err(ParishError::WorldGraph(format!(
+                        "connection from {} to {} is not bidirectional",
+                        loc.name, target_loc.name
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns a reference to a location by id.
+    pub fn get(&self, id: LocationId) -> Option<&LocationData> {
+        self.locations.get(&id)
+    }
+
+    /// Returns all neighbors of a location with their connections.
+    pub fn neighbors(&self, id: LocationId) -> Vec<(LocationId, &Connection)> {
+        match self.locations.get(&id) {
+            Some(loc) => loc
+                .connections
+                .iter()
+                .map(|conn| (conn.target, conn))
+                .collect(),
+            None => Vec::new(),
+        }
+    }
+
+    /// Finds a location by name using case-insensitive fuzzy matching.
+    ///
+    /// Matching priority: exact match > query in name > name in query >
+    /// stripped-article match. Common articles ("the", "a", "an") are
+    /// stripped for fuzzy matching.
+    pub fn find_by_name(&self, name: &str) -> Option<LocationId> {
+        let lower = name.to_lowercase();
+        let stripped = strip_articles(&lower);
+
+        // First try exact match (case-insensitive)
+        for (id, loc) in &self.locations {
+            if loc.name.to_lowercase() == lower {
+                return Some(*id);
+            }
+        }
+
+        // Then try: query contained in location name
+        for (id, loc) in &self.locations {
+            if loc.name.to_lowercase().contains(&lower) {
+                return Some(*id);
+            }
+        }
+
+        // Then try: location name contained in query
+        for (id, loc) in &self.locations {
+            let loc_lower = loc.name.to_lowercase();
+            if lower.contains(&loc_lower) {
+                return Some(*id);
+            }
+        }
+
+        // Then try with articles stripped from both sides
+        if stripped != lower {
+            for (id, loc) in &self.locations {
+                let loc_stripped = strip_articles(&loc.name.to_lowercase());
+                if loc_stripped.contains(&stripped) || stripped.contains(&loc_stripped) {
+                    return Some(*id);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Finds the shortest path between two locations using BFS.
+    ///
+    /// Returns `None` if no path exists. The returned path includes
+    /// both the start and end locations.
+    pub fn shortest_path(&self, from: LocationId, to: LocationId) -> Option<Vec<LocationId>> {
+        if from == to {
+            return Some(vec![from]);
+        }
+        if !self.locations.contains_key(&from) || !self.locations.contains_key(&to) {
+            return None;
+        }
+
+        let mut visited = HashSet::new();
+        let mut queue = VecDeque::new();
+        let mut predecessors: HashMap<LocationId, LocationId> = HashMap::new();
+
+        visited.insert(from);
+        queue.push_back(from);
+
+        while let Some(current) = queue.pop_front() {
+            for (neighbor_id, _) in self.neighbors(current) {
+                if !visited.contains(&neighbor_id) {
+                    visited.insert(neighbor_id);
+                    predecessors.insert(neighbor_id, current);
+
+                    if neighbor_id == to {
+                        // Reconstruct path
+                        let mut path = vec![to];
+                        let mut node = to;
+                        while let Some(&pred) = predecessors.get(&node) {
+                            path.push(pred);
+                            node = pred;
+                        }
+                        path.reverse();
+                        return Some(path);
+                    }
+
+                    queue.push_back(neighbor_id);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Returns the total traversal time along a path in game minutes.
+    ///
+    /// Given a sequence of location ids (as returned by `shortest_path`),
+    /// sums the traversal times of each edge along the path.
+    pub fn path_travel_time(&self, path: &[LocationId]) -> u16 {
+        if path.len() < 2 {
+            return 0;
+        }
+
+        let mut total = 0u16;
+        for window in path.windows(2) {
+            let from = window[0];
+            let to = window[1];
+            if let Some(loc) = self.locations.get(&from)
+                && let Some(conn) = loc.connections.iter().find(|c| c.target == to)
+            {
+                total = total.saturating_add(conn.traversal_minutes);
+            }
+        }
+        total
+    }
+
+    /// Returns the connection from one location to another, if they are neighbors.
+    pub fn connection_between(&self, from: LocationId, to: LocationId) -> Option<&Connection> {
+        self.locations
+            .get(&from)?
+            .connections
+            .iter()
+            .find(|c| c.target == to)
+    }
+
+    /// Returns the number of locations in the graph.
+    pub fn location_count(&self) -> usize {
+        self.locations.len()
+    }
+
+    /// Returns all location ids in the graph.
+    pub fn location_ids(&self) -> Vec<LocationId> {
+        self.locations.keys().copied().collect()
+    }
+}
+
+impl Default for WorldGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Strips common English articles from the beginning of a string.
+fn strip_articles(s: &str) -> String {
+    let trimmed = s.trim();
+    for article in &["the ", "a ", "an "] {
+        if let Some(rest) = trimmed.strip_prefix(article) {
+            return rest.to_string();
+        }
+    }
+    trimmed.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_graph_json() -> &'static str {
+        r#"{
+            "locations": [
+                {
+                    "id": 1,
+                    "name": "The Crossroads",
+                    "description_template": "A quiet crossroads at {time}. The weather is {weather}.",
+                    "indoor": false,
+                    "public": true,
+                    "connections": [
+                        {"target": 2, "traversal_minutes": 5, "path_description": "a short lane"},
+                        {"target": 3, "traversal_minutes": 8, "path_description": "a winding boreen"}
+                    ],
+                    "associated_npcs": [],
+                    "mythological_significance": null
+                },
+                {
+                    "id": 2,
+                    "name": "Darcy's Pub",
+                    "description_template": "The warm interior of Darcy's Pub at {time}.",
+                    "indoor": true,
+                    "public": true,
+                    "connections": [
+                        {"target": 1, "traversal_minutes": 5, "path_description": "a short lane back to the crossroads"}
+                    ],
+                    "associated_npcs": [],
+                    "mythological_significance": null
+                },
+                {
+                    "id": 3,
+                    "name": "St. Brigid's Church",
+                    "description_template": "The old stone church stands in {weather} {time} light.",
+                    "indoor": false,
+                    "public": true,
+                    "connections": [
+                        {"target": 1, "traversal_minutes": 8, "path_description": "the boreen back to the crossroads"},
+                        {"target": 4, "traversal_minutes": 10, "path_description": "a path through the graveyard"}
+                    ],
+                    "associated_npcs": [],
+                    "mythological_significance": null
+                },
+                {
+                    "id": 4,
+                    "name": "The Fairy Fort",
+                    "description_template": "An ancient ring fort on the hill. {weather}.",
+                    "indoor": false,
+                    "public": true,
+                    "connections": [
+                        {"target": 3, "traversal_minutes": 10, "path_description": "the path back past the church"}
+                    ],
+                    "associated_npcs": [],
+                    "mythological_significance": "A rath said to be home to the sídhe. Locals avoid it after dark."
+                }
+            ]
+        }"#
+    }
+
+    #[test]
+    fn test_load_from_str() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        assert_eq!(graph.location_count(), 4);
+    }
+
+    #[test]
+    fn test_get_location() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let loc = graph.get(LocationId(1)).unwrap();
+        assert_eq!(loc.name, "The Crossroads");
+        assert!(!loc.indoor);
+        assert!(loc.public);
+    }
+
+    #[test]
+    fn test_get_nonexistent() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        assert!(graph.get(LocationId(99)).is_none());
+    }
+
+    #[test]
+    fn test_neighbors() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let neighbors = graph.neighbors(LocationId(1));
+        assert_eq!(neighbors.len(), 2);
+
+        let target_ids: Vec<LocationId> = neighbors.iter().map(|(id, _)| *id).collect();
+        assert!(target_ids.contains(&LocationId(2)));
+        assert!(target_ids.contains(&LocationId(3)));
+    }
+
+    #[test]
+    fn test_neighbors_empty() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let neighbors = graph.neighbors(LocationId(99));
+        assert!(neighbors.is_empty());
+    }
+
+    #[test]
+    fn test_find_by_name_exact() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let id = graph.find_by_name("Darcy's Pub").unwrap();
+        assert_eq!(id, LocationId(2));
+    }
+
+    #[test]
+    fn test_find_by_name_case_insensitive() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let id = graph.find_by_name("darcy's pub").unwrap();
+        assert_eq!(id, LocationId(2));
+    }
+
+    #[test]
+    fn test_find_by_name_partial() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let id = graph.find_by_name("pub").unwrap();
+        assert_eq!(id, LocationId(2));
+    }
+
+    #[test]
+    fn test_find_by_name_church() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let id = graph.find_by_name("church").unwrap();
+        assert_eq!(id, LocationId(3));
+    }
+
+    #[test]
+    fn test_find_by_name_not_found() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        assert!(graph.find_by_name("castle").is_none());
+    }
+
+    #[test]
+    fn test_shortest_path_adjacent() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let path = graph.shortest_path(LocationId(1), LocationId(2)).unwrap();
+        assert_eq!(path, vec![LocationId(1), LocationId(2)]);
+    }
+
+    #[test]
+    fn test_shortest_path_multi_hop() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let path = graph.shortest_path(LocationId(2), LocationId(4)).unwrap();
+        // 2 -> 1 -> 3 -> 4
+        assert_eq!(
+            path,
+            vec![LocationId(2), LocationId(1), LocationId(3), LocationId(4)]
+        );
+    }
+
+    #[test]
+    fn test_shortest_path_same_location() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let path = graph.shortest_path(LocationId(1), LocationId(1)).unwrap();
+        assert_eq!(path, vec![LocationId(1)]);
+    }
+
+    #[test]
+    fn test_shortest_path_nonexistent() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        assert!(graph.shortest_path(LocationId(1), LocationId(99)).is_none());
+    }
+
+    #[test]
+    fn test_path_travel_time() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let path = vec![LocationId(2), LocationId(1), LocationId(3), LocationId(4)];
+        let time = graph.path_travel_time(&path);
+        // 5 + 8 + 10 = 23
+        assert_eq!(time, 23);
+    }
+
+    #[test]
+    fn test_path_travel_time_single() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        assert_eq!(graph.path_travel_time(&[LocationId(1)]), 0);
+    }
+
+    #[test]
+    fn test_path_travel_time_empty() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        assert_eq!(graph.path_travel_time(&[]), 0);
+    }
+
+    #[test]
+    fn test_connection_between() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let conn = graph
+            .connection_between(LocationId(1), LocationId(2))
+            .unwrap();
+        assert_eq!(conn.traversal_minutes, 5);
+        assert_eq!(conn.path_description, "a short lane");
+    }
+
+    #[test]
+    fn test_connection_between_none() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        assert!(
+            graph
+                .connection_between(LocationId(1), LocationId(4))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_mythological_significance() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let fort = graph.get(LocationId(4)).unwrap();
+        assert!(fort.mythological_significance.is_some());
+        assert!(
+            fort.mythological_significance
+                .as_ref()
+                .unwrap()
+                .contains("sídhe")
+        );
+
+        let crossroads = graph.get(LocationId(1)).unwrap();
+        assert!(crossroads.mythological_significance.is_none());
+    }
+
+    #[test]
+    fn test_validation_missing_target() {
+        let json = r#"{
+            "locations": [
+                {
+                    "id": 1,
+                    "name": "A",
+                    "description_template": "A",
+                    "indoor": false,
+                    "public": true,
+                    "connections": [{"target": 99, "traversal_minutes": 5, "path_description": "path"}]
+                }
+            ]
+        }"#;
+        let result = WorldGraph::load_from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("non-existent"));
+    }
+
+    #[test]
+    fn test_validation_not_bidirectional() {
+        let json = r#"{
+            "locations": [
+                {
+                    "id": 1,
+                    "name": "A",
+                    "description_template": "A",
+                    "indoor": false,
+                    "public": true,
+                    "connections": [{"target": 2, "traversal_minutes": 5, "path_description": "path"}]
+                },
+                {
+                    "id": 2,
+                    "name": "B",
+                    "description_template": "B",
+                    "indoor": false,
+                    "public": true,
+                    "connections": [{"target": 1, "traversal_minutes": 5, "path_description": "path"}]
+                },
+                {
+                    "id": 3,
+                    "name": "C",
+                    "description_template": "C",
+                    "indoor": false,
+                    "public": true,
+                    "connections": [{"target": 1, "traversal_minutes": 5, "path_description": "path"}]
+                }
+            ]
+        }"#;
+        let result = WorldGraph::load_from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("not bidirectional"));
+    }
+
+    #[test]
+    fn test_validation_orphan_node() {
+        let json = r#"{
+            "locations": [
+                {
+                    "id": 1,
+                    "name": "A",
+                    "description_template": "A",
+                    "indoor": false,
+                    "public": true,
+                    "connections": []
+                }
+            ]
+        }"#;
+        let result = WorldGraph::load_from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("orphan"));
+    }
+
+    #[test]
+    fn test_validation_duplicate_id() {
+        let json = r#"{
+            "locations": [
+                {
+                    "id": 1,
+                    "name": "A",
+                    "description_template": "A",
+                    "indoor": false,
+                    "public": true,
+                    "connections": [{"target": 1, "traversal_minutes": 5, "path_description": "loop"}]
+                },
+                {
+                    "id": 1,
+                    "name": "B",
+                    "description_template": "B",
+                    "indoor": false,
+                    "public": true,
+                    "connections": [{"target": 1, "traversal_minutes": 5, "path_description": "loop"}]
+                }
+            ]
+        }"#;
+        let result = WorldGraph::load_from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("duplicate"));
+    }
+
+    #[test]
+    fn test_location_ids() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let ids = graph.location_ids();
+        assert_eq!(ids.len(), 4);
+    }
+}

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -4,13 +4,24 @@
 //! with traversal times. Geography is static; only people and events
 //! within it are dynamic.
 
+pub mod description;
+pub mod encounter;
+pub mod graph;
+pub mod movement;
 pub mod time;
 
 use std::collections::HashMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
 use time::GameClock;
 
+use crate::error::ParishError;
+use graph::{LocationData, WorldGraph};
+
 /// Unique identifier for a location in the world graph.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct LocationId(pub u32);
 
 /// A named location in the game world.
@@ -34,15 +45,17 @@ pub struct Location {
 
 /// Central game state container.
 ///
-/// Holds the game clock, player position, all locations, weather,
+/// Holds the game clock, player position, the world graph, weather,
 /// and the scrollback text log displayed in the TUI.
 pub struct WorldState {
     /// The game clock mapping real time to game time.
     pub clock: GameClock,
     /// The player's current location.
     pub player_location: LocationId,
-    /// All locations in the world, keyed by id.
+    /// All locations in the world, keyed by id (legacy, used by NPC context).
     pub locations: HashMap<LocationId, Location>,
+    /// The world graph with full location data and connections.
+    pub graph: WorldGraph,
     /// Current weather description (e.g. "Clear", "Overcast").
     pub weather: String,
     /// Scrollback text log displayed in the main TUI panel.
@@ -78,9 +91,49 @@ impl WorldState {
             clock,
             player_location: crossroads_id,
             locations,
+            graph: WorldGraph::new(),
             weather: "Clear".to_string(),
             text_log: Vec::new(),
         }
+    }
+
+    /// Creates a world state from a parish data file.
+    ///
+    /// Loads the world graph from JSON and sets the player at the
+    /// specified starting location. Also populates the legacy `locations`
+    /// map for backward compatibility with NPC context building.
+    pub fn from_parish_file(path: &Path, start_location: LocationId) -> Result<Self, ParishError> {
+        use chrono::{TimeZone, Utc};
+
+        let graph = WorldGraph::load_from_file(path)?;
+
+        // Build legacy locations map from graph data
+        let mut locations = HashMap::new();
+        for loc_id in graph.location_ids() {
+            if let Some(data) = graph.get(loc_id) {
+                locations.insert(
+                    loc_id,
+                    Location {
+                        id: loc_id,
+                        name: data.name.clone(),
+                        description: data.description_template.clone(),
+                        indoor: data.indoor,
+                        public: data.public,
+                    },
+                );
+            }
+        }
+
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap());
+
+        Ok(Self {
+            clock,
+            player_location: start_location,
+            locations,
+            graph,
+            weather: "Clear".to_string(),
+            text_log: Vec::new(),
+        })
     }
 
     /// Returns a reference to the player's current location.
@@ -92,6 +145,11 @@ impl WorldState {
         self.locations
             .get(&self.player_location)
             .expect("player location must exist in world")
+    }
+
+    /// Returns the current location's data from the world graph, if loaded.
+    pub fn current_location_data(&self) -> Option<&LocationData> {
+        self.graph.get(self.player_location)
     }
 
     /// Appends a line to the text log.
@@ -150,5 +208,28 @@ mod tests {
         set.insert(LocationId(2));
         assert_eq!(set.len(), 2);
         assert!(set.contains(&LocationId(1)));
+    }
+
+    #[test]
+    fn test_from_parish_file() {
+        let path = Path::new("data/parish.json");
+        if path.exists() {
+            let world = WorldState::from_parish_file(path, LocationId(1)).unwrap();
+            assert_eq!(world.player_location, LocationId(1));
+            assert!(world.locations.len() >= 12);
+            assert!(world.graph.location_count() >= 12);
+            assert_eq!(world.current_location().name, "The Crossroads");
+        }
+    }
+
+    #[test]
+    fn test_current_location_data() {
+        let path = Path::new("data/parish.json");
+        if path.exists() {
+            let world = WorldState::from_parish_file(path, LocationId(1)).unwrap();
+            let data = world.current_location_data().unwrap();
+            assert_eq!(data.name, "The Crossroads");
+            assert!(data.description_template.contains("{time}"));
+        }
     }
 }

--- a/src/world/movement.rs
+++ b/src/world/movement.rs
@@ -1,0 +1,263 @@
+//! Movement system — resolving movement commands and traversal with time.
+//!
+//! Handles resolving player movement intents to destinations, computing
+//! travel time along paths, and producing narration text for travel.
+
+use super::LocationId;
+use super::graph::WorldGraph;
+
+/// The result of resolving a movement command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MovementResult {
+    /// Player arrived at a destination after the given number of game minutes.
+    Arrived {
+        /// The destination location id.
+        destination: LocationId,
+        /// The path taken (including start and end).
+        path: Vec<LocationId>,
+        /// Total travel time in game minutes.
+        minutes: u16,
+        /// Narration text describing the journey.
+        narration: String,
+    },
+    /// The target location could not be found.
+    NotFound(String),
+    /// The player is already at the target location.
+    AlreadyHere,
+}
+
+/// Resolves a movement intent target to a `MovementResult`.
+///
+/// Uses fuzzy name matching to find the destination, then BFS to find
+/// the shortest path. Travel narration is generated from the first
+/// connection's path description.
+pub fn resolve_movement(target: &str, graph: &WorldGraph, current: LocationId) -> MovementResult {
+    // Try to find the target location
+    let destination_id = match graph.find_by_name(target) {
+        Some(id) => id,
+        None => return MovementResult::NotFound(target.to_string()),
+    };
+
+    // Check if already there
+    if destination_id == current {
+        return MovementResult::AlreadyHere;
+    }
+
+    // Find shortest path
+    let path = match graph.shortest_path(current, destination_id) {
+        Some(p) => p,
+        None => return MovementResult::NotFound(target.to_string()),
+    };
+
+    // Calculate total travel time
+    let minutes = graph.path_travel_time(&path);
+
+    // Build narration from first step's connection description
+    let narration = build_travel_narration(&path, graph, minutes);
+
+    MovementResult::Arrived {
+        destination: destination_id,
+        path,
+        minutes,
+        narration,
+    }
+}
+
+/// Builds travel narration text from a path through the world graph.
+///
+/// For single-hop journeys, uses the connection's path description.
+/// For multi-hop journeys, describes the first step with a summary.
+fn build_travel_narration(path: &[LocationId], graph: &WorldGraph, total_minutes: u16) -> String {
+    if path.len() < 2 {
+        return String::new();
+    }
+
+    let dest_name = graph
+        .get(*path.last().unwrap())
+        .map(|l| l.name.as_str())
+        .unwrap_or("your destination");
+
+    if path.len() == 2 {
+        // Direct connection
+        if let Some(conn) = graph.connection_between(path[0], path[1]) {
+            return format!(
+                "You walk along {}. ({} minutes)",
+                conn.path_description, total_minutes
+            );
+        }
+    }
+
+    // Multi-hop: describe the first leg and summarize
+    let first_desc = graph
+        .connection_between(path[0], path[1])
+        .map(|c| c.path_description.as_str())
+        .unwrap_or("the road");
+
+    format!(
+        "You set off along {} toward {}. ({} minutes)",
+        first_desc, dest_name, total_minutes
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::world::graph::WorldGraph;
+
+    fn test_graph() -> WorldGraph {
+        let json = r#"{
+            "locations": [
+                {
+                    "id": 1,
+                    "name": "The Crossroads",
+                    "description_template": "A crossroads.",
+                    "indoor": false,
+                    "public": true,
+                    "connections": [
+                        {"target": 2, "traversal_minutes": 5, "path_description": "a short lane"},
+                        {"target": 3, "traversal_minutes": 8, "path_description": "a winding boreen"}
+                    ]
+                },
+                {
+                    "id": 2,
+                    "name": "Darcy's Pub",
+                    "description_template": "A pub.",
+                    "indoor": true,
+                    "public": true,
+                    "connections": [
+                        {"target": 1, "traversal_minutes": 5, "path_description": "back to the crossroads"}
+                    ]
+                },
+                {
+                    "id": 3,
+                    "name": "St. Brigid's Church",
+                    "description_template": "A church.",
+                    "indoor": false,
+                    "public": true,
+                    "connections": [
+                        {"target": 1, "traversal_minutes": 8, "path_description": "the boreen back"},
+                        {"target": 4, "traversal_minutes": 10, "path_description": "a path through the graveyard"}
+                    ]
+                },
+                {
+                    "id": 4,
+                    "name": "The Fairy Fort",
+                    "description_template": "A fairy fort.",
+                    "indoor": false,
+                    "public": true,
+                    "connections": [
+                        {"target": 3, "traversal_minutes": 10, "path_description": "back past the church"}
+                    ]
+                }
+            ]
+        }"#;
+        WorldGraph::load_from_str(json).unwrap()
+    }
+
+    #[test]
+    fn test_resolve_direct_movement() {
+        let graph = test_graph();
+        let result = resolve_movement("pub", &graph, LocationId(1));
+        match result {
+            MovementResult::Arrived {
+                destination,
+                minutes,
+                narration,
+                ..
+            } => {
+                assert_eq!(destination, LocationId(2));
+                assert_eq!(minutes, 5);
+                assert!(narration.contains("short lane"));
+                assert!(narration.contains("5 minutes"));
+            }
+            other => panic!("expected Arrived, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_resolve_multi_hop_movement() {
+        let graph = test_graph();
+        // From pub to fairy fort: pub -> crossroads -> church -> fairy fort
+        let result = resolve_movement("fairy fort", &graph, LocationId(2));
+        match result {
+            MovementResult::Arrived {
+                destination,
+                path,
+                minutes,
+                narration,
+                ..
+            } => {
+                assert_eq!(destination, LocationId(4));
+                assert_eq!(path.len(), 4); // pub -> crossroads -> church -> fort
+                assert_eq!(minutes, 5 + 8 + 10); // 23 minutes
+                assert!(narration.contains("minutes"));
+            }
+            other => panic!("expected Arrived, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_resolve_already_here() {
+        let graph = test_graph();
+        let result = resolve_movement("crossroads", &graph, LocationId(1));
+        assert_eq!(result, MovementResult::AlreadyHere);
+    }
+
+    #[test]
+    fn test_resolve_not_found() {
+        let graph = test_graph();
+        let result = resolve_movement("castle", &graph, LocationId(1));
+        match result {
+            MovementResult::NotFound(name) => assert_eq!(name, "castle"),
+            other => panic!("expected NotFound, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_resolve_case_insensitive() {
+        let graph = test_graph();
+        let result = resolve_movement("DARCY'S PUB", &graph, LocationId(1));
+        match result {
+            MovementResult::Arrived { destination, .. } => {
+                assert_eq!(destination, LocationId(2));
+            }
+            other => panic!("expected Arrived, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_resolve_partial_name() {
+        let graph = test_graph();
+        let result = resolve_movement("church", &graph, LocationId(1));
+        match result {
+            MovementResult::Arrived { destination, .. } => {
+                assert_eq!(destination, LocationId(3));
+            }
+            other => panic!("expected Arrived, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_narration_direct() {
+        let graph = test_graph();
+        let path = vec![LocationId(1), LocationId(2)];
+        let narration = build_travel_narration(&path, &graph, 5);
+        assert_eq!(narration, "You walk along a short lane. (5 minutes)");
+    }
+
+    #[test]
+    fn test_narration_multi_hop() {
+        let graph = test_graph();
+        let path = vec![LocationId(2), LocationId(1), LocationId(3), LocationId(4)];
+        let narration = build_travel_narration(&path, &graph, 23);
+        assert!(narration.contains("The Fairy Fort"));
+        assert!(narration.contains("23 minutes"));
+    }
+
+    #[test]
+    fn test_narration_empty_path() {
+        let graph = test_graph();
+        let narration = build_travel_narration(&[], &graph, 0);
+        assert!(narration.is_empty());
+    }
+}

--- a/tests/world_graph_integration.rs
+++ b/tests/world_graph_integration.rs
@@ -1,0 +1,302 @@
+//! Integration tests for the world graph and parish data.
+//!
+//! These tests validate the actual `data/parish.json` file and test
+//! end-to-end scenarios: loading, pathfinding, movement, encounters,
+//! and dynamic descriptions.
+
+use std::path::Path;
+
+use parish::world::LocationId;
+use parish::world::description::render_description;
+use parish::world::encounter::check_encounter;
+use parish::world::graph::WorldGraph;
+use parish::world::movement::{MovementResult, resolve_movement};
+use parish::world::time::TimeOfDay;
+
+fn load_parish_graph() -> WorldGraph {
+    let path = Path::new("data/parish.json");
+    WorldGraph::load_from_file(path).expect("data/parish.json should load and validate")
+}
+
+#[test]
+fn test_parish_json_loads() {
+    let graph = load_parish_graph();
+    assert!(
+        graph.location_count() >= 12,
+        "expected at least 12 locations, got {}",
+        graph.location_count()
+    );
+}
+
+#[test]
+fn test_parish_json_location_count() {
+    let graph = load_parish_graph();
+    assert_eq!(graph.location_count(), 14);
+}
+
+#[test]
+fn test_parish_crossroads_is_hub() {
+    let graph = load_parish_graph();
+    let neighbors = graph.neighbors(LocationId(1));
+    assert!(
+        neighbors.len() >= 4,
+        "crossroads should have at least 4 connections, got {}",
+        neighbors.len()
+    );
+}
+
+#[test]
+fn test_parish_all_connections_bidirectional() {
+    // This is validated on load, but explicitly verify
+    let graph = load_parish_graph();
+    for loc_id in graph.location_ids() {
+        for (neighbor_id, _) in graph.neighbors(loc_id) {
+            let reverse = graph.neighbors(neighbor_id);
+            let has_reverse = reverse.iter().any(|(id, _)| *id == loc_id);
+            assert!(
+                has_reverse,
+                "connection from {:?} to {:?} is not bidirectional",
+                loc_id, neighbor_id
+            );
+        }
+    }
+}
+
+#[test]
+fn test_parish_find_pub() {
+    let graph = load_parish_graph();
+    let id = graph.find_by_name("pub").unwrap();
+    let loc = graph.get(id).unwrap();
+    assert_eq!(loc.name, "Darcy's Pub");
+}
+
+#[test]
+fn test_parish_find_church() {
+    let graph = load_parish_graph();
+    let id = graph.find_by_name("church").unwrap();
+    let loc = graph.get(id).unwrap();
+    assert_eq!(loc.name, "St. Brigid's Church");
+}
+
+#[test]
+fn test_parish_find_fairy_fort() {
+    let graph = load_parish_graph();
+    let id = graph.find_by_name("fairy").unwrap();
+    let loc = graph.get(id).unwrap();
+    assert_eq!(loc.name, "The Fairy Fort");
+}
+
+#[test]
+fn test_parish_path_crossroads_to_pub() {
+    let graph = load_parish_graph();
+    let path = graph.shortest_path(LocationId(1), LocationId(2)).unwrap();
+    assert_eq!(path, vec![LocationId(1), LocationId(2)]);
+    assert_eq!(graph.path_travel_time(&path), 3);
+}
+
+#[test]
+fn test_parish_path_pub_to_fairy_fort() {
+    let graph = load_parish_graph();
+    let path = graph.shortest_path(LocationId(2), LocationId(11)).unwrap();
+    // Should be a multi-hop path
+    assert!(path.len() >= 3);
+    // Total time should be reasonable
+    let time = graph.path_travel_time(&path);
+    assert!(
+        time > 0 && time < 60,
+        "travel time should be reasonable: {}",
+        time
+    );
+}
+
+#[test]
+fn test_parish_all_locations_reachable() {
+    let graph = load_parish_graph();
+    let ids = graph.location_ids();
+    // Every location should be reachable from the crossroads
+    for id in &ids {
+        let path = graph.shortest_path(LocationId(1), *id);
+        assert!(
+            path.is_some(),
+            "location {:?} should be reachable from the crossroads",
+            id
+        );
+    }
+}
+
+#[test]
+fn test_movement_go_to_pub() {
+    let graph = load_parish_graph();
+    let result = resolve_movement("the pub", &graph, LocationId(1));
+    match result {
+        MovementResult::Arrived {
+            destination,
+            minutes,
+            narration,
+            ..
+        } => {
+            assert_eq!(destination, LocationId(2));
+            assert_eq!(minutes, 3);
+            assert!(!narration.is_empty());
+        }
+        other => panic!("expected Arrived at pub, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_movement_go_to_church() {
+    let graph = load_parish_graph();
+    let result = resolve_movement("church", &graph, LocationId(1));
+    match result {
+        MovementResult::Arrived {
+            destination,
+            minutes,
+            ..
+        } => {
+            assert_eq!(destination, LocationId(3));
+            assert_eq!(minutes, 5);
+        }
+        other => panic!("expected Arrived at church, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_movement_already_here() {
+    let graph = load_parish_graph();
+    let result = resolve_movement("crossroads", &graph, LocationId(1));
+    assert_eq!(result, MovementResult::AlreadyHere);
+}
+
+#[test]
+fn test_movement_not_found() {
+    let graph = load_parish_graph();
+    let result = resolve_movement("hogwarts", &graph, LocationId(1));
+    match result {
+        MovementResult::NotFound(name) => assert_eq!(name, "hogwarts"),
+        other => panic!("expected NotFound, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_movement_time_advancement() {
+    // Simulate: move from crossroads to pub, verify clock would advance 3 minutes
+    let graph = load_parish_graph();
+    let result = resolve_movement("pub", &graph, LocationId(1));
+    match result {
+        MovementResult::Arrived { minutes, .. } => {
+            use chrono::{TimeZone, Utc};
+            use parish::world::time::GameClock;
+
+            let mut clock = GameClock::new(Utc.with_ymd_and_hms(2026, 3, 20, 8, 0, 0).unwrap());
+            clock.advance(minutes as i64);
+            let now = clock.now();
+            assert_eq!(now.format("%H:%M").to_string(), "08:03");
+        }
+        other => panic!("expected Arrived, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_encounter_probability_distribution() {
+    // Run 10000 trials at midday (threshold 0.20)
+    let mut hits = 0;
+    for i in 0..10000 {
+        let roll = i as f64 / 10000.0;
+        if check_encounter(TimeOfDay::Midday, roll).is_some() {
+            hits += 1;
+        }
+    }
+    // Should be exactly 2000 (20%)
+    assert_eq!(hits, 2000);
+}
+
+#[test]
+fn test_dynamic_description_rendering() {
+    let graph = load_parish_graph();
+    let loc = graph.get(LocationId(1)).unwrap();
+    let desc = render_description(loc, TimeOfDay::Morning, "Overcast", &[]);
+    assert!(desc.contains("morning"), "should contain time: {}", desc);
+    assert!(
+        desc.contains("overcast"),
+        "should contain weather: {}",
+        desc
+    );
+    assert!(
+        !desc.contains("{time}"),
+        "should not contain raw placeholder: {}",
+        desc
+    );
+    assert!(
+        !desc.contains("{weather}"),
+        "should not contain raw placeholder: {}",
+        desc
+    );
+}
+
+#[test]
+fn test_parish_description_templates_have_placeholders() {
+    let graph = load_parish_graph();
+    for id in graph.location_ids() {
+        let loc = graph.get(id).unwrap();
+        assert!(
+            loc.description_template.contains("{time}"),
+            "location '{}' should have {{time}} placeholder",
+            loc.name
+        );
+        assert!(
+            loc.description_template.contains("{weather}"),
+            "location '{}' should have {{weather}} placeholder",
+            loc.name
+        );
+    }
+}
+
+#[test]
+fn test_parish_traversal_times_reasonable() {
+    let graph = load_parish_graph();
+    for id in graph.location_ids() {
+        for (_, conn) in graph.neighbors(id) {
+            assert!(
+                conn.traversal_minutes >= 2 && conn.traversal_minutes <= 15,
+                "traversal time {} for connection should be 2-15 minutes",
+                conn.traversal_minutes
+            );
+        }
+    }
+}
+
+#[test]
+fn test_parish_indoor_locations() {
+    let graph = load_parish_graph();
+    let pub_loc = graph.get(LocationId(2)).unwrap();
+    assert!(pub_loc.indoor, "Darcy's Pub should be indoor");
+
+    let crossroads = graph.get(LocationId(1)).unwrap();
+    assert!(!crossroads.indoor, "The Crossroads should be outdoor");
+}
+
+#[test]
+fn test_parish_mythological_locations() {
+    let graph = load_parish_graph();
+
+    // The Fairy Fort should have mythological significance
+    let fort = graph.get(LocationId(11)).unwrap();
+    assert!(
+        fort.mythological_significance.is_some(),
+        "The Fairy Fort should have mythological significance"
+    );
+
+    // The Crossroads should have mythological significance
+    let crossroads = graph.get(LocationId(1)).unwrap();
+    assert!(
+        crossroads.mythological_significance.is_some(),
+        "The Crossroads should have mythological significance"
+    );
+
+    // Darcy's Pub should not
+    let pub_loc = graph.get(LocationId(2)).unwrap();
+    assert!(
+        pub_loc.mythological_significance.is_none(),
+        "Darcy's Pub should not have mythological significance"
+    );
+}


### PR DESCRIPTION
## Summary
- **World graph**: 14 hand-authored Kiltoom locations with bidirectional connections, BFS pathfinding, fuzzy name search, and graph validation (`data/parish.json`, `src/world/graph.rs`)
- **Movement system**: Local keyword parser (63 verb patterns) bypasses LLM for movement/look commands. Player can move between locations with travel time, clock advancement, and narration (`src/world/movement.rs`, `src/input/mod.rs`)
- **Dynamic descriptions**: Location templates interpolated with time of day, weather, and NPC presence. Exits shown on arrival and `/look` (`src/world/description.rs`)
- **En-route encounters**: Probability-based random encounters during travel, weighted by time of day (`src/world/encounter.rs`)
- **TUI scrollback**: Page Up/Down, arrow keys, Home/End with auto-scroll and position indicator. Accounts for word-wrapped lines (`src/tui/mod.rs`)
- **Separator fix**: Detect `---` metadata separator inline (not just on its own line), preventing JSON metadata from leaking into NPC dialogue
- **Known issues tracker**: `docs/known-issues.md` with active and resolved issues

## Test plan
- [x] 216 tests passing (195 unit + 21 integration), 1 ignored (live Ollama)
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` all pass
- [x] End-to-end headless test: movement with standard and unusual verbs (saunter, mosey, stroll)
- [x] TUI scrollback manually verified with Page Up/Down
- [x] Inline separator detection verified against real LLM output

🤖 Generated with [Claude Code](https://claude.com/claude-code)