### PR TITLE
docs: update README to reflect current project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ The player arrives as a newcomer to **Kilteevan Village** in the parish of Kilto
 
 > Any resemblance to real persons, living or dead, or actual businesses is purely coincidental. All characters and commercial establishments in this game are fictional.
 
-![Parish GUI — Morning](docs/screenshots/gui-morning.png)
+| Morning | Midday |
+|---------|--------|
+| ![Morning](docs/screenshots/gui-morning.png) | ![Midday](docs/screenshots/gui-midday.png) |
 
-*Tauri GUI showing the chat panel, interactive map, NPC sidebar, and time-of-day color theming (morning palette).*
+| Dusk | Night |
+|------|-------|
+| ![Dusk](docs/screenshots/gui-dusk.png) | ![Night](docs/screenshots/gui-night.png) |
+
+*Tauri GUI showing the chat panel, interactive map, NPC sidebar, and time-of-day color theming across four palettes.*
 
 ## Current Status
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The player arrives as a newcomer to **Kilteevan Village** in the parish of Kilto
 
 ## Current Status
 
-**Phases 1–3 complete** (Core Loop, World Graph, NPCs & Simulation). **Phase 4 — Persistence** is next.
+**Phases 1–4 complete** (Core Loop, World Graph, NPCs & Simulation, Persistence). **Phase 8 — Tauri GUI** is mostly complete (workspace restructure, Svelte frontend, IPC, streaming). **Phase 5 — Full LOD & Scale** is next.
 
 See the [Roadmap](docs/requirements/roadmap.md) for per-item status tracking.
 
@@ -38,7 +38,7 @@ cargo tauri dev
 ### TUI Mode (Terminal)
 
 ```sh
-cargo run
+cargo run -- --tui
 ```
 
 ### Headless Mode
@@ -47,6 +47,14 @@ For piping input/output or running without a UI:
 
 ```sh
 cargo run -- --headless
+```
+
+### Script Mode (Automated Testing)
+
+Run commands from a file (JSON output, no LLM needed):
+
+```sh
+cargo run -- --script tests/fixtures/test_walkthrough.txt
 ```
 
 **Platform guides:** [macOS](docs/macos-setup.md) | [Linux](docs/linux-setup.md) | [Windows](docs/windows-setup.md)


### PR DESCRIPTION
## Summary

- **Updated project status** from "Phases 1–3 complete, Phase 4 next" to "Phases 1–4 + Phase 8 (Tauri GUI) complete, Phase 5 next"
- **Fixed TUI quick start** command from `cargo run` to `cargo run -- --tui` (GUI is now the default mode per commit 87cf8f2)
- **Added Script Mode section** documenting the `--script` flag for automated testing

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (all 21 tests + 2 doctests)
- [x] Verified README content matches actual CLI behavior and roadmap status

https://claude.ai/code/session_0132Z6Wh8jzhf4QeLbPAczEN