### PR TITLE
feat: add SimCity-style game speed controls and halve default speed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Run `cargo fmt`, `cargo clippy`, and `cargo test` before committing.
 
 Every commit **must** satisfy all of the following:
 
-1. **Documentation**: Update relevant documentation for every commit. New public APIs, changed behavior, and architectural decisions must be reflected in doc comments (`///`), `docs/`, or ADRs as appropriate.
+1. **Documentation**: **Every commit must leave docs current.** Update `README.md`, `CLAUDE.md`, `docs/design/`, `docs/adr/`, and doc comments (`///`) to reflect all changes. New public APIs, changed behavior, renamed or removed items, and architectural decisions must be documented before pushing. If you change code, you change the docs — no exceptions.
 2. **Tests required**: All new code must have accompanying unit tests. No new function, struct, or module lands without test coverage.
 3. **Coverage threshold**: Maintain test coverage above **90%**. Use `cargo tarpaulin` (or equivalent) to verify. PRs that drop coverage below 90% must not be merged.
 4. **All standards must pass**: `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` must all succeed. No exceptions, no `#[allow]` without a justifying comment.
@@ -46,7 +46,7 @@ src/
 ├── input/           # Player input parsing, command detection
 ├── world/           # World state, location graph, time, movement, encounters
 │   ├── graph.rs     #   WorldGraph, BFS pathfinding, fuzzy name search
-│   ├── time.rs      #   GameClock, TimeOfDay, Season
+│   ├── time.rs      #   GameClock, GameSpeed, TimeOfDay, Season
 │   ├── movement.rs  #   Movement resolution and travel narration
 │   ├── encounter.rs #   En-route encounter system
 │   └── description.rs # Dynamic location description templates

--- a/docs/adr/007-time-scale-20min-day.md
+++ b/docs/adr/007-time-scale-20min-day.md
@@ -4,7 +4,7 @@
 
 ## Status
 
-Accepted (2026-03-18)
+Superseded (2026-03-23) — Default changed to 40 minutes per day (speed factor 36.0). The original 20-minute pace felt too fast in practice. Runtime-adjustable speed presets now let players choose: Slow (80 min/day), Normal (40 min/day), Fast (20 min/day, the original), or Fastest (10 min/day). See [Time System](../design/time-system.md) for details.
 
 ## Context
 

--- a/docs/design/player-input.md
+++ b/docs/design/player-input.md
@@ -25,6 +25,7 @@ System commands use `/` prefix for now (placeholder — may change to a prefix-f
 |----------------|-------------------------------------------------------------------------|
 | `/pause`       | Freeze all simulation ticks, TUI stays up                              |
 | `/resume`      | Unfreeze simulation                                                     |
+| `/speed [preset]` | Show or set game speed (`slow`/`normal`/`fast`/`fastest`)           |
 | `/quit`        | Persist current state, clean shutdown                                   |
 | `/save`        | Manual snapshot to current branch                                       |
 | `/fork <name>` | Snapshot current state, create new named branch, continue on new branch |

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -54,7 +54,7 @@ API for driving the game without a TUI or LLM. It enables:
 | `Looked { description }` | Player looked around |
 | `AlreadyHere` | Tried to move to current location |
 | `NotFound { target }` | Destination not in world graph |
-| `SystemCommand { response }` | `/pause`, `/status`, `/help`, etc. |
+| `SystemCommand { response }` | `/pause`, `/status`, `/speed`, `/help`, etc. |
 | `NpcResponse { npc, dialogue }` | Canned NPC response consumed |
 | `NpcNotAvailable` | NPC present but no canned response |
 | `UnknownInput` | Input not recognized locally |
@@ -85,6 +85,7 @@ Test scripts live in `tests/fixtures/`:
 | `test_walkthrough.txt` | Full navigation across multiple locations |
 | `test_movement_errors.txt` | Already-here, not-found, various verbs |
 | `test_commands.txt` | All system commands |
+| `test_speed.txt` | Game speed preset commands |
 
 ## Usage in Tests
 

--- a/docs/design/time-system.md
+++ b/docs/design/time-system.md
@@ -4,14 +4,28 @@
 
 ## Day/Night Cycle
 
-- **20 real-world minutes = 1 in-game day** (matches Minecraft pacing)
-- Night portion: ~7-8 real minutes
+- **40 real-world minutes = 1 in-game day** at Normal speed (factor 36.0)
+- Night portion: ~14-16 real minutes
+
+## Game Speed Presets
+
+Speed is adjustable at runtime via the `/speed` command, inspired by SimCity:
+
+| Command | Preset | Factor | Real time per game day |
+|---------|--------|--------|----------------------|
+| `/speed slow` | Slow | 18.0 | 80 minutes |
+| `/speed normal` | Normal (default) | 36.0 | 40 minutes |
+| `/speed fast` | Fast | 72.0 | 20 minutes |
+| `/speed fastest` | Fastest | 144.0 | 10 minutes |
+
+`/speed` alone shows the current pace. Speed changes recalibrate the clock
+seamlessly — current game time is preserved, only the rate of passage changes.
 
 ## Seasons & Years
 
-- **Target: 2-3 real-world hours = 1 in-game year**
+- **Target: 4-6 real-world hours = 1 in-game year** at Normal speed
 - ~6-9 in-game days per season
-- Each season lasts ~30-45 real-world minutes
+- Each season lasts ~60-90 real-world minutes at Normal speed
 - A full year is experienced in a single play session
 - Multiple years of play show parish evolution: relationships deepen, people age, things change
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -362,6 +362,27 @@ impl GuiApp {
                 self.world
                     .log("Time stirs again in the parish.".to_string());
             }
+            Command::ShowSpeed => {
+                let speed_name = self
+                    .world
+                    .clock
+                    .current_speed()
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| format!("Custom ({}x)", self.world.clock.speed_factor()));
+                self.world
+                    .log(format!("The parish moves at {} pace.", speed_name));
+            }
+            Command::SetSpeed(speed) => {
+                use crate::world::time::GameSpeed;
+                self.world.clock.set_speed(speed);
+                let msg = match speed {
+                    GameSpeed::Slow => "The parish slows to a gentle amble.",
+                    GameSpeed::Normal => "The parish settles into its natural stride.",
+                    GameSpeed::Fast => "The parish quickens its step.",
+                    GameSpeed::Fastest => "The parish fair flies — hold onto your hat!",
+                };
+                self.world.log(msg.to_string());
+            }
             Command::Status => {
                 let time = self.world.clock.time_of_day();
                 let season = self.world.clock.season();
@@ -382,6 +403,10 @@ impl GuiApp {
                 self.world.log("  /pause    — Hold time still".to_string());
                 self.world
                     .log("  /resume   — Let time flow again".to_string());
+                self.world.log(
+                    "  /speed    — Show or change game speed (slow/normal/fast/fastest)"
+                        .to_string(),
+                );
                 self.world.log("  /status   — Where am I?".to_string());
                 self.world
                     .log("  /improv   — Toggle improv craft mode".to_string());

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -17,6 +17,7 @@ use crate::npc::{
 use crate::tui::App;
 use crate::world::description::{format_exits, render_description};
 use crate::world::movement::{self, MovementResult};
+use crate::world::time::GameSpeed;
 use anyhow::Result;
 use std::io::{BufRead, Write};
 use std::path::Path;
@@ -202,6 +203,25 @@ fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             app.world.clock.resume();
             println!("Time stirs again in the parish.");
         }
+        Command::ShowSpeed => {
+            let speed_name = app
+                .world
+                .clock
+                .current_speed()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| format!("Custom ({}x)", app.world.clock.speed_factor()));
+            println!("The parish moves at {} pace.", speed_name);
+        }
+        Command::SetSpeed(speed) => {
+            app.world.clock.set_speed(speed);
+            let msg = match speed {
+                GameSpeed::Slow => "The parish slows to a gentle amble.",
+                GameSpeed::Normal => "The parish settles into its natural stride.",
+                GameSpeed::Fast => "The parish quickens its step.",
+                GameSpeed::Fastest => "The parish fair flies — hold onto your hat!",
+            };
+            println!("{}", msg);
+        }
         Command::Status => {
             let time = app.world.clock.time_of_day();
             let season = app.world.clock.season();
@@ -218,6 +238,7 @@ fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             println!("  /quit     - Take your leave");
             println!("  /pause    - Hold time still");
             println!("  /resume   - Let time flow again");
+            println!("  /speed    - Show or change game speed (slow/normal/fast/fastest)");
             println!("  /status   - Where am I?");
             println!("  /irish    - Toggle Irish words sidebar (TUI only)");
             println!("  /improv   - Toggle improv craft for NPC dialogue");
@@ -803,5 +824,25 @@ mod tests {
         assert!(rebuild);
         assert_eq!(app.api_key, Some("sk-new-key-12345678".to_string()));
         assert!(app.client.is_some());
+    }
+
+    #[test]
+    fn test_handle_headless_command_show_speed() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::ShowSpeed);
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[test]
+    fn test_handle_headless_command_set_speed() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::SetSpeed(GameSpeed::Fast));
+        assert!(!quit);
+        assert!(!rebuild);
+        assert!(
+            (app.world.clock.speed_factor() - 72.0).abs() < f64::EPSILON,
+            "Speed should be 72.0 after setting Fast"
+        );
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -6,6 +6,7 @@
 
 use crate::error::ParishError;
 use crate::inference::openai_client::OpenAiClient;
+use crate::world::time::GameSpeed;
 use serde::Deserialize;
 
 /// A system command entered by the player.
@@ -64,6 +65,10 @@ pub enum Command {
     ShowCloudKey,
     /// Set cloud API key at runtime.
     SetCloudKey(String),
+    /// Show current game speed.
+    ShowSpeed,
+    /// Set game speed to a named preset.
+    SetSpeed(GameSpeed),
 }
 
 /// The kind of player action parsed from natural language input.
@@ -188,6 +193,14 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
             Some(Command::Debug(None))
         } else {
             Some(Command::Debug(Some(sub)))
+        }
+    } else if lower == "/speed" {
+        Some(Command::ShowSpeed)
+    } else if lower.starts_with("/speed ") {
+        let arg = trimmed[7..].trim();
+        match GameSpeed::from_name(arg) {
+            Some(speed) => Some(Command::SetSpeed(speed)),
+            None => Some(Command::ShowSpeed),
         }
     } else if lower == "/cloud" {
         Some(Command::ShowCloud)
@@ -1013,5 +1026,55 @@ mod tests {
             parse_system_command("/cloud foobar"),
             Some(Command::ShowCloud)
         );
+    }
+
+    #[test]
+    fn test_parse_speed_show() {
+        assert_eq!(parse_system_command("/speed"), Some(Command::ShowSpeed));
+    }
+
+    #[test]
+    fn test_parse_speed_set_variants() {
+        assert_eq!(
+            parse_system_command("/speed slow"),
+            Some(Command::SetSpeed(GameSpeed::Slow))
+        );
+        assert_eq!(
+            parse_system_command("/speed normal"),
+            Some(Command::SetSpeed(GameSpeed::Normal))
+        );
+        assert_eq!(
+            parse_system_command("/speed fast"),
+            Some(Command::SetSpeed(GameSpeed::Fast))
+        );
+        assert_eq!(
+            parse_system_command("/speed fastest"),
+            Some(Command::SetSpeed(GameSpeed::Fastest))
+        );
+    }
+
+    #[test]
+    fn test_parse_speed_case_insensitive() {
+        assert_eq!(
+            parse_system_command("/speed FAST"),
+            Some(Command::SetSpeed(GameSpeed::Fast))
+        );
+        assert_eq!(
+            parse_system_command("/speed Slow"),
+            Some(Command::SetSpeed(GameSpeed::Slow))
+        );
+        assert_eq!(
+            parse_system_command("/SPEED normal"),
+            Some(Command::SetSpeed(GameSpeed::Normal))
+        );
+    }
+
+    #[test]
+    fn test_parse_speed_invalid_fallback() {
+        assert_eq!(
+            parse_system_command("/speed bogus"),
+            Some(Command::ShowSpeed)
+        );
+        assert_eq!(parse_system_command("/speed   "), Some(Command::ShowSpeed));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use parish::npc::{
 use parish::tui::{self, App};
 use parish::world::description::{format_exits, render_description};
 use parish::world::movement::{self, MovementResult};
+use parish::world::time::GameSpeed;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -654,6 +655,26 @@ fn handle_system_command(app: &mut App, cmd: Command) -> bool {
             app.world.clock.resume();
             app.world.log("Time stirs again in the parish.".to_string());
         }
+        Command::ShowSpeed => {
+            let speed_name = app
+                .world
+                .clock
+                .current_speed()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| format!("Custom ({}x)", app.world.clock.speed_factor()));
+            app.world
+                .log(format!("The parish moves at {} pace.", speed_name));
+        }
+        Command::SetSpeed(speed) => {
+            app.world.clock.set_speed(speed);
+            let msg = match speed {
+                GameSpeed::Slow => "The parish slows to a gentle amble.",
+                GameSpeed::Normal => "The parish settles into its natural stride.",
+                GameSpeed::Fast => "The parish quickens its step.",
+                GameSpeed::Fastest => "The parish fair flies — hold onto your hat!",
+            };
+            app.world.log(msg.to_string());
+        }
         Command::Status => {
             let time = app.world.clock.time_of_day();
             let season = app.world.clock.season();
@@ -674,6 +695,9 @@ fn handle_system_command(app: &mut App, cmd: Command) -> bool {
             app.world.log("  /pause    — Hold time still".to_string());
             app.world
                 .log("  /resume   — Let time flow again".to_string());
+            app.world.log(
+                "  /speed    — Show or change game speed (slow/normal/fast/fastest)".to_string(),
+            );
             app.world.log("  /status   — Where am I?".to_string());
             app.world
                 .log("  /irish    — Toggle the Irish words sidebar (or press Tab)".to_string());

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -303,6 +303,26 @@ impl GameTestHarness {
                     response: "Time resumed".to_string(),
                 }
             }
+            Command::ShowSpeed => {
+                let speed_name = self
+                    .app
+                    .world
+                    .clock
+                    .current_speed()
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| {
+                        format!("Custom ({}x)", self.app.world.clock.speed_factor())
+                    });
+                let msg = format!("Speed: {}", speed_name);
+                self.app.world.log(msg.clone());
+                ActionResult::SystemCommand { response: msg }
+            }
+            Command::SetSpeed(speed) => {
+                self.app.world.clock.set_speed(speed);
+                let msg = format!("Speed changed to {}.", speed);
+                self.app.world.log(msg.clone());
+                ActionResult::SystemCommand { response: msg }
+            }
             Command::Status => {
                 let time = self.app.world.clock.time_of_day();
                 let season = self.app.world.clock.season();
@@ -954,5 +974,46 @@ mod tests {
                 "Tier debug should show player location"
             );
         }
+    }
+
+    #[test]
+    fn test_system_command_show_speed() {
+        let mut h = GameTestHarness::new();
+        let result = h.execute("/speed");
+        if let ActionResult::SystemCommand { response } = result {
+            assert!(
+                response.contains("Normal"),
+                "Default speed should be Normal, got: {}",
+                response
+            );
+        } else {
+            panic!("Expected SystemCommand");
+        }
+    }
+
+    #[test]
+    fn test_system_command_set_speed() {
+        let mut h = GameTestHarness::new();
+        let result = h.execute("/speed fast");
+        if let ActionResult::SystemCommand { response } = result {
+            assert!(
+                response.contains("Fast"),
+                "Should confirm speed change, got: {}",
+                response
+            );
+        } else {
+            panic!("Expected SystemCommand");
+        }
+        assert!(
+            (h.app.world.clock.speed_factor() - 72.0).abs() < f64::EPSILON,
+            "Speed should be 72.0 after /speed fast"
+        );
+
+        // Change again and verify
+        h.execute("/speed slow");
+        assert!(
+            (h.app.world.clock.speed_factor() - 18.0).abs() < f64::EPSILON,
+            "Speed should be 18.0 after /speed slow"
+        );
     }
 }

--- a/src/world/time.rs
+++ b/src/world/time.rs
@@ -189,7 +189,7 @@ pub struct GameClock {
     start_game: DateTime<Utc>,
     /// Whether the clock is paused.
     paused: bool,
-    /// Game-time seconds per real-time second (default 72.0).
+    /// Game-time seconds per real-time second (default 36.0).
     speed_factor: f64,
     /// Game time when the clock was paused (only valid when `paused` is true).
     paused_game_time: DateTime<Utc>,

--- a/src/world/time.rs
+++ b/src/world/time.rs
@@ -1,6 +1,7 @@
 //! Game time system.
 //!
-//! 20 real-world minutes = 1 in-game day (speed factor 72.0).
+//! 40 real-world minutes = 1 in-game day (speed factor 36.0, "Normal").
+//! Adjustable at runtime via [`GameSpeed`] presets (Slow/Normal/Fast/Fastest).
 //! Tracks time of day, season, and Irish calendar festivals
 //! (Imbolc, Bealtaine, Lughnasa, Samhain).
 
@@ -125,11 +126,62 @@ impl fmt::Display for Festival {
     }
 }
 
+/// Named speed presets for the game clock, inspired by SimCity.
+///
+/// Each variant maps to a speed factor (game-time seconds per real-time second).
+/// The default is `Normal` (36.0 = 40 real minutes per game day).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GameSpeed {
+    /// Slowest pace — 18.0 factor (80 real minutes per game day).
+    Slow,
+    /// Default pace — 36.0 factor (40 real minutes per game day).
+    Normal,
+    /// Fast pace — 72.0 factor (20 real minutes per game day).
+    Fast,
+    /// Fastest pace — 144.0 factor (10 real minutes per game day).
+    Fastest,
+}
+
+impl GameSpeed {
+    /// Returns the speed factor for this preset.
+    pub fn factor(self) -> f64 {
+        match self {
+            GameSpeed::Slow => 18.0,
+            GameSpeed::Normal => 36.0,
+            GameSpeed::Fast => 72.0,
+            GameSpeed::Fastest => 144.0,
+        }
+    }
+
+    /// Parses a speed preset from a string (case-insensitive).
+    pub fn from_name(s: &str) -> Option<GameSpeed> {
+        match s.to_lowercase().as_str() {
+            "slow" => Some(GameSpeed::Slow),
+            "normal" => Some(GameSpeed::Normal),
+            "fast" => Some(GameSpeed::Fast),
+            "fastest" => Some(GameSpeed::Fastest),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for GameSpeed {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GameSpeed::Slow => write!(f, "Slow"),
+            GameSpeed::Normal => write!(f, "Normal"),
+            GameSpeed::Fast => write!(f, "Fast"),
+            GameSpeed::Fastest => write!(f, "Fastest"),
+        }
+    }
+}
+
 /// Maps real-world elapsed time to accelerated game time.
 ///
-/// The default speed factor of 72.0 means 20 real-world minutes
+/// The default speed factor of 36.0 means 40 real-world minutes
 /// equals 1 in-game day (24 hours). The clock can be paused,
-/// resumed, and manually advanced (e.g. during travel).
+/// resumed, manually advanced (e.g. during travel), and its speed
+/// changed at runtime via [`GameSpeed`] presets.
 pub struct GameClock {
     /// Wall-clock instant when the clock was created or last resumed.
     start_real: Instant,
@@ -146,13 +198,13 @@ pub struct GameClock {
 impl GameClock {
     /// Creates a new game clock starting at the given game time.
     ///
-    /// The default speed factor is 72.0 (20 real minutes = 1 game day).
+    /// The default speed factor is 36.0 (40 real minutes = 1 game day).
     pub fn new(start_game: DateTime<Utc>) -> Self {
         Self {
             start_real: Instant::now(),
             start_game,
             paused: false,
-            speed_factor: 72.0,
+            speed_factor: 36.0,
             paused_game_time: start_game,
         }
     }
@@ -227,6 +279,43 @@ impl GameClock {
     /// Returns whether the clock is paused.
     pub fn is_paused(&self) -> bool {
         self.paused
+    }
+
+    /// Returns the current speed factor.
+    pub fn speed_factor(&self) -> f64 {
+        self.speed_factor
+    }
+
+    /// Changes the speed factor at runtime, recalibrating the clock.
+    ///
+    /// Captures the current game time, resets the real-time anchor to now,
+    /// and applies the new speed factor going forward. Works correctly
+    /// whether the clock is paused or running.
+    pub fn set_speed(&mut self, speed: GameSpeed) {
+        if self.paused {
+            self.speed_factor = speed.factor();
+        } else {
+            let current = self.now();
+            self.start_game = current;
+            self.start_real = Instant::now();
+            self.speed_factor = speed.factor();
+        }
+    }
+
+    /// Returns the named speed preset matching the current factor, if any.
+    pub fn current_speed(&self) -> Option<GameSpeed> {
+        const EPSILON: f64 = 0.01;
+        if (self.speed_factor - 18.0).abs() < EPSILON {
+            Some(GameSpeed::Slow)
+        } else if (self.speed_factor - 36.0).abs() < EPSILON {
+            Some(GameSpeed::Normal)
+        } else if (self.speed_factor - 72.0).abs() < EPSILON {
+            Some(GameSpeed::Fast)
+        } else if (self.speed_factor - 144.0).abs() < EPSILON {
+            Some(GameSpeed::Fastest)
+        } else {
+            None
+        }
     }
 }
 
@@ -365,5 +454,83 @@ mod tests {
 
         let clock = GameClock::new(game_time(2026, 5, 2, 12));
         assert_eq!(clock.check_festival(), None);
+    }
+
+    #[test]
+    fn test_game_speed_factor() {
+        assert!((GameSpeed::Slow.factor() - 18.0).abs() < f64::EPSILON);
+        assert!((GameSpeed::Normal.factor() - 36.0).abs() < f64::EPSILON);
+        assert!((GameSpeed::Fast.factor() - 72.0).abs() < f64::EPSILON);
+        assert!((GameSpeed::Fastest.factor() - 144.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_game_speed_from_name() {
+        assert_eq!(GameSpeed::from_name("slow"), Some(GameSpeed::Slow));
+        assert_eq!(GameSpeed::from_name("NORMAL"), Some(GameSpeed::Normal));
+        assert_eq!(GameSpeed::from_name("Fast"), Some(GameSpeed::Fast));
+        assert_eq!(GameSpeed::from_name("fastest"), Some(GameSpeed::Fastest));
+        assert_eq!(GameSpeed::from_name("bogus"), None);
+        assert_eq!(GameSpeed::from_name(""), None);
+    }
+
+    #[test]
+    fn test_game_speed_display() {
+        assert_eq!(GameSpeed::Slow.to_string(), "Slow");
+        assert_eq!(GameSpeed::Normal.to_string(), "Normal");
+        assert_eq!(GameSpeed::Fast.to_string(), "Fast");
+        assert_eq!(GameSpeed::Fastest.to_string(), "Fastest");
+    }
+
+    #[test]
+    fn test_default_speed_is_normal() {
+        let clock = GameClock::new(game_time(2026, 6, 15, 12));
+        assert!((clock.speed_factor() - 36.0).abs() < f64::EPSILON);
+        assert_eq!(clock.current_speed(), Some(GameSpeed::Normal));
+    }
+
+    #[test]
+    fn test_set_speed_while_running() {
+        let mut clock = GameClock::new(game_time(2026, 6, 15, 12));
+        let time_before = clock.now();
+        clock.set_speed(GameSpeed::Fast);
+        assert!((clock.speed_factor() - 72.0).abs() < f64::EPSILON);
+        // Time should be continuous (not jump)
+        let time_after = clock.now();
+        let diff = (time_after - time_before).num_seconds().abs();
+        assert!(
+            diff < 2,
+            "Time should be nearly continuous after speed change"
+        );
+    }
+
+    #[test]
+    fn test_set_speed_while_paused() {
+        let mut clock = GameClock::new(game_time(2026, 6, 15, 12));
+        clock.pause();
+        let paused_time = clock.now();
+        clock.set_speed(GameSpeed::Fastest);
+        assert!((clock.speed_factor() - 144.0).abs() < f64::EPSILON);
+        // Paused time should not change
+        assert_eq!(clock.now(), paused_time);
+    }
+
+    #[test]
+    fn test_current_speed() {
+        let mut clock = GameClock::new(game_time(2026, 6, 15, 12));
+        assert_eq!(clock.current_speed(), Some(GameSpeed::Normal));
+
+        clock.set_speed(GameSpeed::Slow);
+        assert_eq!(clock.current_speed(), Some(GameSpeed::Slow));
+
+        clock.set_speed(GameSpeed::Fast);
+        assert_eq!(clock.current_speed(), Some(GameSpeed::Fast));
+
+        clock.set_speed(GameSpeed::Fastest);
+        assert_eq!(clock.current_speed(), Some(GameSpeed::Fastest));
+
+        // Custom speed returns None
+        let clock = GameClock::with_speed(game_time(2026, 6, 15, 12), 50.0);
+        assert_eq!(clock.current_speed(), None);
     }
 }

--- a/tests/fixtures/test_speed.txt
+++ b/tests/fixtures/test_speed.txt
@@ -1,0 +1,12 @@
+# Test speed commands
+/speed
+/speed slow
+/speed
+/speed fast
+/speed
+/speed normal
+/speed
+/speed fastest
+/speed
+/speed bogus
+/quit


### PR DESCRIPTION
The default speed factor was 72x (20 min/day), which felt too fast.
Halved it to 36x (40 min/day) and added /speed command with four
presets: slow (18x), normal (36x), fast (72x), fastest (144x).

The set_speed() method properly recalibrates the clock by snapshotting
current game time before applying the new factor, ensuring continuity.

https://claude.ai/code/session_015xjrCt3CgcWFUKkZhi2z8m