### PR TITLE
feat: set starting location to Kilteevan Village

### DIFF
--- a/data/parish.json
+++ b/data/parish.json
@@ -12,7 +12,8 @@
                 {"target": 4, "traversal_minutes": 2, "path_description": "the road past a hand-lettered sign"},
                 {"target": 6, "traversal_minutes": 4, "path_description": "a muddy path along the schoolmaster's wall"},
                 {"target": 9, "traversal_minutes": 8, "path_description": "a narrow road between stone walls"},
-                {"target": 13, "traversal_minutes": 3, "path_description": "a few steps across the road"}
+                {"target": 13, "traversal_minutes": 3, "path_description": "a few steps across the road"},
+                {"target": 15, "traversal_minutes": 6, "path_description": "the Kilteevan road heading south past low fields"}
             ],
             "associated_npcs": [],
             "mythological_significance": "Crossroads hold power in Irish folklore — a place between places, where the veil is thin."
@@ -183,6 +184,18 @@
             ],
             "associated_npcs": [],
             "mythological_significance": null
+        },
+        {
+            "id": 15,
+            "name": "Kilteevan Village",
+            "description_template": "The small village of Kilteevan — a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The {weather} sky hangs over the quiet street. It is {time}.",
+            "indoor": false,
+            "public": true,
+            "connections": [
+                {"target": 1, "traversal_minutes": 6, "path_description": "the road north past low fields to the crossroads"}
+            ],
+            "associated_npcs": [],
+            "mythological_significance": "Kilteevan — Cill Tíobáin, the church of St. Tíobán. The ruins of the old church stand in a field nearby, half-swallowed by ivy and elder."
         }
     ]
 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -48,7 +48,8 @@ pub async fn run_headless(setup: OllamaSetup) -> Result<()> {
     let mut app = App::new();
     let parish_path = Path::new("data/parish.json");
     if parish_path.exists() {
-        match crate::world::WorldState::from_parish_file(parish_path, crate::world::LocationId(1)) {
+        match crate::world::WorldState::from_parish_file(parish_path, crate::world::LocationId(15))
+        {
             Ok(world) => app.world = world,
             Err(e) => eprintln!("Warning: Failed to load parish data: {}", e),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,8 +78,10 @@ async fn main() -> Result<()> {
     let mut app = App::new();
     let parish_path = Path::new("data/parish.json");
     if parish_path.exists() {
-        match parish::world::WorldState::from_parish_file(parish_path, parish::world::LocationId(1))
-        {
+        match parish::world::WorldState::from_parish_file(
+            parish_path,
+            parish::world::LocationId(15),
+        ) {
             Ok(world) => app.world = world,
             Err(e) => tracing::warn!("Failed to load parish data: {}", e),
         }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -11,9 +11,9 @@
 //! use parish::testing::{GameTestHarness, ActionResult};
 //!
 //! let mut h = GameTestHarness::new();
-//! let result = h.execute("go to pub");
+//! let result = h.execute("go to crossroads");
 //! assert!(matches!(result, ActionResult::Moved { .. }));
-//! assert_eq!(h.player_location(), "Darcy's Pub");
+//! assert_eq!(h.player_location(), "The Crossroads");
 //! ```
 
 use crate::input::{self, Command, InputResult, IntentKind};
@@ -89,9 +89,9 @@ pub enum ActionResult {
 /// use parish::testing::GameTestHarness;
 ///
 /// let mut h = GameTestHarness::new();
+/// assert_eq!(h.player_location(), "Kilteevan Village");
+/// h.execute("go to crossroads");
 /// assert_eq!(h.player_location(), "The Crossroads");
-/// h.execute("go to pub");
-/// assert_eq!(h.player_location(), "Darcy's Pub");
 /// ```
 pub struct GameTestHarness {
     /// The underlying game state.
@@ -104,12 +104,12 @@ impl GameTestHarness {
     /// Creates a new harness with the full parish world loaded.
     ///
     /// Loads `data/parish.json` for the world graph and adds the test NPC
-    /// (Padraig O'Brien at The Crossroads). The player starts at The Crossroads.
+    /// (Padraig O'Brien at The Crossroads). The player starts at Kilteevan Village.
     pub fn new() -> Self {
         let mut app = App::new();
         let parish_path = Path::new("data/parish.json");
         if parish_path.exists() {
-            match crate::world::WorldState::from_parish_file(parish_path, LocationId(1)) {
+            match crate::world::WorldState::from_parish_file(parish_path, LocationId(15)) {
                 Ok(world) => app.world = world,
                 Err(e) => eprintln!("Warning: Failed to load parish data: {}", e),
             }
@@ -259,7 +259,8 @@ impl GameTestHarness {
             | Command::Fork(_)
             | Command::Load(_)
             | Command::Branches
-            | Command::Log => {
+            | Command::Log
+            | Command::ToggleSidebar => {
                 self.app
                     .world
                     .log("[Not yet implemented — coming in Phase 4]".to_string());
@@ -470,15 +471,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_harness_new_starts_at_crossroads() {
+    fn test_harness_new_starts_at_kilteevan() {
         let h = GameTestHarness::new();
-        assert_eq!(h.player_location(), "The Crossroads");
-        assert_eq!(h.location_id(), LocationId(1));
+        assert_eq!(h.player_location(), "Kilteevan Village");
+        assert_eq!(h.location_id(), LocationId(15));
     }
 
     #[test]
     fn test_harness_has_test_npc() {
-        let h = GameTestHarness::new();
+        let mut h = GameTestHarness::new();
+        // NPC is at The Crossroads, navigate there first
+        h.execute("go to crossroads");
         let npcs = h.npcs_here();
         assert!(npcs.contains(&"Padraig O'Brien"));
     }
@@ -499,6 +502,7 @@ mod tests {
     #[test]
     fn test_move_to_pub() {
         let mut h = GameTestHarness::new();
+        h.execute("go to crossroads");
         let result = h.execute("go to pub");
         assert!(matches!(result, ActionResult::Moved { .. }));
         assert_eq!(h.player_location(), "Darcy's Pub");
@@ -509,7 +513,7 @@ mod tests {
         let mut h = GameTestHarness::new();
         let before = h.time_of_day();
         // Move far enough to potentially change time
-        h.execute("go to pub");
+        h.execute("go to crossroads");
         // Time should still be deterministic — just verify it didn't break
         let _after = h.time_of_day();
         // Clock was Morning, a short trip shouldn't change it
@@ -519,9 +523,9 @@ mod tests {
     #[test]
     fn test_move_already_here() {
         let mut h = GameTestHarness::new();
-        let result = h.execute("go to crossroads");
+        let result = h.execute("go to kilteevan");
         assert_eq!(result, ActionResult::AlreadyHere);
-        assert_eq!(h.player_location(), "The Crossroads");
+        assert_eq!(h.player_location(), "Kilteevan Village");
     }
 
     #[test]
@@ -529,7 +533,7 @@ mod tests {
         let mut h = GameTestHarness::new();
         let result = h.execute("go to narnia");
         assert!(matches!(result, ActionResult::NotFound { .. }));
-        assert_eq!(h.player_location(), "The Crossroads");
+        assert_eq!(h.player_location(), "Kilteevan Village");
     }
 
     #[test]
@@ -571,7 +575,7 @@ mod tests {
         let mut h = GameTestHarness::new();
         let result = h.execute("/status");
         if let ActionResult::SystemCommand { response } = result {
-            assert!(response.contains("The Crossroads"));
+            assert!(response.contains("Kilteevan Village"));
             assert!(response.contains("Morning"));
         } else {
             panic!("Expected SystemCommand");
@@ -597,6 +601,7 @@ mod tests {
     fn test_canned_npc_response() {
         let mut h = GameTestHarness::new();
         h.add_canned_response("Padraig O'Brien", "Ah, good morning to ye!");
+        h.execute("go to crossroads");
         let result = h.execute("hello there");
         assert!(matches!(result, ActionResult::NpcResponse { .. }));
         if let ActionResult::NpcResponse { npc, dialogue } = result {
@@ -611,6 +616,7 @@ mod tests {
         h.add_canned_response("Padraig O'Brien", "First response");
         h.add_canned_response("Padraig O'Brien", "Second response");
 
+        h.execute("go to crossroads");
         let r1 = h.execute("hello");
         let r2 = h.execute("how are you");
 
@@ -627,6 +633,7 @@ mod tests {
         let mut h = GameTestHarness::new();
         h.add_canned_response("Padraig O'Brien", "Only one response");
 
+        h.execute("go to crossroads");
         let r1 = h.execute("hello");
         assert!(matches!(r1, ActionResult::NpcResponse { .. }));
 
@@ -637,8 +644,7 @@ mod tests {
     #[test]
     fn test_npc_not_at_location() {
         let mut h = GameTestHarness::new();
-        h.execute("go to church");
-        // No NPC at church
+        // Player starts at Kilteevan — no NPC here
         let result = h.execute("hello there");
         assert_eq!(result, ActionResult::UnknownInput);
     }
@@ -676,27 +682,27 @@ mod tests {
     #[test]
     fn test_movement_round_trip() {
         let mut h = GameTestHarness::new();
-        assert_eq!(h.player_location(), "The Crossroads");
-
-        h.execute("go to pub");
-        assert_eq!(h.player_location(), "Darcy's Pub");
+        assert_eq!(h.player_location(), "Kilteevan Village");
 
         h.execute("go to crossroads");
         assert_eq!(h.player_location(), "The Crossroads");
+
+        h.execute("go to kilteevan");
+        assert_eq!(h.player_location(), "Kilteevan Village");
     }
 
     #[test]
     fn test_movement_various_verbs() {
         let mut h = GameTestHarness::new();
 
-        h.execute("walk to pub");
-        assert_eq!(h.player_location(), "Darcy's Pub");
-
-        h.execute("stroll to crossroads");
+        h.execute("walk to crossroads");
         assert_eq!(h.player_location(), "The Crossroads");
 
-        h.execute("head to church");
-        assert_eq!(h.player_location(), "St. Brigid's Church");
+        h.execute("stroll to kilteevan");
+        assert_eq!(h.player_location(), "Kilteevan Village");
+
+        h.execute("head to crossroads");
+        assert_eq!(h.player_location(), "The Crossroads");
     }
 
     #[test]
@@ -709,7 +715,7 @@ mod tests {
     #[test]
     fn test_default_trait() {
         let h = GameTestHarness::default();
-        assert_eq!(h.player_location(), "The Crossroads");
+        assert_eq!(h.player_location(), "Kilteevan Village");
     }
 
     #[test]

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -214,11 +214,11 @@ mod tests {
     fn test_from_parish_file() {
         let path = Path::new("data/parish.json");
         if path.exists() {
-            let world = WorldState::from_parish_file(path, LocationId(1)).unwrap();
-            assert_eq!(world.player_location, LocationId(1));
+            let world = WorldState::from_parish_file(path, LocationId(15)).unwrap();
+            assert_eq!(world.player_location, LocationId(15));
             assert!(world.locations.len() >= 12);
             assert!(world.graph.location_count() >= 12);
-            assert_eq!(world.current_location().name, "The Crossroads");
+            assert_eq!(world.current_location().name, "Kilteevan Village");
         }
     }
 
@@ -226,9 +226,9 @@ mod tests {
     fn test_current_location_data() {
         let path = Path::new("data/parish.json");
         if path.exists() {
-            let world = WorldState::from_parish_file(path, LocationId(1)).unwrap();
+            let world = WorldState::from_parish_file(path, LocationId(15)).unwrap();
             let data = world.current_location_data().unwrap();
-            assert_eq!(data.name, "The Crossroads");
+            assert_eq!(data.name, "Kilteevan Village");
             assert!(data.description_template.contains("{time}"));
         }
     }

--- a/tests/fixtures/test_movement_errors.txt
+++ b/tests/fixtures/test_movement_errors.txt
@@ -3,6 +3,8 @@
 
 /status
 go to crossroads
+go to kilteevan
+go to kilteevan
 go to narnia
 go to mordor
 walk to pub

--- a/tests/fixtures/test_walkthrough.txt
+++ b/tests/fixtures/test_walkthrough.txt
@@ -3,6 +3,7 @@
 
 /status
 look
+go to crossroads
 go to pub
 look
 /status

--- a/tests/game_harness_integration.rs
+++ b/tests/game_harness_integration.rs
@@ -12,9 +12,13 @@ use parish::world::time::{Season, TimeOfDay};
 fn test_full_walkthrough_crossroads_to_pub_and_back() {
     let mut h = GameTestHarness::new();
 
-    // Start at crossroads
+    // Start at Kilteevan Village
+    assert_eq!(h.player_location(), "Kilteevan Village");
+    assert_eq!(h.location_id(), LocationId(15));
+
+    // Move to crossroads first
+    h.execute("go to crossroads");
     assert_eq!(h.player_location(), "The Crossroads");
-    assert_eq!(h.location_id(), LocationId(1));
 
     // Move to pub
     let r = h.execute("go to pub");
@@ -39,7 +43,10 @@ fn test_full_walkthrough_crossroads_to_pub_and_back() {
 fn test_multi_location_circuit() {
     let mut h = GameTestHarness::new();
 
-    // Crossroads → Pub → Crossroads → Church → Crossroads
+    // Kilteevan → Crossroads → Pub → Crossroads → Church → Crossroads
+    h.execute("go to crossroads");
+    assert_eq!(h.player_location(), "The Crossroads");
+
     h.execute("go to pub");
     assert_eq!(h.player_location(), "Darcy's Pub");
 
@@ -58,7 +65,8 @@ fn test_time_advances_with_travel() {
     let mut h = GameTestHarness::new();
     assert_eq!(h.time_of_day(), TimeOfDay::Morning);
 
-    // Make many trips to advance time significantly
+    // Move to crossroads first, then make many trips
+    h.execute("go to crossroads");
     for _ in 0..20 {
         h.execute("go to pub");
         h.execute("go to crossroads");
@@ -79,9 +87,9 @@ fn test_season_is_spring_at_start() {
 #[test]
 fn test_movement_already_here() {
     let mut h = GameTestHarness::new();
-    let r = h.execute("go to crossroads");
+    let r = h.execute("go to kilteevan");
     assert_eq!(r, ActionResult::AlreadyHere);
-    assert_eq!(h.player_location(), "The Crossroads");
+    assert_eq!(h.player_location(), "Kilteevan Village");
 }
 
 #[test]
@@ -92,7 +100,7 @@ fn test_movement_not_found() {
     if let ActionResult::NotFound { target } = r {
         assert_eq!(target, "atlantis");
     }
-    assert_eq!(h.player_location(), "The Crossroads");
+    assert_eq!(h.player_location(), "Kilteevan Village");
 }
 
 #[test]
@@ -109,7 +117,7 @@ fn test_movement_various_verbs_all_work() {
 
     for verb in &verbs {
         let mut h = GameTestHarness::new();
-        let cmd = format!("{} pub", verb);
+        let cmd = format!("{} crossroads", verb);
         let r = h.execute(&cmd);
         assert!(
             matches!(r, ActionResult::Moved { .. }),
@@ -119,8 +127,8 @@ fn test_movement_various_verbs_all_work() {
         );
         assert_eq!(
             h.player_location(),
-            "Darcy's Pub",
-            "Verb '{}' should move to pub",
+            "The Crossroads",
+            "Verb '{}' should move to crossroads",
             verb
         );
     }
@@ -130,7 +138,14 @@ fn test_movement_various_verbs_all_work() {
 fn test_look_at_multiple_locations() {
     let mut h = GameTestHarness::new();
 
-    // Look at crossroads
+    // Look at Kilteevan
+    let r = h.execute("look");
+    if let ActionResult::Looked { description } = &r {
+        assert!(!description.is_empty());
+    }
+
+    // Move to crossroads and look
+    h.execute("go to crossroads");
     let r = h.execute("look");
     if let ActionResult::Looked { description } = &r {
         assert!(!description.is_empty());
@@ -138,13 +153,6 @@ fn test_look_at_multiple_locations() {
 
     // Move to pub and look
     h.execute("go to pub");
-    let r = h.execute("look");
-    if let ActionResult::Looked { description } = &r {
-        assert!(!description.is_empty());
-    }
-
-    // Move to church and look
-    h.execute("go to church");
     let r = h.execute("look around");
     if let ActionResult::Looked { description } = &r {
         assert!(!description.is_empty());
@@ -191,6 +199,9 @@ fn test_npc_canned_response_at_crossroads() {
     let mut h = GameTestHarness::new();
     h.add_canned_response("Padraig O'Brien", "Top of the morning to ye!");
 
+    // NPC is at The Crossroads, navigate there first
+    h.execute("go to crossroads");
+
     let r = h.execute("hello Padraig");
     if let ActionResult::NpcResponse { npc, dialogue } = r {
         assert_eq!(npc, "Padraig O'Brien");
@@ -207,6 +218,7 @@ fn test_npc_canned_responses_consumed_in_order() {
     h.add_canned_response("Padraig O'Brien", "Second line");
     h.add_canned_response("Padraig O'Brien", "Third line");
 
+    h.execute("go to crossroads");
     let r1 = h.execute("hello");
     let r2 = h.execute("how are you");
     let r3 = h.execute("tell me about the town");
@@ -239,6 +251,7 @@ fn test_npc_not_available_after_canned_exhausted() {
     let mut h = GameTestHarness::new();
     h.add_canned_response("Padraig O'Brien", "Only response");
 
+    h.execute("go to crossroads");
     h.execute("hello");
     let r = h.execute("hello again");
     assert_eq!(r, ActionResult::NpcNotAvailable);
@@ -249,21 +262,18 @@ fn test_npc_not_present_after_moving() {
     let mut h = GameTestHarness::new();
     h.add_canned_response("Padraig O'Brien", "Goodbye!");
 
-    // Move away from NPC
-    h.execute("go to church");
-
-    // NPC is at crossroads, not church
+    // Player starts at Kilteevan — NPC is at crossroads, not here
     let r = h.execute("hello");
     assert_eq!(r, ActionResult::UnknownInput);
 }
 
 #[test]
-fn test_exits_at_crossroads() {
+fn test_exits_at_kilteevan() {
     let h = GameTestHarness::new();
     let exits = h.exits();
     assert!(exits.contains("You can go to:"));
-    // Crossroads is the hub, should have multiple exits
-    assert!(exits.contains("Darcy's Pub"));
+    // Kilteevan connects to The Crossroads
+    assert!(exits.contains("The Crossroads"));
 }
 
 #[test]
@@ -304,14 +314,14 @@ fn test_script_fixture_commands() {
 #[test]
 fn test_moved_result_contains_narration() {
     let mut h = GameTestHarness::new();
-    let r = h.execute("go to pub");
+    let r = h.execute("go to crossroads");
     if let ActionResult::Moved {
         to,
         minutes,
         narration,
     } = r
     {
-        assert_eq!(to, "Darcy's Pub");
+        assert_eq!(to, "The Crossroads");
         assert!(minutes > 0, "Travel should take some time");
         assert!(!narration.is_empty(), "Narration should be non-empty");
     } else {
@@ -341,7 +351,7 @@ fn test_multiple_looks_same_location() {
 fn test_long_journey_fairy_fort() {
     let mut h = GameTestHarness::new();
 
-    // Navigate to the Fairy Fort (may be multiple hops from Crossroads)
+    // Navigate to the Fairy Fort (multiple hops from Kilteevan)
     let r = h.execute("go to fairy fort");
     match r {
         ActionResult::Moved { to, minutes, .. } => {

--- a/tests/world_graph_integration.rs
+++ b/tests/world_graph_integration.rs
@@ -31,7 +31,7 @@ fn test_parish_json_loads() {
 #[test]
 fn test_parish_json_location_count() {
     let graph = load_parish_graph();
-    assert_eq!(graph.location_count(), 14);
+    assert_eq!(graph.location_count(), 15);
 }
 
 #[test]


### PR DESCRIPTION
Add Kilteevan Village (id 15) to the parish world graph as a new location connected to The Crossroads. Change the player's starting location from The Crossroads to Kilteevan Village across all entry points (TUI, headless, test harness, script mode). Update all tests and fixture scripts to account for the new starting position.

https://claude.ai/code/session_01Mhz8KxxMLCuEqn6BhjdbrU