### PR TITLE
feat: add @mention NPC targeting with autocomplete

### DIFF
--- a/crates/parish-core/src/input/mod.rs
+++ b/crates/parish-core/src/input/mod.rs
@@ -474,6 +474,90 @@ pub fn parse_intent_local(raw_input: &str) -> Option<PlayerIntent> {
     None
 }
 
+/// The result of extracting an `@mention` from player input.
+///
+/// Contains the mentioned name and the remaining input text with the
+/// `@mention` stripped out.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MentionExtraction {
+    /// The name that was mentioned (without the `@` prefix).
+    pub name: String,
+    /// The remaining input text after stripping the mention.
+    pub remaining: String,
+}
+
+/// Extracts an `@mention` from the beginning of player input.
+///
+/// Recognises `@Name` at the start of input. The name runs from the `@`
+/// until the next punctuation, double-space, or end of string — so both
+/// single-word names (`@Padraig`) and multi-word names (`@Padraig Darcy`)
+/// are supported.
+///
+/// Returns `None` if the input does not start with `@`.
+///
+/// # Examples
+///
+/// ```
+/// use parish_core::input::extract_mention;
+///
+/// let result = extract_mention("@Padraig hello there");
+/// assert_eq!(result.unwrap().name, "Padraig");
+///
+/// let result = extract_mention("hello @Padraig");
+/// assert!(result.is_none()); // only matches at start
+/// ```
+pub fn extract_mention(raw: &str) -> Option<MentionExtraction> {
+    let trimmed = raw.trim();
+    let rest = trimmed.strip_prefix('@')?;
+
+    if rest.is_empty() || rest.starts_with(' ') {
+        return None;
+    }
+
+    // Name runs until we hit a delimiter that signals end of the name portion.
+    // We split on the first occurrence of common sentence-start patterns:
+    // - A word followed by punctuation characters that start dialogue
+    // - Two spaces (unlikely in names)
+    // Strategy: scan for the first lowercase word following an uppercase-started
+    // word to detect "Name rest of sentence". Simpler: split on first comma,
+    // period, question mark, exclamation, or take everything if none found,
+    // then trim trailing whitespace from name.
+
+    // Find where the name ends. Name = sequence of words where each word
+    // starts with an uppercase letter or is a short connector (e.g., "O'Brien").
+    // Once we hit a word starting with lowercase (and it's not a name particle),
+    // that's the start of the remaining text.
+    let words: Vec<&str> = rest.splitn(20, ' ').collect();
+    let mut name_end = 0;
+
+    for (i, word) in words.iter().enumerate() {
+        let first_char = word.chars().next().unwrap_or(' ');
+        if i == 0 {
+            // First word is always part of the name
+            name_end = 1;
+            continue;
+        }
+        // If word starts with uppercase, it's likely part of the name
+        if first_char.is_uppercase() {
+            name_end = i + 1;
+        } else {
+            break;
+        }
+    }
+
+    let name = words[..name_end].join(" ");
+    let remaining = words[name_end..].join(" ");
+
+    if name.is_empty() {
+        return None;
+    }
+
+    Some(MentionExtraction {
+        name,
+        remaining: remaining.trim().to_string(),
+    })
+}
+
 /// Parses natural language input into a structured `PlayerIntent`.
 ///
 /// First tries local keyword matching for common commands (movement, look).
@@ -1158,5 +1242,62 @@ mod tests {
     #[test]
     fn test_parse_speed_whitespace_shows_current() {
         assert_eq!(parse_system_command("/speed   "), Some(Command::ShowSpeed));
+    }
+
+    // --- extract_mention tests ---
+
+    #[test]
+    fn test_extract_mention_simple_name() {
+        let result = extract_mention("@Padraig hello there").unwrap();
+        assert_eq!(result.name, "Padraig");
+        assert_eq!(result.remaining, "hello there");
+    }
+
+    #[test]
+    fn test_extract_mention_full_name() {
+        let result = extract_mention("@Padraig Darcy hello").unwrap();
+        assert_eq!(result.name, "Padraig Darcy");
+        assert_eq!(result.remaining, "hello");
+    }
+
+    #[test]
+    fn test_extract_mention_name_only() {
+        let result = extract_mention("@Padraig").unwrap();
+        assert_eq!(result.name, "Padraig");
+        assert_eq!(result.remaining, "");
+    }
+
+    #[test]
+    fn test_extract_mention_no_at() {
+        assert!(extract_mention("hello there").is_none());
+    }
+
+    #[test]
+    fn test_extract_mention_at_not_at_start() {
+        assert!(extract_mention("hello @Padraig").is_none());
+    }
+
+    #[test]
+    fn test_extract_mention_bare_at() {
+        assert!(extract_mention("@").is_none());
+    }
+
+    #[test]
+    fn test_extract_mention_at_space() {
+        assert!(extract_mention("@ hello").is_none());
+    }
+
+    #[test]
+    fn test_extract_mention_with_sentence() {
+        let result = extract_mention("@Siobhan how are you today?").unwrap();
+        assert_eq!(result.name, "Siobhan");
+        assert_eq!(result.remaining, "how are you today?");
+    }
+
+    #[test]
+    fn test_extract_mention_whitespace_trimmed() {
+        let result = extract_mention("  @Padraig  hello  ").unwrap();
+        assert_eq!(result.name, "Padraig");
+        assert_eq!(result.remaining, "hello");
     }
 }

--- a/crates/parish-core/src/npc/manager.rs
+++ b/crates/parish-core/src/npc/manager.rs
@@ -158,6 +158,36 @@ impl NpcManager {
             .collect()
     }
 
+    /// Finds an NPC at a location by name (case-insensitive).
+    ///
+    /// Matches against the NPC's display name (full name if introduced,
+    /// brief description otherwise). Checks for exact match first, then
+    /// falls back to first-name prefix matching (e.g., "Padraig" matches
+    /// "Padraig Darcy").
+    pub fn find_by_name(&self, name: &str, location: LocationId) -> Option<&Npc> {
+        let npcs = self.npcs_at(location);
+        let lower = name.to_lowercase();
+
+        // Exact match on display name
+        if let Some(npc) = npcs
+            .iter()
+            .find(|n| self.display_name(n).to_lowercase() == lower)
+        {
+            return Some(npc);
+        }
+
+        // First-name prefix match
+        npcs.iter()
+            .find(|n| {
+                let display = self.display_name(n).to_lowercase();
+                display
+                    .split_whitespace()
+                    .next()
+                    .is_some_and(|first| first == lower)
+            })
+            .copied()
+    }
+
     /// Returns an iterator over all NPCs.
     pub fn all_npcs(&self) -> impl Iterator<Item = &Npc> {
         self.npcs.values()
@@ -716,5 +746,79 @@ mod tests {
     fn test_default_manager() {
         let mgr = NpcManager::default();
         assert_eq!(mgr.npc_count(), 0);
+    }
+
+    #[test]
+    fn test_find_by_name_exact_match() {
+        let mut mgr = NpcManager::new();
+        let mut npc = make_test_npc(1, 2);
+        npc.name = "Padraig Darcy".to_string();
+        mgr.add_npc(npc);
+        mgr.mark_introduced(NpcId(1));
+
+        let found = mgr.find_by_name("Padraig Darcy", LocationId(2));
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, NpcId(1));
+    }
+
+    #[test]
+    fn test_find_by_name_case_insensitive() {
+        let mut mgr = NpcManager::new();
+        let mut npc = make_test_npc(1, 2);
+        npc.name = "Padraig Darcy".to_string();
+        mgr.add_npc(npc);
+        mgr.mark_introduced(NpcId(1));
+
+        let found = mgr.find_by_name("padraig darcy", LocationId(2));
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, NpcId(1));
+    }
+
+    #[test]
+    fn test_find_by_name_first_name_match() {
+        let mut mgr = NpcManager::new();
+        let mut npc = make_test_npc(1, 2);
+        npc.name = "Padraig Darcy".to_string();
+        mgr.add_npc(npc);
+        mgr.mark_introduced(NpcId(1));
+
+        let found = mgr.find_by_name("Padraig", LocationId(2));
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, NpcId(1));
+    }
+
+    #[test]
+    fn test_find_by_name_wrong_location() {
+        let mut mgr = NpcManager::new();
+        let mut npc = make_test_npc(1, 2);
+        npc.name = "Padraig Darcy".to_string();
+        mgr.add_npc(npc);
+        mgr.mark_introduced(NpcId(1));
+
+        let found = mgr.find_by_name("Padraig", LocationId(99));
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_find_by_name_no_match() {
+        let mut mgr = NpcManager::new();
+        mgr.add_npc(make_test_npc(1, 2));
+        mgr.mark_introduced(NpcId(1));
+
+        let found = mgr.find_by_name("Nobody", LocationId(2));
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_find_by_name_unintroduced_uses_brief_description() {
+        let mut mgr = NpcManager::new();
+        let mut npc = make_test_npc(1, 2);
+        npc.brief_description = "an older man behind the bar".to_string();
+        mgr.add_npc(npc);
+        // Not introduced — display name is brief_description
+
+        let found = mgr.find_by_name("an older man behind the bar", LocationId(2));
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, NpcId(1));
     }
 }

--- a/docs/design/input-enrichment-ideas.md
+++ b/docs/design/input-enrichment-ideas.md
@@ -1,0 +1,273 @@
+# Input Line Enrichment Ideas
+
+> Parent: [Player Input](player-input.md) | [GUI Design](gui-design.md) | [Docs Index](../index.md)
+
+Brainstorming ideas for making the text entry line richer and more interactive, drawing from chat apps (Slack, Discord, Telegram, iMessage, Twitch), social platforms (Twitter/X), and games with chat interfaces (Minecraft, MMOs, MUDs).
+
+**Status**: Ideation — none of these are committed. Pick and choose.
+
+---
+
+## 1. `/slash` Command Autocomplete (Slack, Discord, Minecraft)
+
+**Inspiration**: Slack's `/` menu, Minecraft's `/gamemode`, Discord's slash command picker.
+
+When the player types `/`, show an autocomplete dropdown of all available system commands — identical UX to the `@mention` picker. Each entry shows the command name and a brief description.
+
+- Filter as you type: `/sp` narrows to `/speed`, `/save`
+- Show argument hints inline: `/fork <name>`, `/load <name>`
+- Could replace the need to memorize commands or check `/help`
+- Debug commands only appear when `--features debug` is active
+
+**Effort**: Low — reuses the `@mention` dropdown infrastructure almost entirely.
+
+---
+
+## 2. Emote / Action Prefix with `*asterisks*` (MUDs, RP servers, Discord)
+
+**Inspiration**: MUD emote commands (`/me waves`), Discord RP convention (`*sighs heavily*`), tabletop RP.
+
+Let the player wrap text in `*asterisks*` to indicate physical actions rather than speech. The chat log renders these in italics and the LLM system prompt tells the NPC to respond to the action, not dialogue.
+
+- `*tips hat to Padraig*` → displayed as: _You tip your hat to Padraig._
+- `*examines the old map on the wall*` → NPC might narrate what you see
+- `@Siobhan *slides a coin across the bar*` → combine with @mention
+
+The backend would detect `*...*` wrapping and set `PlayerIntent.intent = Interact` or pass an `action_mode: true` flag in the NPC prompt context.
+
+**Effort**: Low — mostly prompt engineering + CSS italic styling.
+
+---
+
+## 3. Input History with Arrow Keys (Terminal, Minecraft, every CLI ever)
+
+**Inspiration**: Bash/zsh history, Minecraft chat history, MUD command recall.
+
+Press Up/Down arrow to cycle through previous inputs. Essential for:
+
+- Re-issuing a movement command: "go to the pub" → just press Up
+- Editing a typo: press Up, fix, submit
+- Replaying a question to a different NPC: Up, change @mention, submit
+
+Store last N inputs (e.g., 50) in the Svelte store. Persist across sessions via localStorage.
+
+**Effort**: Low — purely frontend, no backend changes.
+
+---
+
+## 4. Typing Indicator / NPC "Thinking" Animation (iMessage, Slack, Telegram)
+
+**Inspiration**: iMessage's `...` bubble, Slack's "X is typing...", Telegram's "recording audio..."
+
+When an NPC is generating a response (inference in progress), show a subtle indicator in the chat panel or next to their name in the sidebar:
+
+- Three animated dots (`...`) in the chat area where their response will appear
+- NPC's name in the sidebar gets a subtle pulse or "thinking" label
+- Different animation for different cognitive states: Tier 1 NPCs "think carefully", quick responses could show brief hesitation
+
+Currently we show "Waiting..." in the input placeholder. This is functional but cold — the typing indicator makes NPCs feel alive.
+
+**Effort**: Low-Medium — frontend animation work, ties into existing `streamingActive` state.
+
+---
+
+## 5. Whisper / Private Message Syntax (Twitch, MMOs, MUDs)
+
+**Inspiration**: Twitch `/w username`, WoW `/whisper`, MUD `tell`.
+
+When multiple NPCs are present, let the player whisper to one so others don't "hear":
+
+- `@Padraig (whisper) I saw Father Callahan at the fairy fort last night`
+- Or use a dedicated prefix: `>Padraig the land agent is cheating you`
+
+The NPC system prompt would note this was whispered privately. Other NPCs present don't incorporate it into their context. Creates gameplay possibilities — sharing secrets, conspiracies, confiding.
+
+**Effort**: Medium — needs backend changes to exclude whispered content from other NPCs' context windows.
+
+---
+
+## 6. Quick Reactions / Emoji Responses (Slack, Discord, iMessage, Telegram)
+
+**Inspiration**: Slack's emoji reactions on messages, Discord reactions, iMessage tapbacks.
+
+Let the player react to NPC dialogue with a quick gesture instead of typing a full response:
+
+- Click a small reaction bar below the NPC's message: nod, laugh, frown, shrug, applaud
+- Or type shortcodes: `:nod:`, `:laugh:`, `:suspicious:`
+- The NPC receives the reaction as context: "The player nodded in response"
+- Faster than typing "I nod" — reduces friction for roleplay
+
+Keep reactions period-appropriate: no modern emoji, use gestures and expressions from 1820s Ireland.
+
+**Effort**: Medium — frontend reaction UI + backend prompt injection.
+
+---
+
+## 7. Location Quick-Travel Buttons (Minecraft coordinates, MMO fast travel)
+
+**Inspiration**: Clicking coordinates in Minecraft chat, MMO teleport lists, map markers.
+
+Show clickable location chips above or beside the input field for adjacent locations:
+
+- `[Darcy's Pub]` `[The Church]` `[Murphy's Farm]`
+- Clicking one is equivalent to typing "go to Darcy's Pub"
+- Updates dynamically based on current location's exits
+- Could also appear inline when NPCs mention locations: "You should visit **[the fairy fort]**"
+
+The MapPanel already handles click-to-travel. This brings that affordance closer to the text flow for players who don't use the map.
+
+**Effort**: Low — frontend chip components + existing movement IPC.
+
+---
+
+## 8. Multi-line Input / Shift+Enter (Slack, Discord, Telegram)
+
+**Inspiration**: Slack's Shift+Enter for newlines, Discord multi-line input, Telegram's expandable input.
+
+Allow Shift+Enter to insert a newline for longer messages. The input field expands vertically (up to ~4 lines) then scrolls. Enter alone still submits.
+
+Useful for:
+- Longer roleplay actions: describing a complex gesture
+- Dictating a letter or message in-game
+- Composing a prayer or song verse (period-appropriate)
+
+**Effort**: Low — swap `<input>` for `<textarea>`, handle Shift+Enter vs Enter.
+
+---
+
+## 9. Contextual Action Suggestions / Smart Replies (Google Messages, iMessage, Twitch predictions)
+
+**Inspiration**: Google Messages' smart replies, Gmail suggested responses, Twitch prediction prompts.
+
+Show 2-3 contextual quick-reply chips above the input based on the current situation:
+
+- At the pub with Padraig: `[Order a drink]` `[Ask about the news]` `[Tell a story]`
+- At the church: `[Pray]` `[Speak to the priest]` `[Examine the headstones]`
+- After an NPC says something surprising: `[Tell me more]` `[I don't believe you]` `[Change the subject]`
+
+Could be generated by a lightweight LLM call (Tier 3 model) or hand-crafted per location type. Reduces blank-page paralysis for new players.
+
+**Effort**: High — needs a suggestion generation system (LLM or rule-based), context-aware.
+
+---
+
+## 10. Streamer / Audience Mode (Twitch Chat, Twitch Plays)
+
+**Inspiration**: Twitch Plays Pokemon, Twitch chat voting, audience participation games.
+
+A spectator mode where multiple people can suggest inputs via a WebSocket:
+
+- Suggestions appear as a vote tally above the input
+- The "player" picks one, or the most-voted action auto-submits after a timer
+- NPCs could react to the chaos: "Why do ye keep changing yer mind?"
+
+Wild idea — but Parish's streaming NPC responses would look great on a Twitch stream.
+
+**Effort**: Very High — needs WebSocket server, voting UI, audience client.
+
+---
+
+## 11. Inline Rich Text Preview (Slack, Discord, Twitter)
+
+**Inspiration**: Slack's message formatting preview, Discord markdown, Twitter's URL cards.
+
+As the player types, show a live preview of how their input will be interpreted:
+
+- `@Padraig` renders as a highlighted mention chip (blue, like Slack)
+- `*action*` renders in italics
+- `/command` renders with a command icon
+- Location names auto-link: typing "the pub" highlights it as a recognized location
+
+The input field becomes a mini rich-text editor while staying plain-text underneath.
+
+**Effort**: Medium — needs a contenteditable div or overlay rendering layer.
+
+---
+
+## 12. Input Tone Indicator (original — no direct app analog)
+
+**Inspiration**: Email tone detectors, Grammarly sentiment, but adapted for 1820s RP.
+
+A subtle indicator beside the input showing how the NPC will likely perceive the player's tone:
+
+- Friendly / Neutral / Hostile / Suspicious / Formal / Playful
+- Updates as you type, based on keyword analysis
+- Helps players calibrate — "will Padraig take offense at this?"
+- Ties into the anachronism detection system (already built)
+
+Could be a small colored dot or word that shifts: `tone: friendly` → `tone: confrontational`
+
+**Effort**: Medium — needs a lightweight tone classifier (could reuse anachronism detection patterns).
+
+---
+
+## 13. Recent Conversation Context Chip (Telegram reply-to, Discord reply threads)
+
+**Inspiration**: Telegram's reply-to-message, Discord's reply feature, Slack threads.
+
+Let the player reference a specific previous NPC statement by clicking "reply" on it in the chat log. This pins a small context chip above the input:
+
+- `Replying to Padraig: "The land agent came through yesterday..."` [x]
+- The backend includes this specific quote in the NPC prompt context
+- Avoids the "what were we talking about?" problem in long conversations
+- Click [x] to dismiss
+
+**Effort**: Medium — frontend reply UI + backend context injection.
+
+---
+
+## 14. Voice / Shout Range Modifier (MMOs, MUDs, Minecraft)
+
+**Inspiration**: WoW `/say` vs `/yell` vs `/whisper`, MUD room-scope messaging, Minecraft chat range mods.
+
+Let the player control the "volume" of their speech with prefixes or a toggle:
+
+| Prefix | Range | Effect |
+|--------|-------|--------|
+| *(normal)* | Room | Only NPCs present hear you |
+| `!` or CAPS | Shout | NPCs in adjacent locations may hear/react |
+| `>` | Whisper | Only targeted NPC hears |
+| `(thought)` | Internal | No NPC hears — narrated as inner monologue |
+
+A shout at the crossroads might draw NPCs from the pub. A whisper ensures privacy. Inner monologue lets the player think "on screen" for roleplay flavor.
+
+**Effort**: Medium-High — backend needs to propagate input to NPCs at adjacent locations.
+
+---
+
+## 15. Tab-Complete for Known Nouns (MUDs, Zork, CLI)
+
+**Inspiration**: Classic MUD tab completion, bash tab completion, IDE autocomplete.
+
+Press Tab to cycle through completable tokens based on what's in the current context:
+
+- Location names: `pub` → `Darcy's Pub`
+- NPC names (without @): `Padr` → `Padraig`
+- Known objects: `sto` → `stone cross`
+- System commands: `/s` → `/save`
+
+Different from @mention — this is general-purpose completion for any recognized game noun.
+
+**Effort**: Medium — needs a "known nouns" registry aggregating locations, NPCs, and objects.
+
+---
+
+## Priority Ranking
+
+| Idea | Effort | Impact | Recommendation |
+|------|--------|--------|----------------|
+| `/slash` command autocomplete | Low | High | **Build next** — reuses @mention infra |
+| Input history (Up/Down) | Low | High | **Build next** — table stakes UX |
+| `*action*` emotes | Low | Medium | **Build soon** — enhances RP |
+| Multi-line input | Low | Medium | Build soon |
+| Typing indicator | Low-Med | Medium | Build soon — makes NPCs feel alive |
+| Location quick-travel chips | Low | Medium | Build soon |
+| Whisper syntax | Medium | Medium | Build later — needs context scoping |
+| Quick reactions | Medium | Medium | Build later |
+| Reply-to context | Medium | Medium | Build later |
+| Inline rich preview | Medium | Low-Med | Nice to have |
+| Tone indicator | Medium | Low-Med | Nice to have |
+| Tab-complete nouns | Medium | Medium | Build later |
+| Voice range modifiers | Med-High | High | Build later — great emergent gameplay |
+| Contextual suggestions | High | High | Build later — needs LLM or rules |
+| Streamer mode | Very High | Niche | Someday/maybe |

--- a/docs/design/input-enrichment-ideas.md
+++ b/docs/design/input-enrichment-ideas.md
@@ -86,20 +86,99 @@ The NPC system prompt would note this was whispered privately. Other NPCs presen
 
 ---
 
-## 6. Quick Reactions / Emoji Responses (Slack, Discord, iMessage, Telegram)
+## 6. Bidirectional Emoji Reactions (Slack, Discord, iMessage, Telegram)
 
-**Inspiration**: Slack's emoji reactions on messages, Discord reactions, iMessage tapbacks.
+**Inspiration**: Slack's emoji reactions on messages, Discord reactions, iMessage tapbacks — but **both directions**.
 
-Let the player react to NPC dialogue with a quick gesture instead of typing a full response:
+### Player reacts to NPC messages
 
-- Click a small reaction bar below the NPC's message: nod, laugh, frown, shrug, applaud
-- Or type shortcodes: `:nod:`, `:laugh:`, `:suspicious:`
-- The NPC receives the reaction as context: "The player nodded in response"
-- Faster than typing "I nod" — reduces friction for roleplay
+Hover over (or tap) any NPC message in the chat log to reveal a reaction picker. Click to attach a reaction emoji beneath the message:
 
-Keep reactions period-appropriate: no modern emoji, use gestures and expressions from 1820s Ireland.
+```
+Padraig Darcy:
+  "Ah, the land agent was here again. Raised the rent on
+   Murphy's place by a full shilling."
+   😠 👀 😢
+```
 
-**Effort**: Medium — frontend reaction UI + backend prompt injection.
+- The reaction is injected into the NPC's conversation context on the next exchange: "The player reacted with anger to your comment about the rent increase"
+- NPCs adjust their behavior accordingly — a laugh might encourage gossip, anger might make them cautious, a suspicious look might make them clam up
+- Multiple reactions accumulate: the NPC sees the pattern of your nonverbal responses over time
+
+### NPCs react to player messages
+
+When the player says something, present NPCs can spontaneously attach reactions to the player's message — **without generating a full dialogue response**:
+
+```
+You:
+  "I heard Father Callahan was seen at the fairy fort."
+   😳 (Padraig)   🤫 (Siobhan)
+```
+
+- Generated cheaply: the LLM returns a reaction emoji as structured output alongside (or instead of) a full response
+- Multiple NPCs can react simultaneously — even NPCs who aren't the conversation target
+- Creates a sense of a living room: say something provocative and watch the reactions ripple
+- Could use a tiny/fast model or even rule-based keyword matching for common reactions
+
+### NPC-to-NPC reactions
+
+When an NPC speaks, other NPCs present can react too:
+
+```
+Padraig Darcy:
+  "The harvest will be poor this year, mark my words."
+   😟 (Siobhan)   🙄 (Niamh)
+```
+
+- Generated during Tier 2 background ticks — no extra latency for the player
+- Reveals NPC relationships and opinions nonverbally
+- Siobhan the farmer worries about the harvest; Niamh rolls her eyes at her father's doom-saying
+
+### Reaction Palette
+
+Period-appropriate gestures mapped to emoji. The UI shows emoji but the NPC context receives the natural language description:
+
+| Emoji | NPC sees | When to use |
+|-------|----------|-------------|
+| 😊 | "smiled warmly" | Approval, friendliness |
+| 😠 | "looked angry" | Disagreement, offense |
+| 😢 | "looked sorrowful" | Sympathy, sadness |
+| 😳 | "looked startled" | Surprise, shock |
+| 🤔 | "looked thoughtful" | Pondering, interest |
+| 😏 | "smirked knowingly" | Skepticism, irony |
+| 👀 | "raised an eyebrow" | Curiosity, suspicion |
+| 🤫 | "made a hushing gesture" | Secrecy, warning |
+| 😂 | "laughed heartily" | Amusement |
+| 🙄 | "rolled their eyes" | Dismissal, impatience |
+| 🍺 | "raised a glass" | Toast, camaraderie |
+| ✝️ | "crossed themselves" | Piety, superstition, shock |
+
+### Implementation sketch
+
+```
+ChatPanel.svelte:
+  - Each message gets a hover → reaction picker (row of emoji buttons)
+  - Reactions stored in textLog entries: reactions: [{emoji, source}]
+  - Rendered below message text, small and inline
+
+Backend (commands.rs):
+  - New IPC command: react_to_message(message_id, emoji)
+  - Stores reaction in NPC conversation context for next exchange
+  - New IPC event: npc_reaction — emitted when NPC reacts
+
+NPC prompt injection:
+  - "Recent nonverbal reactions from the player: smiled at your joke,
+     looked angry when you mentioned the rent"
+  - "React to the player's message with a single emoji from this set: [...]"
+
+Tier 2 ticks:
+  - When NPCs are in the same room, generate reactions to each other's
+    statements as part of the group simulation prompt
+```
+
+**Effort**: Medium-High — reaction UI + backend context tracking + NPC reaction generation.
+
+**Why this is worth the effort**: Reactions are the fastest form of player expression. They let you participate in a conversation without composing a sentence. And NPC reactions make a room full of characters feel alive — you can *see* Siobhan's worry and Niamh's eye-roll without either of them saying a word.
 
 ---
 
@@ -252,18 +331,110 @@ Different from @mention — this is general-purpose completion for any recognize
 
 ---
 
+## 16. Push-to-Talk Voice Input (Claude Code, Discord, Xbox Game Chat)
+
+**Inspiration**: Claude Code's spacebar-hold voice mode, Discord push-to-talk, Xbox party chat, Siri hold-to-speak.
+
+Hold spacebar (when the input field is empty) to speak instead of type. Release to transcribe and insert the text into the input field — then the player can review/edit before hitting Enter.
+
+### UX flow
+
+1. Player holds spacebar (input field must be empty or focused and empty to avoid capturing typing)
+2. Microphone activates — a visual waveform/pulse indicator appears in/above the input field
+3. Player speaks: "Go to the pub and talk to Padraig about the harvest"
+4. Player releases spacebar
+5. Transcribed text appears in the input field: `go to the pub and talk to Padraig about the harvest`
+6. Player can edit, add @mentions, or just hit Enter to submit
+
+### Implementation options
+
+| Approach | Platforms | Latency | Offline | Dependencies |
+|----------|-----------|---------|---------|-------------|
+| **Web Speech API** | Windows + macOS | Low | No* | None — built into WebView |
+| **Whisper.cpp sidecar** | All (incl. Linux) | Medium | Yes | ~75MB model, `cpal` for mic capture |
+| **Whisper via Ollama** | All | Medium | Yes | Ollama (already required) |
+
+\* Web Speech API on some platforms sends audio to cloud services for recognition.
+
+**Recommended phased approach:**
+
+1. **Phase 1**: Web Speech API — works immediately on Windows (WebView2/Chromium) and macOS (WKWebView). Zero new dependencies. Feature-detect and hide the button on unsupported platforms (Linux/WebKitGTK).
+2. **Phase 2**: Whisper.cpp as a Tauri sidecar process for full offline, cross-platform support. Ship the `tiny` or `base` model (~75MB). Captures audio via Rust `cpal` crate, pipes to whisper, returns text via IPC.
+
+### Platform support matrix
+
+| Platform | WebView | Web Speech API | Whisper sidecar |
+|----------|---------|----------------|-----------------|
+| Windows | WebView2 (Chromium) | Works | Works |
+| macOS | WKWebView | Works (uses Siri STT) | Works |
+| Linux | WebKitGTK | Unreliable | Works (recommended path) |
+
+### Frontend implementation sketch
+
+```svelte
+<!-- In InputField.svelte -->
+<script>
+  let isRecording = $state(false);
+
+  function handleKeydown(e: KeyboardEvent) {
+    // Hold space to record (only when input is empty)
+    if (e.key === ' ' && text === '' && !isRecording) {
+      e.preventDefault();
+      startRecording();
+    }
+  }
+
+  function handleKeyup(e: KeyboardEvent) {
+    if (e.key === ' ' && isRecording) {
+      stopRecording(); // triggers transcription → fills text
+    }
+  }
+
+  function startRecording() {
+    isRecording = true;
+    const recognition = new webkitSpeechRecognition();
+    recognition.lang = 'en-IE'; // Irish English!
+    recognition.interimResults = true;
+    recognition.onresult = (e) => {
+      text = e.results[0][0].transcript;
+    };
+    recognition.start();
+  }
+</script>
+
+{#if isRecording}
+  <div class="recording-indicator">Listening...</div>
+{/if}
+```
+
+### Considerations
+
+- **Language**: Set recognition locale to `en-IE` (Irish English) for better handling of place names and Irish-English speech patterns
+- **Privacy**: Web Speech API may send audio to cloud services; document this. Whisper.cpp is fully local.
+- **Irish words**: Neither Web Speech API nor Whisper will handle Irish Gaelic words well. Player can always edit the transcription before submitting.
+- **Keybinding conflict**: Only activate spacebar-hold when input is empty. When the player has typed text, spacebar inserts a normal space.
+- **Tauri permissions**: Need to add microphone capability to `src-tauri/capabilities/default.json`
+- **Visual feedback**: Show a waveform or pulsing dot during recording so the player knows the mic is active
+
+**Effort**: Low (Web Speech API path) to Medium (Whisper sidecar path).
+
+**Why this matters**: Voice input is faster than typing for natural language. Parish is a conversation game — speaking to NPCs instead of typing to them is a natural fit. And with push-to-talk (not always-on), it stays intentional.
+
+---
+
 ## Priority Ranking
 
 | Idea | Effort | Impact | Recommendation |
 |------|--------|--------|----------------|
 | `/slash` command autocomplete | Low | High | **Build next** — reuses @mention infra |
 | Input history (Up/Down) | Low | High | **Build next** — table stakes UX |
+| Push-to-talk voice input | Low | High | **Build next** — Web Speech API phase first |
 | `*action*` emotes | Low | Medium | **Build soon** — enhances RP |
 | Multi-line input | Low | Medium | Build soon |
 | Typing indicator | Low-Med | Medium | Build soon — makes NPCs feel alive |
 | Location quick-travel chips | Low | Medium | Build soon |
+| Bidirectional emoji reactions | Med-High | High | **Build soon** — makes rooms feel alive |
 | Whisper syntax | Medium | Medium | Build later — needs context scoping |
-| Quick reactions | Medium | Medium | Build later |
 | Reply-to context | Medium | Medium | Build later |
 | Inline rich preview | Medium | Low-Med | Nice to have |
 | Tone indicator | Medium | Low-Med | Nice to have |

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -96,7 +96,7 @@ src/
 ├── testing.rs           # GameTestHarness for automated script-based testing
 ├── debug.rs             # Debug commands and metrics (feature-gated)
 ├── input/
-│   └── mod.rs           # Player input parsing, command detection
+│   └── mod.rs           # Player input parsing, command detection, @mention extraction
 ├── world/
 │   ├── mod.rs           # WorldState, Weather enum, location types
 │   ├── graph.rs         # WorldGraph (adjacency list, BFS pathfinding)

--- a/docs/design/player-input.md
+++ b/docs/design/player-input.md
@@ -13,6 +13,40 @@ Examples:
 - "Look around"
 - "Pick up the stone"
 
+## NPC @Mention Targeting
+
+Players can direct dialogue to a specific NPC using `@mention` syntax at the start of their input, similar to chat apps like Slack or Discord.
+
+Examples:
+
+- `@Padraig how's business?` — talks to Padraig Darcy
+- `@Siobhan tell me about the harvest` — talks to Siobhan Murphy
+- `hello everyone` — talks to the first NPC present (default behavior)
+
+### Autocomplete
+
+When the player types `@` in the input field (Tauri GUI), an autocomplete dropdown appears listing all NPCs at the current location. The dropdown:
+
+- Filters as the player types (e.g., `@Pa` narrows to "Padraig Darcy")
+- Supports keyboard navigation (Arrow keys, Tab/Enter to select, Escape to dismiss)
+- Shows NPC name and occupation (if introduced)
+- Inserts `@FirstName` into the input on selection
+
+### Name Matching
+
+The backend matches `@mentions` case-insensitively against NPC display names:
+
+- **Exact match**: `@Padraig Darcy` matches the full name
+- **First-name match**: `@Padraig` matches by first name
+- **Brief description match**: Un-introduced NPCs can be targeted by their brief description
+- **Fallback**: If no match is found, the first NPC at the location is used
+
+### Source
+
+- `parish_core::input::extract_mention()` — Extracts `@name` from input
+- `NpcManager::find_by_name()` — Case-insensitive NPC lookup at a location
+- `InputField.svelte` — Autocomplete dropdown UI
+
 ## System Commands
 
 System commands use `/` prefix for now (placeholder — may change to a prefix-free autocomplete system later).

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,8 @@ High-level architecture and detailed subsystem designs. Start with [Architecture
 | [Weather System](design/weather-system.md) | Weather states and simulation effects | — |
 | [GUI Design](design/gui-design.md) | Tauri 2 + Svelte 5 desktop GUI with map, chat, and sidebars | — |
 | [Map Evolution](design/map-evolution.md) | Brainstorm: minimap, OSM tiles, fog of war, label fixes | RFC |
-| [Player Input](design/player-input.md) | Natural language input, system commands | [ADR-006](adr/006-natural-language-input.md) |
+| [Player Input](design/player-input.md) | Natural language input, system commands, @mention targeting | [ADR-006](adr/006-natural-language-input.md) |
+| [Input Enrichment Ideas](design/input-enrichment-ideas.md) | Brainstorm: slash autocomplete, emotes, history, whispers, reactions | RFC |
 | [Persistence](design/persistence.md) | WAL journal, snapshots, branching saves | [ADR-003](adr/003-sqlite-wal-persistence.md), [ADR-004](adr/004-git-like-branching-saves.md) |
 | [NPC System](design/npc-system.md) | Entity model, context construction, gossip | [ADR-008](adr/008-structured-json-llm-output.md) |
 | [Inference Pipeline](design/inference-pipeline.md) | LLM integration, queue, model selection | [ADR-005](adr/005-ollama-local-inference.md), [ADR-010](adr/010-prompt-injection-defenses.md), [ADR-015](adr/015-per-category-inference-providers.md) |

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,7 +13,7 @@ use parish_core::config::Provider;
 use parish_core::debug_snapshot::{self, DebugEvent, DebugSnapshot, InferenceDebug};
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceQueue, spawn_inference_worker};
-use parish_core::input::{InputResult, classify_input, parse_intent_local};
+use parish_core::input::{InputResult, classify_input, extract_mention, parse_intent_local};
 use parish_core::npc::parse_npc_stream_response;
 use parish_core::npc::ticks;
 use parish_core::world::description::{format_exits, render_description};
@@ -639,8 +639,14 @@ async fn handle_game_input(
         return;
     }
 
+    // Extract @mention for NPC targeting, if present
+    let (target_name, dialogue) = match extract_mention(&raw) {
+        Some(mention) => (Some(mention.name), mention.remaining),
+        None => (None, raw),
+    };
+
     // Try NPC conversation
-    handle_npc_conversation(raw, state, app).await;
+    handle_npc_conversation(dialogue, target_name, state, app).await;
 }
 
 /// Resolves movement to a named location.
@@ -752,8 +758,12 @@ async fn handle_look(state: &Arc<AppState>, app: &tauri::AppHandle) {
 }
 
 /// Routes input to the NPC at the player's location, or shows idle message.
+///
+/// If `target_name` is provided (from an `@mention`), the matching NPC
+/// is selected. Otherwise falls back to the first NPC at the location.
 async fn handle_npc_conversation(
     raw: String,
+    target_name: Option<String>,
     state: tauri::State<'_, Arc<AppState>>,
     app: tauri::AppHandle,
 ) {
@@ -763,7 +773,16 @@ async fn handle_npc_conversation(
         let queue = state.inference_queue.lock().await;
 
         let npcs_here = npc_manager.npcs_at(world.player_location);
-        let npc = npcs_here.first().cloned().cloned();
+
+        // If an @mention was provided, try to find that NPC; otherwise first NPC
+        let npc = if let Some(ref name) = target_name {
+            npc_manager
+                .find_by_name(name, world.player_location)
+                .cloned()
+                .or_else(|| npcs_here.first().cloned().cloned())
+        } else {
+            npcs_here.first().cloned().cloned()
+        };
 
         if let (Some(npc), Some(q)) = (npc, queue.clone()) {
             let display = npc_manager.display_name(&npc).to_string();

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -34,6 +34,17 @@ body {
 	height: 100%;
 }
 
+/* Layout: ChatPanel fills space, InputField pinned to bottom.
+   Must be global — Svelte scoped styles can't reach into child components. */
+.chat-panel {
+	flex: 1 1 0 !important;
+	min-height: 0 !important;
+}
+
+.input-wrapper {
+	flex: 0 0 auto !important;
+}
+
 ::-webkit-scrollbar {
 	width: 6px;
 }

--- a/ui/src/components/ChatPanel.svelte
+++ b/ui/src/components/ChatPanel.svelte
@@ -54,6 +54,7 @@
 <style>
 	.chat-panel {
 		flex: 1;
+		min-height: 0;
 		overflow-y: auto;
 		padding: 1rem;
 		display: flex;

--- a/ui/src/components/InputField.svelte
+++ b/ui/src/components/InputField.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
-	import { streamingActive } from '../stores/game';
+	import { streamingActive, npcsHere } from '../stores/game';
 	import { submitInput } from '$lib/ipc';
 
 	let inputEl: HTMLInputElement;
 	let text = $state('');
+	let showMentions = $state(false);
+	let selectedIndex = $state(0);
+	let mentionQuery = $state('');
+
+	const filteredNpcs = $derived(
+		$npcsHere.filter((npc) =>
+			npc.name.toLowerCase().startsWith(mentionQuery.toLowerCase())
+		)
+	);
 
 	$effect(() => {
 		if (!$streamingActive && inputEl) {
@@ -11,38 +20,169 @@
 		}
 	});
 
+	$effect(() => {
+		// Reset selection when filtered list changes
+		if (selectedIndex >= filteredNpcs.length) {
+			selectedIndex = Math.max(0, filteredNpcs.length - 1);
+		}
+	});
+
+	function detectMention() {
+		if (!inputEl) return;
+		const value = text;
+		// Only trigger when @ is at the start of input
+		if (value.startsWith('@')) {
+			const afterAt = value.slice(1);
+			// Extract the mention query (everything up to end or first lowercase-started word after a name)
+			const spaceIdx = afterAt.indexOf(' ');
+			// Show dropdown while typing the name portion
+			if (spaceIdx === -1) {
+				mentionQuery = afterAt;
+				showMentions = afterAt.length > 0 && $npcsHere.length > 0;
+			} else {
+				// Check if there's still a plausible name being typed
+				// e.g., "@Padraig D" should still show dropdown
+				const words = afterAt.split(' ');
+				const allCapitalized = words.every(
+					(w) => w.length === 0 || w[0] === w[0].toUpperCase()
+				);
+				if (allCapitalized && words[words.length - 1] === '') {
+					// Trailing space after capitalized words — could be continuing a name
+					mentionQuery = afterAt.trimEnd();
+					showMentions = $npcsHere.length > 0;
+				} else if (allCapitalized) {
+					mentionQuery = afterAt;
+					showMentions = $npcsHere.length > 0;
+				} else {
+					showMentions = false;
+				}
+			}
+		} else {
+			showMentions = false;
+		}
+		selectedIndex = 0;
+	}
+
+	function selectNpc(npcName: string) {
+		// Use first name only for brevity
+		const firstName = npcName.split(' ')[0];
+		const afterMention = text.startsWith('@') ? getTextAfterMention() : '';
+		text = `@${firstName} ${afterMention}`;
+		showMentions = false;
+		inputEl?.focus();
+		// Move cursor to end
+		requestAnimationFrame(() => {
+			if (inputEl) {
+				inputEl.selectionStart = inputEl.selectionEnd = text.length;
+			}
+		});
+	}
+
+	function getTextAfterMention(): string {
+		const value = text;
+		if (!value.startsWith('@')) return value;
+		const afterAt = value.slice(1);
+		const words = afterAt.split(' ');
+		// Skip capitalized words (part of the mention)
+		let i = 0;
+		for (; i < words.length; i++) {
+			if (words[i].length > 0 && words[i][0] !== words[i][0].toUpperCase()) {
+				break;
+			}
+		}
+		return words.slice(i).join(' ');
+	}
+
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
+		if (showMentions && filteredNpcs.length > 0) {
+			selectNpc(filteredNpcs[selectedIndex].name);
+			return;
+		}
 		const trimmed = text.trim();
 		if (!trimmed || $streamingActive) return;
 		text = '';
+		showMentions = false;
 		await submitInput(trimmed);
 	}
 
 	function handleKeydown(e: KeyboardEvent) {
+		if (showMentions && filteredNpcs.length > 0) {
+			if (e.key === 'ArrowDown') {
+				e.preventDefault();
+				selectedIndex = (selectedIndex + 1) % filteredNpcs.length;
+				return;
+			}
+			if (e.key === 'ArrowUp') {
+				e.preventDefault();
+				selectedIndex =
+					(selectedIndex - 1 + filteredNpcs.length) % filteredNpcs.length;
+				return;
+			}
+			if (e.key === 'Tab') {
+				e.preventDefault();
+				selectNpc(filteredNpcs[selectedIndex].name);
+				return;
+			}
+			if (e.key === 'Escape') {
+				e.preventDefault();
+				showMentions = false;
+				return;
+			}
+		}
 		if (e.key === 'Enter') {
 			handleSubmit(e);
 		}
 	}
+
+	function handleInput() {
+		detectMention();
+	}
 </script>
 
-<form class="input-form" onsubmit={handleSubmit}>
-	<input
-		bind:this={inputEl}
-		bind:value={text}
-		onkeydown={handleKeydown}
-		disabled={$streamingActive}
-		placeholder={$streamingActive ? 'Waiting…' : 'What do you do?'}
-		class="input-field"
-		autocomplete="off"
-		spellcheck="false"
-	/>
-	<button type="submit" disabled={$streamingActive || !text.trim()} class="send-btn">
-		Send
-	</button>
-</form>
+<div class="input-wrapper">
+	{#if showMentions && filteredNpcs.length > 0}
+		<ul class="mention-dropdown" role="listbox" aria-label="Mention NPC">
+			{#each filteredNpcs as npc, i}
+				<li
+					role="option"
+					aria-selected={i === selectedIndex}
+					class="mention-item"
+					class:selected={i === selectedIndex}
+					onmousedown={(e) => { e.preventDefault(); selectNpc(npc.name); }}
+					onmouseenter={() => (selectedIndex = i)}
+				>
+					<span class="mention-name">{npc.name}</span>
+					{#if npc.introduced}
+						<span class="mention-detail">{npc.occupation}</span>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	{/if}
+	<form class="input-form" onsubmit={handleSubmit}>
+		<input
+			bind:this={inputEl}
+			bind:value={text}
+			onkeydown={handleKeydown}
+			oninput={handleInput}
+			disabled={$streamingActive}
+			placeholder={$streamingActive ? 'Waiting…' : 'What do you do? (@ to mention NPC)'}
+			class="input-field"
+			autocomplete="off"
+			spellcheck="false"
+		/>
+		<button type="submit" disabled={$streamingActive || !text.trim()} class="send-btn">
+			Send
+		</button>
+	</form>
+</div>
 
 <style>
+	.input-wrapper {
+		position: relative;
+	}
+
 	.input-form {
 		display: flex;
 		gap: 0.5rem;
@@ -95,6 +235,51 @@
 	}
 
 	.send-btn:hover:not(:disabled) {
+		opacity: 0.85;
+	}
+
+	.mention-dropdown {
+		position: absolute;
+		bottom: 100%;
+		left: 0.75rem;
+		right: 0.75rem;
+		margin: 0;
+		padding: 0.25rem 0;
+		list-style: none;
+		background: var(--color-panel-bg);
+		border: 1px solid var(--color-border);
+		border-radius: 4px;
+		box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.3);
+		max-height: 12rem;
+		overflow-y: auto;
+		z-index: 10;
+	}
+
+	.mention-item {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.4rem 0.75rem;
+		cursor: pointer;
+		color: var(--color-fg);
+		font-size: 0.9rem;
+	}
+
+	.mention-item.selected {
+		background: var(--color-accent);
+		color: var(--color-bg);
+	}
+
+	.mention-name {
+		font-weight: 600;
+	}
+
+	.mention-detail {
+		font-size: 0.8rem;
+		opacity: 0.7;
+	}
+
+	.mention-item.selected .mention-detail {
 		opacity: 0.85;
 	}
 </style>

--- a/ui/src/components/InputField.svelte
+++ b/ui/src/components/InputField.svelte
@@ -2,95 +2,198 @@
 	import { streamingActive, npcsHere } from '../stores/game';
 	import { submitInput } from '$lib/ipc';
 
-	let inputEl: HTMLInputElement;
-	let text = $state('');
+	let editorEl: HTMLDivElement;
 	let showMentions = $state(false);
 	let selectedIndex = $state(0);
 	let mentionQuery = $state('');
 
 	const filteredNpcs = $derived(
-		$npcsHere.filter((npc) =>
-			npc.name.toLowerCase().startsWith(mentionQuery.toLowerCase())
-		)
+		mentionQuery === ''
+			? $npcsHere
+			: $npcsHere.filter((npc) =>
+					npc.name.toLowerCase().startsWith(mentionQuery.toLowerCase())
+				)
 	);
 
 	$effect(() => {
-		if (!$streamingActive && inputEl) {
-			inputEl.focus();
+		if (!$streamingActive && editorEl) {
+			editorEl.focus();
 		}
 	});
 
 	$effect(() => {
-		// Reset selection when filtered list changes
 		if (selectedIndex >= filteredNpcs.length) {
 			selectedIndex = Math.max(0, filteredNpcs.length - 1);
 		}
 	});
 
-	function detectMention() {
-		if (!inputEl) return;
-		const value = text;
-		// Only trigger when @ is at the start of input
-		if (value.startsWith('@')) {
-			const afterAt = value.slice(1);
-			// Extract the mention query (everything up to end or first lowercase-started word after a name)
-			const spaceIdx = afterAt.indexOf(' ');
-			// Show dropdown while typing the name portion
-			if (spaceIdx === -1) {
-				mentionQuery = afterAt;
-				showMentions = afterAt.length > 0 && $npcsHere.length > 0;
-			} else {
-				// Check if there's still a plausible name being typed
-				// e.g., "@Padraig D" should still show dropdown
-				const words = afterAt.split(' ');
-				const allCapitalized = words.every(
-					(w) => w.length === 0 || w[0] === w[0].toUpperCase()
-				);
-				if (allCapitalized && words[words.length - 1] === '') {
-					// Trailing space after capitalized words — could be continuing a name
-					mentionQuery = afterAt.trimEnd();
-					showMentions = $npcsHere.length > 0;
-				} else if (allCapitalized) {
-					mentionQuery = afterAt;
-					showMentions = $npcsHere.length > 0;
-				} else {
-					showMentions = false;
-				}
+	/** Returns the full plain-text content of the editor, converting chips to @Name. */
+	function getPlainText(): string {
+		if (!editorEl) return '';
+		let result = '';
+		for (const node of editorEl.childNodes) {
+			if (node.nodeType === Node.TEXT_NODE) {
+				result += node.textContent ?? '';
+			} else if (node instanceof HTMLElement && node.dataset.npc) {
+				result += `@${node.dataset.npc}`;
+			} else if (node instanceof HTMLElement) {
+				result += node.textContent ?? '';
 			}
+		}
+		return result;
+	}
+
+	/** Returns true if the editor is visually empty (no text, no chips). */
+	function isEditorEmpty(): boolean {
+		if (!editorEl) return true;
+		return getPlainText().trim() === '';
+	}
+
+	/** Clears the editor content. */
+	function clearEditor() {
+		if (editorEl) {
+			editorEl.innerHTML = '';
+		}
+	}
+
+	/** Gets the plain text currently being typed (excluding chips). */
+	function getCurrentTypingText(): string {
+		if (!editorEl) return '';
+		// Get text from the text node the cursor is in, or fall back to full text
+		const sel = window.getSelection();
+		if (sel && sel.rangeCount > 0) {
+			const node = sel.getRangeAt(0).startContainer;
+			if (node.nodeType === Node.TEXT_NODE) {
+				return node.textContent ?? '';
+			}
+		}
+		// Fallback: use the full plain text of the editor
+		return getPlainText();
+	}
+
+	/** Finds an @-trigger in the text currently being typed. */
+	function findMentionTrigger(): { query: string } | null {
+		const text = getCurrentTypingText();
+		const atIdx = text.lastIndexOf('@');
+		if (atIdx === -1) return null;
+		// @ must be at start or preceded by a space
+		if (atIdx > 0 && text[atIdx - 1] !== ' ') return null;
+		const query = text.slice(atIdx + 1);
+		// Don't trigger if there's a space in the query
+		if (query.includes(' ')) return null;
+		return { query };
+	}
+
+	function detectMention() {
+		const trigger = findMentionTrigger();
+		if (trigger !== null && $npcsHere.length > 0) {
+			mentionQuery = trigger.query;
+			showMentions = true;
+			selectedIndex = 0;
 		} else {
 			showMentions = false;
 		}
-		selectedIndex = 0;
 	}
 
 	function selectNpc(npcName: string) {
-		// Use first name only for brevity
-		const firstName = npcName.split(' ')[0];
-		const afterMention = text.startsWith('@') ? getTextAfterMention() : '';
-		text = `@${firstName} ${afterMention}`;
-		showMentions = false;
-		inputEl?.focus();
-		// Move cursor to end
-		requestAnimationFrame(() => {
-			if (inputEl) {
-				inputEl.selectionStart = inputEl.selectionEnd = text.length;
-			}
-		});
-	}
+		if (!editorEl) return;
 
-	function getTextAfterMention(): string {
-		const value = text;
-		if (!value.startsWith('@')) return value;
-		const afterAt = value.slice(1);
-		const words = afterAt.split(' ');
-		// Skip capitalized words (part of the mention)
-		let i = 0;
-		for (; i < words.length; i++) {
-			if (words[i].length > 0 && words[i][0] !== words[i][0].toUpperCase()) {
-				break;
+		const sel = window.getSelection();
+		let textNode: Text | null = null;
+		let cursorOffset = 0;
+
+		// Find the text node containing the @mention
+		if (sel && sel.rangeCount > 0) {
+			const range = sel.getRangeAt(0);
+			const node = range.startContainer;
+			if (node.nodeType === Node.TEXT_NODE) {
+				textNode = node as Text;
+				cursorOffset = range.startOffset;
 			}
 		}
-		return words.slice(i).join(' ');
+
+		// Fallback: find the first text node in the editor
+		if (!textNode) {
+			for (const child of editorEl.childNodes) {
+				if (child.nodeType === Node.TEXT_NODE && (child.textContent ?? '').includes('@')) {
+					textNode = child as Text;
+					cursorOffset = (child.textContent ?? '').length;
+					break;
+				}
+			}
+		}
+
+		if (!textNode) {
+			// Last resort: just replace the entire editor content
+			const chip = document.createElement('span');
+			chip.className = 'mention-chip';
+			chip.contentEditable = 'false';
+			chip.dataset.npc = npcName;
+			chip.textContent = `@${npcName}`;
+			editorEl.innerHTML = '';
+			editorEl.appendChild(chip);
+			const trailing = document.createTextNode('\u00A0');
+			editorEl.appendChild(trailing);
+			const range = document.createRange();
+			range.setStart(trailing, 1);
+			range.collapse(true);
+			sel?.removeAllRanges();
+			sel?.addRange(range);
+			showMentions = false;
+			editorEl.focus();
+			return;
+		}
+
+		const text = textNode.textContent ?? '';
+		const atIdx = text.lastIndexOf('@');
+		if (atIdx === -1) {
+			showMentions = false;
+			return;
+		}
+
+		const before = text.slice(0, atIdx);
+		const after = text.slice(cursorOffset);
+
+		// Build chip
+		const chip = document.createElement('span');
+		chip.className = 'mention-chip';
+		chip.contentEditable = 'false';
+		chip.dataset.npc = npcName;
+		chip.textContent = `@${npcName}`;
+
+		// Replace text node with: [before] [chip] [nbsp + after]
+		const parent = textNode.parentNode!;
+		if (before) {
+			parent.insertBefore(document.createTextNode(before), textNode);
+		}
+		parent.insertBefore(chip, textNode);
+		const trailing = document.createTextNode(`\u00A0${after}`);
+		parent.insertBefore(trailing, textNode);
+		parent.removeChild(textNode);
+
+		// Place cursor after chip
+		const range = document.createRange();
+		range.setStart(trailing, 1);
+		range.collapse(true);
+		sel?.removeAllRanges();
+		sel?.addRange(range);
+
+		showMentions = false;
+		editorEl.focus();
+	}
+
+	/** Dissolves a mention chip back into plain text. */
+	function dissolveChip(chip: HTMLElement) {
+		const text = chip.textContent ?? '';
+		const textNode = document.createTextNode(text);
+		chip.parentNode?.replaceChild(textNode, chip);
+		// Place cursor at end of dissolved text
+		const sel = window.getSelection();
+		const range = document.createRange();
+		range.setStart(textNode, text.length);
+		range.collapse(true);
+		sel?.removeAllRanges();
+		sel?.addRange(range);
 	}
 
 	async function handleSubmit(e: Event) {
@@ -99,9 +202,9 @@
 			selectNpc(filteredNpcs[selectedIndex].name);
 			return;
 		}
-		const trimmed = text.trim();
+		const trimmed = getPlainText().trim();
 		if (!trimmed || $streamingActive) return;
-		text = '';
+		clearEditor();
 		showMentions = false;
 		await submitInput(trimmed);
 	}
@@ -130,13 +233,67 @@
 				return;
 			}
 		}
+
+		// Backspace into a chip: dissolve it
+		if (e.key === 'Backspace') {
+			const sel = window.getSelection();
+			if (sel && sel.rangeCount > 0) {
+				const range = sel.getRangeAt(0);
+				if (range.collapsed && range.startOffset === 0 && range.startContainer.nodeType === Node.TEXT_NODE) {
+					const prev = range.startContainer.previousSibling;
+					if (prev instanceof HTMLElement && prev.dataset.npc) {
+						e.preventDefault();
+						dissolveChip(prev);
+						return;
+					}
+				}
+				// Also handle: cursor is right after chip with no text node between
+				if (range.collapsed && range.startContainer === editorEl) {
+					const idx = range.startOffset;
+					const child = editorEl.childNodes[idx - 1];
+					if (child instanceof HTMLElement && child.dataset.npc) {
+						e.preventDefault();
+						dissolveChip(child);
+						return;
+					}
+				}
+			}
+		}
+
+		// Delete into a chip: dissolve it
+		if (e.key === 'Delete') {
+			const sel = window.getSelection();
+			if (sel && sel.rangeCount > 0) {
+				const range = sel.getRangeAt(0);
+				if (range.collapsed) {
+					const node = range.startContainer;
+					if (node.nodeType === Node.TEXT_NODE && range.startOffset === (node.textContent?.length ?? 0)) {
+						const next = node.nextSibling;
+						if (next instanceof HTMLElement && next.dataset.npc) {
+							e.preventDefault();
+							dissolveChip(next);
+							return;
+						}
+					}
+				}
+			}
+		}
+
 		if (e.key === 'Enter') {
+			e.preventDefault();
 			handleSubmit(e);
 		}
 	}
 
 	function handleInput() {
 		detectMention();
+	}
+
+	// Prevent pasting rich content — only plain text
+	function handlePaste(e: ClipboardEvent) {
+		e.preventDefault();
+		const text = e.clipboardData?.getData('text/plain') ?? '';
+		document.execCommand('insertText', false, text);
 	}
 </script>
 
@@ -160,27 +317,33 @@
 			{/each}
 		</ul>
 	{/if}
-	<form class="input-form" onsubmit={handleSubmit}>
-		<input
-			bind:this={inputEl}
-			bind:value={text}
-			onkeydown={handleKeydown}
-			oninput={handleInput}
-			disabled={$streamingActive}
-			placeholder={$streamingActive ? 'Waiting…' : 'What do you do? (@ to mention NPC)'}
-			class="input-field"
-			autocomplete="off"
-			spellcheck="false"
-		/>
-		<button type="submit" disabled={$streamingActive || !text.trim()} class="send-btn">
+	<div class="input-form">
+		<div class="editor-wrap">
+			<div
+				bind:this={editorEl}
+				class="input-field"
+				class:disabled={$streamingActive}
+				contenteditable={!$streamingActive}
+				role="textbox"
+				tabindex="0"
+				aria-label="Player input"
+				onkeydown={handleKeydown}
+				onkeyup={handleInput}
+				oninput={handleInput}
+				onpaste={handlePaste}
+				data-placeholder={$streamingActive ? 'Waiting…' : 'What do you do? (@ to mention NPC)'}
+			></div>
+		</div>
+		<button type="button" onclick={handleSubmit} disabled={$streamingActive || isEditorEmpty()} class="send-btn">
 			Send
 		</button>
-	</form>
+	</div>
 </div>
 
 <style>
 	.input-wrapper {
 		position: relative;
+		flex: 0 0 auto;
 	}
 
 	.input-form {
@@ -191,8 +354,12 @@
 		border-top: 1px solid var(--color-border);
 	}
 
-	.input-field {
+	.editor-wrap {
 		flex: 1;
+		position: relative;
+	}
+
+	.input-field {
 		background: var(--color-input-bg);
 		border: 1px solid var(--color-border);
 		color: var(--color-fg);
@@ -201,19 +368,41 @@
 		font-family: inherit;
 		border-radius: 4px;
 		outline: none;
+		max-height: 6em;
+		overflow-y: auto;
+		white-space: pre-wrap;
+		word-wrap: break-word;
+		overflow-wrap: break-word;
 	}
 
 	.input-field:focus {
 		border-color: var(--color-accent);
 	}
 
-	.input-field:disabled {
+	.input-field.disabled {
 		opacity: 0.5;
 		cursor: not-allowed;
+		pointer-events: none;
 	}
 
-	.input-field::placeholder {
+	/* Placeholder via :empty pseudo-element */
+	.input-field:empty::before {
+		content: attr(data-placeholder);
 		color: var(--color-muted);
+		pointer-events: none;
+	}
+
+	.input-field :global(.mention-chip) {
+		display: inline;
+		font-weight: 700;
+		color: var(--color-accent);
+		border: 1.5px solid var(--color-accent);
+		border-radius: 3px;
+		padding: 0.05em 0.3em;
+		margin: 0 0.1em;
+		cursor: default;
+		user-select: all;
+		white-space: nowrap;
 	}
 
 	.send-btn {

--- a/ui/src/components/InputField.test.ts
+++ b/ui/src/components/InputField.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
-import { streamingActive } from '../stores/game';
+import { streamingActive, npcsHere } from '../stores/game';
 import InputField from './InputField.svelte';
 
 // Mock ipc submitInput
@@ -11,6 +11,7 @@ vi.mock('$lib/ipc', () => ({
 describe('InputField', () => {
 	beforeEach(() => {
 		streamingActive.set(false);
+		npcsHere.set([]);
 	});
 
 	it('renders an input field', () => {
@@ -20,7 +21,7 @@ describe('InputField', () => {
 
 	it('has correct placeholder when idle', () => {
 		const { getByPlaceholderText } = render(InputField);
-		expect(getByPlaceholderText('What do you do?')).toBeTruthy();
+		expect(getByPlaceholderText('What do you do? (@ to mention NPC)')).toBeTruthy();
 	});
 
 	it('is disabled when streaming', () => {
@@ -36,5 +37,80 @@ describe('InputField', () => {
 		await fireEvent.keyDown(input, { key: 'Enter' });
 		// Input should be cleared
 		expect(input.value).toBe('');
+	});
+
+	describe('NPC mention autocomplete', () => {
+		const testNpcs = [
+			{ name: 'Padraig Darcy', occupation: 'Publican', mood: 'content', introduced: true },
+			{ name: 'Siobhan Murphy', occupation: 'Farmer', mood: 'determined', introduced: true },
+			{ name: 'Father Callahan', occupation: 'Priest', mood: 'serene', introduced: false }
+		];
+
+		beforeEach(() => {
+			npcsHere.set(testNpcs);
+		});
+
+		it('shows mention dropdown when @ is typed with a letter', async () => {
+			const { getByRole, queryByRole } = render(InputField);
+			const input = getByRole('textbox') as HTMLInputElement;
+
+			// No dropdown initially
+			expect(queryByRole('listbox')).toBeNull();
+
+			// Type @P
+			await fireEvent.input(input, { target: { value: '@P' } });
+			expect(queryByRole('listbox')).toBeTruthy();
+		});
+
+		it('filters NPCs by typed text', async () => {
+			const { getByRole, queryAllByRole } = render(InputField);
+			const input = getByRole('textbox') as HTMLInputElement;
+
+			// Type @P — should show Padraig only
+			await fireEvent.input(input, { target: { value: '@P' } });
+			const options = queryAllByRole('option');
+			expect(options.length).toBe(1);
+			expect(options[0].textContent).toContain('Padraig Darcy');
+		});
+
+		it('shows all NPCs when only @ and first letter matches multiple', async () => {
+			const { getByRole, queryAllByRole } = render(InputField);
+			const input = getByRole('textbox') as HTMLInputElement;
+
+			// Type @S — only Siobhan starts with S
+			await fireEvent.input(input, { target: { value: '@S' } });
+			const options = queryAllByRole('option');
+			expect(options.length).toBe(1);
+			expect(options[0].textContent).toContain('Siobhan Murphy');
+		});
+
+		it('does not show dropdown when no NPCs present', async () => {
+			npcsHere.set([]);
+			const { getByRole, queryByRole } = render(InputField);
+			const input = getByRole('textbox') as HTMLInputElement;
+
+			await fireEvent.input(input, { target: { value: '@P' } });
+			expect(queryByRole('listbox')).toBeNull();
+		});
+
+		it('dismisses dropdown on Escape', async () => {
+			const { getByRole, queryByRole } = render(InputField);
+			const input = getByRole('textbox') as HTMLInputElement;
+
+			await fireEvent.input(input, { target: { value: '@P' } });
+			expect(queryByRole('listbox')).toBeTruthy();
+
+			await fireEvent.keyDown(input, { key: 'Escape' });
+			expect(queryByRole('listbox')).toBeNull();
+		});
+
+		it('shows occupation for introduced NPCs', async () => {
+			const { getByRole, queryAllByRole } = render(InputField);
+			const input = getByRole('textbox') as HTMLInputElement;
+
+			await fireEvent.input(input, { target: { value: '@P' } });
+			const options = queryAllByRole('option');
+			expect(options[0].textContent).toContain('Publican');
+		});
 	});
 });

--- a/ui/src/components/InputField.test.ts
+++ b/ui/src/components/InputField.test.ts
@@ -14,29 +14,34 @@ describe('InputField', () => {
 		npcsHere.set([]);
 	});
 
-	it('renders an input field', () => {
+	it('renders an editable input area', () => {
 		const { getByRole } = render(InputField);
-		expect(getByRole('textbox')).toBeTruthy();
+		const editor = getByRole('textbox');
+		expect(editor).toBeTruthy();
+		expect(editor.getAttribute('contenteditable')).toBe('true');
 	});
 
-	it('has correct placeholder when idle', () => {
-		const { getByPlaceholderText } = render(InputField);
-		expect(getByPlaceholderText('What do you do? (@ to mention NPC)')).toBeTruthy();
+	it('shows placeholder when empty', () => {
+		const { getByRole } = render(InputField);
+		const editor = getByRole('textbox');
+		expect(editor.dataset.placeholder).toBe('What do you do? (@ to mention NPC)');
 	});
 
-	it('is disabled when streaming', () => {
+	it('is not editable when streaming', () => {
 		streamingActive.set(true);
 		const { getByRole } = render(InputField);
-		expect((getByRole('textbox') as HTMLInputElement).disabled).toBe(true);
+		const editor = getByRole('textbox');
+		expect(editor.getAttribute('contenteditable')).toBe('false');
 	});
 
-	it('clears input after submit', async () => {
+	it('clears editor after submit', async () => {
 		const { getByRole } = render(InputField);
-		const input = getByRole('textbox') as HTMLInputElement;
-		await fireEvent.input(input, { target: { value: 'hello' } });
-		await fireEvent.keyDown(input, { key: 'Enter' });
-		// Input should be cleared
-		expect(input.value).toBe('');
+		const editor = getByRole('textbox');
+		// Type text into contenteditable
+		editor.textContent = 'hello';
+		await fireEvent.input(editor);
+		await fireEvent.keyDown(editor, { key: 'Enter' });
+		expect(editor.textContent).toBe('');
 	});
 
 	describe('NPC mention autocomplete', () => {
@@ -50,35 +55,50 @@ describe('InputField', () => {
 			npcsHere.set(testNpcs);
 		});
 
+		/** Helper to simulate typing into contenteditable with cursor position. */
+		function typeIntoEditor(editor: HTMLElement, text: string) {
+			editor.textContent = text;
+			// Set cursor at end
+			const range = document.createRange();
+			const sel = window.getSelection();
+			if (editor.firstChild) {
+				range.setStart(editor.firstChild, text.length);
+			} else {
+				range.setStart(editor, 0);
+			}
+			range.collapse(true);
+			sel?.removeAllRanges();
+			sel?.addRange(range);
+		}
+
 		it('shows mention dropdown when @ is typed with a letter', async () => {
 			const { getByRole, queryByRole } = render(InputField);
-			const input = getByRole('textbox') as HTMLInputElement;
+			const editor = getByRole('textbox');
 
-			// No dropdown initially
 			expect(queryByRole('listbox')).toBeNull();
 
-			// Type @P
-			await fireEvent.input(input, { target: { value: '@P' } });
+			typeIntoEditor(editor, '@P');
+			await fireEvent.input(editor);
 			expect(queryByRole('listbox')).toBeTruthy();
 		});
 
 		it('filters NPCs by typed text', async () => {
 			const { getByRole, queryAllByRole } = render(InputField);
-			const input = getByRole('textbox') as HTMLInputElement;
+			const editor = getByRole('textbox');
 
-			// Type @P — should show Padraig only
-			await fireEvent.input(input, { target: { value: '@P' } });
+			typeIntoEditor(editor, '@P');
+			await fireEvent.input(editor);
 			const options = queryAllByRole('option');
 			expect(options.length).toBe(1);
 			expect(options[0].textContent).toContain('Padraig Darcy');
 		});
 
-		it('shows all NPCs when only @ and first letter matches multiple', async () => {
+		it('shows matching NPCs for @S', async () => {
 			const { getByRole, queryAllByRole } = render(InputField);
-			const input = getByRole('textbox') as HTMLInputElement;
+			const editor = getByRole('textbox');
 
-			// Type @S — only Siobhan starts with S
-			await fireEvent.input(input, { target: { value: '@S' } });
+			typeIntoEditor(editor, '@S');
+			await fireEvent.input(editor);
 			const options = queryAllByRole('option');
 			expect(options.length).toBe(1);
 			expect(options[0].textContent).toContain('Siobhan Murphy');
@@ -87,30 +107,50 @@ describe('InputField', () => {
 		it('does not show dropdown when no NPCs present', async () => {
 			npcsHere.set([]);
 			const { getByRole, queryByRole } = render(InputField);
-			const input = getByRole('textbox') as HTMLInputElement;
+			const editor = getByRole('textbox');
 
-			await fireEvent.input(input, { target: { value: '@P' } });
+			typeIntoEditor(editor, '@P');
+			await fireEvent.input(editor);
 			expect(queryByRole('listbox')).toBeNull();
 		});
 
 		it('dismisses dropdown on Escape', async () => {
 			const { getByRole, queryByRole } = render(InputField);
-			const input = getByRole('textbox') as HTMLInputElement;
+			const editor = getByRole('textbox');
 
-			await fireEvent.input(input, { target: { value: '@P' } });
+			typeIntoEditor(editor, '@P');
+			await fireEvent.input(editor);
 			expect(queryByRole('listbox')).toBeTruthy();
 
-			await fireEvent.keyDown(input, { key: 'Escape' });
+			await fireEvent.keyDown(editor, { key: 'Escape' });
 			expect(queryByRole('listbox')).toBeNull();
 		});
 
 		it('shows occupation for introduced NPCs', async () => {
 			const { getByRole, queryAllByRole } = render(InputField);
-			const input = getByRole('textbox') as HTMLInputElement;
+			const editor = getByRole('textbox');
 
-			await fireEvent.input(input, { target: { value: '@P' } });
+			typeIntoEditor(editor, '@P');
+			await fireEvent.input(editor);
 			const options = queryAllByRole('option');
 			expect(options[0].textContent).toContain('Publican');
+		});
+
+		it('inserts a mention chip with full name on selection', async () => {
+			const { getByRole, queryAllByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '@P');
+			await fireEvent.input(editor);
+
+			// Select via Enter
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			// Should have a chip with full name
+			const chip = editor.querySelector('.mention-chip');
+			expect(chip).toBeTruthy();
+			expect(chip?.textContent).toBe('@Padraig Darcy');
+			expect((chip as HTMLElement)?.dataset.npc).toBe('Padraig Darcy');
 		});
 	});
 });

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -197,6 +197,7 @@
 	.chat-col {
 		display: flex;
 		flex-direction: column;
+		min-height: 0;
 		overflow: hidden;
 	}
 


### PR DESCRIPTION
Allow players to direct dialogue to a specific NPC by typing @Name at
the start of input. An autocomplete dropdown appears in the GUI when @
is typed, showing NPCs at the current location with keyboard navigation
(arrows, Tab/Enter to select, Escape to dismiss).

Backend: extract_mention() parses @Name from input, NpcManager::find_by_name()
matches by full name, first name, or brief description (case-insensitive).
Falls back to first NPC if no match found.

https://claude.ai/code/session_01G25WL1oBbgHNNCPyV1bhr5