### PR TITLE
feat: per-category inference provider configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ src/
 ├── main.rs          # Entry point, CLI args (clap), mode routing
 ├── lib.rs           # Module declarations
 ├── error.rs         # ParishError (thiserror)
-├── config.rs        # Provider configuration (TOML + env + CLI)
+├── config.rs        # Provider configuration (TOML + env + CLI, per-category overrides)
 ├── headless.rs      # Headless stdin/stdout REPL mode
 ├── testing.rs       # GameTestHarness for automated testing
 ├── debug.rs         # Debug commands and metrics (feature-gated)
@@ -60,7 +60,7 @@ src/
 │   ├── memory.rs    #   ShortTermMemory (ring buffer)
 │   ├── overhear.rs  #   Atmospheric overhear for nearby Tier 2
 │   └── data.rs      #   NPC data loader (JSON)
-├── inference/       # LLM client (OpenAI-compatible), queue, Ollama bootstrap
+├── inference/       # LLM client (OpenAI-compatible), queue, per-category routing, Ollama bootstrap
 ├── persistence/     # SQLite save/load, WAL journal, branching saves
 │   ├── database.rs  #   Database + AsyncDatabase (schema, CRUD)
 │   ├── snapshot.rs  #   GameSnapshot, ClockSnapshot, NpcSnapshot

--- a/docs/adr/017-per-category-inference-providers.md
+++ b/docs/adr/017-per-category-inference-providers.md
@@ -1,0 +1,46 @@
+# ADR-017: Per-Category Inference Providers
+
+## Status
+
+Accepted
+
+## Context
+
+Parish has three distinct inference categories with different requirements:
+
+- **Dialogue** (Tier 1): Player-facing NPC conversation. Benefits from high-quality cloud models. Uses streaming.
+- **Simulation** (Tier 2): Background NPC group interactions. Runs frequently, tolerates lower quality. Non-streaming JSON.
+- **Intent**: Player input parsing. Needs low latency. Small structured JSON output.
+
+The previous dual-client architecture (ADR-013) only supported two tiers: a single local provider and an optional cloud provider for dialogue. Simulation and intent were always locked to the local provider. Users wanted flexibility to:
+
+- Run all categories on a remote server (no local GPU required)
+- Use different models per category (e.g., large model for dialogue, small for intent)
+- Mix local and cloud providers freely across categories
+
+## Decision
+
+Each inference category can independently configure its own provider, model, base URL, and API key. Unconfigured categories inherit from the base `[provider]` config.
+
+### Configuration layers (per category, later overrides earlier):
+
+1. Base `[provider]` config (fallback)
+2. TOML `[provider.<category>]` section
+3. `PARISH_<CATEGORY>_*` environment variables
+4. `--<category>-*` CLI flags
+5. Legacy `[cloud]` / `PARISH_CLOUD_*` / `--cloud-*` (dialogue only, lowest priority override)
+
+### New types:
+
+- `InferenceCategory` enum: `Dialogue`, `Simulation`, `Intent`
+- `CategoryConfig`: Resolved per-category provider config
+- `CliCategoryOverrides`: Per-category CLI flag overrides
+- `InferenceClients`: Refactored from dual local/cloud fields to a `HashMap<InferenceCategory, (Client, Model)>` with a base fallback
+
+## Consequences
+
+- Full flexibility: any category can use any OpenAI-compatible provider
+- Backward compatible: existing `[cloud]` config, `--cloud-*` flags, and `PARISH_CLOUD_*` env vars continue to work
+- The `InferenceClients` struct is now generic over categories rather than hardcoded to local/cloud
+- Adding new inference categories in the future requires only adding a variant to the enum
+- Slightly more complex configuration surface, but all overrides are optional

--- a/docs/adr/017-per-category-inference-providers.md
+++ b/docs/adr/017-per-category-inference-providers.md
@@ -30,6 +30,14 @@ Each inference category can independently configure its own provider, model, bas
 4. `--<category>-*` CLI flags
 5. Legacy `[cloud]` / `PARISH_CLOUD_*` / `--cloud-*` (dialogue only, lowest priority override)
 
+### Runtime slash commands (all modes):
+
+- `/model.<category> [name]` — Show or set model for a category
+- `/provider.<category> [name]` — Show or set provider for a category
+- `/key.<category> [value]` — Show or set API key for a category
+
+Where `<category>` is `dialogue`, `simulation`, or `intent`. The base `/model`, `/provider`, `/key` commands also display per-category overrides.
+
 ### New types:
 
 - `InferenceCategory` enum: `Dialogue`, `Simulation`, `Intent`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@ This directory contains Architecture Decision Records (ADRs) for the Parish proj
 | [014](014-web-mobile-architecture.md) | Web & Mobile Architecture | Accepted | 2026-03-23 |
 | [015](015-ambient-sound-system.md) | Ambient Sound System | Accepted | 2026-03-24 |
 | [016](016-tauri-svelte-gui.md) | Replace egui with Tauri 2 + Svelte GUI | Accepted | 2026-03-24 |
+| [017](017-per-category-inference-providers.md) | Per-Category Inference Providers | Accepted | 2026-03-23 |
 
 ## ADR Template
 

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -164,34 +164,44 @@ model = "anthropic/claude-sonnet-4-20250514"
 CLI: `--provider`, `--base-url`, `--api-key`, `--model`
 Env: `PARISH_PROVIDER`, `PARISH_BASE_URL`, `PARISH_API_KEY`, `PARISH_MODEL`
 
-### Dual-Client Architecture: Cloud Dialogue + Local Simulation
+### Per-Category Provider Routing
 
-Parish supports an optional **cloud LLM provider** for player-facing Tier 1 dialogue while keeping local inference for background NPC simulation and intent parsing (see [ADR-013](../adr/013-cloud-llm-dialogue.md)):
+Each inference category can use a different provider, model, and endpoint. Categories without explicit overrides inherit from the base `[provider]` config:
 
-| Inference Type | Client | Default |
+| Category | Purpose | Default |
 |---|---|---|
-| Tier 1 dialogue (player-facing) | Cloud (if configured) | Local fallback |
-| Tier 2 simulation (NPC background) | Local (always) | Ollama |
-| Intent parsing | Local (always) | Ollama |
+| **Dialogue** | Player-facing NPC conversation (Tier 1, streaming) | Base provider |
+| **Simulation** | Background NPC group interactions (Tier 2, JSON) | Base provider |
+| **Intent** | Player input parsing (JSON, low-latency) | Base provider |
 
-Cloud provider is configured independently via `[cloud]` TOML section:
+Per-category overrides in TOML:
 
 ```toml
 [provider]
 name = "ollama"
+model = "qwen3:14b"
 
-[cloud]
+[provider.dialogue]
 name = "openrouter"
+base_url = "https://openrouter.ai/api"
 api_key = "sk-or-..."
 model = "anthropic/claude-sonnet-4-20250514"
+
+[provider.simulation]
+model = "qwen3:8b"
+
+[provider.intent]
+model = "qwen3:1.5b"
 ```
 
-CLI: `--cloud-provider`, `--cloud-base-url`, `--cloud-api-key`, `--cloud-model`
-Env: `PARISH_CLOUD_PROVIDER`, `PARISH_CLOUD_BASE_URL`, `PARISH_CLOUD_API_KEY`, `PARISH_CLOUD_MODEL`
+Per-category CLI flags: `--dialogue-provider`, `--dialogue-model`, `--simulation-model`, `--intent-model`, etc.
+Per-category env vars: `PARISH_DIALOGUE_PROVIDER`, `PARISH_DIALOGUE_MODEL`, `PARISH_SIMULATION_MODEL`, `PARISH_INTENT_MODEL`, etc.
+
+**Legacy support**: The `[cloud]` TOML section, `--cloud-*` CLI flags, and `PARISH_CLOUD_*` env vars still work and map to the dialogue category. Explicit `[provider.dialogue]` overrides take precedence over `[cloud]`.
 
 Runtime commands: `/cloud`, `/cloud model <name>`, `/cloud key <key>`, `/cloud provider <name>`
 
-The `InferenceClients` struct (in `src/inference/mod.rs`) routes requests to the correct client via `dialogue_client()`, `simulation_client()`, and `intent_client()` methods.
+The `InferenceClients` struct (in `src/inference/mod.rs`) routes requests via `dialogue_client()`, `simulation_client()`, and `intent_client()` methods, falling back to the base provider when no per-category override exists.
 
 ### Ollama Bootstrap & GPU Detection (Default Path)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ High-level architecture and detailed subsystem designs. Start with [Architecture
 | [Player Input](design/player-input.md) | Natural language input, system commands | [ADR-006](adr/006-natural-language-input.md) |
 | [Persistence](design/persistence.md) | WAL journal, snapshots, branching saves | [ADR-003](adr/003-sqlite-wal-persistence.md), [ADR-004](adr/004-git-like-branching-saves.md) |
 | [NPC System](design/npc-system.md) | Entity model, context construction, gossip | [ADR-008](adr/008-structured-json-llm-output.md) |
-| [Inference Pipeline](design/inference-pipeline.md) | LLM integration, queue, model selection | [ADR-005](adr/005-ollama-local-inference.md), [ADR-010](adr/010-prompt-injection-defenses.md) |
+| [Inference Pipeline](design/inference-pipeline.md) | LLM integration, queue, model selection | [ADR-005](adr/005-ollama-local-inference.md), [ADR-010](adr/010-prompt-injection-defenses.md), [ADR-015](adr/015-per-category-inference-providers.md) |
 | [Debug System](design/debug-system.md) | Debug commands, live TUI panel, metrics (feature-gated) | — |
 | [Testing Harness](design/testing.md) | GameTestHarness, script mode, query APIs | — |
 | [Geo-Tool](design/geo-tool.md) | OSM geographic data conversion tool | [ADR-011](adr/011-geo-tool-osm-pipeline.md) |
@@ -66,6 +66,8 @@ Key decisions with rationale and alternatives considered. See [ADR Index](adr/RE
 | [013](adr/013-cloud-llm-dialogue.md) | Cloud LLM for player dialogue | Accepted |
 | [014](adr/014-web-mobile-architecture.md) | Web & mobile thin-client architecture | Accepted |
 | [015](adr/015-ambient-sound-system.md) | Ambient sound system via rodio (GUI-only) | Accepted |
+| [016](adr/016-tauri-svelte-gui.md) | Replace egui with Tauri 2 + Svelte GUI | Accepted |
+| [017](adr/017-per-category-inference-providers.md) | Per-category inference providers | Accepted |
 
 ## Requirements & Status
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,9 +3,15 @@
 //! Supports Ollama (local, default), LM Studio (local), OpenRouter (cloud),
 //! and custom OpenAI-compatible endpoints. Configuration is resolved from
 //! a TOML file, environment variables, and CLI flags (in that priority order).
+//!
+//! Each inference category (dialogue, simulation, intent) can be independently
+//! configured with its own provider, model, base URL, and API key via
+//! per-category TOML sections, environment variables, or CLI flags. Unconfigured
+//! categories inherit from the base `[provider]` config.
 
 use crate::error::ParishError;
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::path::Path;
 
 /// Default base URL for each provider.
@@ -66,6 +72,71 @@ impl Provider {
     pub fn requires_model(&self) -> bool {
         !matches!(self, Provider::Ollama)
     }
+}
+
+/// Inference categories that can each have independent provider configuration.
+///
+/// Each category can override the base `[provider]` config with its own
+/// provider, model, base URL, and API key. Unconfigured categories fall
+/// back to the base provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum InferenceCategory {
+    /// Player-facing NPC dialogue (Tier 1, streaming).
+    Dialogue,
+    /// Background NPC simulation (Tier 2, JSON).
+    Simulation,
+    /// Player input intent parsing (JSON, low-latency).
+    Intent,
+}
+
+impl InferenceCategory {
+    /// All defined inference categories.
+    pub const ALL: [InferenceCategory; 3] = [
+        InferenceCategory::Dialogue,
+        InferenceCategory::Simulation,
+        InferenceCategory::Intent,
+    ];
+
+    /// Returns the lowercase name used in TOML keys, env var prefixes, and CLI flags.
+    pub fn name(&self) -> &'static str {
+        match self {
+            InferenceCategory::Dialogue => "dialogue",
+            InferenceCategory::Simulation => "simulation",
+            InferenceCategory::Intent => "intent",
+        }
+    }
+
+    /// Returns the SCREAMING_CASE prefix used in environment variables.
+    fn env_prefix(&self) -> &'static str {
+        match self {
+            InferenceCategory::Dialogue => "PARISH_DIALOGUE",
+            InferenceCategory::Simulation => "PARISH_SIMULATION",
+            InferenceCategory::Intent => "PARISH_INTENT",
+        }
+    }
+}
+
+/// Resolved provider configuration for a single inference category.
+///
+/// Built by layering the base `[provider]` config with per-category
+/// overrides from TOML, environment variables, and CLI flags.
+#[derive(Debug, Clone)]
+pub struct CategoryConfig {
+    /// The provider backend for this category.
+    pub provider: Provider,
+    /// Base URL for the provider API.
+    pub base_url: String,
+    /// API key for authenticated providers.
+    pub api_key: Option<String>,
+    /// Model name. `None` for Ollama (auto-selected).
+    pub model: Option<String>,
+}
+
+/// CLI-provided overrides for per-category provider configuration.
+#[derive(Debug, Default)]
+pub struct CliCategoryOverrides {
+    /// Per-category CLI overrides keyed by category name.
+    pub categories: HashMap<String, CliOverrides>,
 }
 
 /// Resolved provider configuration ready for use.
@@ -133,6 +204,28 @@ struct TomlProvider {
     /// API key for cloud providers.
     api_key: Option<String>,
     /// Model name override.
+    model: Option<String>,
+    /// Per-category overrides: `[provider.dialogue]`, `[provider.simulation]`, `[provider.intent]`.
+    #[serde(default)]
+    dialogue: Option<TomlCategoryOverride>,
+    /// Per-category override for simulation.
+    #[serde(default)]
+    simulation: Option<TomlCategoryOverride>,
+    /// Per-category override for intent parsing.
+    #[serde(default)]
+    intent: Option<TomlCategoryOverride>,
+}
+
+/// Per-category provider override in TOML (e.g. `[provider.dialogue]`).
+#[derive(Debug, Deserialize, Default, Clone)]
+struct TomlCategoryOverride {
+    /// Provider name override for this category.
+    name: Option<String>,
+    /// Base URL override for this category.
+    base_url: Option<String>,
+    /// API key override for this category.
+    api_key: Option<String>,
+    /// Model name override for this category.
     model: Option<String>,
 }
 
@@ -380,9 +473,237 @@ pub fn resolve_cloud_config(
     }))
 }
 
+/// Resolves per-category provider configurations.
+///
+/// For each [`InferenceCategory`], layers overrides on top of the base
+/// [`ProviderConfig`]:
+/// 1. Start with the base provider config as defaults
+/// 2. Layer TOML `[provider.<category>]` overrides
+/// 3. Layer `PARISH_<CATEGORY>_*` environment variables
+/// 4. Layer per-category CLI flags
+/// 5. For dialogue only: fall back to legacy `[cloud]` / `PARISH_CLOUD_*` / `--cloud-*`
+///
+/// Returns a map from category to resolved [`CategoryConfig`]. Categories with
+/// no overrides are omitted (callers should fall back to the base config).
+pub fn resolve_category_configs(
+    config_path: Option<&Path>,
+    base: &ProviderConfig,
+    cli_categories: &CliCategoryOverrides,
+    cli_cloud: &CliCloudOverrides,
+) -> Result<HashMap<InferenceCategory, CategoryConfig>, ParishError> {
+    let toml_cfg = load_toml(config_path)?;
+    let mut result = HashMap::new();
+
+    for category in InferenceCategory::ALL {
+        // Get the TOML override for this category
+        let toml_override = match category {
+            InferenceCategory::Dialogue => toml_cfg.provider.dialogue.clone(),
+            InferenceCategory::Simulation => toml_cfg.provider.simulation.clone(),
+            InferenceCategory::Intent => toml_cfg.provider.intent.clone(),
+        };
+
+        // Get CLI overrides for this category
+        let cli_override = cli_categories.categories.get(category.name());
+
+        // Check if there are any overrides at all for this category
+        let has_toml = toml_override.as_ref().is_some_and(|t| {
+            t.name.is_some() || t.base_url.is_some() || t.api_key.is_some() || t.model.is_some()
+        });
+        let has_env = env_non_empty(&format!("{}_PROVIDER", category.env_prefix())).is_some()
+            || env_non_empty(&format!("{}_BASE_URL", category.env_prefix())).is_some()
+            || env_non_empty(&format!("{}_API_KEY", category.env_prefix())).is_some()
+            || env_non_empty(&format!("{}_MODEL", category.env_prefix())).is_some();
+        let has_cli = cli_override.is_some_and(|c| {
+            c.provider.is_some() || c.base_url.is_some() || c.api_key.is_some() || c.model.is_some()
+        });
+
+        // For dialogue: also check legacy [cloud] config
+        let has_legacy_cloud = category == InferenceCategory::Dialogue
+            && (toml_cfg.cloud.name.is_some()
+                || toml_cfg.cloud.base_url.is_some()
+                || toml_cfg.cloud.api_key.is_some()
+                || toml_cfg.cloud.model.is_some()
+                || env_non_empty("PARISH_CLOUD_PROVIDER").is_some()
+                || env_non_empty("PARISH_CLOUD_BASE_URL").is_some()
+                || env_non_empty("PARISH_CLOUD_API_KEY").is_some()
+                || env_non_empty("PARISH_CLOUD_MODEL").is_some()
+                || cli_cloud.provider.is_some()
+                || cli_cloud.base_url.is_some()
+                || cli_cloud.api_key.is_some()
+                || cli_cloud.model.is_some());
+
+        if !has_toml && !has_env && !has_cli && !has_legacy_cloud {
+            continue;
+        }
+
+        // Start from base config
+        let mut provider_str: Option<String> = None;
+        let mut cat_base_url: Option<String> = None;
+        let mut cat_api_key: Option<String> = base.api_key.clone();
+        let mut cat_model: Option<String> = base.model.clone();
+
+        // Layer 1: Legacy [cloud] for dialogue (lowest priority override)
+        if category == InferenceCategory::Dialogue {
+            if let Some(ref name) = toml_cfg.cloud.name {
+                provider_str = Some(name.clone());
+            }
+            if let Some(ref url) = toml_cfg.cloud.base_url {
+                cat_base_url = Some(url.clone());
+            }
+            if let Some(ref key) = toml_cfg.cloud.api_key {
+                cat_api_key = Some(key.clone());
+            }
+            if let Some(ref m) = toml_cfg.cloud.model {
+                cat_model = Some(m.clone());
+            }
+            // Legacy cloud env vars
+            if let Some(val) = env_non_empty("PARISH_CLOUD_PROVIDER") {
+                provider_str = Some(val);
+            }
+            if let Some(val) = env_non_empty("PARISH_CLOUD_BASE_URL") {
+                cat_base_url = Some(val);
+            }
+            if let Some(val) = env_non_empty("PARISH_CLOUD_API_KEY") {
+                cat_api_key = Some(val);
+            }
+            if let Some(val) = env_non_empty("PARISH_CLOUD_MODEL") {
+                cat_model = Some(val);
+            }
+            // Legacy cloud CLI flags
+            if let Some(ref val) = cli_cloud.provider {
+                provider_str = Some(val.clone());
+            }
+            if let Some(ref val) = cli_cloud.base_url {
+                cat_base_url = Some(val.clone());
+            }
+            if let Some(ref val) = cli_cloud.api_key {
+                cat_api_key = Some(val.clone());
+            }
+            if let Some(ref val) = cli_cloud.model {
+                cat_model = Some(val.clone());
+            }
+        }
+
+        // Layer 2: TOML [provider.<category>] overrides legacy cloud
+        if let Some(ref toml_ov) = toml_override {
+            if let Some(ref name) = toml_ov.name {
+                provider_str = Some(name.clone());
+            }
+            if let Some(ref url) = toml_ov.base_url {
+                cat_base_url = Some(url.clone());
+            }
+            if let Some(ref key) = toml_ov.api_key {
+                cat_api_key = Some(key.clone());
+            }
+            if let Some(ref m) = toml_ov.model {
+                cat_model = Some(m.clone());
+            }
+        }
+
+        // Layer 3: Per-category env vars
+        let prefix = category.env_prefix();
+        if let Some(val) = env_non_empty(&format!("{prefix}_PROVIDER")) {
+            provider_str = Some(val);
+        }
+        if let Some(val) = env_non_empty(&format!("{prefix}_BASE_URL")) {
+            cat_base_url = Some(val);
+        }
+        if let Some(val) = env_non_empty(&format!("{prefix}_API_KEY")) {
+            cat_api_key = Some(val);
+        }
+        if let Some(val) = env_non_empty(&format!("{prefix}_MODEL")) {
+            cat_model = Some(val);
+        }
+
+        // Layer 4: Per-category CLI flags
+        if let Some(cli_ov) = cli_override {
+            if let Some(ref val) = cli_ov.provider {
+                provider_str = Some(val.clone());
+            }
+            if let Some(ref val) = cli_ov.base_url {
+                cat_base_url = Some(val.clone());
+            }
+            if let Some(ref val) = cli_ov.api_key {
+                cat_api_key = Some(val.clone());
+            }
+            if let Some(ref val) = cli_ov.model {
+                cat_model = Some(val.clone());
+            }
+        }
+
+        // Resolve provider: if overridden use that, else inherit base
+        let provider = match &provider_str {
+            Some(s) => Provider::from_str_loose(s)?,
+            None => base.provider.clone(),
+        };
+
+        // Resolve base URL: if overridden use that, else use provider default or base
+        let resolved_base_url = match cat_base_url {
+            Some(url) if !url.is_empty() => url,
+            _ => {
+                if provider_str.is_some() {
+                    // Provider was overridden, use its default URL
+                    provider.default_base_url().to_string()
+                } else {
+                    base.base_url.clone()
+                }
+            }
+        };
+
+        // Filter empty strings
+        let cat_api_key = cat_api_key.filter(|s| !s.is_empty());
+        let cat_model = cat_model.filter(|s| !s.is_empty());
+
+        // Validate
+        if provider.requires_api_key() && cat_api_key.is_none() {
+            return Err(ParishError::Config(format!(
+                "{} {:?} provider requires an API key. Set {}_API_KEY or --{}-api-key.",
+                category.name(),
+                provider,
+                prefix,
+                category.name()
+            )));
+        }
+        if provider == Provider::Custom && resolved_base_url.is_empty() {
+            return Err(ParishError::Config(format!(
+                "{} custom provider requires a base_url. Set {}_BASE_URL or --{}-base-url.",
+                category.name(),
+                prefix,
+                category.name()
+            )));
+        }
+
+        result.insert(
+            category,
+            CategoryConfig {
+                provider,
+                base_url: resolved_base_url,
+                api_key: cat_api_key,
+                model: cat_model,
+            },
+        );
+    }
+
+    Ok(result)
+}
+
 /// Returns the value of an environment variable if it exists and is non-empty.
 fn env_non_empty(key: &str) -> Option<String> {
     std::env::var(key).ok().filter(|v| !v.is_empty())
+}
+
+/// Loads the TOML config from the given path or default location.
+fn load_toml(config_path: Option<&Path>) -> Result<TomlConfig, ParishError> {
+    if let Some(path) = config_path {
+        read_toml_config(path)
+    } else {
+        let cwd_path = Path::new("parish.toml");
+        if cwd_path.exists() {
+            read_toml_config(cwd_path)
+        } else {
+            Ok(TomlConfig::default())
+        }
+    }
 }
 
 /// Reads and parses a TOML config file. Returns default config if file doesn't exist.
@@ -425,6 +746,13 @@ mod tests {
             std::env::remove_var("PARISH_CLOUD_BASE_URL");
             std::env::remove_var("PARISH_CLOUD_API_KEY");
             std::env::remove_var("PARISH_CLOUD_MODEL");
+            // Per-category env vars
+            for cat in &["DIALOGUE", "SIMULATION", "INTENT"] {
+                std::env::remove_var(format!("PARISH_{cat}_PROVIDER"));
+                std::env::remove_var(format!("PARISH_{cat}_BASE_URL"));
+                std::env::remove_var(format!("PARISH_{cat}_API_KEY"));
+                std::env::remove_var(format!("PARISH_{cat}_MODEL"));
+            }
         }
     }
 
@@ -808,5 +1136,253 @@ model = "toml-model"
         assert_eq!(config.provider, Provider::Ollama);
         assert_eq!(config.base_url, "http://remote-ollama:11434");
         assert_eq!(config.model, "llama3");
+    }
+
+    // --- Per-category config tests ---
+
+    #[test]
+    fn test_category_names() {
+        assert_eq!(InferenceCategory::Dialogue.name(), "dialogue");
+        assert_eq!(InferenceCategory::Simulation.name(), "simulation");
+        assert_eq!(InferenceCategory::Intent.name(), "intent");
+    }
+
+    #[test]
+    fn test_resolve_category_configs_empty_when_no_overrides() {
+        clear_parish_env();
+        let base = ProviderConfig {
+            provider: Provider::Ollama,
+            base_url: "http://localhost:11434".to_string(),
+            api_key: None,
+            model: Some("qwen3:14b".to_string()),
+        };
+        let cli_cat = CliCategoryOverrides::default();
+        let cli_cloud = CliCloudOverrides::default();
+        let configs =
+            resolve_category_configs(Some(Path::new("/nonexistent")), &base, &cli_cat, &cli_cloud)
+                .unwrap();
+        assert!(configs.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_category_configs_from_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("parish.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"
+[provider]
+name = "ollama"
+model = "qwen3:14b"
+
+[provider.dialogue]
+name = "openrouter"
+base_url = "https://openrouter.ai/api"
+api_key = "sk-cat-test"
+model = "anthropic/claude-sonnet-4-20250514"
+
+[provider.intent]
+model = "qwen3:1.5b"
+"#
+        )
+        .unwrap();
+
+        clear_parish_env();
+        let base = ProviderConfig {
+            provider: Provider::Ollama,
+            base_url: "http://localhost:11434".to_string(),
+            api_key: None,
+            model: Some("qwen3:14b".to_string()),
+        };
+        let cli_cat = CliCategoryOverrides::default();
+        let cli_cloud = CliCloudOverrides::default();
+        let configs = resolve_category_configs(Some(&path), &base, &cli_cat, &cli_cloud).unwrap();
+
+        // Dialogue should be overridden to OpenRouter
+        let dialogue = configs.get(&InferenceCategory::Dialogue).unwrap();
+        assert_eq!(dialogue.provider, Provider::OpenRouter);
+        assert_eq!(dialogue.base_url, "https://openrouter.ai/api");
+        assert_eq!(dialogue.api_key.as_deref(), Some("sk-cat-test"));
+        assert_eq!(
+            dialogue.model.as_deref(),
+            Some("anthropic/claude-sonnet-4-20250514")
+        );
+
+        // Intent should inherit Ollama but override model
+        let intent = configs.get(&InferenceCategory::Intent).unwrap();
+        assert_eq!(intent.provider, Provider::Ollama);
+        assert_eq!(intent.base_url, "http://localhost:11434");
+        assert_eq!(intent.model.as_deref(), Some("qwen3:1.5b"));
+
+        // Simulation should not be present (no overrides)
+        assert!(!configs.contains_key(&InferenceCategory::Simulation));
+    }
+
+    #[test]
+    fn test_resolve_category_configs_legacy_cloud_maps_to_dialogue() {
+        clear_parish_env();
+        let base = ProviderConfig {
+            provider: Provider::Ollama,
+            base_url: "http://localhost:11434".to_string(),
+            api_key: None,
+            model: Some("qwen3:14b".to_string()),
+        };
+        let cli_cat = CliCategoryOverrides::default();
+        let cli_cloud = CliCloudOverrides {
+            provider: Some("openrouter".to_string()),
+            base_url: None,
+            api_key: Some("sk-legacy".to_string()),
+            model: Some("gpt-4".to_string()),
+        };
+        let configs =
+            resolve_category_configs(Some(Path::new("/nonexistent")), &base, &cli_cat, &cli_cloud)
+                .unwrap();
+
+        let dialogue = configs.get(&InferenceCategory::Dialogue).unwrap();
+        assert_eq!(dialogue.provider, Provider::OpenRouter);
+        assert_eq!(dialogue.api_key.as_deref(), Some("sk-legacy"));
+        assert_eq!(dialogue.model.as_deref(), Some("gpt-4"));
+    }
+
+    #[test]
+    fn test_resolve_category_configs_toml_overrides_legacy_cloud() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("parish.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"
+[provider]
+name = "ollama"
+
+[cloud]
+name = "openrouter"
+api_key = "sk-cloud-legacy"
+model = "legacy-model"
+
+[provider.dialogue]
+name = "custom"
+base_url = "https://my-api.example.com"
+api_key = "sk-new"
+model = "new-model"
+"#
+        )
+        .unwrap();
+
+        clear_parish_env();
+        let base = ProviderConfig {
+            provider: Provider::Ollama,
+            base_url: "http://localhost:11434".to_string(),
+            api_key: None,
+            model: None,
+        };
+        let cli_cat = CliCategoryOverrides::default();
+        let cli_cloud = CliCloudOverrides::default();
+        let configs = resolve_category_configs(Some(&path), &base, &cli_cat, &cli_cloud).unwrap();
+
+        // [provider.dialogue] should override [cloud]
+        let dialogue = configs.get(&InferenceCategory::Dialogue).unwrap();
+        assert_eq!(dialogue.provider, Provider::Custom);
+        assert_eq!(dialogue.base_url, "https://my-api.example.com");
+        assert_eq!(dialogue.api_key.as_deref(), Some("sk-new"));
+        assert_eq!(dialogue.model.as_deref(), Some("new-model"));
+    }
+
+    #[test]
+    fn test_resolve_category_configs_cli_overrides() {
+        clear_parish_env();
+        let base = ProviderConfig {
+            provider: Provider::Ollama,
+            base_url: "http://localhost:11434".to_string(),
+            api_key: None,
+            model: Some("qwen3:14b".to_string()),
+        };
+        let mut categories = HashMap::new();
+        categories.insert(
+            "simulation".to_string(),
+            CliOverrides {
+                provider: Some("openrouter".to_string()),
+                base_url: None,
+                api_key: Some("sk-sim".to_string()),
+                model: Some("sim-model".to_string()),
+            },
+        );
+        let cli_cat = CliCategoryOverrides { categories };
+        let cli_cloud = CliCloudOverrides::default();
+        let configs =
+            resolve_category_configs(Some(Path::new("/nonexistent")), &base, &cli_cat, &cli_cloud)
+                .unwrap();
+
+        let sim = configs.get(&InferenceCategory::Simulation).unwrap();
+        assert_eq!(sim.provider, Provider::OpenRouter);
+        assert_eq!(sim.base_url, "https://openrouter.ai/api");
+        assert_eq!(sim.api_key.as_deref(), Some("sk-sim"));
+        assert_eq!(sim.model.as_deref(), Some("sim-model"));
+    }
+
+    #[test]
+    fn test_resolve_category_configs_validates_api_key() {
+        clear_parish_env();
+        let base = ProviderConfig {
+            provider: Provider::Ollama,
+            base_url: "http://localhost:11434".to_string(),
+            api_key: None,
+            model: None,
+        };
+        let mut categories = HashMap::new();
+        categories.insert(
+            "intent".to_string(),
+            CliOverrides {
+                provider: Some("openrouter".to_string()),
+                base_url: None,
+                api_key: None,
+                model: Some("model".to_string()),
+            },
+        );
+        let cli_cat = CliCategoryOverrides { categories };
+        let cli_cloud = CliCloudOverrides::default();
+        let result =
+            resolve_category_configs(Some(Path::new("/nonexistent")), &base, &cli_cat, &cli_cloud);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("intent"), "got: {}", err_msg);
+        assert!(err_msg.contains("API key"), "got: {}", err_msg);
+    }
+
+    #[test]
+    fn test_resolve_category_configs_inherits_base_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("parish.toml");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"
+[provider]
+name = "ollama"
+base_url = "http://remote-ollama:11434"
+
+[provider.simulation]
+model = "qwen3:8b"
+"#
+        )
+        .unwrap();
+
+        clear_parish_env();
+        let base = ProviderConfig {
+            provider: Provider::Ollama,
+            base_url: "http://remote-ollama:11434".to_string(),
+            api_key: None,
+            model: Some("qwen3:14b".to_string()),
+        };
+        let cli_cat = CliCategoryOverrides::default();
+        let cli_cloud = CliCloudOverrides::default();
+        let configs = resolve_category_configs(Some(&path), &base, &cli_cat, &cli_cloud).unwrap();
+
+        let sim = configs.get(&InferenceCategory::Simulation).unwrap();
+        assert_eq!(sim.provider, Provider::Ollama);
+        // Should inherit the base URL since provider wasn't overridden
+        assert_eq!(sim.base_url, "http://remote-ollama:11434");
+        assert_eq!(sim.model.as_deref(), Some("qwen3:8b"));
     }
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -93,6 +93,22 @@ pub struct GuiApp {
     pub intent_client: Option<OpenAiClient>,
     /// The model name for intent parsing.
     pub intent_model: String,
+    /// Provider name for intent category (None = inherits base).
+    pub intent_provider_name: Option<String>,
+    /// API key for intent category.
+    pub intent_api_key: Option<String>,
+    /// Base URL for intent category.
+    pub intent_base_url: Option<String>,
+    /// The LLM client for simulation (may differ from base client).
+    pub simulation_client: Option<OpenAiClient>,
+    /// The model name for simulation.
+    pub simulation_model: String,
+    /// Provider name for simulation category (None = inherits base).
+    pub simulation_provider_name: Option<String>,
+    /// API key for simulation category.
+    pub simulation_api_key: Option<String>,
+    /// Base URL for simulation category.
+    pub simulation_base_url: Option<String>,
     /// Whether improv craft mode is enabled.
     pub improv_enabled: bool,
     /// Irish pronunciation hints from NPC responses.
@@ -172,6 +188,14 @@ impl GuiApp {
             dialogue_model: String::new(),
             intent_client: None,
             intent_model: String::new(),
+            intent_provider_name: None,
+            intent_api_key: None,
+            intent_base_url: None,
+            simulation_client: None,
+            simulation_model: String::new(),
+            simulation_provider_name: None,
+            simulation_api_key: None,
+            simulation_base_url: None,
             improv_enabled: false,
             pronunciation_hints: Vec::new(),
             debug_log: VecDeque::with_capacity(DEBUG_LOG_CAPACITY),
@@ -194,6 +218,107 @@ impl GuiApp {
             active_branch_id: 1,
             latest_snapshot_id: 0,
             last_autosave: None,
+        }
+    }
+
+    /// Returns the provider name for a given inference category (or None if inheriting base).
+    pub fn category_provider_name(&self, cat: crate::config::InferenceCategory) -> Option<&str> {
+        use crate::config::InferenceCategory;
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_provider_name.as_deref(),
+            InferenceCategory::Simulation => self.simulation_provider_name.as_deref(),
+            InferenceCategory::Intent => self.intent_provider_name.as_deref(),
+        }
+    }
+
+    /// Returns the model name for a given inference category.
+    pub fn category_model(&self, cat: crate::config::InferenceCategory) -> &str {
+        use crate::config::InferenceCategory;
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_model_name.as_deref().unwrap_or(""),
+            InferenceCategory::Simulation => &self.simulation_model,
+            InferenceCategory::Intent => &self.intent_model,
+        }
+    }
+
+    /// Returns the API key for a given inference category.
+    pub fn category_api_key(&self, cat: crate::config::InferenceCategory) -> Option<&str> {
+        use crate::config::InferenceCategory;
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_api_key.as_deref(),
+            InferenceCategory::Simulation => self.simulation_api_key.as_deref(),
+            InferenceCategory::Intent => self.intent_api_key.as_deref(),
+        }
+    }
+
+    /// Returns the base URL for a given inference category.
+    pub fn category_base_url(&self, cat: crate::config::InferenceCategory) -> Option<&str> {
+        use crate::config::InferenceCategory;
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_base_url.as_deref(),
+            InferenceCategory::Simulation => self.simulation_base_url.as_deref(),
+            InferenceCategory::Intent => self.intent_base_url.as_deref(),
+        }
+    }
+
+    /// Sets the provider name for a given inference category.
+    pub fn set_category_provider_name(
+        &mut self,
+        cat: crate::config::InferenceCategory,
+        name: String,
+    ) {
+        use crate::config::InferenceCategory;
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_provider_name = Some(name),
+            InferenceCategory::Simulation => self.simulation_provider_name = Some(name),
+            InferenceCategory::Intent => self.intent_provider_name = Some(name),
+        }
+    }
+
+    /// Sets the model name for a given inference category.
+    pub fn set_category_model(&mut self, cat: crate::config::InferenceCategory, model: String) {
+        use crate::config::InferenceCategory;
+        match cat {
+            InferenceCategory::Dialogue => {
+                self.cloud_model_name = Some(model.clone());
+                self.dialogue_model = model;
+            }
+            InferenceCategory::Simulation => self.simulation_model = model,
+            InferenceCategory::Intent => self.intent_model = model,
+        }
+    }
+
+    /// Sets the API key for a given inference category.
+    pub fn set_category_api_key(&mut self, cat: crate::config::InferenceCategory, key: String) {
+        use crate::config::InferenceCategory;
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_api_key = Some(key),
+            InferenceCategory::Simulation => self.simulation_api_key = Some(key),
+            InferenceCategory::Intent => self.intent_api_key = Some(key),
+        }
+    }
+
+    /// Sets the base URL for a given inference category.
+    pub fn set_category_base_url(&mut self, cat: crate::config::InferenceCategory, url: String) {
+        use crate::config::InferenceCategory;
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_base_url = Some(url),
+            InferenceCategory::Simulation => self.simulation_base_url = Some(url),
+            InferenceCategory::Intent => self.intent_base_url = Some(url),
+        }
+    }
+
+    /// Sets the client for a given inference category.
+    pub fn set_category_client(
+        &mut self,
+        cat: crate::config::InferenceCategory,
+        client: OpenAiClient,
+    ) {
+        use crate::config::InferenceCategory;
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_client = Some(client),
+            InferenceCategory::Simulation => self.simulation_client = Some(client),
+            InferenceCategory::Intent => self.intent_client = Some(client),
         }
     }
 
@@ -781,6 +906,86 @@ impl GuiApp {
                     Some(OpenAiClient::new(base_url, self.cloud_api_key.as_deref()));
                 rebuild = true;
                 self.world.log("Cloud API key updated.".to_string());
+            }
+            Command::ShowCategoryProvider(cat) => {
+                if let Some(provider) = self.category_provider_name(cat) {
+                    self.world
+                        .log(format!("{} provider: {}", cat.name(), provider));
+                } else {
+                    self.world.log(format!(
+                        "{} provider: (inherits base: {})",
+                        cat.name(),
+                        self.provider_name
+                    ));
+                }
+            }
+            Command::SetCategoryProvider(cat, name) => {
+                match crate::config::Provider::from_str_loose(&name) {
+                    Ok(provider) => {
+                        let base_url = provider.default_base_url().to_string();
+                        let provider_name = format!("{:?}", provider).to_lowercase();
+                        let api_key = self.category_api_key(cat).map(|s| s.to_string());
+                        self.set_category_provider_name(cat, provider_name.clone());
+                        self.set_category_base_url(cat, base_url.clone());
+                        self.set_category_client(
+                            cat,
+                            OpenAiClient::new(&base_url, api_key.as_deref()),
+                        );
+                        rebuild = true;
+                        self.world.log(format!(
+                            "{} provider changed to {}.",
+                            cat.name(),
+                            provider_name
+                        ));
+                    }
+                    Err(e) => {
+                        self.world.log(format!("{}", e));
+                    }
+                }
+            }
+            Command::ShowCategoryModel(cat) => {
+                let model = self.category_model(cat);
+                if model.is_empty() {
+                    self.world.log(format!(
+                        "{} model: (inherits base: {})",
+                        cat.name(),
+                        self.model_name
+                    ));
+                } else {
+                    self.world.log(format!("{} model: {}", cat.name(), model));
+                }
+            }
+            Command::SetCategoryModel(cat, name) => {
+                let cat_name = cat.name();
+                self.set_category_model(cat, name.clone());
+                self.world
+                    .log(format!("{} model changed to {}.", cat_name, name));
+            }
+            Command::ShowCategoryKey(cat) => match self.category_api_key(cat) {
+                Some(key) if key.len() > 8 => {
+                    let masked = format!("{}...{}", &key[..4], &key[key.len() - 4..]);
+                    self.world
+                        .log(format!("{} API key: {}", cat.name(), masked));
+                }
+                Some(_) => {
+                    self.world
+                        .log(format!("{} API key: (set, too short to mask)", cat.name()));
+                }
+                None => {
+                    self.world.log(format!("{} API key: (not set)", cat.name()));
+                }
+            },
+            Command::SetCategoryKey(cat, value) => {
+                let cat_name = cat.name();
+                self.set_category_api_key(cat, value);
+                let base_url = self
+                    .category_base_url(cat)
+                    .unwrap_or(&self.base_url)
+                    .to_string();
+                let api_key = self.category_api_key(cat).map(|s| s.to_string());
+                self.set_category_client(cat, OpenAiClient::new(&base_url, api_key.as_deref()));
+                rebuild = true;
+                self.world.log(format!("{} API key updated.", cat_name));
             }
         }
         self.world.log(String::new());

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -89,6 +89,10 @@ pub struct GuiApp {
     pub cloud_base_url: Option<String>,
     /// The model name used by the dialogue inference queue.
     pub dialogue_model: String,
+    /// The LLM client for intent parsing (may differ from base client).
+    pub intent_client: Option<OpenAiClient>,
+    /// The model name for intent parsing.
+    pub intent_model: String,
     /// Whether improv craft mode is enabled.
     pub improv_enabled: bool,
     /// Irish pronunciation hints from NPC responses.
@@ -166,6 +170,8 @@ impl GuiApp {
             cloud_api_key: None,
             cloud_base_url: None,
             dialogue_model: String::new(),
+            intent_client: None,
+            intent_model: String::new(),
             improv_enabled: false,
             pronunciation_hints: Vec::new(),
             debug_log: VecDeque::with_capacity(DEBUG_LOG_CAPACITY),
@@ -1139,19 +1145,29 @@ pub fn run_gui(
     }
 
     app.inference_queue = Some(queue);
-    app.client = Some(clients.local.clone());
-    app.model_name = clients.local_model.clone();
+    app.client = Some(clients.base.clone());
+    app.model_name = clients.base_model.clone();
     app.dialogue_model = dialogue_model;
     app.provider_name = format!("{:?}", config.provider).to_lowercase();
     app.base_url = config.base_url.clone();
     app.api_key = config.api_key.clone();
     app.improv_enabled = improv;
 
-    // Set cloud fields if configured
-    if let Some(cc) = cloud_config {
+    // Set intent client/model
+    let (intent_cl, intent_mdl) = clients.intent_client();
+    app.intent_client = Some(intent_cl.clone());
+    app.intent_model = intent_mdl.to_string();
+
+    // Set cloud/dialogue fields if configured
+    if clients.has_custom_dialogue() {
+        let (dial_cl, dial_mdl) = clients.dialogue_client();
+        app.cloud_client = Some(dial_cl.clone());
+        app.cloud_model_name = Some(dial_mdl.to_string());
+    } else if let Some(cc) = cloud_config {
         app.cloud_provider_name = Some(format!("{:?}", cc.provider).to_lowercase());
         app.cloud_model_name = Some(cc.model.clone());
-        app.cloud_client = clients.cloud.clone();
+        let (dial_cl, _) = clients.dialogue_client();
+        app.cloud_client = Some(dial_cl.clone());
         app.cloud_api_key = cc.api_key.clone();
         app.cloud_base_url = Some(cc.base_url.clone());
     }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -4,7 +4,7 @@
 //! (NPC inference, intent parsing, system commands) as the TUI mode.
 //! Activated with `--headless` on the command line.
 
-use crate::config::{CloudConfig, Provider, ProviderConfig};
+use crate::config::{CategoryConfig, CloudConfig, InferenceCategory, Provider, ProviderConfig};
 use crate::inference::openai_client::OpenAiClient;
 use crate::inference::{self, InferenceClients, InferenceQueue};
 use crate::input::{Command, InputResult, classify_input, parse_intent};
@@ -18,6 +18,7 @@ use crate::tui::App;
 use crate::world::description::{format_exits, render_description};
 use crate::world::movement::{self, MovementResult};
 use anyhow::Result;
+use std::collections::HashMap;
 use std::io::{BufRead, Write};
 use std::path::Path;
 use std::sync::Arc;
@@ -35,6 +36,7 @@ pub async fn run_headless(
     clients: InferenceClients,
     provider_config: &ProviderConfig,
     cloud_config: Option<&CloudConfig>,
+    category_configs: &HashMap<InferenceCategory, CategoryConfig>,
     improv: bool,
 ) -> Result<()> {
     println!("=== Parish — Headless Mode ===");
@@ -80,6 +82,23 @@ pub async fn run_headless(
     let (intent_cl, intent_mdl) = clients.intent_client();
     app.intent_client = Some(intent_cl.clone());
     app.intent_model = intent_mdl.to_string();
+
+    // Set simulation client/model
+    let (sim_cl, sim_mdl) = clients.simulation_client();
+    app.simulation_client = Some(sim_cl.clone());
+    app.simulation_model = sim_mdl.to_string();
+
+    // Initialize per-category provider metadata from config
+    if let Some(cat_cfg) = category_configs.get(&InferenceCategory::Intent) {
+        app.intent_provider_name = Some(format!("{:?}", cat_cfg.provider).to_lowercase());
+        app.intent_api_key = cat_cfg.api_key.clone();
+        app.intent_base_url = Some(cat_cfg.base_url.clone());
+    }
+    if let Some(cat_cfg) = category_configs.get(&InferenceCategory::Simulation) {
+        app.simulation_provider_name = Some(format!("{:?}", cat_cfg.provider).to_lowercase());
+        app.simulation_api_key = cat_cfg.api_key.clone();
+        app.simulation_base_url = Some(cat_cfg.base_url.clone());
+    }
 
     // Set cloud/dialogue fields if configured
     if clients.has_custom_dialogue() {
@@ -332,10 +351,15 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             println!("  /status   - Where am I?");
             println!("  /irish    - Toggle Irish words sidebar (TUI only)");
             println!("  /improv   - Toggle improv craft for NPC dialogue");
-            println!("  /provider - Show or change local LLM provider");
-            println!("  /model    - Show or change local model name");
-            println!("  /key      - Show or change local API key");
-            println!("  /cloud    - Show or change cloud dialogue provider");
+            println!("  /provider - Show or change base LLM provider");
+            println!("  /model    - Show or change base model name");
+            println!("  /key      - Show or change base API key");
+            println!("  /cloud    - Show or change cloud dialogue provider (legacy)");
+            println!(
+                "  /model.<cat>    - Show or change model for a category (dialogue/simulation/intent)"
+            );
+            println!("  /provider.<cat> - Show or change provider for a category");
+            println!("  /key.<cat>      - Show or change API key for a category");
             println!("  /help     - Show this help");
             println!("  /save     - Save game");
             println!("  /fork <n> - Fork a new timeline branch");
@@ -355,10 +379,11 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             }
         }
         Command::ShowProvider => {
-            if let Some(ref cloud) = app.cloud_provider_name {
-                println!("Local: {} | Cloud: {}", app.provider_name, cloud);
-            } else {
-                println!("Provider: {}", app.provider_name);
+            println!("Base: {}", app.provider_name);
+            for cat in InferenceCategory::ALL {
+                if let Some(provider) = app.category_provider_name(cat) {
+                    println!("  {}: {}", cat.name(), provider);
+                }
             }
         }
         Command::SetProvider(name) => match Provider::from_str_loose(&name) {
@@ -375,9 +400,15 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
         },
         Command::ShowModel => {
             if app.model_name.is_empty() {
-                println!("Model: (auto-detect)");
+                println!("Base model: (auto-detect)");
             } else {
-                println!("Model: {}", app.model_name);
+                println!("Base model: {}", app.model_name);
+            }
+            for cat in InferenceCategory::ALL {
+                let model = app.category_model(cat);
+                if !model.is_empty() {
+                    println!("  {}: {}", cat.name(), model);
+                }
             }
         }
         Command::SetModel(name) => {
@@ -616,6 +647,66 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             app.cloud_client = Some(OpenAiClient::new(base_url, app.cloud_api_key.as_deref()));
             rebuild = true;
             println!("Cloud API key updated.");
+        }
+        Command::ShowCategoryProvider(cat) => {
+            let name = cat.name();
+            if let Some(provider) = app.category_provider_name(cat) {
+                println!("{} provider: {}", name, provider);
+            } else {
+                println!("{} provider: (inherits base: {})", name, app.provider_name);
+            }
+        }
+        Command::SetCategoryProvider(cat, name) => match Provider::from_str_loose(&name) {
+            Ok(provider) => {
+                let base_url = provider.default_base_url().to_string();
+                let provider_name = format!("{:?}", provider).to_lowercase();
+                let api_key = app.category_api_key(cat).map(|s| s.to_string());
+                app.set_category_provider_name(cat, provider_name.clone());
+                app.set_category_base_url(cat, base_url.clone());
+                app.set_category_client(cat, OpenAiClient::new(&base_url, api_key.as_deref()));
+                rebuild = true;
+                println!("{} provider changed to {}.", cat.name(), provider_name);
+            }
+            Err(e) => {
+                println!("{}", e);
+            }
+        },
+        Command::ShowCategoryModel(cat) => {
+            let model = app.category_model(cat);
+            if model.is_empty() {
+                println!("{} model: (inherits base: {})", cat.name(), app.model_name);
+            } else {
+                println!("{} model: {}", cat.name(), model);
+            }
+        }
+        Command::SetCategoryModel(cat, name) => {
+            let cat_name = cat.name();
+            app.set_category_model(cat, name.clone());
+            println!("{} model changed to {}.", cat_name, name);
+        }
+        Command::ShowCategoryKey(cat) => match app.category_api_key(cat) {
+            Some(key) if key.len() > 8 => {
+                let masked = format!("{}...{}", &key[..4], &key[key.len() - 4..]);
+                println!("{} API key: {}", cat.name(), masked);
+            }
+            Some(_) => {
+                println!("{} API key: (set, too short to mask)", cat.name());
+            }
+            None => {
+                println!("{} API key: (not set)", cat.name());
+            }
+        },
+        Command::SetCategoryKey(cat, value) => {
+            let cat_name = cat.name();
+            app.set_category_api_key(cat, value);
+            let base_url = app
+                .category_base_url(cat)
+                .unwrap_or(&app.base_url)
+                .to_string();
+            let api_key = app.category_api_key(cat).map(|s| s.to_string());
+            app.set_category_client(cat, OpenAiClient::new(&base_url, api_key.as_deref()));
+            rebuild = true;
+            println!("{} API key updated.", cat_name);
         }
     }
     (false, rebuild)
@@ -1136,5 +1227,74 @@ mod tests {
             (app.world.clock.speed_factor() - 72.0).abs() < f64::EPSILON,
             "Speed should be 72.0 after setting Fast"
         );
+    }
+
+    #[tokio::test]
+    async fn test_handle_set_category_model_dialogue() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(
+            &mut app,
+            Command::SetCategoryModel(InferenceCategory::Dialogue, "gpt-4".to_string()),
+        )
+        .await;
+        assert!(!quit);
+        assert!(!rebuild);
+        assert_eq!(app.cloud_model_name.as_deref(), Some("gpt-4"));
+        assert_eq!(app.dialogue_model, "gpt-4");
+    }
+
+    #[tokio::test]
+    async fn test_handle_set_category_model_intent() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(
+            &mut app,
+            Command::SetCategoryModel(InferenceCategory::Intent, "qwen3:1.5b".to_string()),
+        )
+        .await;
+        assert!(!quit);
+        assert!(!rebuild);
+        assert_eq!(app.intent_model, "qwen3:1.5b");
+    }
+
+    #[tokio::test]
+    async fn test_handle_set_category_model_simulation() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(
+            &mut app,
+            Command::SetCategoryModel(InferenceCategory::Simulation, "qwen3:8b".to_string()),
+        )
+        .await;
+        assert!(!quit);
+        assert!(!rebuild);
+        assert_eq!(app.simulation_model, "qwen3:8b");
+    }
+
+    #[tokio::test]
+    async fn test_handle_set_category_provider_rebuilds() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(
+            &mut app,
+            Command::SetCategoryProvider(InferenceCategory::Intent, "openrouter".to_string()),
+        )
+        .await;
+        assert!(!quit);
+        assert!(
+            rebuild,
+            "Setting a category provider should trigger rebuild"
+        );
+        assert_eq!(app.intent_provider_name.as_deref(), Some("openrouter"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_set_category_key_rebuilds() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(
+            &mut app,
+            Command::SetCategoryKey(InferenceCategory::Dialogue, "sk-test-key".to_string()),
+        )
+        .await;
+        assert!(!quit);
+        assert!(rebuild, "Setting a category key should trigger rebuild");
+        assert_eq!(app.cloud_api_key.as_deref(), Some("sk-test-key"));
     }
 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -39,15 +39,13 @@ pub async fn run_headless(
 ) -> Result<()> {
     println!("=== Parish — Headless Mode ===");
     println!(
-        "Local: {} ({})",
-        clients.local_model,
+        "Base: {} ({})",
+        clients.base_model,
         provider_config.provider_display()
     );
-    if clients.has_cloud() {
-        println!(
-            "Cloud: {} (dialogue)",
-            clients.cloud_model.as_deref().unwrap_or("?")
-        );
+    if clients.has_custom_dialogue() {
+        let (_, dial_model) = clients.dialogue_client();
+        println!("Dialogue: {} (override)", dial_model);
     }
     println!("Type /help for commands, /quit to exit.");
     println!();
@@ -70,19 +68,29 @@ pub async fn run_headless(
         }
     }
     app.inference_queue = Some(queue);
-    app.client = Some(clients.local.clone());
-    app.model_name = clients.local_model.clone();
+    app.client = Some(clients.base.clone());
+    app.model_name = clients.base_model.clone();
     app.dialogue_model = dialogue_model;
     app.provider_name = format!("{:?}", provider_config.provider).to_lowercase();
     app.base_url = provider_config.base_url.clone();
     app.api_key = provider_config.api_key.clone();
     app.improv_enabled = improv;
 
-    // Set cloud fields if configured
-    if let Some(cc) = cloud_config {
+    // Set intent client/model
+    let (intent_cl, intent_mdl) = clients.intent_client();
+    app.intent_client = Some(intent_cl.clone());
+    app.intent_model = intent_mdl.to_string();
+
+    // Set cloud/dialogue fields if configured
+    if clients.has_custom_dialogue() {
+        let (dial_cl, dial_mdl) = clients.dialogue_client();
+        app.cloud_client = Some(dial_cl.clone());
+        app.cloud_model_name = Some(dial_mdl.to_string());
+    } else if let Some(cc) = cloud_config {
         app.cloud_provider_name = Some(format!("{:?}", cc.provider).to_lowercase());
         app.cloud_model_name = Some(cc.model.clone());
-        app.cloud_client = clients.cloud.clone();
+        let (dial_cl, _) = clients.dialogue_client();
+        app.cloud_client = Some(dial_cl.clone());
         app.cloud_api_key = cc.api_key.clone();
         app.cloud_base_url = Some(cc.base_url.clone());
     }
@@ -184,8 +192,8 @@ pub async fn run_headless(
                 }
             }
             InputResult::GameInput(text) => {
-                let intent_client = app.client.clone().unwrap();
-                let intent_model = app.model_name.clone();
+                let intent_client = app.intent_client.clone().unwrap();
+                let intent_model = app.intent_model.clone();
                 handle_headless_game_input(
                     &mut app,
                     &intent_client,

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -86,51 +86,67 @@ impl InferenceQueue {
     }
 }
 
-/// Holds both local and cloud LLM clients for request routing.
+/// Per-category LLM client routing with a base provider fallback.
 ///
-/// The local client is used for Tier 2 background NPC simulation and intent parsing.
-/// The cloud client (if configured) is used for Tier 1 player-facing dialogue.
-/// Falls back to local if no cloud client is configured.
+/// Each inference category (dialogue, simulation, intent) can have its own
+/// provider, model, and endpoint. Categories without explicit overrides
+/// fall back to the base provider.
 #[derive(Clone)]
 pub struct InferenceClients {
-    /// Local client (Ollama/LM Studio) for background tasks and intent parsing.
-    pub local: OpenAiClient,
-    /// Local model name (e.g. "qwen3:14b").
-    pub local_model: String,
-    /// Cloud client for player dialogue (None = use local for everything).
-    pub cloud: Option<OpenAiClient>,
-    /// Cloud model name (e.g. "anthropic/claude-sonnet-4-20250514").
-    pub cloud_model: Option<String>,
+    /// Per-category (client, model) overrides.
+    overrides: std::collections::HashMap<crate::config::InferenceCategory, (OpenAiClient, String)>,
+    /// Base client used when no per-category override exists.
+    pub base: OpenAiClient,
+    /// Base model name (e.g. "qwen3:14b").
+    pub base_model: String,
 }
 
 impl InferenceClients {
-    /// Returns the client and model to use for player dialogue (Tier 1).
-    ///
-    /// Prefers cloud if configured, falls back to local.
-    pub fn dialogue_client(&self) -> (&OpenAiClient, &str) {
-        match (&self.cloud, &self.cloud_model) {
-            (Some(client), Some(model)) => (client, model),
-            _ => (&self.local, &self.local_model),
+    /// Creates a new `InferenceClients` with the given base client and per-category overrides.
+    pub fn new(
+        base: OpenAiClient,
+        base_model: String,
+        overrides: std::collections::HashMap<
+            crate::config::InferenceCategory,
+            (OpenAiClient, String),
+        >,
+    ) -> Self {
+        Self {
+            overrides,
+            base,
+            base_model,
         }
     }
 
-    /// Returns the client and model to use for background NPC simulation (Tier 2).
+    /// Returns the client and model for a given inference category.
     ///
-    /// Always uses the local client.
+    /// Uses the per-category override if configured, otherwise falls back to the base.
+    pub fn client_for(&self, category: crate::config::InferenceCategory) -> (&OpenAiClient, &str) {
+        match self.overrides.get(&category) {
+            Some((client, model)) => (client, model),
+            None => (&self.base, &self.base_model),
+        }
+    }
+
+    /// Returns the client and model to use for player dialogue (Tier 1).
+    pub fn dialogue_client(&self) -> (&OpenAiClient, &str) {
+        self.client_for(crate::config::InferenceCategory::Dialogue)
+    }
+
+    /// Returns the client and model to use for background NPC simulation (Tier 2).
     pub fn simulation_client(&self) -> (&OpenAiClient, &str) {
-        (&self.local, &self.local_model)
+        self.client_for(crate::config::InferenceCategory::Simulation)
     }
 
     /// Returns the client and model to use for intent parsing.
-    ///
-    /// Always uses the local client for low-latency structured output.
     pub fn intent_client(&self) -> (&OpenAiClient, &str) {
-        (&self.local, &self.local_model)
+        self.client_for(crate::config::InferenceCategory::Intent)
     }
 
-    /// Whether a cloud provider is configured for dialogue.
-    pub fn has_cloud(&self) -> bool {
-        self.cloud.is_some() && self.cloud_model.is_some()
+    /// Whether the dialogue category uses a different provider than the base.
+    pub fn has_custom_dialogue(&self) -> bool {
+        self.overrides
+            .contains_key(&crate::config::InferenceCategory::Dialogue)
     }
 }
 
@@ -271,58 +287,82 @@ mod tests {
     }
 
     #[test]
-    fn test_inference_clients_dialogue_uses_cloud() {
-        let local = OpenAiClient::new("http://localhost:11434", None);
+    fn test_inference_clients_dialogue_uses_override() {
+        use crate::config::InferenceCategory;
+        use std::collections::HashMap;
+
+        let base = OpenAiClient::new("http://localhost:11434", None);
         let cloud = OpenAiClient::new("https://openrouter.ai/api", Some("sk-test"));
-        let clients = InferenceClients {
-            local,
-            local_model: "qwen3:14b".to_string(),
-            cloud: Some(cloud),
-            cloud_model: Some("anthropic/claude-sonnet-4-20250514".to_string()),
-        };
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            InferenceCategory::Dialogue,
+            (cloud, "anthropic/claude-sonnet-4-20250514".to_string()),
+        );
+        let clients = InferenceClients::new(base, "qwen3:14b".to_string(), overrides);
         let (_client, model) = clients.dialogue_client();
         assert_eq!(model, "anthropic/claude-sonnet-4-20250514");
-        assert!(clients.has_cloud());
+        assert!(clients.has_custom_dialogue());
     }
 
     #[test]
-    fn test_inference_clients_dialogue_falls_back_to_local() {
-        let local = OpenAiClient::new("http://localhost:11434", None);
-        let clients = InferenceClients {
-            local,
-            local_model: "qwen3:14b".to_string(),
-            cloud: None,
-            cloud_model: None,
-        };
+    fn test_inference_clients_dialogue_falls_back_to_base() {
+        use std::collections::HashMap;
+
+        let base = OpenAiClient::new("http://localhost:11434", None);
+        let clients = InferenceClients::new(base, "qwen3:14b".to_string(), HashMap::new());
         let (_client, model) = clients.dialogue_client();
         assert_eq!(model, "qwen3:14b");
-        assert!(!clients.has_cloud());
+        assert!(!clients.has_custom_dialogue());
     }
 
     #[test]
-    fn test_inference_clients_simulation_always_local() {
-        let local = OpenAiClient::new("http://localhost:11434", None);
+    fn test_inference_clients_simulation_falls_back_to_base() {
+        use crate::config::InferenceCategory;
+        use std::collections::HashMap;
+
+        let base = OpenAiClient::new("http://localhost:11434", None);
         let cloud = OpenAiClient::new("https://openrouter.ai/api", Some("sk-test"));
-        let clients = InferenceClients {
-            local,
-            local_model: "qwen3:14b".to_string(),
-            cloud: Some(cloud),
-            cloud_model: Some("gpt-4".to_string()),
-        };
+        let mut overrides = HashMap::new();
+        overrides.insert(InferenceCategory::Dialogue, (cloud, "gpt-4".to_string()));
+        let clients = InferenceClients::new(base, "qwen3:14b".to_string(), overrides);
         let (_client, model) = clients.simulation_client();
         assert_eq!(model, "qwen3:14b");
     }
 
     #[test]
-    fn test_inference_clients_intent_always_local() {
-        let local = OpenAiClient::new("http://localhost:11434", None);
-        let cloud = OpenAiClient::new("https://openrouter.ai/api", Some("sk-test"));
-        let clients = InferenceClients {
-            local,
-            local_model: "qwen3:14b".to_string(),
-            cloud: Some(cloud),
-            cloud_model: Some("gpt-4".to_string()),
-        };
+    fn test_inference_clients_per_category_overrides() {
+        use crate::config::InferenceCategory;
+        use std::collections::HashMap;
+
+        let base = OpenAiClient::new("http://localhost:11434", None);
+        let dial = OpenAiClient::new("https://openrouter.ai/api", Some("sk-dial"));
+        let sim = OpenAiClient::new("http://localhost:11434", None);
+        let intent = OpenAiClient::new("http://localhost:1234", None);
+        let mut overrides = HashMap::new();
+        overrides.insert(InferenceCategory::Dialogue, (dial, "claude-4".to_string()));
+        overrides.insert(InferenceCategory::Simulation, (sim, "qwen3:8b".to_string()));
+        overrides.insert(
+            InferenceCategory::Intent,
+            (intent, "qwen3:1.5b".to_string()),
+        );
+        let clients = InferenceClients::new(base, "qwen3:14b".to_string(), overrides);
+
+        let (_, model) = clients.dialogue_client();
+        assert_eq!(model, "claude-4");
+
+        let (_, model) = clients.simulation_client();
+        assert_eq!(model, "qwen3:8b");
+
+        let (_, model) = clients.intent_client();
+        assert_eq!(model, "qwen3:1.5b");
+    }
+
+    #[test]
+    fn test_inference_clients_intent_falls_back_to_base() {
+        use std::collections::HashMap;
+
+        let base = OpenAiClient::new("http://localhost:11434", None);
+        let clients = InferenceClients::new(base, "qwen3:14b".to_string(), HashMap::new());
         let (_client, model) = clients.intent_client();
         assert_eq!(model, "qwen3:14b");
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4,6 +4,7 @@
 //! All other input is natural language sent to the LLM for
 //! intent parsing (move, talk, look, interact, examine).
 
+use crate::config::InferenceCategory;
 use crate::error::ParishError;
 use crate::inference::openai_client::OpenAiClient;
 use crate::world::time::GameSpeed;
@@ -71,6 +72,18 @@ pub enum Command {
     SetSpeed(GameSpeed),
     /// Invalid speed preset was requested.
     InvalidSpeed(String),
+    /// Show provider for a specific inference category.
+    ShowCategoryProvider(InferenceCategory),
+    /// Set provider for a specific inference category.
+    SetCategoryProvider(InferenceCategory, String),
+    /// Show model for a specific inference category.
+    ShowCategoryModel(InferenceCategory),
+    /// Set model for a specific inference category.
+    SetCategoryModel(InferenceCategory, String),
+    /// Show API key for a specific inference category (masked).
+    ShowCategoryKey(InferenceCategory),
+    /// Set API key for a specific inference category.
+    SetCategoryKey(InferenceCategory, String),
 }
 
 /// The kind of player action parsed from natural language input.
@@ -160,6 +173,8 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
         Some(Command::ToggleSidebar)
     } else if lower == "/improv" {
         Some(Command::ToggleImprov)
+    } else if let Some(cmd) = parse_category_command(trimmed, &lower) {
+        Some(cmd)
     } else if lower == "/provider" {
         Some(Command::ShowProvider)
     } else if lower.starts_with("/provider ") {
@@ -243,6 +258,52 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
     } else {
         None
     }
+}
+
+/// Parses dot-notation per-category commands like `/model.dialogue`, `/provider.intent`.
+///
+/// Returns `Some(Command)` if the input matches a `/<base>.<category>` pattern
+/// where base is `model`, `provider`, or `key`, and category is `dialogue`,
+/// `simulation`, or `intent`.
+fn parse_category_command(trimmed: &str, lower: &str) -> Option<Command> {
+    // Try each base command with dot-notation
+    for (prefix, show_fn, set_fn) in &[
+        (
+            "/model.",
+            Command::ShowCategoryModel as fn(InferenceCategory) -> Command,
+            Command::SetCategoryModel as fn(InferenceCategory, String) -> Command,
+        ),
+        (
+            "/provider.",
+            Command::ShowCategoryProvider as fn(InferenceCategory) -> Command,
+            Command::SetCategoryProvider as fn(InferenceCategory, String) -> Command,
+        ),
+        (
+            "/key.",
+            Command::ShowCategoryKey as fn(InferenceCategory) -> Command,
+            Command::SetCategoryKey as fn(InferenceCategory, String) -> Command,
+        ),
+    ] {
+        if let Some(rest) = lower.strip_prefix(prefix) {
+            // Split on first space: "dialogue foo" → ("dialogue", "foo")
+            let (cat_str, arg) = match rest.find(' ') {
+                Some(pos) => (&rest[..pos], trimmed[prefix.len() + pos..].trim()),
+                None => (rest, ""),
+            };
+            let category = match cat_str {
+                "dialogue" => InferenceCategory::Dialogue,
+                "simulation" => InferenceCategory::Simulation,
+                "intent" => InferenceCategory::Intent,
+                _ => return None,
+            };
+            if arg.is_empty() {
+                return Some(show_fn(category));
+            } else {
+                return Some(set_fn(category, arg.to_string()));
+            }
+        }
+    }
+    None
 }
 
 /// Classifies raw input as either a system command or game input.
@@ -1085,5 +1146,100 @@ mod tests {
     #[test]
     fn test_parse_speed_whitespace_shows_current() {
         assert_eq!(parse_system_command("/speed   "), Some(Command::ShowSpeed));
+    }
+
+    #[test]
+    fn test_parse_category_model_show() {
+        assert_eq!(
+            parse_system_command("/model.dialogue"),
+            Some(Command::ShowCategoryModel(InferenceCategory::Dialogue))
+        );
+        assert_eq!(
+            parse_system_command("/model.simulation"),
+            Some(Command::ShowCategoryModel(InferenceCategory::Simulation))
+        );
+        assert_eq!(
+            parse_system_command("/model.intent"),
+            Some(Command::ShowCategoryModel(InferenceCategory::Intent))
+        );
+    }
+
+    #[test]
+    fn test_parse_category_model_set() {
+        assert_eq!(
+            parse_system_command("/model.dialogue openrouter/free"),
+            Some(Command::SetCategoryModel(
+                InferenceCategory::Dialogue,
+                "openrouter/free".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_system_command("/model.intent qwen3:1.5b"),
+            Some(Command::SetCategoryModel(
+                InferenceCategory::Intent,
+                "qwen3:1.5b".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_category_model_case_insensitive() {
+        assert_eq!(
+            parse_system_command("/MODEL.DIALOGUE SomeModel"),
+            Some(Command::SetCategoryModel(
+                InferenceCategory::Dialogue,
+                "SomeModel".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_category_provider_show_and_set() {
+        assert_eq!(
+            parse_system_command("/provider.dialogue"),
+            Some(Command::ShowCategoryProvider(InferenceCategory::Dialogue))
+        );
+        assert_eq!(
+            parse_system_command("/provider.simulation openrouter"),
+            Some(Command::SetCategoryProvider(
+                InferenceCategory::Simulation,
+                "openrouter".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_category_key_show_and_set() {
+        assert_eq!(
+            parse_system_command("/key.intent"),
+            Some(Command::ShowCategoryKey(InferenceCategory::Intent))
+        );
+        assert_eq!(
+            parse_system_command("/key.dialogue sk-test-1234"),
+            Some(Command::SetCategoryKey(
+                InferenceCategory::Dialogue,
+                "sk-test-1234".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_category_unknown_category() {
+        // Unknown category should fall through to None
+        assert_eq!(parse_system_command("/model.unknown"), None);
+        assert_eq!(parse_system_command("/provider.foo"), None);
+        assert_eq!(parse_system_command("/key.bar"), None);
+    }
+
+    #[test]
+    fn test_parse_category_preserves_arg_case() {
+        // Model names should preserve original case
+        assert_eq!(
+            parse_system_command("/model.dialogue Anthropic/Claude-Sonnet"),
+            Some(Command::SetCategoryModel(
+                InferenceCategory::Dialogue,
+                "Anthropic/Claude-Sonnet".to_string()
+            ))
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,6 +212,7 @@ async fn main() -> Result<()> {
             clients.clone(),
             &provider_config,
             cloud_config.as_ref(),
+            &category_configs,
             cli.improv,
         )
         .await;
@@ -269,6 +270,23 @@ async fn main() -> Result<()> {
         let (intent_cl, intent_mdl) = clients.intent_client();
         app.intent_client = Some(intent_cl.clone());
         app.intent_model = intent_mdl.to_string();
+
+        // Set simulation client/model (may differ from base)
+        let (sim_cl, sim_mdl) = clients.simulation_client();
+        app.simulation_client = Some(sim_cl.clone());
+        app.simulation_model = sim_mdl.to_string();
+
+        // Initialize per-category provider metadata from config
+        if let Some(cat_cfg) = category_configs.get(&InferenceCategory::Intent) {
+            app.intent_provider_name = Some(format!("{:?}", cat_cfg.provider).to_lowercase());
+            app.intent_api_key = cat_cfg.api_key.clone();
+            app.intent_base_url = Some(cat_cfg.base_url.clone());
+        }
+        if let Some(cat_cfg) = category_configs.get(&InferenceCategory::Simulation) {
+            app.simulation_provider_name = Some(format!("{:?}", cat_cfg.provider).to_lowercase());
+            app.simulation_api_key = cat_cfg.api_key.clone();
+            app.simulation_base_url = Some(cat_cfg.base_url.clone());
+        }
 
         // Load NPCs from data file
         let npcs_path = Path::new("data/npcs.json");
@@ -927,11 +945,11 @@ async fn handle_system_command(app: &mut App, cmd: Command) -> bool {
             }
         }
         Command::ShowProvider => {
-            if let Some(ref cloud) = app.cloud_provider_name {
-                app.world
-                    .log(format!("Local: {} | Cloud: {}", app.provider_name, cloud));
-            } else {
-                app.world.log(format!("Provider: {}", app.provider_name));
+            app.world.log(format!("Base: {}", app.provider_name));
+            for cat in InferenceCategory::ALL {
+                if let Some(provider) = app.category_provider_name(cat) {
+                    app.world.log(format!("  {}: {}", cat.name(), provider));
+                }
             }
         }
         Command::SetProvider(name) => match Provider::from_str_loose(&name) {
@@ -949,9 +967,15 @@ async fn handle_system_command(app: &mut App, cmd: Command) -> bool {
         },
         Command::ShowModel => {
             if app.model_name.is_empty() {
-                app.world.log("Model: (auto-detect)".to_string());
+                app.world.log("Base model: (auto-detect)".to_string());
             } else {
-                app.world.log(format!("Model: {}", app.model_name));
+                app.world.log(format!("Base model: {}", app.model_name));
+            }
+            for cat in InferenceCategory::ALL {
+                let model = app.category_model(cat);
+                if !model.is_empty() {
+                    app.world.log(format!("  {}: {}", cat.name(), model));
+                }
             }
         }
         Command::SetModel(name) => {
@@ -1207,6 +1231,80 @@ async fn handle_system_command(app: &mut App, cmd: Command) -> bool {
             app.cloud_client = Some(OpenAiClient::new(base_url, app.cloud_api_key.as_deref()));
             rebuild_inference = true;
             app.world.log("Cloud API key updated.".to_string());
+        }
+        Command::ShowCategoryProvider(cat) => {
+            if let Some(provider) = app.category_provider_name(cat) {
+                app.world
+                    .log(format!("{} provider: {}", cat.name(), provider));
+            } else {
+                app.world.log(format!(
+                    "{} provider: (inherits base: {})",
+                    cat.name(),
+                    app.provider_name
+                ));
+            }
+        }
+        Command::SetCategoryProvider(cat, name) => match Provider::from_str_loose(&name) {
+            Ok(provider) => {
+                let base_url = provider.default_base_url().to_string();
+                let provider_name = format!("{:?}", provider).to_lowercase();
+                let api_key = app.category_api_key(cat).map(|s| s.to_string());
+                app.set_category_provider_name(cat, provider_name.clone());
+                app.set_category_base_url(cat, base_url.clone());
+                app.set_category_client(cat, OpenAiClient::new(&base_url, api_key.as_deref()));
+                rebuild_inference = true;
+                app.world.log(format!(
+                    "{} provider changed to {}.",
+                    cat.name(),
+                    provider_name
+                ));
+            }
+            Err(e) => {
+                app.world.log(format!("{}", e));
+            }
+        },
+        Command::ShowCategoryModel(cat) => {
+            let model = app.category_model(cat);
+            if model.is_empty() {
+                app.world.log(format!(
+                    "{} model: (inherits base: {})",
+                    cat.name(),
+                    app.model_name
+                ));
+            } else {
+                app.world.log(format!("{} model: {}", cat.name(), model));
+            }
+        }
+        Command::SetCategoryModel(cat, name) => {
+            let cat_name = cat.name();
+            app.set_category_model(cat, name.clone());
+            app.world
+                .log(format!("{} model changed to {}.", cat_name, name));
+        }
+        Command::ShowCategoryKey(cat) => match app.category_api_key(cat) {
+            Some(key) if key.len() > 8 => {
+                let masked = format!("{}...{}", &key[..4], &key[key.len() - 4..]);
+                app.world.log(format!("{} API key: {}", cat.name(), masked));
+            }
+            Some(_) => {
+                app.world
+                    .log(format!("{} API key: (set, too short to mask)", cat.name()));
+            }
+            None => {
+                app.world.log(format!("{} API key: (not set)", cat.name()));
+            }
+        },
+        Command::SetCategoryKey(cat, value) => {
+            let cat_name = cat.name();
+            app.set_category_api_key(cat, value);
+            let base_url = app
+                .category_base_url(cat)
+                .unwrap_or(&app.base_url)
+                .to_string();
+            let api_key = app.category_api_key(cat).map(|s| s.to_string());
+            app.set_category_client(cat, OpenAiClient::new(&base_url, api_key.as_deref()));
+            rebuild_inference = true;
+            app.world.log(format!("{} API key updated.", cat_name));
         }
     }
     app.world.log(String::new());

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use clap::Parser;
 use parish::config::{
-    CliCloudOverrides, CliOverrides, CloudConfig, Provider, ProviderConfig, resolve_cloud_config,
-    resolve_config,
+    CliCategoryOverrides, CliCloudOverrides, CliOverrides, InferenceCategory, Provider,
+    ProviderConfig, resolve_category_configs, resolve_cloud_config, resolve_config,
 };
 use parish::headless;
 use parish::inference::openai_client::OpenAiClient;
@@ -78,6 +78,46 @@ struct Cli {
     #[arg(long, env = "PARISH_CLOUD_API_KEY")]
     cloud_api_key: Option<String>,
 
+    // --- Per-category provider overrides ---
+    /// Dialogue LLM provider override
+    #[arg(long, env = "PARISH_DIALOGUE_PROVIDER")]
+    dialogue_provider: Option<String>,
+    /// Dialogue LLM model override
+    #[arg(long, env = "PARISH_DIALOGUE_MODEL")]
+    dialogue_model: Option<String>,
+    /// Dialogue LLM base URL override
+    #[arg(long, env = "PARISH_DIALOGUE_BASE_URL")]
+    dialogue_base_url: Option<String>,
+    /// Dialogue LLM API key override
+    #[arg(long, env = "PARISH_DIALOGUE_API_KEY")]
+    dialogue_api_key: Option<String>,
+
+    /// Simulation LLM provider override
+    #[arg(long, env = "PARISH_SIMULATION_PROVIDER")]
+    simulation_provider: Option<String>,
+    /// Simulation LLM model override
+    #[arg(long, env = "PARISH_SIMULATION_MODEL")]
+    simulation_model: Option<String>,
+    /// Simulation LLM base URL override
+    #[arg(long, env = "PARISH_SIMULATION_BASE_URL")]
+    simulation_base_url: Option<String>,
+    /// Simulation LLM API key override
+    #[arg(long, env = "PARISH_SIMULATION_API_KEY")]
+    simulation_api_key: Option<String>,
+
+    /// Intent parsing LLM provider override
+    #[arg(long, env = "PARISH_INTENT_PROVIDER")]
+    intent_provider: Option<String>,
+    /// Intent parsing LLM model override
+    #[arg(long, env = "PARISH_INTENT_MODEL")]
+    intent_model: Option<String>,
+    /// Intent parsing LLM base URL override
+    #[arg(long, env = "PARISH_INTENT_BASE_URL")]
+    intent_base_url: Option<String>,
+    /// Intent parsing LLM API key override
+    #[arg(long, env = "PARISH_INTENT_API_KEY")]
+    intent_api_key: Option<String>,
+
     /// Run in TUI mode (terminal interface) instead of default GUI
     #[arg(long)]
     tui: bool,
@@ -131,7 +171,7 @@ async fn main() -> Result<()> {
     };
     let provider_config = resolve_config(config_path, &overrides)?;
 
-    // Resolve cloud provider configuration (optional, for dialogue)
+    // Resolve cloud provider configuration (legacy, for backward compat)
     let cloud_overrides = CliCloudOverrides {
         provider: cli.cloud_provider.clone(),
         base_url: cli.cloud_base_url.clone(),
@@ -140,17 +180,30 @@ async fn main() -> Result<()> {
     };
     let cloud_config = resolve_cloud_config(config_path, &cloud_overrides)?;
 
+    // Build per-category CLI overrides
+    let cli_category_overrides = build_cli_category_overrides(&cli);
+
+    // Resolve per-category provider configs
+    let category_configs = resolve_category_configs(
+        config_path,
+        &provider_config,
+        &cli_category_overrides,
+        &cloud_overrides,
+    )?;
+
     // Set up local inference client based on provider
     let (client, model, mut ollama_process) = setup_provider(&cli, &provider_config).await?;
 
-    // Build dual-client routing struct
-    let clients = build_inference_clients(&client, &model, &cloud_config);
+    // Build per-category client routing struct
+    let clients = build_inference_clients(&client, &model, &category_configs);
 
-    if cloud_config.is_some() {
+    for (cat, cfg) in &category_configs {
         tracing::info!(
-            "Cloud dialogue enabled: {:?} with model {}",
-            clients.cloud_model.as_deref().unwrap_or("?"),
-            clients.cloud_model.as_deref().unwrap_or("?")
+            "{:?} category: {:?} provider at {} with model {}",
+            cat,
+            cfg.provider,
+            cfg.base_url,
+            cfg.model.as_deref().unwrap_or("(auto)")
         );
     }
 
@@ -187,22 +240,35 @@ async fn main() -> Result<()> {
             }
         }
         app.inference_queue = Some(queue);
-        app.client = Some(clients.local.clone());
-        app.model_name = clients.local_model.clone();
+        app.client = Some(clients.base.clone());
+        app.model_name = clients.base_model.clone();
         app.dialogue_model = dial_model.to_string();
         app.provider_name = format!("{:?}", provider_config.provider).to_lowercase();
         app.base_url = provider_config.base_url.clone();
         app.api_key = provider_config.api_key.clone();
         app.improv_enabled = cli.improv;
 
-        // Set cloud fields if configured
-        if let Some(ref cc) = cloud_config {
+        // Set cloud fields if configured (legacy compat + new per-category)
+        if let Some(cat_cfg) = category_configs.get(&InferenceCategory::Dialogue) {
+            app.cloud_provider_name = Some(format!("{:?}", cat_cfg.provider).to_lowercase());
+            app.cloud_model_name = cat_cfg.model.clone();
+            let (dial_cl, _) = clients.dialogue_client();
+            app.cloud_client = Some(dial_cl.clone());
+            app.cloud_api_key = cat_cfg.api_key.clone();
+            app.cloud_base_url = Some(cat_cfg.base_url.clone());
+        } else if let Some(ref cc) = cloud_config {
             app.cloud_provider_name = Some(format!("{:?}", cc.provider).to_lowercase());
             app.cloud_model_name = Some(cc.model.clone());
-            app.cloud_client = clients.cloud.clone();
+            let (dial_cl, _) = clients.dialogue_client();
+            app.cloud_client = Some(dial_cl.clone());
             app.cloud_api_key = cc.api_key.clone();
             app.cloud_base_url = Some(cc.base_url.clone());
         }
+
+        // Set intent client/model (may differ from base)
+        let (intent_cl, intent_mdl) = clients.intent_client();
+        app.intent_client = Some(intent_cl.clone());
+        app.intent_model = intent_mdl.to_string();
 
         // Load NPCs from data file
         let npcs_path = Path::new("data/npcs.json");
@@ -356,9 +422,9 @@ async fn main() -> Result<()> {
                         }
                     }
                     InputResult::GameInput(text) => {
-                        // Always parse intent first (uses local client for low latency)
-                        let (intent_client, intent_model) =
-                            (app.client.clone().unwrap(), app.model_name.clone());
+                        // Parse intent (uses intent client, may be per-category override or base)
+                        let intent_client = app.intent_client.clone().unwrap();
+                        let intent_model = app.intent_model.clone();
                         let intent = parse_intent(&intent_client, &text, &intent_model).await?;
 
                         match intent.intent {
@@ -667,25 +733,68 @@ async fn setup_provider(
     }
 }
 
-/// Builds the dual-client inference routing struct from local and cloud configs.
+/// Builds the per-category inference routing struct from base and category configs.
 fn build_inference_clients(
-    local_client: &OpenAiClient,
-    local_model: &str,
-    cloud_config: &Option<CloudConfig>,
+    base_client: &OpenAiClient,
+    base_model: &str,
+    category_configs: &std::collections::HashMap<InferenceCategory, parish::config::CategoryConfig>,
 ) -> InferenceClients {
-    let (cloud_client, cloud_model) = match cloud_config {
-        Some(cc) => {
-            let client = OpenAiClient::new(&cc.base_url, cc.api_key.as_deref());
-            (Some(client), Some(cc.model.clone()))
-        }
-        None => (None, None),
-    };
-    InferenceClients {
-        local: local_client.clone(),
-        local_model: local_model.to_string(),
-        cloud: cloud_client,
-        cloud_model,
+    let mut overrides = std::collections::HashMap::new();
+    for (category, cfg) in category_configs {
+        let client = OpenAiClient::new(&cfg.base_url, cfg.api_key.as_deref());
+        let model = cfg.model.clone().unwrap_or_else(|| base_model.to_string());
+        overrides.insert(*category, (client, model));
     }
+    InferenceClients::new(base_client.clone(), base_model.to_string(), overrides)
+}
+
+/// Builds per-category CLI overrides from the parsed CLI arguments.
+fn build_cli_category_overrides(cli: &Cli) -> CliCategoryOverrides {
+    let mut categories = std::collections::HashMap::new();
+
+    let dialogue = CliOverrides {
+        provider: cli.dialogue_provider.clone(),
+        base_url: cli.dialogue_base_url.clone(),
+        api_key: cli.dialogue_api_key.clone(),
+        model: cli.dialogue_model.clone(),
+    };
+    if dialogue.provider.is_some()
+        || dialogue.base_url.is_some()
+        || dialogue.api_key.is_some()
+        || dialogue.model.is_some()
+    {
+        categories.insert("dialogue".to_string(), dialogue);
+    }
+
+    let simulation = CliOverrides {
+        provider: cli.simulation_provider.clone(),
+        base_url: cli.simulation_base_url.clone(),
+        api_key: cli.simulation_api_key.clone(),
+        model: cli.simulation_model.clone(),
+    };
+    if simulation.provider.is_some()
+        || simulation.base_url.is_some()
+        || simulation.api_key.is_some()
+        || simulation.model.is_some()
+    {
+        categories.insert("simulation".to_string(), simulation);
+    }
+
+    let intent = CliOverrides {
+        provider: cli.intent_provider.clone(),
+        base_url: cli.intent_base_url.clone(),
+        api_key: cli.intent_api_key.clone(),
+        model: cli.intent_model.clone(),
+    };
+    if intent.provider.is_some()
+        || intent.base_url.is_some()
+        || intent.api_key.is_some()
+        || intent.model.is_some()
+    {
+        categories.insert("intent".to_string(), intent);
+    }
+
+    CliCategoryOverrides { categories }
 }
 
 /// Atmospheric idle messages shown when no NPC is present for conversation.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -654,7 +654,13 @@ impl GameTestHarness {
             | Command::ShowCloudModel
             | Command::SetCloudModel(_)
             | Command::ShowCloudKey
-            | Command::SetCloudKey(_) => {
+            | Command::SetCloudKey(_)
+            | Command::ShowCategoryProvider(_)
+            | Command::SetCategoryProvider(_, _)
+            | Command::ShowCategoryModel(_)
+            | Command::SetCategoryModel(_, _)
+            | Command::ShowCategoryKey(_)
+            | Command::SetCategoryKey(_, _) => {
                 let msg = "Cloud commands not available in test mode.".to_string();
                 self.app.world.log(msg.clone());
                 ActionResult::SystemCommand { response: msg }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -242,6 +242,10 @@ pub struct App {
     pub latest_snapshot_id: i64,
     /// Wall-clock time of the last autosave.
     pub last_autosave: Option<Instant>,
+    /// The LLM client for intent parsing (may differ from base client).
+    pub intent_client: Option<OpenAiClient>,
+    /// The model name for intent parsing.
+    pub intent_model: String,
 }
 
 impl App {
@@ -276,6 +280,8 @@ impl App {
             active_branch_id: 1,
             latest_snapshot_id: 0,
             last_autosave: None,
+            intent_client: None,
+            intent_model: String::new(),
         }
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -9,6 +9,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::config::InferenceCategory;
 use crate::inference::InferenceQueue;
 use crate::inference::openai_client::OpenAiClient;
 use crate::loading::LoadingAnimation;
@@ -246,6 +247,22 @@ pub struct App {
     pub intent_client: Option<OpenAiClient>,
     /// The model name for intent parsing.
     pub intent_model: String,
+    /// Provider name for intent category (None = inherits base).
+    pub intent_provider_name: Option<String>,
+    /// API key for intent category.
+    pub intent_api_key: Option<String>,
+    /// Base URL for intent category.
+    pub intent_base_url: Option<String>,
+    /// The LLM client for simulation (may differ from base client).
+    pub simulation_client: Option<OpenAiClient>,
+    /// The model name for simulation.
+    pub simulation_model: String,
+    /// Provider name for simulation category (None = inherits base).
+    pub simulation_provider_name: Option<String>,
+    /// API key for simulation category.
+    pub simulation_api_key: Option<String>,
+    /// Base URL for simulation category.
+    pub simulation_base_url: Option<String>,
 }
 
 impl App {
@@ -282,6 +299,107 @@ impl App {
             last_autosave: None,
             intent_client: None,
             intent_model: String::new(),
+            intent_provider_name: None,
+            intent_api_key: None,
+            intent_base_url: None,
+            simulation_client: None,
+            simulation_model: String::new(),
+            simulation_provider_name: None,
+            simulation_api_key: None,
+            simulation_base_url: None,
+        }
+    }
+
+    /// Returns the provider name for a given inference category (or None if inheriting base).
+    pub fn category_provider_name(&self, cat: InferenceCategory) -> Option<&str> {
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_provider_name.as_deref(),
+            InferenceCategory::Simulation => self.simulation_provider_name.as_deref(),
+            InferenceCategory::Intent => self.intent_provider_name.as_deref(),
+        }
+    }
+
+    /// Returns the model name for a given inference category (empty string if inheriting base).
+    pub fn category_model(&self, cat: InferenceCategory) -> &str {
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_model_name.as_deref().unwrap_or(""),
+            InferenceCategory::Simulation => &self.simulation_model,
+            InferenceCategory::Intent => &self.intent_model,
+        }
+    }
+
+    /// Returns the API key for a given inference category.
+    pub fn category_api_key(&self, cat: InferenceCategory) -> Option<&str> {
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_api_key.as_deref(),
+            InferenceCategory::Simulation => self.simulation_api_key.as_deref(),
+            InferenceCategory::Intent => self.intent_api_key.as_deref(),
+        }
+    }
+
+    /// Returns the base URL for a given inference category.
+    pub fn category_base_url(&self, cat: InferenceCategory) -> Option<&str> {
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_base_url.as_deref(),
+            InferenceCategory::Simulation => self.simulation_base_url.as_deref(),
+            InferenceCategory::Intent => self.intent_base_url.as_deref(),
+        }
+    }
+
+    /// Returns the client for a given inference category.
+    pub fn category_client(&self, cat: InferenceCategory) -> Option<&OpenAiClient> {
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_client.as_ref(),
+            InferenceCategory::Simulation => self.simulation_client.as_ref(),
+            InferenceCategory::Intent => self.intent_client.as_ref(),
+        }
+    }
+
+    /// Sets the provider name for a given inference category.
+    pub fn set_category_provider_name(&mut self, cat: InferenceCategory, name: String) {
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_provider_name = Some(name),
+            InferenceCategory::Simulation => self.simulation_provider_name = Some(name),
+            InferenceCategory::Intent => self.intent_provider_name = Some(name),
+        }
+    }
+
+    /// Sets the model name for a given inference category.
+    pub fn set_category_model(&mut self, cat: InferenceCategory, model: String) {
+        match cat {
+            InferenceCategory::Dialogue => {
+                self.cloud_model_name = Some(model.clone());
+                self.dialogue_model = model;
+            }
+            InferenceCategory::Simulation => self.simulation_model = model,
+            InferenceCategory::Intent => self.intent_model = model,
+        }
+    }
+
+    /// Sets the API key for a given inference category.
+    pub fn set_category_api_key(&mut self, cat: InferenceCategory, key: String) {
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_api_key = Some(key),
+            InferenceCategory::Simulation => self.simulation_api_key = Some(key),
+            InferenceCategory::Intent => self.intent_api_key = Some(key),
+        }
+    }
+
+    /// Sets the base URL for a given inference category.
+    pub fn set_category_base_url(&mut self, cat: InferenceCategory, url: String) {
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_base_url = Some(url),
+            InferenceCategory::Simulation => self.simulation_base_url = Some(url),
+            InferenceCategory::Intent => self.intent_base_url = Some(url),
+        }
+    }
+
+    /// Sets the client for a given inference category.
+    pub fn set_category_client(&mut self, cat: InferenceCategory, client: OpenAiClient) {
+        match cat {
+            InferenceCategory::Dialogue => self.cloud_client = Some(client),
+            InferenceCategory::Simulation => self.simulation_client = Some(client),
+            InferenceCategory::Intent => self.intent_client = Some(client),
         }
     }
 


### PR DESCRIPTION
## Summary

- Each inference category (dialogue, simulation, intent) can now independently use a different LLM provider, model, base URL, and API key
- Unconfigured categories inherit from the base `[provider]` config
- Legacy `[cloud]` config, `--cloud-*` flags, and `PARISH_CLOUD_*` env vars still work (map to dialogue category)
- Refactors `InferenceClients` from hardcoded local/cloud dual-client to a `HashMap<InferenceCategory, (Client, Model)>` with base fallback

### New configuration options

**TOML** (`parish.toml`):
```toml
[provider]
name = "ollama"
model = "qwen3:14b"

[provider.dialogue]
name = "openrouter"
api_key = "sk-..."
model = "anthropic/claude-sonnet-4-20250514"

[provider.simulation]
model = "qwen3:8b"

[provider.intent]
model = "qwen3:1.5b"
```

**CLI flags**: `--dialogue-provider`, `--dialogue-model`, `--simulation-model`, `--intent-model`, etc.

**Env vars**: `PARISH_DIALOGUE_PROVIDER`, `PARISH_DIALOGUE_MODEL`, `PARISH_SIMULATION_MODEL`, `PARISH_INTENT_MODEL`, etc.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 570 tests pass (including new per-category config tests)
- [x] `cargo run -- --script tests/fixtures/test_walkthrough.txt` — manual verification passes
- [x] Backward compat: legacy `[cloud]` config maps to dialogue category
- [x] New `[provider.dialogue]` overrides legacy `[cloud]`
- [x] Per-category CLI and env var overrides work
- [x] Validation: missing API key for OpenRouter category produces clear error

https://claude.ai/code/session_01YPtPfXYPiAc8FGkWf1Xs8E