### PR TITLE
feat: add multi-provider LLM support via OpenAI-compatible API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,6 +1115,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1492,6 +1493,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1813,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2336,6 +2387,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 chrono = { version = "0.4", features = ["serde"] }
+toml = "0.8"
 
 [[bin]]
 name = "parish"

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -19,8 +19,8 @@ The core innovation is a cognitive level-of-detail (LOD) system: NPCs near the p
 | Language      | **Rust**                                 | Core game engine, simulation, TUI                  |
 | Async Runtime | **Tokio**                                | Concurrent simulation tiers, async inference calls |
 | TUI           | **Ratatui + Crossterm**                  | Terminal UI with 24-bit true color                 |
-| LLM Inference | **Ollama** (local, via REST API)         | NPC cognition, natural language parsing            |
-| HTTP Client   | **Reqwest**                              | Communication with Ollama at `localhost:11434`     |
+| LLM Inference | **OpenAI-compatible API** (Ollama, LM Studio, OpenRouter, custom) | NPC cognition, natural language parsing |
+| HTTP Client   | **Reqwest**                              | Communication with LLM provider via `/v1/chat/completions` |
 | Serialization | **Serde** (JSON)                         | World state, LLM structured output                 |
 | Persistence   | **SQLite** (via rusqlite)                | Save system, NPC memory, world events              |
 | Entity System | **Bevy ECS** (standalone) or hand-rolled | World simulation data model                        |
@@ -40,7 +40,7 @@ Player Input → Command Detection → [System Command OR Game Input]
                                           ↓
                                    Inference Queue (Tokio channel)
                                           ↓
-                                   Ollama API (localhost:11434)
+                                   LLM Provider (OpenAI-compatible API)
                                           ↓
                                    Structured JSON Response
                                           ↓
@@ -60,9 +60,11 @@ src/
 ├── tui/                 # Ratatui terminal UI
 ├── world/               # World state, location graph, time system
 ├── npc/                 # NPC data model, behavior, cognition tiers
+├── config.rs            # Provider configuration (TOML + env + CLI)
 ├── inference/
-│   ├── client.rs        # Ollama HTTP client, process management
-│   ├── setup.rs         # GPU detection, model selection, auto-pull
+│   ├── openai_client.rs # OpenAI-compatible HTTP client (all providers)
+│   ├── client.rs        # Ollama process management
+│   ├── setup.rs         # GPU detection, model selection, auto-pull (Ollama)
 │   └── mod.rs           # Inference queue, worker task
 ├── persistence/         # SQLite save/load, WAL journal
 └── input/               # Player input parsing, command detection
@@ -86,14 +88,39 @@ src/
 
 - [ADR Index](../adr/README.md)
 
-## Ollama Bootstrap & GPU Detection
+## Multi-Provider LLM Support
 
-On startup, Parish runs a self-contained setup sequence (see `src/inference/setup.rs`):
+Parish supports any OpenAI-compatible LLM provider via the `/v1/chat/completions` API:
+
+| Provider | Type | Notes |
+|----------|------|-------|
+| **Ollama** (default) | Local | Auto-start, GPU detection, model pulling |
+| **LM Studio** | Local | Bring your own model |
+| **OpenRouter** | Cloud | Access to Claude, GPT-4, Gemini, etc. Requires API key |
+| **Custom** | Any | Any OpenAI-compatible endpoint |
+
+### Configuration
+
+Provider is configured via `parish.toml`, env vars, or CLI flags (later overrides earlier):
+
+```toml
+[provider]
+name = "openrouter"
+api_key = "sk-or-..."
+model = "anthropic/claude-sonnet-4-20250514"
+```
+
+CLI: `--provider`, `--base-url`, `--api-key`, `--model`
+Env: `PARISH_PROVIDER`, `PARISH_BASE_URL`, `PARISH_API_KEY`, `PARISH_MODEL`
+
+### Ollama Bootstrap & GPU Detection (Default Path)
+
+When using the Ollama provider (the default), Parish runs a self-contained setup sequence (see `src/inference/setup.rs`):
 
 1. **Detect Ollama** — checks if the `ollama` binary is on PATH
-2. **Auto-install** — if missing, runs the official install script (`https://ollama.com/install.sh`) which auto-detects GPU vendor (CUDA/ROCm/CPU)
+2. **Auto-install** — if missing, runs the official install script
 3. **Start server** — spawns `ollama serve` if not already running; kills on exit
-4. **Detect GPU/VRAM** — queries `nvidia-smi` or `rocm-smi` for VRAM info; falls back to CPU-only
+4. **Detect GPU/VRAM** — queries `nvidia-smi` or `rocm-smi` for VRAM info
 5. **Select model** — picks the best model for available VRAM:
    - ≥12GB → `qwen3:14b` (Tier 1)
    - ≥6GB → `qwen3:8b` (Tier 2)
@@ -102,6 +129,8 @@ On startup, Parish runs a self-contained setup sequence (see `src/inference/setu
 6. **Auto-pull** — downloads the model via Ollama's `/api/pull` if not already local
 
 The `PARISH_MODEL` env var or `--model` CLI flag overrides auto-selection.
+
+For non-Ollama providers, none of these steps run — the user provides the endpoint and model name directly.
 
 ## Headless Mode
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,494 @@
+//! Provider configuration for LLM inference backends.
+//!
+//! Supports Ollama (local, default), LM Studio (local), OpenRouter (cloud),
+//! and custom OpenAI-compatible endpoints. Configuration is resolved from
+//! a TOML file, environment variables, and CLI flags (in that priority order).
+
+use crate::error::ParishError;
+use serde::Deserialize;
+use std::path::Path;
+
+/// Default base URL for each provider.
+const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
+const DEFAULT_LMSTUDIO_URL: &str = "http://localhost:1234";
+const DEFAULT_OPENROUTER_URL: &str = "https://openrouter.ai/api";
+
+/// Supported LLM provider backends.
+///
+/// All providers use the OpenAI-compatible chat completions API
+/// (`/v1/chat/completions`). Ollama is the default and includes
+/// auto-start, GPU detection, and model pulling features.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum Provider {
+    /// Local Ollama server with auto-management (default).
+    #[default]
+    Ollama,
+    /// Local LM Studio server.
+    LmStudio,
+    /// OpenRouter cloud gateway (requires API key).
+    OpenRouter,
+    /// Any OpenAI-compatible endpoint (requires base_url).
+    Custom,
+}
+
+impl Provider {
+    /// Parses a provider name string (case-insensitive).
+    pub fn from_str_loose(s: &str) -> Result<Self, ParishError> {
+        match s.to_lowercase().as_str() {
+            "ollama" => Ok(Provider::Ollama),
+            "lmstudio" | "lm_studio" | "lm-studio" => Ok(Provider::LmStudio),
+            "openrouter" | "open_router" | "open-router" => Ok(Provider::OpenRouter),
+            "custom" => Ok(Provider::Custom),
+            other => Err(ParishError::Config(format!(
+                "unknown provider '{}'. Expected: ollama, lmstudio, openrouter, custom",
+                other
+            ))),
+        }
+    }
+
+    /// Returns the default base URL for this provider.
+    pub fn default_base_url(&self) -> &'static str {
+        match self {
+            Provider::Ollama => DEFAULT_OLLAMA_URL,
+            Provider::LmStudio => DEFAULT_LMSTUDIO_URL,
+            Provider::OpenRouter => DEFAULT_OPENROUTER_URL,
+            Provider::Custom => "",
+        }
+    }
+
+    /// Whether this provider requires an API key.
+    pub fn requires_api_key(&self) -> bool {
+        matches!(self, Provider::OpenRouter)
+    }
+
+    /// Whether this provider requires an explicit model name
+    /// (no auto-detection available).
+    pub fn requires_model(&self) -> bool {
+        !matches!(self, Provider::Ollama)
+    }
+}
+
+/// Resolved provider configuration ready for use.
+///
+/// Built from the TOML config file, environment variables, and CLI
+/// flags via [`resolve_config`].
+#[derive(Debug, Clone)]
+pub struct ProviderConfig {
+    /// The selected provider backend.
+    pub provider: Provider,
+    /// Base URL for the provider API.
+    pub base_url: String,
+    /// API key for authenticated providers (OpenRouter, etc.).
+    pub api_key: Option<String>,
+    /// Model name override. Required for non-Ollama providers.
+    pub model: Option<String>,
+}
+
+/// Raw TOML file structure for `parish.toml`.
+#[derive(Debug, Deserialize, Default)]
+struct TomlConfig {
+    #[serde(default)]
+    provider: TomlProvider,
+}
+
+/// The `[provider]` section of the TOML config.
+#[derive(Debug, Deserialize, Default)]
+struct TomlProvider {
+    /// Provider name: "ollama", "lmstudio", "openrouter", "custom".
+    name: Option<String>,
+    /// Base URL override.
+    base_url: Option<String>,
+    /// API key for cloud providers.
+    api_key: Option<String>,
+    /// Model name override.
+    model: Option<String>,
+}
+
+/// CLI-provided overrides for provider configuration.
+#[derive(Debug, Default)]
+pub struct CliOverrides {
+    /// `--provider` flag value.
+    pub provider: Option<String>,
+    /// `--base-url` flag value.
+    pub base_url: Option<String>,
+    /// `--api-key` flag value.
+    pub api_key: Option<String>,
+    /// `--model` flag value.
+    pub model: Option<String>,
+}
+
+/// Resolves provider configuration from file, env vars, and CLI flags.
+///
+/// Resolution order (later overrides earlier):
+/// 1. Hardcoded defaults per provider
+/// 2. TOML config file (if it exists)
+/// 3. Environment variables: `PARISH_PROVIDER`, `PARISH_BASE_URL`,
+///    `PARISH_API_KEY`, `PARISH_MODEL`
+/// 4. CLI flags via `CliOverrides`
+///
+/// Also checks for the deprecated `PARISH_OLLAMA_URL` env var and maps
+/// it to `base_url` with a warning.
+pub fn resolve_config(
+    config_path: Option<&Path>,
+    cli: &CliOverrides,
+) -> Result<ProviderConfig, ParishError> {
+    // Layer 1: Read TOML file (optional)
+    let toml_cfg = if let Some(path) = config_path {
+        read_toml_config(path)?
+    } else {
+        // Try default paths
+        let cwd_path = Path::new("parish.toml");
+        if cwd_path.exists() {
+            read_toml_config(cwd_path)?
+        } else {
+            TomlConfig::default()
+        }
+    };
+
+    // Layer 2: Start with TOML values
+    let mut provider_str = toml_cfg.provider.name;
+    let mut base_url = toml_cfg.provider.base_url;
+    let mut api_key = toml_cfg.provider.api_key;
+    let mut model = toml_cfg.provider.model;
+
+    // Layer 3: Environment variables override TOML
+    if let Some(val) = env_non_empty("PARISH_PROVIDER") {
+        provider_str = Some(val);
+    }
+    if let Some(val) = env_non_empty("PARISH_BASE_URL") {
+        base_url = Some(val);
+    }
+    // Deprecated: map PARISH_OLLAMA_URL to base_url if no explicit base_url set
+    if base_url.is_none()
+        && let Some(val) = env_non_empty("PARISH_OLLAMA_URL")
+    {
+        tracing::warn!("PARISH_OLLAMA_URL is deprecated, use PARISH_BASE_URL instead");
+        base_url = Some(val);
+    }
+    if let Some(val) = env_non_empty("PARISH_API_KEY") {
+        api_key = Some(val);
+    }
+    if let Some(val) = env_non_empty("PARISH_MODEL") {
+        model = Some(val);
+    }
+
+    // Layer 4: CLI flags override everything
+    if let Some(ref val) = cli.provider {
+        provider_str = Some(val.clone());
+    }
+    if let Some(ref val) = cli.base_url {
+        base_url = Some(val.clone());
+    }
+    if let Some(ref val) = cli.api_key {
+        api_key = Some(val.clone());
+    }
+    if let Some(ref val) = cli.model {
+        model = Some(val.clone());
+    }
+
+    // Resolve provider enum
+    let provider = match &provider_str {
+        Some(s) => Provider::from_str_loose(s)?,
+        None => Provider::default(),
+    };
+
+    // Apply default base URL if none specified
+    let base_url = base_url.unwrap_or_else(|| provider.default_base_url().to_string());
+
+    // Filter out empty api_key/model strings
+    let api_key = api_key.filter(|s| !s.is_empty());
+    let model = model.filter(|s| !s.is_empty());
+
+    // Validate
+    if provider.requires_api_key() && api_key.is_none() {
+        return Err(ParishError::Config(format!(
+            "{:?} provider requires an API key. Set PARISH_API_KEY or --api-key.",
+            provider
+        )));
+    }
+    if provider == Provider::Custom && base_url.is_empty() {
+        return Err(ParishError::Config(
+            "Custom provider requires a base_url. Set PARISH_BASE_URL or --base-url.".to_string(),
+        ));
+    }
+
+    Ok(ProviderConfig {
+        provider,
+        base_url,
+        api_key,
+        model,
+    })
+}
+
+/// Returns the value of an environment variable if it exists and is non-empty.
+fn env_non_empty(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
+}
+
+/// Reads and parses a TOML config file. Returns default config if file doesn't exist.
+fn read_toml_config(path: &Path) -> Result<TomlConfig, ParishError> {
+    if !path.exists() {
+        return Ok(TomlConfig::default());
+    }
+    let content = std::fs::read_to_string(path).map_err(|e| {
+        ParishError::Config(format!(
+            "failed to read config file {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    toml::from_str(&content).map_err(|e| {
+        ParishError::Config(format!(
+            "failed to parse config file {}: {}",
+            path.display(),
+            e
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Clears all PARISH_ env vars so tests don't interfere with each other.
+    fn clear_parish_env() {
+        // SAFETY: Tests run single-threaded via `cargo test -- --test-threads=1`
+        // or are independent enough that concurrent env mutation is acceptable.
+        unsafe {
+            std::env::remove_var("PARISH_PROVIDER");
+            std::env::remove_var("PARISH_BASE_URL");
+            std::env::remove_var("PARISH_OLLAMA_URL");
+            std::env::remove_var("PARISH_API_KEY");
+            std::env::remove_var("PARISH_MODEL");
+        }
+    }
+
+    #[test]
+    fn test_provider_from_str_loose() {
+        assert_eq!(
+            Provider::from_str_loose("ollama").unwrap(),
+            Provider::Ollama
+        );
+        assert_eq!(
+            Provider::from_str_loose("OLLAMA").unwrap(),
+            Provider::Ollama
+        );
+        assert_eq!(
+            Provider::from_str_loose("lmstudio").unwrap(),
+            Provider::LmStudio
+        );
+        assert_eq!(
+            Provider::from_str_loose("lm-studio").unwrap(),
+            Provider::LmStudio
+        );
+        assert_eq!(
+            Provider::from_str_loose("lm_studio").unwrap(),
+            Provider::LmStudio
+        );
+        assert_eq!(
+            Provider::from_str_loose("openrouter").unwrap(),
+            Provider::OpenRouter
+        );
+        assert_eq!(
+            Provider::from_str_loose("open-router").unwrap(),
+            Provider::OpenRouter
+        );
+        assert_eq!(
+            Provider::from_str_loose("custom").unwrap(),
+            Provider::Custom
+        );
+        assert!(Provider::from_str_loose("unknown").is_err());
+    }
+
+    #[test]
+    fn test_provider_default_base_url() {
+        assert_eq!(
+            Provider::Ollama.default_base_url(),
+            "http://localhost:11434"
+        );
+        assert_eq!(
+            Provider::LmStudio.default_base_url(),
+            "http://localhost:1234"
+        );
+        assert_eq!(
+            Provider::OpenRouter.default_base_url(),
+            "https://openrouter.ai/api"
+        );
+        assert_eq!(Provider::Custom.default_base_url(), "");
+    }
+
+    #[test]
+    fn test_provider_requirements() {
+        assert!(!Provider::Ollama.requires_api_key());
+        assert!(!Provider::LmStudio.requires_api_key());
+        assert!(Provider::OpenRouter.requires_api_key());
+        assert!(!Provider::Custom.requires_api_key());
+
+        assert!(!Provider::Ollama.requires_model());
+        assert!(Provider::LmStudio.requires_model());
+        assert!(Provider::OpenRouter.requires_model());
+        assert!(Provider::Custom.requires_model());
+    }
+
+    #[test]
+    fn test_resolve_config_defaults() {
+        clear_parish_env();
+
+        let cli = CliOverrides::default();
+        let config = resolve_config(Some(Path::new("/nonexistent/parish.toml")), &cli).unwrap();
+        assert_eq!(config.provider, Provider::Ollama);
+        assert_eq!(config.base_url, "http://localhost:11434");
+        assert!(config.api_key.is_none());
+        assert!(config.model.is_none());
+    }
+
+    #[test]
+    fn test_resolve_config_from_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("parish.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"
+[provider]
+name = "lmstudio"
+base_url = "http://myhost:5555"
+model = "my-model"
+"#
+        )
+        .unwrap();
+
+        clear_parish_env();
+
+        let cli = CliOverrides::default();
+        let config = resolve_config(Some(&path), &cli).unwrap();
+        assert_eq!(config.provider, Provider::LmStudio);
+        assert_eq!(config.base_url, "http://myhost:5555");
+        assert_eq!(config.model.as_deref(), Some("my-model"));
+    }
+
+    #[test]
+    fn test_resolve_config_cli_overrides_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("parish.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"
+[provider]
+name = "lmstudio"
+model = "toml-model"
+"#
+        )
+        .unwrap();
+
+        clear_parish_env();
+
+        let cli = CliOverrides {
+            provider: None,
+            base_url: None,
+            api_key: None,
+            model: Some("cli-model".to_string()),
+        };
+        let config = resolve_config(Some(&path), &cli).unwrap();
+        assert_eq!(config.provider, Provider::LmStudio);
+        assert_eq!(config.model.as_deref(), Some("cli-model"));
+    }
+
+    #[test]
+    fn test_resolve_config_openrouter_requires_api_key() {
+        clear_parish_env();
+
+        let cli = CliOverrides {
+            provider: Some("openrouter".to_string()),
+            base_url: None,
+            api_key: None,
+            model: Some("anthropic/claude-sonnet-4-20250514".to_string()),
+        };
+        let result = resolve_config(Some(Path::new("/nonexistent")), &cli);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("API key"), "got: {}", err_msg);
+    }
+
+    #[test]
+    fn test_resolve_config_openrouter_with_api_key() {
+        clear_parish_env();
+
+        let cli = CliOverrides {
+            provider: Some("openrouter".to_string()),
+            base_url: None,
+            api_key: Some("sk-test-key".to_string()),
+            model: Some("anthropic/claude-sonnet-4-20250514".to_string()),
+        };
+        let config = resolve_config(Some(Path::new("/nonexistent")), &cli).unwrap();
+        assert_eq!(config.provider, Provider::OpenRouter);
+        assert_eq!(config.base_url, "https://openrouter.ai/api");
+        assert_eq!(config.api_key.as_deref(), Some("sk-test-key"));
+    }
+
+    #[test]
+    fn test_resolve_config_custom_requires_base_url() {
+        clear_parish_env();
+
+        let cli = CliOverrides {
+            provider: Some("custom".to_string()),
+            base_url: None,
+            api_key: None,
+            model: Some("some-model".to_string()),
+        };
+        let result = resolve_config(Some(Path::new("/nonexistent")), &cli);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("base_url"), "got: {}", err_msg);
+    }
+
+    #[test]
+    fn test_resolve_config_empty_strings_filtered() {
+        clear_parish_env();
+
+        let cli = CliOverrides {
+            provider: None,
+            base_url: None,
+            api_key: Some(String::new()),
+            model: Some(String::new()),
+        };
+        let config = resolve_config(Some(Path::new("/nonexistent")), &cli).unwrap();
+        assert!(config.api_key.is_none());
+        assert!(config.model.is_none());
+    }
+
+    #[test]
+    fn test_read_toml_config_missing_file() {
+        let config = read_toml_config(Path::new("/nonexistent/parish.toml")).unwrap();
+        assert!(config.provider.name.is_none());
+    }
+
+    #[test]
+    fn test_read_toml_config_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("parish.toml");
+        std::fs::write(&path, "").unwrap();
+        let config = read_toml_config(&path).unwrap();
+        assert!(config.provider.name.is_none());
+    }
+
+    #[test]
+    fn test_read_toml_config_invalid_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("parish.toml");
+        std::fs::write(&path, "this is not valid toml {{{{").unwrap();
+        let result = read_toml_config(&path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_toml_config_minimal() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("parish.toml");
+        std::fs::write(&path, "[provider]\nname = \"ollama\"\n").unwrap();
+        let config = read_toml_config(&path).unwrap();
+        assert_eq!(config.provider.name.as_deref(), Some("ollama"));
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,4 +24,7 @@ pub enum ParishError {
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("configuration error: {0}")]
+    Config(String),
 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -4,7 +4,7 @@
 //! (NPC inference, intent parsing, system commands) as the TUI mode.
 //! Activated with `--headless` on the command line.
 
-use crate::inference::client::OllamaClient;
+use crate::inference::openai_client::OpenAiClient;
 use crate::inference::setup::OllamaSetup;
 use crate::inference::{self, InferenceQueue};
 use crate::input::{Command, InputResult, classify_input, parse_intent};
@@ -172,7 +172,7 @@ fn handle_headless_command(app: &mut App, cmd: Command) -> bool {
 /// Handles game input (NPC interaction or intent parsing) in headless mode.
 async fn handle_headless_game_input(
     app: &mut App,
-    client: &OllamaClient,
+    client: &OpenAiClient,
     model: &str,
     text: &str,
     request_id: &mut u64,

--- a/src/inference/client.rs
+++ b/src/inference/client.rs
@@ -221,6 +221,11 @@ pub struct OllamaProcess {
 }
 
 impl OllamaProcess {
+    /// Creates a no-op process handle (for non-Ollama providers).
+    pub fn none() -> Self {
+        Self { child: None }
+    }
+
     /// Checks if Ollama is reachable. If not, starts `ollama serve` in the
     /// background and waits for it to become ready (up to 30 seconds).
     ///

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -1,12 +1,14 @@
-//! LLM inference pipeline via Ollama.
+//! LLM inference pipeline for OpenAI-compatible providers.
 //!
 //! Manages a request queue (Tokio mpsc channel), routes requests
-//! to the Ollama API, and returns responses via oneshot channels.
+//! to the configured LLM provider (Ollama, LM Studio, OpenRouter, etc.),
+//! and returns responses via oneshot channels.
 
 pub mod client;
+pub mod openai_client;
 pub mod setup;
 
-use client::OllamaClient;
+use openai_client::OpenAiClient;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 
@@ -86,11 +88,11 @@ impl InferenceQueue {
 
 /// Spawns the inference worker task.
 ///
-/// The worker pulls requests from the mpsc receiver, calls the Ollama
+/// The worker pulls requests from the mpsc receiver, calls the LLM
 /// client, and sends responses back through each request's oneshot channel.
 /// The task runs until the sender side of the channel is dropped.
 pub fn spawn_inference_worker(
-    client: OllamaClient,
+    client: OpenAiClient,
     mut rx: mpsc::Receiver<InferenceRequest>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {

--- a/src/inference/openai_client.rs
+++ b/src/inference/openai_client.rs
@@ -1,0 +1,612 @@
+//! OpenAI-compatible HTTP client for LLM inference.
+//!
+//! Talks to any provider that implements the OpenAI chat completions API:
+//! Ollama (`/v1/chat/completions`), LM Studio, OpenRouter, or any custom
+//! OpenAI-compatible endpoint. Uses SSE (Server-Sent Events) for streaming.
+
+use crate::error::ParishError;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+/// Default timeout for non-streaming requests (30 seconds).
+const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+/// Timeout for streaming requests (5 minutes).
+const STREAMING_TIMEOUT_SECS: u64 = 300;
+
+/// HTTP client for OpenAI-compatible chat completions endpoints.
+///
+/// Works with Ollama, LM Studio, OpenRouter, and any provider that
+/// implements the `/v1/chat/completions` API. Provides the same
+/// logical interface as the legacy Ollama-native client: plain text
+/// generation, streaming generation, and structured JSON output.
+#[derive(Clone)]
+pub struct OpenAiClient {
+    /// HTTP client with default timeout.
+    client: reqwest::Client,
+    /// Base URL (e.g. "http://localhost:11434" or "https://openrouter.ai/api").
+    base_url: String,
+    /// Optional API key for authenticated providers.
+    api_key: Option<String>,
+}
+
+/// A single message in the chat completions request.
+#[derive(Serialize, Debug)]
+struct ChatMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+/// Request body for the `/v1/chat/completions` endpoint.
+#[derive(Serialize, Debug)]
+struct ChatCompletionRequest<'a> {
+    model: &'a str,
+    messages: Vec<ChatMessage<'a>>,
+    stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response_format: Option<ResponseFormat>,
+}
+
+/// Controls structured output format.
+#[derive(Serialize, Debug)]
+struct ResponseFormat {
+    #[serde(rename = "type")]
+    format_type: String,
+}
+
+/// Non-streaming response from chat completions.
+#[derive(Deserialize, Debug)]
+struct ChatCompletionResponse {
+    #[serde(default)]
+    choices: Vec<Choice>,
+}
+
+/// A single completion choice.
+#[derive(Deserialize, Debug)]
+struct Choice {
+    #[serde(default)]
+    message: MessageContent,
+}
+
+/// Message content in a non-streaming response.
+#[derive(Deserialize, Debug, Default)]
+struct MessageContent {
+    #[serde(default)]
+    content: Option<String>,
+}
+
+/// A single SSE chunk from a streaming response.
+#[derive(Deserialize, Debug)]
+pub(crate) struct ChatCompletionChunk {
+    #[serde(default)]
+    pub(crate) choices: Vec<StreamChoice>,
+}
+
+/// A single choice in a streaming chunk.
+#[derive(Deserialize, Debug)]
+pub(crate) struct StreamChoice {
+    #[serde(default)]
+    pub(crate) delta: Delta,
+    #[serde(default)]
+    pub(crate) finish_reason: Option<String>,
+}
+
+/// Delta content in a streaming chunk.
+#[derive(Deserialize, Debug, Default)]
+pub(crate) struct Delta {
+    #[serde(default)]
+    pub(crate) content: Option<String>,
+}
+
+impl OpenAiClient {
+    /// Creates a new client for an OpenAI-compatible endpoint.
+    ///
+    /// The `base_url` should be the root URL without `/v1/chat/completions`
+    /// (e.g. "http://localhost:11434" for Ollama, "https://openrouter.ai/api"
+    /// for OpenRouter). The `/v1/chat/completions` path is appended
+    /// automatically.
+    pub fn new(base_url: &str, api_key: Option<&str>) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+            .build()
+            .expect("failed to build reqwest client");
+
+        Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key: api_key.map(|s| s.to_string()),
+        }
+    }
+
+    /// Returns the base URL of this client.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Sends a non-streaming chat completion request and returns the response text.
+    ///
+    /// Builds a messages array from the prompt and optional system message,
+    /// posts to `/v1/chat/completions` with `stream: false`, and extracts
+    /// `choices[0].message.content`.
+    pub async fn generate(
+        &self,
+        model: &str,
+        prompt: &str,
+        system: Option<&str>,
+    ) -> Result<String, ParishError> {
+        let body = self.build_request(model, prompt, system, false, false);
+        let resp = self.send_request(&body).await?;
+        let completion: ChatCompletionResponse = resp.json().await?;
+        Ok(extract_content(&completion))
+    }
+
+    /// Sends a streaming chat completion request, forwarding tokens as they arrive.
+    ///
+    /// Posts to `/v1/chat/completions` with `stream: true`. Parses SSE
+    /// (Server-Sent Events) data lines, extracts delta content, and sends
+    /// each token through `token_tx`. Returns the full accumulated text
+    /// after the stream completes. Uses a 5-minute timeout.
+    pub async fn generate_stream(
+        &self,
+        model: &str,
+        prompt: &str,
+        system: Option<&str>,
+        token_tx: mpsc::UnboundedSender<String>,
+    ) -> Result<String, ParishError> {
+        let body = self.build_request(model, prompt, system, true, false);
+
+        // Use a longer timeout for streaming
+        let streaming_client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(STREAMING_TIMEOUT_SECS))
+            .build()
+            .expect("failed to build streaming reqwest client");
+
+        let url = format!("{}/v1/chat/completions", self.base_url);
+        let mut req = streaming_client.post(&url).json(&body);
+        req = self.apply_auth_headers(req);
+
+        let resp = req
+            .send()
+            .await?
+            .error_for_status()
+            .map_err(|e| ParishError::Inference(e.to_string()))?;
+
+        let mut accumulated = String::new();
+        let mut line_buf = String::new();
+
+        let mut response = resp;
+        while let Some(chunk) = response.chunk().await? {
+            let text = String::from_utf8_lossy(&chunk);
+            line_buf.push_str(&text);
+
+            while let Some(newline_pos) = line_buf.find('\n') {
+                let line: String = line_buf.drain(..=newline_pos).collect();
+                match process_sse_line(&line, &token_tx, &mut accumulated) {
+                    SseResult::Continue => {}
+                    SseResult::Done => return Ok(accumulated),
+                }
+            }
+        }
+
+        // Process any remaining data in the buffer
+        let remaining = line_buf.trim();
+        if !remaining.is_empty() {
+            process_sse_line(remaining, &token_tx, &mut accumulated);
+        }
+
+        Ok(accumulated)
+    }
+
+    /// Sends a non-streaming request and deserializes the response as structured JSON.
+    ///
+    /// Requests JSON output via `response_format: {"type": "json_object"}` and
+    /// parses the response content into the target type `T`. Use
+    /// `#[serde(default)]` on optional fields in `T` for robustness.
+    pub async fn generate_json<T: DeserializeOwned>(
+        &self,
+        model: &str,
+        prompt: &str,
+        system: Option<&str>,
+    ) -> Result<T, ParishError> {
+        let body = self.build_request(model, prompt, system, false, true);
+        let resp = self.send_request(&body).await?;
+        let completion: ChatCompletionResponse = resp.json().await?;
+        let content = extract_content(&completion);
+        let parsed: T = serde_json::from_str(&content)?;
+        Ok(parsed)
+    }
+
+    /// Builds a chat completion request body.
+    fn build_request<'a>(
+        &self,
+        model: &'a str,
+        prompt: &'a str,
+        system: Option<&'a str>,
+        stream: bool,
+        json_mode: bool,
+    ) -> ChatCompletionRequest<'a> {
+        let mut messages = Vec::new();
+        if let Some(sys) = system {
+            messages.push(ChatMessage {
+                role: "system",
+                content: sys,
+            });
+        }
+        messages.push(ChatMessage {
+            role: "user",
+            content: prompt,
+        });
+
+        let response_format = if json_mode {
+            Some(ResponseFormat {
+                format_type: "json_object".to_string(),
+            })
+        } else {
+            None
+        };
+
+        ChatCompletionRequest {
+            model,
+            messages,
+            stream,
+            response_format,
+        }
+    }
+
+    /// Sends a non-streaming request and returns the raw response.
+    async fn send_request(
+        &self,
+        body: &ChatCompletionRequest<'_>,
+    ) -> Result<reqwest::Response, ParishError> {
+        let url = format!("{}/v1/chat/completions", self.base_url);
+        let mut req = self.client.post(&url).json(body);
+        req = self.apply_auth_headers(req);
+
+        req.send()
+            .await?
+            .error_for_status()
+            .map_err(|e| ParishError::Inference(e.to_string()))
+    }
+
+    /// Applies authorization and provider-specific headers to a request.
+    fn apply_auth_headers(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.api_key {
+            Some(key) => req
+                .header("Authorization", format!("Bearer {}", key))
+                .header("HTTP-Referer", "https://github.com/parish-game/parish")
+                .header("X-Title", "Parish"),
+            None => req,
+        }
+    }
+}
+
+/// Result of processing a single SSE line.
+enum SseResult {
+    /// Continue reading more lines.
+    Continue,
+    /// Stream is complete.
+    Done,
+}
+
+/// Processes a single SSE line: extracts content, sends tokens, detects completion.
+fn process_sse_line(
+    line: &str,
+    token_tx: &mpsc::UnboundedSender<String>,
+    accumulated: &mut String,
+) -> SseResult {
+    let Some(data) = parse_sse_line(line) else {
+        return SseResult::Continue;
+    };
+    match data {
+        SseData::Done => SseResult::Done,
+        SseData::Chunk(chunk_data) => {
+            if let Some(text) = chunk_data
+                .choices
+                .first()
+                .and_then(|c| c.delta.content.as_deref())
+                .filter(|t| !t.is_empty())
+            {
+                let _ = token_tx.send(text.to_string());
+                accumulated.push_str(text);
+            }
+            if chunk_data
+                .choices
+                .first()
+                .and_then(|c| c.finish_reason.as_deref())
+                == Some("stop")
+            {
+                return SseResult::Done;
+            }
+            SseResult::Continue
+        }
+    }
+}
+
+/// Parsed SSE data from a streaming line.
+enum SseData {
+    /// The `[DONE]` sentinel, indicating stream end.
+    Done,
+    /// A parsed chunk of streaming data.
+    Chunk(ChatCompletionChunk),
+}
+
+/// Parses a single SSE line from a streaming response.
+///
+/// Handles the `data: ` prefix (with or without space), `[DONE]` sentinel,
+/// and `: ` keepalive comments. Returns `None` for empty lines, comments,
+/// or unparseable data.
+fn parse_sse_line(line: &str) -> Option<SseData> {
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+
+    // SSE comment (keepalive)
+    if line.starts_with(": ") || line == ":" {
+        return None;
+    }
+
+    // Strip the "data: " or "data:" prefix
+    let data = if let Some(d) = line.strip_prefix("data: ") {
+        d
+    } else if let Some(d) = line.strip_prefix("data:") {
+        d
+    } else {
+        return None;
+    };
+
+    let data = data.trim();
+
+    if data == "[DONE]" {
+        return Some(SseData::Done);
+    }
+
+    serde_json::from_str::<ChatCompletionChunk>(data)
+        .ok()
+        .map(SseData::Chunk)
+}
+
+/// Extracts the text content from a non-streaming response.
+fn extract_content(resp: &ChatCompletionResponse) -> String {
+    resp.choices
+        .first()
+        .and_then(|c| c.message.content.as_deref())
+        .unwrap_or("")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_openai_client_new() {
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        assert_eq!(client.base_url(), "http://localhost:11434");
+        assert!(client.api_key.is_none());
+    }
+
+    #[test]
+    fn test_openai_client_trailing_slash() {
+        let client = OpenAiClient::new("http://localhost:11434/", None);
+        assert_eq!(client.base_url(), "http://localhost:11434");
+    }
+
+    #[test]
+    fn test_openai_client_with_api_key() {
+        let client = OpenAiClient::new("https://openrouter.ai/api", Some("sk-test"));
+        assert_eq!(client.api_key.as_deref(), Some("sk-test"));
+    }
+
+    #[test]
+    fn test_build_request_with_system() {
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        let req = client.build_request("model", "hello", Some("you are helpful"), false, false);
+        assert_eq!(req.model, "model");
+        assert_eq!(req.messages.len(), 2);
+        assert_eq!(req.messages[0].role, "system");
+        assert_eq!(req.messages[0].content, "you are helpful");
+        assert_eq!(req.messages[1].role, "user");
+        assert_eq!(req.messages[1].content, "hello");
+        assert!(!req.stream);
+        assert!(req.response_format.is_none());
+    }
+
+    #[test]
+    fn test_build_request_without_system() {
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        let req = client.build_request("model", "hello", None, false, false);
+        assert_eq!(req.messages.len(), 1);
+        assert_eq!(req.messages[0].role, "user");
+    }
+
+    #[test]
+    fn test_build_request_json_mode() {
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        let req = client.build_request("model", "hello", None, false, true);
+        let fmt = req.response_format.unwrap();
+        assert_eq!(fmt.format_type, "json_object");
+    }
+
+    #[test]
+    fn test_build_request_streaming() {
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        let req = client.build_request("model", "hello", None, true, false);
+        assert!(req.stream);
+    }
+
+    #[test]
+    fn test_chat_completion_response_deserialize() {
+        let json = r#"{"choices":[{"message":{"content":"Hello!"}}]}"#;
+        let resp: ChatCompletionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(extract_content(&resp), "Hello!");
+    }
+
+    #[test]
+    fn test_chat_completion_response_empty_choices() {
+        let json = r#"{"choices":[]}"#;
+        let resp: ChatCompletionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(extract_content(&resp), "");
+    }
+
+    #[test]
+    fn test_chat_completion_response_null_content() {
+        let json = r#"{"choices":[{"message":{"content":null}}]}"#;
+        let resp: ChatCompletionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(extract_content(&resp), "");
+    }
+
+    #[test]
+    fn test_chat_completion_response_missing_fields() {
+        let json = r#"{}"#;
+        let resp: ChatCompletionResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(extract_content(&resp), "");
+    }
+
+    #[test]
+    fn test_chat_completion_chunk_deserialize() {
+        let json = r#"{"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}"#;
+        let chunk: ChatCompletionChunk = serde_json::from_str(json).unwrap();
+        assert_eq!(chunk.choices[0].delta.content.as_deref(), Some("Hello"));
+        assert!(chunk.choices[0].finish_reason.is_none());
+    }
+
+    #[test]
+    fn test_chat_completion_chunk_finish() {
+        let json = r#"{"choices":[{"delta":{},"finish_reason":"stop"}]}"#;
+        let chunk: ChatCompletionChunk = serde_json::from_str(json).unwrap();
+        assert!(chunk.choices[0].delta.content.is_none());
+        assert_eq!(chunk.choices[0].finish_reason.as_deref(), Some("stop"));
+    }
+
+    #[test]
+    fn test_chat_completion_chunk_empty() {
+        let json = r#"{}"#;
+        let chunk: ChatCompletionChunk = serde_json::from_str(json).unwrap();
+        assert!(chunk.choices.is_empty());
+    }
+
+    #[test]
+    fn test_parse_sse_line_data() {
+        let line = r#"data: {"choices":[{"delta":{"content":"hi"}}]}"#;
+        match parse_sse_line(line).unwrap() {
+            SseData::Chunk(c) => {
+                assert_eq!(c.choices[0].delta.content.as_deref(), Some("hi"));
+            }
+            SseData::Done => panic!("expected chunk"),
+        }
+    }
+
+    #[test]
+    fn test_parse_sse_line_data_no_space() {
+        let line = r#"data:{"choices":[{"delta":{"content":"hi"}}]}"#;
+        match parse_sse_line(line).unwrap() {
+            SseData::Chunk(c) => {
+                assert_eq!(c.choices[0].delta.content.as_deref(), Some("hi"));
+            }
+            SseData::Done => panic!("expected chunk"),
+        }
+    }
+
+    #[test]
+    fn test_parse_sse_line_done() {
+        assert!(matches!(
+            parse_sse_line("data: [DONE]").unwrap(),
+            SseData::Done
+        ));
+    }
+
+    #[test]
+    fn test_parse_sse_line_empty() {
+        assert!(parse_sse_line("").is_none());
+        assert!(parse_sse_line("   ").is_none());
+    }
+
+    #[test]
+    fn test_parse_sse_line_comment() {
+        assert!(parse_sse_line(": keepalive").is_none());
+        assert!(parse_sse_line(":").is_none());
+    }
+
+    #[test]
+    fn test_parse_sse_line_not_data() {
+        assert!(parse_sse_line("event: message").is_none());
+    }
+
+    #[test]
+    fn test_parse_sse_line_invalid_json() {
+        assert!(parse_sse_line("data: {invalid}").is_none());
+    }
+
+    #[test]
+    fn test_request_serialization() {
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        let req = client.build_request("qwen3:14b", "hello", Some("be brief"), false, false);
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["model"], "qwen3:14b");
+        assert_eq!(json["messages"][0]["role"], "system");
+        assert_eq!(json["messages"][0]["content"], "be brief");
+        assert_eq!(json["messages"][1]["role"], "user");
+        assert_eq!(json["messages"][1]["content"], "hello");
+        assert_eq!(json["stream"], false);
+        assert!(json.get("response_format").is_none());
+    }
+
+    #[test]
+    fn test_request_serialization_json_mode() {
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        let req = client.build_request("qwen3:14b", "hello", None, false, true);
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["response_format"]["type"], "json_object");
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires Ollama running on localhost:11434
+    async fn test_generate_live() {
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        let result = client
+            .generate("qwen3:14b", "Say hello in one word.", None)
+            .await;
+        assert!(result.is_ok());
+        assert!(!result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires Ollama running on localhost:11434
+    async fn test_generate_stream_live() {
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let result = client
+            .generate_stream("qwen3:14b", "Say hello in one word.", None, tx)
+            .await;
+        assert!(result.is_ok());
+
+        // Verify tokens were sent
+        let mut tokens = Vec::new();
+        while let Ok(t) = rx.try_recv() {
+            tokens.push(t);
+        }
+        assert!(!tokens.is_empty());
+    }
+
+    #[tokio::test]
+    #[ignore] // Requires Ollama running on localhost:11434
+    async fn test_generate_json_live() {
+        #[derive(Deserialize, Debug)]
+        struct TestResponse {
+            #[serde(default)]
+            greeting: String,
+        }
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        let result: Result<TestResponse, _> = client
+            .generate_json(
+                "qwen3:14b",
+                "Return a JSON object with a 'greeting' field containing 'hello'.",
+                None,
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+}

--- a/src/inference/setup.rs
+++ b/src/inference/setup.rs
@@ -5,7 +5,8 @@
 //! available hardware, and automatic model pulling.
 
 use crate::error::ParishError;
-use crate::inference::client::{OllamaClient, OllamaProcess};
+use crate::inference::client::OllamaProcess;
+use crate::inference::openai_client::OpenAiClient;
 use serde::Deserialize;
 use std::process::Command;
 use std::time::Duration;
@@ -80,8 +81,8 @@ impl std::fmt::Display for ModelConfig {
 pub struct OllamaSetup {
     /// The managed Ollama server process (stops on drop if we started it).
     pub process: OllamaProcess,
-    /// The configured HTTP client.
-    pub client: OllamaClient,
+    /// The configured OpenAI-compatible HTTP client.
+    pub client: OpenAiClient,
     /// The selected model name.
     pub model_name: String,
     /// Detected GPU information.
@@ -542,11 +543,8 @@ struct PullProgressLine {
 ///
 /// Queries the `/api/tags` endpoint and checks if the model name
 /// appears in the list of locally available models.
-pub async fn is_model_available(
-    client: &OllamaClient,
-    model_name: &str,
-) -> Result<bool, ParishError> {
-    let url = format!("{}/api/tags", client.base_url());
+pub async fn is_model_available(base_url: &str, model_name: &str) -> Result<bool, ParishError> {
+    let url = format!("{}/api/tags", base_url);
     let http = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()
@@ -582,7 +580,7 @@ pub async fn is_model_available(
 ///
 /// Returns `ParishError::ModelNotAvailable` if the pull fails.
 pub async fn pull_model(
-    client: &OllamaClient,
+    base_url: &str,
     model_name: &str,
     progress: &dyn SetupProgress,
 ) -> Result<(), ParishError> {
@@ -591,7 +589,7 @@ pub async fn pull_model(
         model_name
     ));
 
-    let url = format!("{}/api/pull", client.base_url());
+    let url = format!("{}/api/pull", base_url);
     let http = reqwest::Client::builder()
         .timeout(Duration::from_secs(3600)) // Model downloads can take a while
         .build()
@@ -645,11 +643,11 @@ pub async fn pull_model(
 /// Returns `Ok(())` if the model is available (either already present
 /// or successfully pulled).
 pub async fn ensure_model_available(
-    client: &OllamaClient,
+    base_url: &str,
     model_name: &str,
     progress: &dyn SetupProgress,
 ) -> Result<(), ParishError> {
-    if is_model_available(client, model_name).await? {
+    if is_model_available(base_url, model_name).await? {
         progress.on_status(&format!(
             "The storyteller already has '{}' in hand.",
             model_name
@@ -657,7 +655,7 @@ pub async fn ensure_model_available(
         return Ok(());
     }
 
-    pull_model(client, model_name, progress).await
+    pull_model(base_url, model_name, progress).await
 }
 
 /// Builds GPU-specific environment variables for the Ollama process.
@@ -759,12 +757,14 @@ pub async fn setup_ollama(
         }
     };
 
-    // Step 5: Ensure model is available
-    let client = OllamaClient::new(base_url);
-    ensure_model_available(&client, &model_config.model_name, progress).await?;
+    // Step 5: Ensure model is available (uses Ollama native /api/tags + /api/pull)
+    ensure_model_available(base_url, &model_config.model_name, progress).await?;
 
-    // Step 6: Warm up the model (load into VRAM before player gets the prompt)
-    warmup_model(&client, &model_config.model_name, progress).await?;
+    // Step 6: Warm up the model (uses Ollama native /api/generate)
+    warmup_model(base_url, &model_config.model_name, progress).await?;
+
+    // Create an OpenAI-compatible client pointing at Ollama's /v1/ endpoint
+    let client = OpenAiClient::new(base_url, None);
 
     Ok(OllamaSetup {
         process,
@@ -783,7 +783,7 @@ pub async fn setup_ollama(
 /// Uses a dedicated HTTP client with a 5-minute timeout since the first
 /// model load (moving weights from disk to VRAM) can be slow.
 async fn warmup_model(
-    client: &OllamaClient,
+    base_url: &str,
     model_name: &str,
     progress: &dyn SetupProgress,
 ) -> Result<(), ParishError> {
@@ -795,7 +795,7 @@ async fn warmup_model(
         .build()
         .map_err(|e| ParishError::Setup(format!("failed to build warmup client: {}", e)))?;
 
-    let url = format!("{}/api/generate", client.base_url());
+    let url = format!("{}/api/generate", base_url);
     let body = serde_json::json!({
         "model": model_name,
         "prompt": "Hi",

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -5,7 +5,7 @@
 //! intent parsing (move, talk, look, interact, examine).
 
 use crate::error::ParishError;
-use crate::inference::client::OllamaClient;
+use crate::inference::openai_client::OpenAiClient;
 use serde::Deserialize;
 
 /// A system command entered by the player.
@@ -295,10 +295,10 @@ pub fn parse_intent_local(raw_input: &str) -> Option<PlayerIntent> {
 /// Parses natural language input into a structured `PlayerIntent`.
 ///
 /// First tries local keyword matching for common commands (movement, look).
-/// Falls back to Ollama LLM for ambiguous input. If the LLM call fails,
+/// Falls back to LLM for ambiguous input. If the LLM call fails,
 /// returns `IntentKind::Unknown`.
 pub async fn parse_intent(
-    client: &OllamaClient,
+    client: &OpenAiClient,
     raw_input: &str,
     model: &str,
 ) -> Result<PlayerIntent, ParishError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod error;
 pub mod headless;
 pub mod inference;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use clap::Parser;
+use parish::config::{CliOverrides, Provider, ProviderConfig, resolve_config};
 use parish::headless;
+use parish::inference::openai_client::OpenAiClient;
 use parish::inference::setup::{self, StdoutProgress};
 use parish::inference::{self, InferenceQueue};
 use parish::input::{Command, InputResult, classify_input, parse_intent};
@@ -17,9 +19,6 @@ use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use tracing_subscriber::EnvFilter;
 
-/// Default Ollama API base URL.
-const DEFAULT_OLLAMA_URL: &str = "http://localhost:11434";
-
 /// Parish — An Irish Living World Text Adventure
 #[derive(Parser, Debug)]
 #[command(name = "parish", version, about)]
@@ -28,17 +27,29 @@ struct Cli {
     #[arg(long)]
     headless: bool,
 
-    /// Run commands from a script file (one per line, JSON output, no Ollama needed)
+    /// Run commands from a script file (one per line, JSON output, no LLM needed)
     #[arg(long, value_name = "FILE")]
     script: Option<String>,
 
-    /// Override the Ollama model (skips auto-detection)
+    /// LLM provider: ollama (default), lmstudio, openrouter, custom
+    #[arg(long, env = "PARISH_PROVIDER")]
+    provider: Option<String>,
+
+    /// Override the model name (required for non-Ollama providers)
     #[arg(long, env = "PARISH_MODEL")]
     model: Option<String>,
 
-    /// Override the Ollama API URL
-    #[arg(long, env = "PARISH_OLLAMA_URL", default_value = DEFAULT_OLLAMA_URL)]
-    ollama_url: String,
+    /// Override the API base URL
+    #[arg(long, env = "PARISH_BASE_URL")]
+    base_url: Option<String>,
+
+    /// API key for cloud providers (e.g. OpenRouter)
+    #[arg(long, env = "PARISH_API_KEY")]
+    api_key: Option<String>,
+
+    /// Path to config file (default: parish.toml)
+    #[arg(long)]
+    config: Option<String>,
 }
 
 #[tokio::main]
@@ -51,23 +62,40 @@ async fn main() -> Result<()> {
 
     let cli = Cli::parse();
 
-    // Script mode — no Ollama needed, synchronous execution
+    // Script mode — no LLM needed, synchronous execution
     if let Some(script_path) = &cli.script {
         return parish::testing::run_script_mode(Path::new(script_path));
     }
 
-    // Run the full Ollama setup sequence
-    let progress = StdoutProgress;
-    let setup = setup::setup_ollama(&cli.ollama_url, cli.model.as_deref(), &progress).await?;
+    // Resolve provider configuration from file + env + CLI
+    let config_path = cli.config.as_ref().map(|p| Path::new(p.as_str()));
+    let overrides = CliOverrides {
+        provider: cli.provider.clone(),
+        base_url: cli.base_url.clone(),
+        api_key: cli.api_key.clone(),
+        model: cli.model.clone(),
+    };
+    let provider_config = resolve_config(config_path, &overrides)?;
+
+    // Set up inference client based on provider
+    let (client, model, mut ollama_process) = setup_provider(&cli, &provider_config).await?;
 
     if cli.headless {
+        // Build OllamaSetup-compatible struct for headless mode
+        let setup = setup::OllamaSetup {
+            process: ollama_process,
+            client,
+            model_name: model,
+            gpu_info: setup::GpuInfo {
+                vendor: setup::GpuVendor::CpuOnly,
+                vram_total_mb: 0,
+                vram_free_mb: 0,
+            },
+        };
         return headless::run_headless(setup).await;
     }
 
     // TUI mode
-    let model = setup.model_name.clone();
-    let client = setup.client.clone();
-    let mut ollama_process = setup.process;
 
     // Initialize inference pipeline
     let (tx, rx) = mpsc::channel(32);
@@ -345,6 +373,51 @@ async fn main() -> Result<()> {
     tracing::info!("Parish exited cleanly.");
 
     Ok(())
+}
+
+/// Sets up the inference client based on the resolved provider configuration.
+///
+/// For Ollama: runs the full setup sequence (GPU detect, auto-start, model pull, warmup).
+/// For other providers: creates an OpenAI-compatible client directly.
+async fn setup_provider(
+    _cli: &Cli,
+    config: &ProviderConfig,
+) -> Result<(
+    OpenAiClient,
+    String,
+    parish::inference::client::OllamaProcess,
+)> {
+    match config.provider {
+        Provider::Ollama => {
+            let progress = StdoutProgress;
+            let setup =
+                setup::setup_ollama(&config.base_url, config.model.as_deref(), &progress).await?;
+            let model = setup.model_name.clone();
+            let client = setup.client.clone();
+            let process = setup.process;
+            Ok((client, model, process))
+        }
+        _ => {
+            // Non-Ollama providers: require model name
+            let model = config.model.clone().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "{:?} provider requires a model name. Set --model or PARISH_MODEL.",
+                    config.provider
+                )
+            })?;
+            let client = OpenAiClient::new(&config.base_url, config.api_key.as_deref());
+            tracing::info!(
+                "Using {:?} provider at {} with model {}",
+                config.provider,
+                config.base_url,
+                model
+            );
+
+            // No OllamaProcess management for non-Ollama providers
+            let dummy_process = parish::inference::client::OllamaProcess::none();
+            Ok((client, model, dummy_process))
+        }
+    }
 }
 
 /// Atmospheric idle messages shown when no NPC is present for conversation.


### PR DESCRIPTION
Switch from Ollama's native /api/generate to the OpenAI-compatible /v1/chat/completions endpoint, enabling support for any provider: Ollama (default), LM Studio, OpenRouter, or custom endpoints.

- Add src/config.rs: Provider enum, ProviderConfig, TOML+env+CLI config resolution with parish.toml support
- Add src/inference/openai_client.rs: OpenAiClient with SSE streaming, JSON mode (response_format), and Bearer auth for cloud providers
- Update inference pipeline to use OpenAiClient everywhere
- Decouple Ollama management (warmup, model pull) from inference client
- New CLI flags: --provider, --base-url, --api-key, --config
- Backward-compatible: Ollama remains default with all auto-setup features
- Deprecation warning for PARISH_OLLAMA_URL env var

https://claude.ai/code/session_01QwVwV1TX9GWfAQJk2jgUFg