### PR TITLE
feat: smooth color transitions for time, season, and weather

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ src/
 ├── world/           # World state, location graph, time, movement, encounters
 │   ├── graph.rs     #   WorldGraph, BFS pathfinding, fuzzy name search
 │   ├── time.rs      #   GameClock, GameSpeed, TimeOfDay, Season
+│   ├── palette.rs   #   Smooth color interpolation (time/season/weather tinting)
 │   ├── movement.rs  #   Movement resolution and travel narration
 │   ├── encounter.rs #   En-route encounter system
 │   └── description.rs # Dynamic location description templates

--- a/docs/design/gui-design.md
+++ b/docs/design/gui-design.md
@@ -91,7 +91,7 @@ Two collapsible sections (`CollapsingHeader`):
 
 ## Color System
 
-The GUI uses the same 7 time-of-day palettes as the TUI, converted to `egui::Color32`:
+The GUI uses smoothly interpolated time-of-day palettes with season and weather tinting, computed by the shared `src/world/palette.rs` engine and converted to `egui::Color32`. The 7 base keyframe palettes define colors at anchor hours, with linear interpolation between them for gradual transitions:
 
 | Time | Background | Text | Accent |
 |------|-----------|------|--------|
@@ -103,7 +103,7 @@ The GUI uses the same 7 time-of-day palettes as the TUI, converted to `egui::Col
 | Night | `(20,25,40)` near-black | `(180,180,190)` silver | `(100,110,140)` blue-grey |
 | Midnight | `(10,12,20)` darkest | `(150,150,165)` muted | `(70,75,100)` dark blue |
 
-The `GuiPalette` struct extends the TUI's 3-color palette to 7 colors, adding derived values for panels, inputs, borders, and muted text. Palettes are applied each frame via `ctx.set_visuals()`.
+The `GuiPalette` struct extends the TUI's 3-color palette to 7 colors, adding derived values for panels, inputs, borders, and muted text. Palettes are computed each frame by `compute_palette()` (from `src/world/palette.rs`), which smoothly interpolates between keyframes and applies season/weather tinting, then applied via `ctx.set_visuals()`. See [Weather System](weather-system.md) for tint parameters.
 
 ## GuiApp Struct
 
@@ -135,7 +135,7 @@ The `eframe::App::update()` method runs each frame:
 
 1. Drain streaming buffer → append to `world.text_log`
 2. Check idle tick (20-second interval for NPC schedule simulation)
-3. Apply time-of-day palette to `ctx.set_visuals()`
+3. Compute smoothly interpolated palette (time + season + weather) and apply to `ctx.set_visuals()`
 4. Render all panels
 5. Process submitted input through `classify_input()` / game logic
 6. Request repaint if streaming or after 500ms for clock updates
@@ -216,7 +216,8 @@ The capture uses egui's `ViewportCommand::Screenshot` API with `image` crate for
 ## Source Modules
 
 - [`src/gui/mod.rs`](../../src/gui/mod.rs) — `GuiApp` struct, `eframe::App` impl, game loop
-- [`src/gui/theme.rs`](../../src/gui/theme.rs) — Time-of-day color palettes for egui
+- [`src/gui/theme.rs`](../../src/gui/theme.rs) — Smooth time-of-day color palettes for egui
+- [`src/world/palette.rs`](../../src/world/palette.rs) — Shared color interpolation engine
 - [`src/gui/chat_panel.rs`](../../src/gui/chat_panel.rs) — Scrollable text log
 - [`src/gui/map_panel.rs`](../../src/gui/map_panel.rs) — Interactive location graph
 - [`src/gui/status_bar.rs`](../../src/gui/status_bar.rs) — Top status bar

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -64,9 +64,10 @@ src/
 ├── input/
 │   └── mod.rs           # Player input parsing, command detection
 ├── world/
-│   ├── mod.rs           # WorldState, location types
+│   ├── mod.rs           # WorldState, Weather enum, location types
 │   ├── graph.rs         # WorldGraph (adjacency list, BFS pathfinding)
 │   ├── time.rs          # GameClock, TimeOfDay, Season
+│   ├── palette.rs       # Smooth color interpolation engine (time/season/weather)
 │   ├── movement.rs      # Movement resolution, fuzzy destination matching
 │   ├── encounter.rs     # En-route encounter system
 │   └── description.rs   # Dynamic location description templates
@@ -90,7 +91,7 @@ src/
 │   └── debug_panel.rs   # Debug overlay panel
 ├── gui/
 │   ├── mod.rs           # ParishGui, eframe integration
-│   ├── theme.rs         # Time-of-day color theming
+│   ├── theme.rs         # Time-of-day color theming (smooth interpolation)
 │   ├── chat_panel.rs    # Chat/dialogue display
 │   ├── map_panel.rs     # Interactive parish map
 │   ├── sidebar.rs       # Irish word pronunciation sidebar

--- a/docs/design/player-input.md
+++ b/docs/design/player-input.md
@@ -25,7 +25,7 @@ System commands use `/` prefix for now (placeholder — may change to a prefix-f
 |----------------|-------------------------------------------------------------------------|
 | `/pause`       | Freeze all simulation ticks, TUI stays up                              |
 | `/resume`      | Unfreeze simulation                                                     |
-| `/speed [preset]` | Show or set game speed (`slow`/`normal`/`fast`/`fastest`)           |
+| `/speed [preset]` | Show or set game speed (`slow`/`normal`/`fast`/`fastest`/`ludicrous`) |
 | `/quit`        | Persist current state, clean shutdown                                   |
 | `/save`        | Manual snapshot to current branch                                       |
 | `/fork <name>` | Snapshot current state, create new named branch, continue on new branch |

--- a/docs/design/time-system.md
+++ b/docs/design/time-system.md
@@ -17,6 +17,7 @@ Speed is adjustable at runtime via the `/speed` command, inspired by SimCity:
 | `/speed normal` | Normal (default) | 36.0 | 40 minutes |
 | `/speed fast` | Fast | 72.0 | 20 minutes |
 | `/speed fastest` | Fastest | 144.0 | 10 minutes |
+| `/speed ludicrous` | Ludicrous | 864.0 | 100 seconds |
 
 `/speed` alone shows the current pace. Speed changes recalibrate the clock
 seamlessly — current game time is preserved, only the rate of passage changes.

--- a/docs/design/weather-system.md
+++ b/docs/design/weather-system.md
@@ -2,7 +2,19 @@
 
 > Parent: [Architecture Overview](overview.md) | [Docs Index](../index.md)
 
-Weather is a simulation driver, not just visual dressing. Weather state is part of world state and affects NPC context prompts.
+Weather is a simulation driver, not just visual dressing. Weather state is part of world state and affects NPC context prompts, location descriptions, and color palettes.
+
+## Weather Enum
+
+The `Weather` enum in `src/world/mod.rs` defines five conditions:
+
+| Variant      | Description                               |
+|--------------|-------------------------------------------|
+| `Clear`      | Default — no palette modification         |
+| `Overcast`   | Slightly darker and desaturated           |
+| `Rain`       | Darker with a blue-gray tint              |
+| `Fog`        | Washed out, low contrast                  |
+| `Storm`      | Much darker and heavily desaturated       |
 
 ## Effects on Simulation
 
@@ -15,27 +27,46 @@ Weather is a simulation driver, not just visual dressing. Weather state is part 
 | **Overcast**      | Muted mood, reduced outdoor activity                          |
 | **Storms**        | Disruptive, affects travel and NPC schedules                  |
 
-## TUI Color Palette Modifiers
+## Palette Tinting
 
-Weather modifies the base time-of-day color palette in the TUI:
+Weather modifies the base time-of-day color palette via multiplicative tinting in `src/world/palette.rs`. The tinting system applies three layers:
 
-| Weather   | Palette Effect              |
-|-----------|-----------------------------|
-| Overcast  | Muted/desaturated           |
-| Rain      | Cooler tones, grey cast     |
-| Fog       | Heavily desaturated         |
-| Clear     | Full saturation             |
+1. **Time-of-day interpolation** — smooth linear interpolation between 7 keyframe palettes based on exact hour and minute
+2. **Season tinting** — subtle color shifts (Winter: cooler/bluer, Summer: warmer, Autumn: amber, Spring: greener)
+3. **Weather tinting** — brightness, desaturation, and color temperature adjustments
 
-See [TUI Design](tui-design.md) for the full color system.
+### Weather Tint Parameters
+
+| Weather   | RGB Multiplier         | Desaturation | Brightness | Contrast Reduction |
+|-----------|------------------------|-------------|------------|-------------------|
+| Clear     | (1.0, 1.0, 1.0)       | 0%          | 100%       | 0%                |
+| Overcast  | (0.95, 0.95, 0.97)    | 15%         | 92%        | 0%                |
+| Rain      | (0.88, 0.90, 0.95)    | 20%         | 85%        | 0%                |
+| Fog       | (0.97, 0.97, 0.98)    | 35%         | 95%        | 15%               |
+| Storm     | (0.80, 0.82, 0.85)    | 30%         | 75%        | 0%                |
+
+### Season Tint Parameters
+
+| Season  | RGB Multiplier         | Desaturation |
+|---------|------------------------|-------------|
+| Spring  | (0.98, 1.02, 0.98)    | 0%          |
+| Summer  | (1.03, 1.01, 0.97)    | 0%          |
+| Autumn  | (1.06, 1.00, 0.92)    | 0%          |
+| Winter  | (0.94, 0.96, 1.04)    | 8%          |
+
+Both the GUI (`src/gui/theme.rs`) and TUI (`src/tui/mod.rs`) consume the same `RawPalette` from the interpolation engine.
 
 ## Related
 
 - [TUI Design](tui-design.md) — Weather palette modifiers and visual atmosphere
+- [GUI Design](gui-design.md) — GUI color theming with smooth transitions
 - [Time System](time-system.md) — Seasons drive weather patterns
 - [NPC System](npc-system.md) — Weather affects NPC schedules, behavior, and dialogue
 
 ## Source Modules
 
-- [`src/world/`](../../src/world/) — World state, weather state
-- [`src/tui/`](../../src/tui/) — Weather-driven palette modifiers
+- [`src/world/mod.rs`](../../src/world/mod.rs) — `Weather` enum definition
+- [`src/world/palette.rs`](../../src/world/palette.rs) — Smooth interpolation engine, season/weather tinting
+- [`src/gui/theme.rs`](../../src/gui/theme.rs) — GUI palette conversion and application
+- [`src/tui/mod.rs`](../../src/tui/mod.rs) — TUI palette conversion
 - [`src/npc/`](../../src/npc/) — Weather-aware NPC behavior

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -382,6 +382,9 @@ impl GuiApp {
                     GameSpeed::Normal => "The parish settles into its natural stride.",
                     GameSpeed::Fast => "The parish quickens its step.",
                     GameSpeed::Fastest => "The parish fair flies — hold onto your hat!",
+                    GameSpeed::Ludicrous => {
+                        "The world is a blur — days pass in the blink of an eye!"
+                    }
                 };
                 self.world.log(msg.to_string());
             }
@@ -406,7 +409,7 @@ impl GuiApp {
                 self.world
                     .log("  /resume   — Let time flow again".to_string());
                 self.world.log(
-                    "  /speed    — Show or change game speed (slow/normal/fast/fastest)"
+                    "  /speed    — Show or change game speed (slow/normal/fast/fastest/ludicrous)"
                         .to_string(),
                 );
                 self.world.log("  /status   — Where am I?".to_string());

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -18,6 +18,8 @@ use std::collections::VecDeque;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+use chrono::Timelike;
+
 use anyhow::Result;
 use eframe::egui;
 use tokio::sync::mpsc;
@@ -37,7 +39,7 @@ use crate::world::description::{format_exits, render_description};
 use crate::world::movement::{self, MovementResult};
 use crate::world::{LocationId, WorldState};
 
-use theme::{apply_palette, gui_palette_for_time};
+use theme::{apply_palette, gui_palette_smooth};
 
 /// Maximum number of debug log entries.
 const DEBUG_LOG_CAPACITY: usize = 50;
@@ -255,7 +257,7 @@ impl GuiApp {
 
         if let Some(loc_data) = self.world.current_location_data() {
             let tod = self.world.clock.time_of_day();
-            let weather = self.world.weather.clone();
+            let weather = self.world.weather.to_string();
             let npc_names: Vec<&str> = self
                 .npc_manager
                 .npcs_at(self.world.player_location)
@@ -282,7 +284,7 @@ impl GuiApp {
     fn show_location_description(&mut self) {
         if let Some(loc_data) = self.world.current_location_data() {
             let tod = self.world.clock.time_of_day();
-            let weather = self.world.weather.clone();
+            let weather = self.world.weather.to_string();
             let npc_names: Vec<&str> = self
                 .npc_manager
                 .npcs_at(self.world.player_location)
@@ -749,8 +751,14 @@ impl eframe::App for GuiApp {
         // Idle tick
         self.maybe_idle_tick();
 
-        // Apply time-of-day palette
-        let palette = gui_palette_for_time(&self.world.clock.time_of_day());
+        // Apply smoothly interpolated time-of-day palette with season/weather tinting
+        let now = self.world.clock.now();
+        let palette = gui_palette_smooth(
+            now.hour(),
+            now.minute(),
+            self.world.clock.season(),
+            self.world.weather,
+        );
         apply_palette(ctx, &palette);
 
         // Request continuous repaint while streaming

--- a/src/gui/status_bar.rs
+++ b/src/gui/status_bar.rs
@@ -45,7 +45,7 @@ pub fn draw_status_bar(ui: &mut egui::Ui, world: &WorldState, palette: &GuiPalet
 
             // Weather
             ui.label(
-                egui::RichText::new(&world.weather)
+                egui::RichText::new(world.weather.to_string())
                     .color(palette.fg)
                     .size(13.0),
             );
@@ -101,7 +101,7 @@ mod tests {
     fn test_world_state_for_status_bar() {
         let world = WorldState::new();
         assert_eq!(world.current_location().name, "The Crossroads");
-        assert_eq!(world.weather, "Clear");
+        assert_eq!(world.weather, crate::world::Weather::Clear);
         assert!(!world.clock.is_paused());
     }
 }

--- a/src/gui/theme.rs
+++ b/src/gui/theme.rs
@@ -6,7 +6,9 @@
 
 use eframe::egui;
 
-use crate::world::time::TimeOfDay;
+use crate::world::Weather;
+use crate::world::palette::{RawPalette, compute_palette};
+use crate::world::time::{Season, TimeOfDay};
 
 /// A color palette for the GUI based on time of day.
 ///
@@ -28,6 +30,28 @@ pub struct GuiPalette {
     pub border: egui::Color32,
     /// Muted text color for secondary information.
     pub muted: egui::Color32,
+}
+
+impl From<RawPalette> for GuiPalette {
+    fn from(raw: RawPalette) -> Self {
+        GuiPalette {
+            bg: egui::Color32::from_rgb(raw.bg.r, raw.bg.g, raw.bg.b),
+            fg: egui::Color32::from_rgb(raw.fg.r, raw.fg.g, raw.fg.b),
+            accent: egui::Color32::from_rgb(raw.accent.r, raw.accent.g, raw.accent.b),
+            panel_bg: egui::Color32::from_rgb(raw.panel_bg.r, raw.panel_bg.g, raw.panel_bg.b),
+            input_bg: egui::Color32::from_rgb(raw.input_bg.r, raw.input_bg.g, raw.input_bg.b),
+            border: egui::Color32::from_rgb(raw.border.r, raw.border.g, raw.border.b),
+            muted: egui::Color32::from_rgb(raw.muted.r, raw.muted.g, raw.muted.b),
+        }
+    }
+}
+
+/// Returns a smoothly interpolated GUI palette for the given time, season, and weather.
+///
+/// Uses linear interpolation between time-of-day keyframes and applies
+/// seasonal and weather color tinting for gradual transitions.
+pub fn gui_palette_smooth(hour: u32, minute: u32, season: Season, weather: Weather) -> GuiPalette {
+    compute_palette(hour, minute, season, weather).into()
 }
 
 /// Returns the GUI palette for the given time of day.
@@ -196,6 +220,30 @@ mod tests {
             let [r, g, _b, _] = p.bg.to_array();
             assert!(r > 200 && g > 200, "Day palette bg should be light: {tod}");
         }
+    }
+
+    #[test]
+    fn test_gui_palette_smooth_returns_valid() {
+        use crate::world::Weather;
+        use crate::world::time::Season;
+
+        let p = gui_palette_smooth(12, 0, Season::Summer, Weather::Clear);
+        assert_ne!(p.bg, egui::Color32::TRANSPARENT);
+        assert_ne!(p.fg, egui::Color32::TRANSPARENT);
+    }
+
+    #[test]
+    fn test_gui_palette_smooth_storm_darkens() {
+        use crate::world::Weather;
+        use crate::world::time::Season;
+
+        let clear = gui_palette_smooth(12, 0, Season::Summer, Weather::Clear);
+        let storm = gui_palette_smooth(12, 0, Season::Summer, Weather::Storm);
+        let [cr, cg, cb, _] = clear.bg.to_array();
+        let [sr, sg, sb, _] = storm.bg.to_array();
+        let clear_lum = cr as f32 * 0.299 + cg as f32 * 0.587 + cb as f32 * 0.114;
+        let storm_lum = sr as f32 * 0.299 + sg as f32 * 0.587 + sb as f32 * 0.114;
+        assert!(storm_lum < clear_lum, "Storm should darken the palette");
     }
 
     #[test]

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -219,6 +219,7 @@ fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
                 GameSpeed::Normal => "The parish settles into its natural stride.",
                 GameSpeed::Fast => "The parish quickens its step.",
                 GameSpeed::Fastest => "The parish fair flies — hold onto your hat!",
+                GameSpeed::Ludicrous => "The world is a blur — days pass in the blink of an eye!",
             };
             println!("{}", msg);
         }
@@ -238,7 +239,9 @@ fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             println!("  /quit     - Take your leave");
             println!("  /pause    - Hold time still");
             println!("  /resume   - Let time flow again");
-            println!("  /speed    - Show or change game speed (slow/normal/fast/fastest)");
+            println!(
+                "  /speed    - Show or change game speed (slow/normal/fast/fastest/ludicrous)"
+            );
             println!("  /status   - Where am I?");
             println!("  /irish    - Toggle Irish words sidebar (TUI only)");
             println!("  /improv   - Toggle improv craft for NPC dialogue");

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -578,7 +578,7 @@ fn print_location_arrival(app: &App) {
             .iter()
             .map(|n| n.name.as_str())
             .collect();
-        let desc = render_description(loc_data, tod, &app.world.weather, &npc_names);
+        let desc = render_description(loc_data, tod, &app.world.weather.to_string(), &npc_names);
         println!("{}", desc);
     } else {
         println!("{}", app.world.current_location().description);
@@ -603,7 +603,7 @@ fn print_location_description(app: &App) {
             .iter()
             .map(|n| n.name.as_str())
             .collect();
-        let desc = render_description(loc_data, tod, &app.world.weather, &npc_names);
+        let desc = render_description(loc_data, tod, &app.world.weather.to_string(), &npc_names);
         println!("{}", desc);
     } else {
         println!("{}", app.world.current_location().description);

--- a/src/main.rs
+++ b/src/main.rs
@@ -672,6 +672,7 @@ fn handle_system_command(app: &mut App, cmd: Command) -> bool {
                 GameSpeed::Normal => "The parish settles into its natural stride.",
                 GameSpeed::Fast => "The parish quickens its step.",
                 GameSpeed::Fastest => "The parish fair flies — hold onto your hat!",
+                GameSpeed::Ludicrous => "The world is a blur — days pass in the blink of an eye!",
             };
             app.world.log(msg.to_string());
         }
@@ -696,7 +697,8 @@ fn handle_system_command(app: &mut App, cmd: Command) -> bool {
             app.world
                 .log("  /resume   — Let time flow again".to_string());
             app.world.log(
-                "  /speed    — Show or change game speed (slow/normal/fast/fastest)".to_string(),
+                "  /speed    — Show or change game speed (slow/normal/fast/fastest/ludicrous)"
+                    .to_string(),
             );
             app.world.log("  /status   — Where am I?".to_string());
             app.world

--- a/src/main.rs
+++ b/src/main.rs
@@ -890,7 +890,7 @@ fn show_location_arrival(app: &mut App) {
     // Render dynamic description if graph is loaded, else use static description
     if let Some(loc_data) = app.world.current_location_data() {
         let tod = app.world.clock.time_of_day();
-        let weather = app.world.weather.clone();
+        let weather = app.world.weather.to_string();
         let npc_names: Vec<&str> = app
             .npc_manager
             .npcs_at(app.world.player_location)
@@ -919,7 +919,7 @@ fn show_location_arrival(app: &mut App) {
 fn show_location_description(app: &mut App) {
     if let Some(loc_data) = app.world.current_location_data() {
         let tod = app.world.clock.time_of_day();
-        let weather = app.world.weather.clone();
+        let weather = app.world.weather.to_string();
         let npc_names: Vec<&str> = app
             .npc_manager
             .npcs_at(app.world.player_location)

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -230,8 +230,8 @@ impl GameTestHarness {
         format_exits(self.app.world.player_location, &self.app.world.graph)
     }
 
-    /// Returns the current weather string.
-    pub fn weather(&self) -> &str {
+    /// Returns the current weather.
+    pub fn weather(&self) -> &crate::world::Weather {
         &self.app.world.weather
     }
 
@@ -575,7 +575,12 @@ impl GameTestHarness {
                 .iter()
                 .map(|n| n.name.as_str())
                 .collect();
-            render_description(loc_data, tod, &self.app.world.weather, &npc_names)
+            render_description(
+                loc_data,
+                tod,
+                &self.app.world.weather.to_string(),
+                &npc_names,
+            )
         } else {
             self.app.world.current_location().description.clone()
         }
@@ -663,7 +668,7 @@ mod tests {
     #[test]
     fn test_harness_initial_weather() {
         let h = GameTestHarness::new();
-        assert_eq!(h.weather(), "Clear");
+        assert_eq!(*h.weather(), crate::world::Weather::Clear);
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -13,6 +13,7 @@ use crate::loading::LoadingAnimation;
 use crate::npc::IrishWordHint;
 use crate::npc::manager::NpcManager;
 use crate::world::WorldState;
+use crate::world::palette::{RawPalette, compute_palette};
 use crate::world::time::TimeOfDay;
 
 /// Maximum number of entries in the debug activity log.
@@ -95,6 +96,29 @@ pub fn palette_for_time(tod: &TimeOfDay) -> ColorPalette {
             accent: Color::Rgb(70, 75, 100),
         },
     }
+}
+
+impl From<RawPalette> for ColorPalette {
+    fn from(raw: RawPalette) -> Self {
+        ColorPalette {
+            bg: Color::Rgb(raw.bg.r, raw.bg.g, raw.bg.b),
+            fg: Color::Rgb(raw.fg.r, raw.fg.g, raw.fg.b),
+            accent: Color::Rgb(raw.accent.r, raw.accent.g, raw.accent.b),
+        }
+    }
+}
+
+/// Returns a smoothly interpolated TUI palette for the given time, season, and weather.
+///
+/// Uses linear interpolation between time-of-day keyframes and applies
+/// seasonal and weather color tinting.
+pub fn palette_smooth(
+    hour: u32,
+    minute: u32,
+    season: crate::world::time::Season,
+    weather: crate::world::Weather,
+) -> ColorPalette {
+    compute_palette(hour, minute, season, weather).into()
 }
 
 /// Scroll state for the main text panel.
@@ -288,9 +312,15 @@ pub fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> io
 /// Draws one frame of the TUI.
 ///
 /// Layout: top bar (3 lines with border), main text panel (fill), input line (3 lines with border).
-/// Colors are driven by the current time-of-day palette.
+/// Colors are driven by the smoothly interpolated time-of-day palette.
 pub fn draw(frame: &mut Frame, app: &mut App) {
-    let palette = palette_for_time(&app.world.clock.time_of_day());
+    let now = app.world.clock.now();
+    let palette = palette_smooth(
+        chrono::Timelike::hour(&now),
+        chrono::Timelike::minute(&now),
+        app.world.clock.season(),
+        app.world.weather,
+    );
     let base_style = Style::default().fg(palette.fg).bg(palette.bg);
     let accent_style = Style::default().fg(palette.accent).bg(palette.bg);
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -8,9 +8,11 @@ pub mod description;
 pub mod encounter;
 pub mod graph;
 pub mod movement;
+pub mod palette;
 pub mod time;
 
 use std::collections::HashMap;
+use std::fmt;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -18,6 +20,36 @@ use time::GameClock;
 
 use crate::error::ParishError;
 use graph::{LocationData, WorldGraph};
+
+/// Current weather conditions in the game world.
+///
+/// Affects color palette tinting (desaturation, brightness, color temperature)
+/// and location description templates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Weather {
+    /// Clear skies — no palette modification.
+    Clear,
+    /// Overcast — slightly darker and desaturated.
+    Overcast,
+    /// Rain — darker with a blue-gray tint.
+    Rain,
+    /// Fog — washed out, low contrast.
+    Fog,
+    /// Storm — much darker and heavily desaturated.
+    Storm,
+}
+
+impl fmt::Display for Weather {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Weather::Clear => write!(f, "Clear"),
+            Weather::Overcast => write!(f, "Overcast"),
+            Weather::Rain => write!(f, "Rain"),
+            Weather::Fog => write!(f, "Fog"),
+            Weather::Storm => write!(f, "Storm"),
+        }
+    }
+}
 
 /// Unique identifier for a location in the world graph.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -56,8 +88,8 @@ pub struct WorldState {
     pub locations: HashMap<LocationId, Location>,
     /// The world graph with full location data and connections.
     pub graph: WorldGraph,
-    /// Current weather description (e.g. "Clear", "Overcast").
-    pub weather: String,
+    /// Current weather conditions affecting palette and descriptions.
+    pub weather: Weather,
     /// Scrollback text log displayed in the main TUI panel.
     pub text_log: Vec<String>,
 }
@@ -92,7 +124,7 @@ impl WorldState {
             player_location: crossroads_id,
             locations,
             graph: WorldGraph::new(),
-            weather: "Clear".to_string(),
+            weather: Weather::Clear,
             text_log: Vec::new(),
         }
     }
@@ -131,7 +163,7 @@ impl WorldState {
             player_location: start_location,
             locations,
             graph,
-            weather: "Clear".to_string(),
+            weather: Weather::Clear,
             text_log: Vec::new(),
         })
     }
@@ -172,9 +204,18 @@ mod tests {
     fn test_world_state_new() {
         let world = WorldState::new();
         assert_eq!(world.player_location, LocationId(1));
-        assert_eq!(world.weather, "Clear");
+        assert_eq!(world.weather, Weather::Clear);
         assert!(world.text_log.is_empty());
         assert_eq!(world.locations.len(), 1);
+    }
+
+    #[test]
+    fn test_weather_display() {
+        assert_eq!(Weather::Clear.to_string(), "Clear");
+        assert_eq!(Weather::Overcast.to_string(), "Overcast");
+        assert_eq!(Weather::Rain.to_string(), "Rain");
+        assert_eq!(Weather::Fog.to_string(), "Fog");
+        assert_eq!(Weather::Storm.to_string(), "Storm");
     }
 
     #[test]

--- a/src/world/palette.rs
+++ b/src/world/palette.rs
@@ -1,0 +1,545 @@
+//! Smooth color palette interpolation engine.
+//!
+//! Provides backend-agnostic RGB palette computation that smoothly
+//! interpolates between time-of-day keyframes and applies seasonal
+//! and weather tinting. Both the GUI ([`crate::gui::theme`]) and
+//! TUI ([`crate::tui`]) consume [`RawPalette`] values from this module.
+
+use super::Weather;
+use super::time::Season;
+
+/// A backend-agnostic RGB color.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RawColor {
+    /// Red channel (0–255).
+    pub r: u8,
+    /// Green channel (0–255).
+    pub g: u8,
+    /// Blue channel (0–255).
+    pub b: u8,
+}
+
+impl RawColor {
+    /// Creates a new `RawColor` from RGB values.
+    pub const fn new(r: u8, g: u8, b: u8) -> Self {
+        Self { r, g, b }
+    }
+}
+
+/// A backend-agnostic color palette with 7 semantic color slots.
+///
+/// Mirrors [`crate::gui::theme::GuiPalette`] but uses [`RawColor`]
+/// instead of egui types, so it can be shared between renderers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RawPalette {
+    /// Main background color.
+    pub bg: RawColor,
+    /// Foreground (text) color.
+    pub fg: RawColor,
+    /// Accent color for status bar and highlights.
+    pub accent: RawColor,
+    /// Slightly offset background for panels.
+    pub panel_bg: RawColor,
+    /// Background for the text input field.
+    pub input_bg: RawColor,
+    /// Border/separator color.
+    pub border: RawColor,
+    /// Muted text color for secondary information.
+    pub muted: RawColor,
+}
+
+/// A keyframe: an anchor hour and its associated palette.
+struct Keyframe {
+    hour: f32,
+    palette: RawPalette,
+}
+
+/// The 7 time-of-day keyframes, ordered by anchor hour.
+///
+/// Anchor hours are the midpoints of each [`TimeOfDay`] range.
+/// RGB values are identical to the original discrete palettes.
+const KEYFRAMES: [Keyframe; 7] = [
+    // Midnight (23:00–4:59) → midpoint wraps; use 1.5
+    Keyframe {
+        hour: 1.5,
+        palette: RawPalette {
+            bg: RawColor::new(10, 12, 20),
+            fg: RawColor::new(150, 150, 165),
+            accent: RawColor::new(70, 75, 100),
+            panel_bg: RawColor::new(15, 18, 28),
+            input_bg: RawColor::new(20, 24, 36),
+            border: RawColor::new(45, 48, 65),
+            muted: RawColor::new(100, 100, 115),
+        },
+    },
+    // Dawn (5:00–6:59) → midpoint 5.5
+    Keyframe {
+        hour: 5.5,
+        palette: RawPalette {
+            bg: RawColor::new(255, 220, 180),
+            fg: RawColor::new(60, 40, 20),
+            accent: RawColor::new(200, 140, 60),
+            panel_bg: RawColor::new(250, 215, 175),
+            input_bg: RawColor::new(245, 210, 170),
+            border: RawColor::new(200, 170, 130),
+            muted: RawColor::new(120, 100, 70),
+        },
+    },
+    // Morning (7:00–9:59) → midpoint 8.0 (use 8.5 for center of 7-9)
+    Keyframe {
+        hour: 8.5,
+        palette: RawPalette {
+            bg: RawColor::new(255, 245, 220),
+            fg: RawColor::new(50, 35, 15),
+            accent: RawColor::new(180, 130, 50),
+            panel_bg: RawColor::new(250, 240, 215),
+            input_bg: RawColor::new(245, 235, 210),
+            border: RawColor::new(210, 190, 150),
+            muted: RawColor::new(120, 100, 60),
+        },
+    },
+    // Midday (10:00–13:59) → midpoint 12.0
+    Keyframe {
+        hour: 12.0,
+        palette: RawPalette {
+            bg: RawColor::new(255, 255, 240),
+            fg: RawColor::new(40, 30, 10),
+            accent: RawColor::new(160, 120, 40),
+            panel_bg: RawColor::new(250, 250, 235),
+            input_bg: RawColor::new(245, 245, 230),
+            border: RawColor::new(210, 200, 170),
+            muted: RawColor::new(110, 100, 60),
+        },
+    },
+    // Afternoon (14:00–16:59) → midpoint 15.5
+    Keyframe {
+        hour: 15.5,
+        palette: RawPalette {
+            bg: RawColor::new(240, 220, 170),
+            fg: RawColor::new(50, 35, 15),
+            accent: RawColor::new(180, 130, 50),
+            panel_bg: RawColor::new(235, 215, 165),
+            input_bg: RawColor::new(230, 210, 160),
+            border: RawColor::new(200, 180, 130),
+            muted: RawColor::new(120, 100, 60),
+        },
+    },
+    // Dusk (17:00–18:59) → midpoint 18.0
+    Keyframe {
+        hour: 18.0,
+        palette: RawPalette {
+            bg: RawColor::new(60, 70, 110),
+            fg: RawColor::new(220, 210, 190),
+            accent: RawColor::new(200, 160, 80),
+            panel_bg: RawColor::new(55, 65, 100),
+            input_bg: RawColor::new(50, 60, 95),
+            border: RawColor::new(90, 100, 140),
+            muted: RawColor::new(160, 150, 140),
+        },
+    },
+    // Night (19:00–22:59) → midpoint 21.0
+    Keyframe {
+        hour: 21.0,
+        palette: RawPalette {
+            bg: RawColor::new(20, 25, 40),
+            fg: RawColor::new(180, 180, 190),
+            accent: RawColor::new(100, 110, 140),
+            panel_bg: RawColor::new(25, 30, 48),
+            input_bg: RawColor::new(30, 35, 55),
+            border: RawColor::new(60, 65, 90),
+            muted: RawColor::new(120, 120, 135),
+        },
+    },
+];
+
+/// Linearly interpolates a single byte channel.
+fn lerp_u8(a: u8, b: u8, t: f32) -> u8 {
+    let v = a as f32 + (b as f32 - a as f32) * t;
+    v.round().clamp(0.0, 255.0) as u8
+}
+
+/// Linearly interpolates between two colors.
+fn lerp_color(a: RawColor, b: RawColor, t: f32) -> RawColor {
+    RawColor {
+        r: lerp_u8(a.r, b.r, t),
+        g: lerp_u8(a.g, b.g, t),
+        b: lerp_u8(a.b, b.b, t),
+    }
+}
+
+/// Linearly interpolates between two palettes (all 7 color fields).
+fn lerp_palette(a: &RawPalette, b: &RawPalette, t: f32) -> RawPalette {
+    RawPalette {
+        bg: lerp_color(a.bg, b.bg, t),
+        fg: lerp_color(a.fg, b.fg, t),
+        accent: lerp_color(a.accent, b.accent, t),
+        panel_bg: lerp_color(a.panel_bg, b.panel_bg, t),
+        input_bg: lerp_color(a.input_bg, b.input_bg, t),
+        border: lerp_color(a.border, b.border, t),
+        muted: lerp_color(a.muted, b.muted, t),
+    }
+}
+
+/// Computes the smoothly interpolated time-of-day palette.
+///
+/// Uses linear interpolation between the two nearest keyframe palettes
+/// based on the exact fractional hour. Handles the circular midnight
+/// wrap-around correctly.
+fn interpolated_palette(hour: u32, minute: u32) -> RawPalette {
+    let frac = hour as f32 + minute as f32 / 60.0;
+
+    // Find the two bounding keyframes on the circular timeline.
+    // KEYFRAMES is sorted by anchor hour: 1.5, 5.5, 8.5, 12.0, 15.5, 18.0, 21.0
+    let n = KEYFRAMES.len(); // 7
+
+    // Check if we're in the wrap-around segment: Night(21.0) → Midnight(1.5+24=25.5)
+    let last = &KEYFRAMES[n - 1]; // Night at 21.0
+    let first = &KEYFRAMES[0]; // Midnight at 1.5
+
+    // Wrap-around span: from 21.0 to 25.5 (i.e., 21.0→24.0→1.5)
+    let wrap_span = (24.0 - last.hour) + first.hour; // 3.0 + 1.5 = 4.5
+
+    if frac >= last.hour {
+        // Between Night(21.0) and Midnight(25.5), current hour is 21.0..24.0
+        let t = (frac - last.hour) / wrap_span;
+        return lerp_palette(&last.palette, &first.palette, t);
+    }
+
+    if frac < first.hour {
+        // Between Night(21.0) and Midnight(1.5), current hour is 0.0..1.5
+        let elapsed = (24.0 - last.hour) + frac;
+        let t = elapsed / wrap_span;
+        return lerp_palette(&last.palette, &first.palette, t);
+    }
+
+    // Normal case: find adjacent keyframes where KEYFRAMES[i].hour <= frac < KEYFRAMES[i+1].hour
+    for i in 0..n - 1 {
+        let from = &KEYFRAMES[i];
+        let to = &KEYFRAMES[i + 1];
+        if frac >= from.hour && frac < to.hour {
+            let t = (frac - from.hour) / (to.hour - from.hour);
+            return lerp_palette(&from.palette, &to.palette, t);
+        }
+    }
+
+    // Fallback (shouldn't be reached)
+    KEYFRAMES[0].palette
+}
+
+/// Season tint parameters: (r_mult, g_mult, b_mult, desaturation).
+fn season_tint(season: Season) -> (f32, f32, f32, f32) {
+    match season {
+        Season::Spring => (0.98, 1.02, 0.98, 0.0),
+        Season::Summer => (1.03, 1.01, 0.97, 0.0),
+        Season::Autumn => (1.06, 1.00, 0.92, 0.0),
+        Season::Winter => (0.94, 0.96, 1.04, 0.08),
+    }
+}
+
+/// Weather tint parameters: (r_mult, g_mult, b_mult, desaturation, brightness, contrast_reduction).
+fn weather_tint(weather: Weather) -> (f32, f32, f32, f32, f32, f32) {
+    match weather {
+        Weather::Clear => (1.0, 1.0, 1.0, 0.0, 1.0, 0.0),
+        Weather::Overcast => (0.95, 0.95, 0.97, 0.15, 0.92, 0.0),
+        Weather::Rain => (0.88, 0.90, 0.95, 0.20, 0.85, 0.0),
+        Weather::Fog => (0.97, 0.97, 0.98, 0.35, 0.95, 0.15),
+        Weather::Storm => (0.80, 0.82, 0.85, 0.30, 0.75, 0.0),
+    }
+}
+
+/// Computes the luminance of an RGB color (ITU-R BT.601).
+fn luminance(c: RawColor) -> f32 {
+    0.299 * c.r as f32 + 0.587 * c.g as f32 + 0.114 * c.b as f32
+}
+
+/// Applies a multiplicative tint, desaturation, and brightness to a single color.
+fn tint_color(
+    c: RawColor,
+    r_mult: f32,
+    g_mult: f32,
+    b_mult: f32,
+    desat: f32,
+    bright: f32,
+) -> RawColor {
+    let lum = luminance(c);
+
+    // Desaturate: blend toward gray (luminance)
+    let r = c.r as f32 + (lum - c.r as f32) * desat;
+    let g = c.g as f32 + (lum - c.g as f32) * desat;
+    let b = c.b as f32 + (lum - c.b as f32) * desat;
+
+    // Apply color multiplier and brightness
+    let r = (r * r_mult * bright).round().clamp(0.0, 255.0) as u8;
+    let g = (g * g_mult * bright).round().clamp(0.0, 255.0) as u8;
+    let b = (b * b_mult * bright).round().clamp(0.0, 255.0) as u8;
+
+    RawColor::new(r, g, b)
+}
+
+/// Applies season tinting to all palette colors.
+fn apply_season_tint(palette: &mut RawPalette, season: Season) {
+    let (rm, gm, bm, desat) = season_tint(season);
+    palette.bg = tint_color(palette.bg, rm, gm, bm, desat, 1.0);
+    palette.fg = tint_color(palette.fg, rm, gm, bm, desat, 1.0);
+    palette.accent = tint_color(palette.accent, rm, gm, bm, desat, 1.0);
+    palette.panel_bg = tint_color(palette.panel_bg, rm, gm, bm, desat, 1.0);
+    palette.input_bg = tint_color(palette.input_bg, rm, gm, bm, desat, 1.0);
+    palette.border = tint_color(palette.border, rm, gm, bm, desat, 1.0);
+    palette.muted = tint_color(palette.muted, rm, gm, bm, desat, 1.0);
+}
+
+/// Applies weather tinting to all palette colors.
+///
+/// For fog, also reduces contrast by blending fg toward bg.
+fn apply_weather_tint(palette: &mut RawPalette, weather: Weather) {
+    let (rm, gm, bm, desat, bright, contrast_reduction) = weather_tint(weather);
+    palette.bg = tint_color(palette.bg, rm, gm, bm, desat, bright);
+    palette.fg = tint_color(palette.fg, rm, gm, bm, desat, bright);
+    palette.accent = tint_color(palette.accent, rm, gm, bm, desat, bright);
+    palette.panel_bg = tint_color(palette.panel_bg, rm, gm, bm, desat, bright);
+    palette.input_bg = tint_color(palette.input_bg, rm, gm, bm, desat, bright);
+    palette.border = tint_color(palette.border, rm, gm, bm, desat, bright);
+    palette.muted = tint_color(palette.muted, rm, gm, bm, desat, bright);
+
+    // Fog contrast reduction: blend fg toward bg
+    if contrast_reduction > 0.0 {
+        palette.fg = lerp_color(palette.fg, palette.bg, contrast_reduction);
+        palette.muted = lerp_color(palette.muted, palette.bg, contrast_reduction * 0.5);
+    }
+}
+
+/// Computes the fully interpolated and tinted palette for the given time, season, and weather.
+///
+/// This is the main entry point for both GUI and TUI renderers.
+/// 1. Smoothly interpolates between time-of-day keyframe palettes
+/// 2. Applies seasonal color tinting
+/// 3. Applies weather color tinting
+pub fn compute_palette(hour: u32, minute: u32, season: Season, weather: Weather) -> RawPalette {
+    let mut palette = interpolated_palette(hour, minute);
+    apply_season_tint(&mut palette, season);
+    apply_weather_tint(&mut palette, weather);
+    palette
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lerp_u8_boundaries() {
+        assert_eq!(lerp_u8(0, 255, 0.0), 0);
+        assert_eq!(lerp_u8(0, 255, 1.0), 255);
+        assert_eq!(lerp_u8(0, 255, 0.5), 128);
+        assert_eq!(lerp_u8(100, 200, 0.5), 150);
+    }
+
+    #[test]
+    fn test_lerp_color() {
+        let a = RawColor::new(0, 0, 0);
+        let b = RawColor::new(255, 255, 255);
+        let mid = lerp_color(a, b, 0.5);
+        assert_eq!(mid, RawColor::new(128, 128, 128));
+    }
+
+    #[test]
+    fn test_keyframe_dawn_exact() {
+        // At Dawn's anchor hour (5:30), should match Dawn palette exactly
+        let p = interpolated_palette(5, 30);
+        assert_eq!(p.bg, KEYFRAMES[1].palette.bg);
+        assert_eq!(p.fg, KEYFRAMES[1].palette.fg);
+        assert_eq!(p.accent, KEYFRAMES[1].palette.accent);
+    }
+
+    #[test]
+    fn test_keyframe_midday_exact() {
+        // At Midday's anchor hour (12:00), should match Midday palette exactly
+        let p = interpolated_palette(12, 0);
+        assert_eq!(p.bg, KEYFRAMES[3].palette.bg);
+    }
+
+    #[test]
+    fn test_keyframe_midnight_exact() {
+        // At Midnight's anchor hour (1:30), should match Midnight palette exactly
+        let p = interpolated_palette(1, 30);
+        assert_eq!(p.bg, KEYFRAMES[0].palette.bg);
+    }
+
+    #[test]
+    fn test_keyframe_night_exact() {
+        // At Night's anchor hour (21:00), should match Night palette exactly
+        let p = interpolated_palette(21, 0);
+        assert_eq!(p.bg, KEYFRAMES[6].palette.bg);
+    }
+
+    #[test]
+    fn test_interpolation_midpoint_dawn_morning() {
+        // Midpoint between Dawn(5.5) and Morning(8.5) is hour 7:00
+        let p = interpolated_palette(7, 0);
+        let dawn_bg = KEYFRAMES[1].palette.bg;
+        let morning_bg = KEYFRAMES[2].palette.bg;
+        // Should be roughly halfway between Dawn and Morning bg
+        let expected_r = ((dawn_bg.r as f32 + morning_bg.r as f32) / 2.0).round() as u8;
+        let expected_g = ((dawn_bg.g as f32 + morning_bg.g as f32) / 2.0).round() as u8;
+        assert!((p.bg.r as i16 - expected_r as i16).unsigned_abs() <= 1);
+        assert!((p.bg.g as i16 - expected_g as i16).unsigned_abs() <= 1);
+    }
+
+    #[test]
+    fn test_midnight_wraparound_hour_23() {
+        // Hour 23 should interpolate between Night(21.0) and Midnight(25.5)
+        let p = interpolated_palette(23, 0);
+        let night_bg = KEYFRAMES[6].palette.bg; // (20, 25, 40)
+        let midnight_bg = KEYFRAMES[0].palette.bg; // (10, 12, 20)
+        // Should be between Night and Midnight
+        assert!(p.bg.r <= night_bg.r && p.bg.r >= midnight_bg.r);
+        assert!(p.bg.g <= night_bg.g && p.bg.g >= midnight_bg.g);
+    }
+
+    #[test]
+    fn test_midnight_wraparound_hour_0() {
+        // Hour 0 should interpolate between Night and Midnight, closer to Midnight
+        let p = interpolated_palette(0, 0);
+        let night_bg = KEYFRAMES[6].palette.bg;
+        let midnight_bg = KEYFRAMES[0].palette.bg;
+        assert!(p.bg.r <= night_bg.r && p.bg.r >= midnight_bg.r);
+    }
+
+    #[test]
+    fn test_every_hour_produces_valid_palette() {
+        for hour in 0..24 {
+            for minute in [0, 15, 30, 45] {
+                let p = interpolated_palette(hour, minute);
+                // Just verify no panics and colors are populated
+                assert_ne!(p.bg, RawColor::new(0, 0, 0));
+            }
+        }
+    }
+
+    #[test]
+    fn test_season_clear_compute() {
+        // With Clear weather and Spring season, compute_palette should still produce valid colors
+        let p = compute_palette(12, 0, Season::Spring, Weather::Clear);
+        assert_ne!(p.bg, RawColor::new(0, 0, 0));
+    }
+
+    #[test]
+    fn test_weather_clear_is_near_identity() {
+        // Clear weather should barely change the palette (only season effect)
+        let base = interpolated_palette(12, 0);
+        let tinted = compute_palette(12, 0, Season::Summer, Weather::Clear);
+        // Summer tint is subtle, bg should be close
+        let diff_r = (base.bg.r as i16 - tinted.bg.r as i16).unsigned_abs();
+        let diff_g = (base.bg.g as i16 - tinted.bg.g as i16).unsigned_abs();
+        assert!(
+            diff_r < 20,
+            "Summer tint should be subtle, got diff_r={diff_r}"
+        );
+        assert!(
+            diff_g < 20,
+            "Summer tint should be subtle, got diff_g={diff_g}"
+        );
+    }
+
+    #[test]
+    fn test_winter_is_bluer() {
+        let base = interpolated_palette(12, 0);
+        let mut winter = base;
+        apply_season_tint(&mut winter, Season::Winter);
+        // Winter blue channel should be >= base (blue multiplier is 1.04)
+        assert!(winter.bg.b >= base.bg.b, "Winter should tint bluer");
+    }
+
+    #[test]
+    fn test_storm_is_darker() {
+        let base = interpolated_palette(12, 0);
+        let stormy = compute_palette(12, 0, Season::Summer, Weather::Storm);
+        let base_lum = luminance(base.bg);
+        let storm_lum = luminance(stormy.bg);
+        assert!(
+            storm_lum < base_lum,
+            "Storm should darken: base_lum={base_lum}, storm_lum={storm_lum}"
+        );
+    }
+
+    #[test]
+    fn test_fog_reduces_contrast() {
+        let clear = compute_palette(12, 0, Season::Summer, Weather::Clear);
+        let foggy = compute_palette(12, 0, Season::Summer, Weather::Fog);
+        let clear_contrast = (luminance(clear.fg) - luminance(clear.bg)).abs();
+        let fog_contrast = (luminance(foggy.fg) - luminance(foggy.bg)).abs();
+        assert!(
+            fog_contrast < clear_contrast,
+            "Fog should reduce contrast: clear={clear_contrast}, fog={fog_contrast}"
+        );
+    }
+
+    #[test]
+    fn test_all_combinations_valid() {
+        let seasons = [
+            Season::Spring,
+            Season::Summer,
+            Season::Autumn,
+            Season::Winter,
+        ];
+        let weathers = [
+            Weather::Clear,
+            Weather::Overcast,
+            Weather::Rain,
+            Weather::Fog,
+            Weather::Storm,
+        ];
+        for season in &seasons {
+            for weather in &weathers {
+                for hour in [0, 6, 12, 18, 23] {
+                    let _p = compute_palette(hour, 0, *season, *weather);
+                    // No panics, channels are within u8 range by construction
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_smooth_transition_no_jumps() {
+        // Walk through every 15-minute increment and verify adjacent palettes
+        // don't have huge color jumps (max delta per channel < 30 per 15 min)
+        let mut prev = interpolated_palette(0, 0);
+        for hour in 0..24 {
+            for minute in (0..60).step_by(15) {
+                if hour == 0 && minute == 0 {
+                    continue;
+                }
+                let curr = interpolated_palette(hour, minute);
+                let dr = (curr.bg.r as i16 - prev.bg.r as i16).unsigned_abs();
+                let dg = (curr.bg.g as i16 - prev.bg.g as i16).unsigned_abs();
+                let db = (curr.bg.b as i16 - prev.bg.b as i16).unsigned_abs();
+                assert!(
+                    dr < 30 && dg < 30 && db < 30,
+                    "Jump too large at {hour}:{minute:02}: dr={dr}, dg={dg}, db={db}"
+                );
+                prev = curr;
+            }
+        }
+    }
+
+    #[test]
+    fn test_luminance() {
+        assert!((luminance(RawColor::new(255, 255, 255)) - 255.0).abs() < 0.01);
+        assert!((luminance(RawColor::new(0, 0, 0))).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_tint_color_identity() {
+        let c = RawColor::new(100, 150, 200);
+        let tinted = tint_color(c, 1.0, 1.0, 1.0, 0.0, 1.0);
+        assert_eq!(tinted, c);
+    }
+
+    #[test]
+    fn test_autumn_is_warmer() {
+        let base = interpolated_palette(12, 0);
+        let mut autumn = base;
+        apply_season_tint(&mut autumn, Season::Autumn);
+        // Autumn red multiplier is 1.06, should increase red
+        assert!(autumn.bg.r >= base.bg.r, "Autumn should tint warmer/redder");
+    }
+}

--- a/src/world/palette.rs
+++ b/src/world/palette.rs
@@ -308,16 +308,69 @@ fn apply_weather_tint(palette: &mut RawPalette, weather: Weather) {
     }
 }
 
+/// Minimum luminance difference between fg and bg to ensure readability.
+///
+/// During transitions between light-bg/dark-fg and dark-bg/light-fg palettes
+/// (e.g. Afternoon→Dusk around 16:00–17:00), linear interpolation causes both
+/// fg and bg to converge to similar medium tones. This floor prevents that
+/// contrast collapse.
+const MIN_FG_BG_CONTRAST: f32 = 80.0;
+
+/// Minimum luminance difference between muted text and bg.
+const MIN_MUTED_BG_CONTRAST: f32 = 45.0;
+
+/// Pushes a foreground color away from a background color to meet a minimum
+/// luminance contrast. Preserves the hue by scaling all channels proportionally.
+fn ensure_color_contrast(fg: RawColor, bg: RawColor, min_contrast: f32) -> RawColor {
+    let fg_lum = luminance(fg);
+    let bg_lum = luminance(bg);
+    let contrast = (fg_lum - bg_lum).abs();
+
+    if contrast >= min_contrast {
+        return fg;
+    }
+
+    // Determine direction: fg should go lighter if bg is dark, darker if bg is light.
+    let bg_is_dark = bg_lum < 128.0;
+    let target_lum = if bg_is_dark {
+        bg_lum + min_contrast
+    } else {
+        bg_lum - min_contrast
+    };
+
+    // Scale fg channels to hit target luminance, preserving relative proportions.
+    if fg_lum < 1.0 {
+        // fg is near-black; just return a gray at target luminance
+        let v = target_lum.round().clamp(0.0, 255.0) as u8;
+        return RawColor::new(v, v, v);
+    }
+
+    let scale = target_lum / fg_lum;
+    let r = (fg.r as f32 * scale).round().clamp(0.0, 255.0) as u8;
+    let g = (fg.g as f32 * scale).round().clamp(0.0, 255.0) as u8;
+    let b = (fg.b as f32 * scale).round().clamp(0.0, 255.0) as u8;
+    RawColor::new(r, g, b)
+}
+
+/// Ensures all text colors in the palette have sufficient contrast against backgrounds.
+fn ensure_contrast(palette: &mut RawPalette) {
+    palette.fg = ensure_color_contrast(palette.fg, palette.bg, MIN_FG_BG_CONTRAST);
+    palette.muted = ensure_color_contrast(palette.muted, palette.bg, MIN_MUTED_BG_CONTRAST);
+    palette.accent = ensure_color_contrast(palette.accent, palette.bg, MIN_MUTED_BG_CONTRAST);
+}
+
 /// Computes the fully interpolated and tinted palette for the given time, season, and weather.
 ///
 /// This is the main entry point for both GUI and TUI renderers.
 /// 1. Smoothly interpolates between time-of-day keyframe palettes
 /// 2. Applies seasonal color tinting
 /// 3. Applies weather color tinting
+/// 4. Enforces minimum contrast between text and background
 pub fn compute_palette(hour: u32, minute: u32, season: Season, weather: Weather) -> RawPalette {
     let mut palette = interpolated_palette(hour, minute);
     apply_season_tint(&mut palette, season);
     apply_weather_tint(&mut palette, weather);
+    ensure_contrast(&mut palette);
     palette
 }
 
@@ -519,6 +572,66 @@ mod tests {
                 prev = curr;
             }
         }
+    }
+
+    #[test]
+    fn test_contrast_floor_afternoon_dusk_transition() {
+        // The Afternoon→Dusk transition (15.5→18.0) crosses light-bg/dark-fg
+        // to dark-bg/light-fg. Verify contrast never drops below the floor.
+        for minute_offset in 0..150 {
+            // Walk from 15:30 to 18:00 in 1-minute increments
+            let total_minutes = 15 * 60 + 30 + minute_offset;
+            let hour = total_minutes / 60;
+            let minute = total_minutes % 60;
+            let p = interpolated_palette(hour, minute);
+            let mut adjusted = p;
+            ensure_contrast(&mut adjusted);
+            let contrast = (luminance(adjusted.fg) - luminance(adjusted.bg)).abs();
+            assert!(
+                contrast >= MIN_FG_BG_CONTRAST - 1.0,
+                "Contrast too low at {hour}:{minute:02}: {contrast:.1} (bg={:?}, fg={:?})",
+                adjusted.bg,
+                adjusted.fg
+            );
+        }
+    }
+
+    #[test]
+    fn test_contrast_floor_all_hours() {
+        // Verify contrast floor holds for every 15-minute slot across the full day
+        for hour in 0..24 {
+            for minute in [0, 15, 30, 45] {
+                let p = compute_palette(hour, minute, Season::Spring, Weather::Clear);
+                let contrast = (luminance(p.fg) - luminance(p.bg)).abs();
+                assert!(
+                    contrast >= MIN_FG_BG_CONTRAST - 1.0,
+                    "Contrast too low at {hour}:{minute:02}: {contrast:.1}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_ensure_color_contrast_noop_when_sufficient() {
+        let fg = RawColor::new(255, 255, 255);
+        let bg = RawColor::new(0, 0, 0);
+        let result = ensure_color_contrast(fg, bg, 80.0);
+        assert_eq!(
+            result, fg,
+            "Should not modify fg when contrast is sufficient"
+        );
+    }
+
+    #[test]
+    fn test_ensure_color_contrast_adjusts_when_needed() {
+        let fg = RawColor::new(130, 130, 130); // luminance ~130
+        let bg = RawColor::new(140, 140, 140); // luminance ~140
+        let result = ensure_color_contrast(fg, bg, 80.0);
+        let contrast = (luminance(result) - luminance(bg)).abs();
+        assert!(
+            contrast >= 79.0,
+            "Should push fg away from bg, got contrast {contrast:.1}"
+        );
     }
 
     #[test]

--- a/src/world/time.rs
+++ b/src/world/time.rs
@@ -140,6 +140,8 @@ pub enum GameSpeed {
     Fast,
     /// Fastest pace — 144.0 factor (10 real minutes per game day).
     Fastest,
+    /// Ludicrous pace for testing — 864.0 factor (100 real seconds per game day).
+    Ludicrous,
 }
 
 impl GameSpeed {
@@ -150,6 +152,7 @@ impl GameSpeed {
             GameSpeed::Normal => 36.0,
             GameSpeed::Fast => 72.0,
             GameSpeed::Fastest => 144.0,
+            GameSpeed::Ludicrous => 864.0,
         }
     }
 
@@ -160,6 +163,7 @@ impl GameSpeed {
             "normal" => Some(GameSpeed::Normal),
             "fast" => Some(GameSpeed::Fast),
             "fastest" => Some(GameSpeed::Fastest),
+            "ludicrous" => Some(GameSpeed::Ludicrous),
             _ => None,
         }
     }
@@ -172,6 +176,7 @@ impl fmt::Display for GameSpeed {
             GameSpeed::Normal => write!(f, "Normal"),
             GameSpeed::Fast => write!(f, "Fast"),
             GameSpeed::Fastest => write!(f, "Fastest"),
+            GameSpeed::Ludicrous => write!(f, "Ludicrous"),
         }
     }
 }
@@ -313,6 +318,8 @@ impl GameClock {
             Some(GameSpeed::Fast)
         } else if (self.speed_factor - 144.0).abs() < EPSILON {
             Some(GameSpeed::Fastest)
+        } else if (self.speed_factor - 864.0).abs() < EPSILON {
+            Some(GameSpeed::Ludicrous)
         } else {
             None
         }
@@ -462,6 +469,7 @@ mod tests {
         assert!((GameSpeed::Normal.factor() - 36.0).abs() < f64::EPSILON);
         assert!((GameSpeed::Fast.factor() - 72.0).abs() < f64::EPSILON);
         assert!((GameSpeed::Fastest.factor() - 144.0).abs() < f64::EPSILON);
+        assert!((GameSpeed::Ludicrous.factor() - 864.0).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -470,6 +478,14 @@ mod tests {
         assert_eq!(GameSpeed::from_name("NORMAL"), Some(GameSpeed::Normal));
         assert_eq!(GameSpeed::from_name("Fast"), Some(GameSpeed::Fast));
         assert_eq!(GameSpeed::from_name("fastest"), Some(GameSpeed::Fastest));
+        assert_eq!(
+            GameSpeed::from_name("ludicrous"),
+            Some(GameSpeed::Ludicrous)
+        );
+        assert_eq!(
+            GameSpeed::from_name("LUDICROUS"),
+            Some(GameSpeed::Ludicrous)
+        );
         assert_eq!(GameSpeed::from_name("bogus"), None);
         assert_eq!(GameSpeed::from_name(""), None);
     }
@@ -480,6 +496,7 @@ mod tests {
         assert_eq!(GameSpeed::Normal.to_string(), "Normal");
         assert_eq!(GameSpeed::Fast.to_string(), "Fast");
         assert_eq!(GameSpeed::Fastest.to_string(), "Fastest");
+        assert_eq!(GameSpeed::Ludicrous.to_string(), "Ludicrous");
     }
 
     #[test]

--- a/tests/game_harness_integration.rs
+++ b/tests/game_harness_integration.rs
@@ -339,7 +339,7 @@ fn test_moved_result_contains_narration() {
 #[test]
 fn test_weather_accessible() {
     let h = GameTestHarness::new();
-    assert_eq!(h.weather(), "Clear");
+    assert_eq!(*h.weather(), parish::world::Weather::Clear);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Smooth time-of-day interpolation**: Replaces 7 discrete palette jumps with linear interpolation between keyframe palettes based on exact game hour+minute. Colors now transition gradually instead of snapping at hour boundaries.
- **Weather enum**: Replaces the placeholder `weather: String` field with a proper `Weather` enum (`Clear`, `Overcast`, `Rain`, `Fog`, `Storm`), each with distinct palette tinting (desaturation, brightness, color temperature, contrast reduction).
- **Season tinting**: Adds subtle seasonal color shifts — Winter is cooler/bluer, Summer warmer, Autumn amber/golden, Spring slightly greener.
- **Shared engine**: New `src/world/palette.rs` module provides backend-agnostic `RawPalette` computation consumed by both GUI and TUI renderers.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 584 tests pass (including 20+ new palette tests)
- [x] `cargo run -- --script tests/fixtures/test_walkthrough.txt` produces correct output
- [ ] Visual verification with `--gui` flag to confirm smooth transitions look correct
- [ ] Screenshot regeneration with `xvfb-run -a cargo run -- --screenshot docs/screenshots`

https://claude.ai/code/session_01W3xi3VTA6ffmcfxuNpnBBo