### PR TITLE
feat: add toggleable improv craft mode for NPC dialogue

### DIFF
--- a/src/headless.rs
+++ b/src/headless.rs
@@ -153,6 +153,7 @@ fn handle_headless_command(app: &mut App, cmd: Command) -> bool {
             println!("  /resume   - Let time flow again");
             println!("  /status   - Where am I?");
             println!("  /irish    - Toggle Irish words sidebar (TUI only)");
+            println!("  /improv   - Toggle improv craft for NPC dialogue");
             println!("  /help     - Show this help");
             println!("  /save     - Save game (not yet arrived)");
             println!("  /fork <n> - Fork save (not yet arrived)");
@@ -161,6 +162,15 @@ fn handle_headless_command(app: &mut App, cmd: Command) -> bool {
         }
         Command::ToggleSidebar => {
             println!("The pronunciation sidebar is only available in TUI mode.");
+            false
+        }
+        Command::ToggleImprov => {
+            app.improv_enabled = !app.improv_enabled;
+            if app.improv_enabled {
+                println!("The characters loosen up — improv craft engaged.");
+            } else {
+                println!("The characters settle back to their usual selves.");
+            }
             false
         }
         Command::Save | Command::Fork(_) | Command::Load(_) | Command::Branches | Command::Log => {
@@ -201,7 +211,7 @@ async fn handle_headless_game_input(
                 .cloned();
 
             if let Some(npc) = npc {
-                let system_prompt = npc::build_tier1_system_prompt(&npc);
+                let system_prompt = npc::build_tier1_system_prompt(&npc, app.improv_enabled);
                 let context = npc::build_tier1_context(&npc, &app.world, text);
 
                 if let Some(queue) = &app.inference_queue {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -36,6 +36,8 @@ pub enum Command {
     Help,
     /// Toggle the Irish pronunciation sidebar.
     ToggleSidebar,
+    /// Toggle improv craft mode for NPC dialogue.
+    ToggleImprov,
 }
 
 /// The kind of player action parsed from natural language input.
@@ -123,6 +125,8 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
         Some(Command::Help)
     } else if lower == "/irish" {
         Some(Command::ToggleSidebar)
+    } else if lower == "/improv" {
+        Some(Command::ToggleImprov)
     } else {
         None
     }
@@ -776,5 +780,23 @@ mod tests {
     fn test_classify_irish_command() {
         let result = classify_input("/irish");
         assert_eq!(result, InputResult::SystemCommand(Command::ToggleSidebar));
+    }
+
+    #[test]
+    fn test_parse_improv_command() {
+        let cmd = parse_system_command("/improv");
+        assert_eq!(cmd, Some(Command::ToggleImprov));
+    }
+
+    #[test]
+    fn test_parse_improv_command_case_insensitive() {
+        let cmd = parse_system_command("/IMPROV");
+        assert_eq!(cmd, Some(Command::ToggleImprov));
+    }
+
+    #[test]
+    fn test_classify_improv_command() {
+        let result = classify_input("/improv");
+        assert_eq!(result, InputResult::SystemCommand(Command::ToggleImprov));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,10 @@ struct Cli {
     /// Path to config file (default: parish.toml)
     #[arg(long)]
     config: Option<String>,
+
+    /// Enable improv craft mode for NPC dialogue
+    #[arg(long, env = "PARISH_IMPROV")]
+    improv: bool,
 }
 
 #[tokio::main]
@@ -115,6 +119,7 @@ async fn main() -> Result<()> {
         }
     }
     app.inference_queue = Some(queue);
+    app.improv_enabled = cli.improv;
     app.npcs.push(Npc::new_test_npc());
 
     // Show initial location description
@@ -185,7 +190,8 @@ async fn main() -> Result<()> {
                                 .cloned();
 
                             if let Some(npc) = npc {
-                                let system_prompt = npc::build_tier1_system_prompt(&npc);
+                                let system_prompt =
+                                    npc::build_tier1_system_prompt(&npc, app.improv_enabled);
                                 let context = npc::build_tier1_context(&npc, &app.world, &text);
 
                                 if let Some(queue) = &app.inference_queue {
@@ -473,6 +479,8 @@ fn handle_system_command(app: &mut App, cmd: Command) {
             app.world.log("  /status   — Where am I?".to_string());
             app.world
                 .log("  /irish    — Toggle the Irish words sidebar (or press Tab)".to_string());
+            app.world
+                .log("  /improv   — Toggle improv craft for NPC dialogue".to_string());
             app.world.log("  /help     — Show this help".to_string());
             app.world
                 .log("  /save     — Save game (not yet arrived)".to_string());
@@ -489,6 +497,16 @@ fn handle_system_command(app: &mut App, cmd: Command) {
             } else {
                 app.world
                     .log("The pronunciation guide folds away.".to_string());
+            }
+        }
+        Command::ToggleImprov => {
+            app.improv_enabled = !app.improv_enabled;
+            if app.improv_enabled {
+                app.world
+                    .log("The characters loosen up — improv craft engaged.".to_string());
+            } else {
+                app.world
+                    .log("The characters settle back to their usual selves.".to_string());
             }
         }
         Command::Save | Command::Fork(_) | Command::Load(_) | Command::Branches | Command::Log => {

--- a/src/npc/mod.rs
+++ b/src/npc/mod.rs
@@ -216,15 +216,68 @@ pub struct NpcAction {
     pub internal_thought: Option<String>,
 }
 
+/// The improv craft guidelines injected into the system prompt when improv mode is enabled.
+///
+/// Distilled from professional long-form improv principles: Yes-And, specificity,
+/// emotional truth, physical grounding, active listening, heightening, and
+/// making the scene partner shine.
+const IMPROV_CRAFT_SECTION: &str = "\n\
+    \n\
+    IMPROV CRAFT: You are a scene partner, not a chatbot. Follow these principles:\n\
+    \n\
+    - YES, AND: Accept everything the player establishes as true and build on it. \
+    Add new information that enriches the scene rather than redirecting it. \
+    Your character can disagree with the player's character, but never negate \
+    the reality they have established. If the player says they saw a ghost on the \
+    hill, there was something on the hill — even if your character is skeptical.\n\
+    \n\
+    - SPECIFICITY: Choose the specific over the general. Real place names, exact \
+    amounts, particular objects. \"A cracked jug of buttermilk left over from Tuesday\" \
+    not \"a drink.\" \"The third stone from the left in Brennan's wall\" not \"a rock.\" \
+    Specific emotions, not vague moods.\n\
+    \n\
+    - EMOTIONAL TRUTH: Scenes are about relationships and honest reactions, not \
+    clever lines. The comedy and drama emerge from truthful characters responding to \
+    circumstances. If the moment calls for vulnerability, go there. Do not reach \
+    for jokes — let humor arise from specificity and human nature.\n\
+    \n\
+    - PHYSICAL GROUNDING: Use object work. Touch things, reference the environment. \
+    Ground every exchange in the physical space — the creak of a chair, the smell of \
+    turf smoke, rain on the windowpane. Your character inhabits a body in a place.\n\
+    \n\
+    - LISTEN AND REACT: Respond to what was actually said, not what you expected. \
+    If the player says something surprising, let it surprise your character too. \
+    If they make what seems like a mistake, treat it as intentional and justify it \
+    within the scene.\n\
+    \n\
+    - HEIGHTEN: Notice the first unusual thing and explore its implications. \
+    \"If this is true, what else is true?\" Same pattern, higher stakes. If the \
+    player mentions they owe money to the landlord, build on that — who else knows? \
+    What are the consequences? What does your character know about it?\n\
+    \n\
+    - RAISE EMOTIONAL STAKES: When a conversation feels stuck, go deeper emotionally, \
+    not wider logistically. Do not introduce new plot elements — have your character \
+    admit something vulnerable, recall a memory, or reveal a deeper feeling about \
+    what is already happening.\n\
+    \n\
+    - MAKE THE PLAYER SHINE: Set the player up for interesting moments. Endow them \
+    with characteristics (\"You always were the sharp one, so\"). Create openings \
+    for them to react rather than steamrolling with your own ideas. Mirror their \
+    energy and commitment level.\n";
+
 /// Builds the Tier 1 system prompt for an NPC.
 ///
 /// Combines the NPC's identity, personality, occupation, and current
 /// mood into a system prompt that establishes character for the LLM.
+/// When `improv` is true, includes the improv craft guidelines section
+/// to improve improvisational quality of NPC responses.
 ///
 /// The prompt instructs the model to output dialogue first (which is
 /// streamed to the player), then a `---` separator, then a JSON metadata
 /// block (which is parsed silently for simulation state).
-pub fn build_tier1_system_prompt(npc: &Npc) -> String {
+pub fn build_tier1_system_prompt(npc: &Npc, improv: bool) -> String {
+    let improv_section = if improv { IMPROV_CRAFT_SECTION } else { "" };
+
     format!(
         "You are {name}, a {age}-year-old {occupation} in a small parish in County Roscommon, \
         Ireland, in the year 1820.\n\
@@ -240,7 +293,8 @@ pub fn build_tier1_system_prompt(npc: &Npc) -> String {
         Never portray Irish characters as excessively drunk, violent as a cultural trait, \
         foolishly superstitious, or speaking in exaggerated stage-Irish dialect. \
         Avoid phrases like \"Top o' the mornin'\" or \"begorrah.\" \
-        Show the wit, intelligence, resilience, and warmth of rural Irish people.\n\
+        Show the wit, intelligence, resilience, and warmth of rural Irish people.\
+        {improv_section}\n\
         \n\
         Personality: {personality}\n\
         \n\
@@ -274,6 +328,7 @@ pub fn build_tier1_system_prompt(npc: &Npc) -> String {
         occupation = npc.occupation,
         personality = npc.personality,
         mood = npc.mood,
+        improv_section = improv_section,
     )
 }
 
@@ -321,7 +376,7 @@ mod tests {
     #[test]
     fn test_build_system_prompt() {
         let npc = Npc::new_test_npc();
-        let prompt = build_tier1_system_prompt(&npc);
+        let prompt = build_tier1_system_prompt(&npc, false);
         assert!(prompt.contains("Padraig O'Brien"));
         assert!(prompt.contains("58-year-old"));
         assert!(prompt.contains("Publican"));
@@ -628,7 +683,7 @@ mod tests {
     #[test]
     fn test_system_prompt_avoids_stereotypes() {
         let npc = Npc::new_test_npc();
-        let prompt = build_tier1_system_prompt(&npc);
+        let prompt = build_tier1_system_prompt(&npc, false);
         assert!(prompt.contains("dignity"), "prompt should mention dignity");
         assert!(
             prompt.contains("Never portray"),
@@ -643,7 +698,7 @@ mod tests {
     #[test]
     fn test_system_prompt_historical_constraints() {
         let npc = Npc::new_test_npc();
-        let prompt = build_tier1_system_prompt(&npc);
+        let prompt = build_tier1_system_prompt(&npc, false);
         assert!(
             prompt.contains("no electricity"),
             "prompt should exclude modern technology"
@@ -656,5 +711,75 @@ mod tests {
             prompt.contains("Do not reference anything that does not exist in 1820"),
             "prompt should have explicit anachronism guard"
         );
+    }
+
+    #[test]
+    fn test_system_prompt_improv_enabled() {
+        let npc = Npc::new_test_npc();
+        let prompt = build_tier1_system_prompt(&npc, true);
+        assert!(
+            prompt.contains("IMPROV CRAFT"),
+            "improv prompt should contain IMPROV CRAFT section"
+        );
+        assert!(
+            prompt.contains("YES, AND"),
+            "improv prompt should contain Yes-And principle"
+        );
+        assert!(
+            prompt.contains("SPECIFICITY"),
+            "improv prompt should contain specificity principle"
+        );
+        assert!(
+            prompt.contains("EMOTIONAL TRUTH"),
+            "improv prompt should contain emotional truth principle"
+        );
+        assert!(
+            prompt.contains("PHYSICAL GROUNDING"),
+            "improv prompt should contain physical grounding principle"
+        );
+        assert!(
+            prompt.contains("LISTEN AND REACT"),
+            "improv prompt should contain listen-and-react principle"
+        );
+        assert!(
+            prompt.contains("HEIGHTEN"),
+            "improv prompt should contain heighten principle"
+        );
+        assert!(
+            prompt.contains("RAISE EMOTIONAL STAKES"),
+            "improv prompt should contain raise-emotional-stakes principle"
+        );
+        assert!(
+            prompt.contains("MAKE THE PLAYER SHINE"),
+            "improv prompt should contain make-player-shine principle"
+        );
+    }
+
+    #[test]
+    fn test_system_prompt_improv_disabled() {
+        let npc = Npc::new_test_npc();
+        let prompt = build_tier1_system_prompt(&npc, false);
+        assert!(
+            !prompt.contains("IMPROV CRAFT"),
+            "non-improv prompt should NOT contain IMPROV CRAFT section"
+        );
+        assert!(
+            !prompt.contains("YES, AND"),
+            "non-improv prompt should NOT contain improv principles"
+        );
+    }
+
+    #[test]
+    fn test_system_prompt_improv_preserves_identity() {
+        let npc = Npc::new_test_npc();
+        let prompt = build_tier1_system_prompt(&npc, true);
+        // Improv mode should still contain all the standard sections
+        assert!(prompt.contains("Padraig O'Brien"));
+        assert!(prompt.contains("58-year-old"));
+        assert!(prompt.contains("Publican"));
+        assert!(prompt.contains("1820"));
+        assert!(prompt.contains("CULTURAL GUIDELINES"));
+        assert!(prompt.contains("irish_words"));
+        assert!(prompt.contains("---"));
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -260,7 +260,8 @@ impl GameTestHarness {
             | Command::Load(_)
             | Command::Branches
             | Command::Log
-            | Command::ToggleSidebar => {
+            | Command::ToggleSidebar
+            | Command::ToggleImprov => {
                 self.app
                     .world
                     .log("[Not yet implemented — coming in Phase 4]".to_string());

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -165,6 +165,8 @@ pub struct App {
     pub sidebar_visible: bool,
     /// Pronunciation hints for Irish words from NPC responses.
     pub pronunciation_hints: Vec<IrishWordHint>,
+    /// Whether improv craft mode is enabled for NPC dialogue.
+    pub improv_enabled: bool,
     /// Counter for rotating idle messages.
     pub idle_counter: usize,
 }
@@ -181,6 +183,7 @@ impl App {
             scroll: ScrollState::new(),
             sidebar_visible: false,
             pronunciation_hints: Vec::new(),
+            improv_enabled: false,
             idle_counter: 0,
         }
     }
@@ -508,6 +511,7 @@ mod tests {
         assert!(app.scroll.auto_scroll);
         assert_eq!(app.scroll.offset, 0);
         assert!(!app.sidebar_visible);
+        assert!(!app.improv_enabled);
         assert!(app.pronunciation_hints.is_empty());
         assert_eq!(app.idle_counter, 0);
     }
@@ -527,6 +531,16 @@ mod tests {
         assert!(app.sidebar_visible);
         app.sidebar_visible = !app.sidebar_visible;
         assert!(!app.sidebar_visible);
+    }
+
+    #[test]
+    fn test_improv_toggle() {
+        let mut app = App::new();
+        assert!(!app.improv_enabled);
+        app.improv_enabled = !app.improv_enabled;
+        assert!(app.improv_enabled);
+        app.improv_enabled = !app.improv_enabled;
+        assert!(!app.improv_enabled);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Distills professional long-form improv principles into an IMPROV CRAFT section injected into the NPC system prompt when enabled
- 8 principles: Yes-And, Specificity, Emotional Truth, Physical Grounding, Listen & React, Heighten, Raise Emotional Stakes, Make the Player Shine
- Toggleable via `--improv` CLI flag, `PARISH_IMPROV` env var, or `/improv` in-game command (TUI and headless)
- When disabled (default), system prompt is unchanged — zero impact on existing behavior

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 354 tests pass (including new improv-specific tests)
- [ ] Run `cargo run -- --improv` and interact with Padraig to verify improv prompt improves dialogue quality
- [ ] Run `cargo run` without flag and verify NPC behavior is unchanged
- [ ] Toggle `/improv` in-game and confirm log messages appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)