### PR TITLE
Update default theme to morning palette and fetch theme on startup

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -1,14 +1,14 @@
 /* Parish — Global CSS Theme */
 
 :root {
-	/* Default palette (overridden at runtime by Rust theme-update events) */
-	--color-bg: #1a1a2e;
-	--color-fg: #e8e0d0;
-	--color-accent: #c4a35a;
-	--color-panel-bg: #16213e;
-	--color-input-bg: #0f3460;
-	--color-border: #2a2a4a;
-	--color-muted: #7a7a9a;
+	/* Default palette: morning (game starts at 8 AM). Overridden at runtime by Rust theme-update events. */
+	--color-bg: #fff5dc;
+	--color-fg: #32230f;
+	--color-accent: #b48232;
+	--color-panel-bg: #faf0d7;
+	--color-input-bg: #f5ebd2;
+	--color-border: #d2be96;
+	--color-muted: #78643c;
 }
 
 *,

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -16,6 +16,7 @@
 		getMap,
 		getNpcsHere,
 		getUiConfig,
+		getTheme,
 		getDebugSnapshot,
 		onWorldUpdate,
 		onStreamToken,
@@ -41,16 +42,18 @@
 	}
 
 	onMount(async () => {
-		// Initial data fetch
+		// Initial data fetch (theme first to avoid color flash)
 		try {
-			const [snap, map, npcs] = await Promise.all([
+			const [snap, map, npcs, theme] = await Promise.all([
 				getWorldSnapshot(),
 				getMap(),
-				getNpcsHere()
+				getNpcsHere(),
+				getTheme()
 			]);
 			worldState.set(snap);
 			mapData.set(map);
 			npcsHere.set(npcs);
+			palette.apply(theme);
 			// Show initial location description in the chat panel
 			if (snap.location_description) {
 				textLog.update((log) => [

--- a/ui/src/stores/theme.ts
+++ b/ui/src/stores/theme.ts
@@ -2,13 +2,13 @@ import { writable } from 'svelte/store';
 import type { ThemePalette } from '$lib/types';
 
 const defaultPalette: ThemePalette = {
-	bg: '#1a1a2e',
-	fg: '#e8e0d0',
-	accent: '#c4a35a',
-	panel_bg: '#16213e',
-	input_bg: '#0f3460',
-	border: '#2a2a4a',
-	muted: '#7a7a9a'
+	bg: '#fff5dc',
+	fg: '#32230f',
+	accent: '#b48232',
+	panel_bg: '#faf0d7',
+	input_bg: '#f5ebd2',
+	border: '#d2be96',
+	muted: '#78643c'
 };
 
 function createPaletteStore() {


### PR DESCRIPTION
## Summary
This PR updates the default color theme from a dark palette to a light morning palette (reflecting the game's 8 AM start time) and ensures the theme is fetched and applied during initial app load to prevent color flashing.

## Key Changes
- **Default theme colors**: Replaced dark theme (`#1a1a2e` bg, `#e8e0d0` fg) with light morning theme (`#fff5dc` bg, `#32230f` fg) across:
  - `ui/src/app.css` - CSS custom properties
  - `ui/src/stores/theme.ts` - TypeScript theme store defaults
  
- **Theme initialization**: Modified `ui/src/routes/+page.svelte` to:
  - Import `getTheme()` function from the backend
  - Fetch theme data during initial `onMount()` alongside other startup data
  - Apply fetched theme immediately via `palette.apply(theme)` to prevent visual flashing
  - Reordered comment to clarify theme is fetched first

## Implementation Details
The theme is now fetched as part of the initial parallel data load (`Promise.all()`) rather than relying solely on runtime Rust theme-update events. This ensures the correct theme colors are applied before the UI renders, eliminating any brief flash of the default colors.

https://claude.ai/code/session_01HgP87cYuE3iYo8euJyfXZe