### PR TITLE
Add max_tokens parameter to control LLM response length

### DIFF
--- a/crates/parish-core/src/inference/mod.rs
+++ b/crates/parish-core/src/inference/mod.rs
@@ -30,6 +30,8 @@ pub struct InferenceRequest {
     /// Optional channel for streaming tokens. If present, the worker streams
     /// individual tokens through this before sending the final response.
     pub token_tx: Option<mpsc::UnboundedSender<String>>,
+    /// Optional maximum number of tokens to generate.
+    pub max_tokens: Option<u32>,
 }
 
 /// The response from an inference request.
@@ -60,9 +62,10 @@ impl InferenceQueue {
     /// Submits an inference request to the queue.
     ///
     /// If `token_tx` is provided, the worker will stream individual tokens
-    /// through it before sending the final complete response. Returns a
-    /// oneshot receiver that will yield the complete response.
-    /// Returns an error if the queue channel is closed.
+    /// through it before sending the final complete response. An optional
+    /// `max_tokens` cap is forwarded to the LLM provider to limit output
+    /// length. Returns a oneshot receiver that will yield the complete
+    /// response. Returns an error if the queue channel is closed.
     pub async fn send(
         &self,
         id: u64,
@@ -70,6 +73,7 @@ impl InferenceQueue {
         prompt: String,
         system: Option<String>,
         token_tx: Option<mpsc::UnboundedSender<String>>,
+        max_tokens: Option<u32>,
     ) -> Result<oneshot::Receiver<InferenceResponse>, mpsc::error::SendError<InferenceRequest>>
     {
         let (response_tx, response_rx) = oneshot::channel();
@@ -80,6 +84,7 @@ impl InferenceQueue {
             system,
             response_tx,
             token_tx,
+            max_tokens,
         };
         self.tx.send(request).await?;
         Ok(response_rx)
@@ -152,11 +157,17 @@ pub fn spawn_inference_worker(
                         &request.prompt,
                         request.system.as_deref(),
                         token_tx,
+                        request.max_tokens,
                     )
                     .await
             } else {
                 client
-                    .generate(&request.model, &request.prompt, request.system.as_deref())
+                    .generate(
+                        &request.model,
+                        &request.prompt,
+                        request.system.as_deref(),
+                        request.max_tokens,
+                    )
                     .await
             };
 

--- a/crates/parish-core/src/inference/openai_client.rs
+++ b/crates/parish-core/src/inference/openai_client.rs
@@ -47,6 +47,8 @@ struct ChatCompletionRequest<'a> {
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     response_format: Option<ResponseFormat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
 }
 
 /// Controls structured output format.
@@ -129,14 +131,16 @@ impl OpenAiClient {
     ///
     /// Builds a messages array from the prompt and optional system message,
     /// posts to `/v1/chat/completions` with `stream: false`, and extracts
-    /// `choices[0].message.content`.
+    /// `choices[0].message.content`. An optional `max_tokens` cap prevents
+    /// excessively long responses.
     pub async fn generate(
         &self,
         model: &str,
         prompt: &str,
         system: Option<&str>,
+        max_tokens: Option<u32>,
     ) -> Result<String, ParishError> {
-        let body = self.build_request(model, prompt, system, false, false);
+        let body = self.build_request(model, prompt, system, false, false, max_tokens);
         let resp = self.send_request(&body).await?;
         let completion: ChatCompletionResponse = resp.json().await?;
         Ok(extract_content(&completion))
@@ -147,15 +151,17 @@ impl OpenAiClient {
     /// Posts to `/v1/chat/completions` with `stream: true`. Parses SSE
     /// (Server-Sent Events) data lines, extracts delta content, and sends
     /// each token through `token_tx`. Returns the full accumulated text
-    /// after the stream completes. Uses a 5-minute timeout.
+    /// after the stream completes. Uses a 5-minute timeout. An optional
+    /// `max_tokens` cap prevents excessively long responses.
     pub async fn generate_stream(
         &self,
         model: &str,
         prompt: &str,
         system: Option<&str>,
         token_tx: mpsc::UnboundedSender<String>,
+        max_tokens: Option<u32>,
     ) -> Result<String, ParishError> {
-        let body = self.build_request(model, prompt, system, true, false);
+        let body = self.build_request(model, prompt, system, true, false, max_tokens);
 
         // Use a longer timeout for streaming
         let streaming_client = reqwest::Client::builder()
@@ -203,14 +209,16 @@ impl OpenAiClient {
     ///
     /// Requests JSON output via `response_format: {"type": "json_object"}` and
     /// parses the response content into the target type `T`. Use
-    /// `#[serde(default)]` on optional fields in `T` for robustness.
+    /// `#[serde(default)]` on optional fields in `T` for robustness. An
+    /// optional `max_tokens` cap prevents excessively long responses.
     pub async fn generate_json<T: DeserializeOwned>(
         &self,
         model: &str,
         prompt: &str,
         system: Option<&str>,
+        max_tokens: Option<u32>,
     ) -> Result<T, ParishError> {
-        let body = self.build_request(model, prompt, system, false, true);
+        let body = self.build_request(model, prompt, system, false, true, max_tokens);
         let resp = self.send_request(&body).await?;
         let completion: ChatCompletionResponse = resp.json().await?;
         let content = extract_content(&completion);
@@ -226,6 +234,7 @@ impl OpenAiClient {
         system: Option<&'a str>,
         stream: bool,
         json_mode: bool,
+        max_tokens: Option<u32>,
     ) -> ChatCompletionRequest<'a> {
         let mut messages = Vec::new();
         if let Some(sys) = system {
@@ -252,6 +261,7 @@ impl OpenAiClient {
             messages,
             stream,
             response_format,
+            max_tokens,
         }
     }
 
@@ -543,7 +553,7 @@ mod tests {
     #[test]
     fn test_request_serialization() {
         let client = OpenAiClient::new("http://localhost:11434", None);
-        let req = client.build_request("qwen3:14b", "hello", Some("be brief"), false, false);
+        let req = client.build_request("qwen3:14b", "hello", Some("be brief"), false, false, None);
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["model"], "qwen3:14b");
         assert_eq!(json["messages"][0]["role"], "system");
@@ -552,14 +562,23 @@ mod tests {
         assert_eq!(json["messages"][1]["content"], "hello");
         assert_eq!(json["stream"], false);
         assert!(json.get("response_format").is_none());
+        assert!(json.get("max_tokens").is_none());
     }
 
     #[test]
     fn test_request_serialization_json_mode() {
         let client = OpenAiClient::new("http://localhost:11434", None);
-        let req = client.build_request("qwen3:14b", "hello", None, false, true);
+        let req = client.build_request("qwen3:14b", "hello", None, false, true, None);
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["response_format"]["type"], "json_object");
+    }
+
+    #[test]
+    fn test_request_serialization_with_max_tokens() {
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        let req = client.build_request("qwen3:14b", "hello", None, false, false, Some(300));
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["max_tokens"], 300);
     }
 
     #[tokio::test]
@@ -567,7 +586,7 @@ mod tests {
     async fn test_generate_live() {
         let client = OpenAiClient::new("http://localhost:11434", None);
         let result = client
-            .generate("qwen3:14b", "Say hello in one word.", None)
+            .generate("qwen3:14b", "Say hello in one word.", None, None)
             .await;
         assert!(result.is_ok());
         assert!(!result.unwrap().is_empty());
@@ -579,7 +598,7 @@ mod tests {
         let client = OpenAiClient::new("http://localhost:11434", None);
         let (tx, mut rx) = mpsc::unbounded_channel();
         let result = client
-            .generate_stream("qwen3:14b", "Say hello in one word.", None, tx)
+            .generate_stream("qwen3:14b", "Say hello in one word.", None, tx, None)
             .await;
         assert!(result.is_ok());
 
@@ -604,6 +623,7 @@ mod tests {
             .generate_json(
                 "qwen3:14b",
                 "Return a JSON object with a 'greeting' field containing 'hello'.",
+                None,
                 None,
             )
             .await;

--- a/crates/parish-core/src/input/mod.rs
+++ b/crates/parish-core/src/input/mod.rs
@@ -479,7 +479,7 @@ pub async fn parse_intent(
     }
 
     let result = client
-        .generate_json::<IntentResponse>(model, raw_input, Some(INTENT_SYSTEM_PROMPT))
+        .generate_json::<IntentResponse>(model, raw_input, Some(INTENT_SYSTEM_PROMPT), None)
         .await;
 
     match result {

--- a/crates/parish-core/src/npc/mod.rs
+++ b/crates/parish-core/src/npc/mod.rs
@@ -39,6 +39,13 @@ pub struct IrishWordHint {
 /// or `  ---\n` on its own line, even when preceded by text on the same line.
 pub const SEPARATOR_HOLDBACK: usize = 24;
 
+/// Maximum tokens for NPC dialogue responses (including the JSON metadata block).
+///
+/// Keeps responses conversational (a few sentences of dialogue plus the compact
+/// metadata JSON). Prevents models from generating excessively long monologues
+/// that break the chat formatting.
+pub const MAX_DIALOGUE_TOKENS: u32 = 300;
+
 /// Rounds a byte offset down to the nearest UTF-8 char boundary in `s`.
 ///
 /// If `pos` is already a char boundary, returns it unchanged. Otherwise
@@ -367,7 +374,13 @@ pub fn build_tier1_system_prompt(npc: &Npc, improv: bool) -> String {
         \n\
         Current mood: {mood}\n\
         \n\
-        Respond in character as {name}. Use this EXACT format:\n\
+        Respond in character as {name}.\n\
+        \n\
+        LENGTH: Keep your dialogue to 2-4 sentences. Be natural and conversational — \
+        this is a back-and-forth exchange, not a monologue. Say what you would naturally \
+        say, then let the player respond. Do not narrate at length or give speeches.\n\
+        \n\
+        Use this EXACT format:\n\
         \n\
         1. First, write what you say or do, in plain text. Stay in character. \
         Pepper your speech naturally with the occasional Irish word or phrase. \

--- a/crates/parish-core/src/npc/ticks.rs
+++ b/crates/parish-core/src/npc/ticks.rs
@@ -224,7 +224,7 @@ pub async fn run_tier2_for_group(
     let participant_ids: Vec<NpcId> = group.npcs.iter().map(|s| s.id).collect();
 
     match client
-        .generate_json::<Tier2Response>(model, &prompt, None)
+        .generate_json::<Tier2Response>(model, &prompt, None, None)
         .await
     {
         Ok(resp) => Some(Tier2Event {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -791,7 +791,14 @@ async fn handle_npc_conversation(
     );
 
     match queue
-        .send(req_id, model, context, Some(system_prompt), Some(token_tx))
+        .send(
+            req_id,
+            model,
+            context,
+            Some(system_prompt),
+            Some(token_tx),
+            Some(parish_core::npc::MAX_DIALOGUE_TOKENS),
+        )
         .await
     {
         Ok(mut response_rx) => {

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -810,6 +810,7 @@ async fn handle_headless_game_input(
                             context,
                             Some(system_prompt),
                             Some(token_tx),
+                            Some(parish_core::npc::MAX_DIALOGUE_TOKENS),
                         )
                         .await
                     {

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -30,6 +30,8 @@ pub struct InferenceRequest {
     /// Optional channel for streaming tokens. If present, the worker streams
     /// individual tokens through this before sending the final response.
     pub token_tx: Option<mpsc::UnboundedSender<String>>,
+    /// Optional maximum number of tokens to generate.
+    pub max_tokens: Option<u32>,
 }
 
 /// The response from an inference request.
@@ -60,9 +62,10 @@ impl InferenceQueue {
     /// Submits an inference request to the queue.
     ///
     /// If `token_tx` is provided, the worker will stream individual tokens
-    /// through it before sending the final complete response. Returns a
-    /// oneshot receiver that will yield the complete response.
-    /// Returns an error if the queue channel is closed.
+    /// through it before sending the final complete response. An optional
+    /// `max_tokens` cap is forwarded to the LLM provider to limit output
+    /// length. Returns a oneshot receiver that will yield the complete
+    /// response. Returns an error if the queue channel is closed.
     pub async fn send(
         &self,
         id: u64,
@@ -70,6 +73,7 @@ impl InferenceQueue {
         prompt: String,
         system: Option<String>,
         token_tx: Option<mpsc::UnboundedSender<String>>,
+        max_tokens: Option<u32>,
     ) -> Result<oneshot::Receiver<InferenceResponse>, mpsc::error::SendError<InferenceRequest>>
     {
         let (response_tx, response_rx) = oneshot::channel();
@@ -80,6 +84,7 @@ impl InferenceQueue {
             system,
             response_tx,
             token_tx,
+            max_tokens,
         };
         self.tx.send(request).await?;
         Ok(response_rx)
@@ -168,11 +173,17 @@ pub fn spawn_inference_worker(
                         &request.prompt,
                         request.system.as_deref(),
                         token_tx,
+                        request.max_tokens,
                     )
                     .await
             } else {
                 client
-                    .generate(&request.model, &request.prompt, request.system.as_deref())
+                    .generate(
+                        &request.model,
+                        &request.prompt,
+                        request.system.as_deref(),
+                        request.max_tokens,
+                    )
                     .await
             };
 
@@ -211,6 +222,7 @@ mod tests {
                 "hello".to_string(),
                 Some("system".to_string()),
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -243,7 +255,14 @@ mod tests {
         let queue = InferenceQueue::new(tx);
 
         let _response_rx = queue
-            .send(2, "model".to_string(), "prompt".to_string(), None, None)
+            .send(
+                2,
+                "model".to_string(),
+                "prompt".to_string(),
+                None,
+                None,
+                None,
+            )
             .await
             .unwrap();
 
@@ -266,6 +285,7 @@ mod tests {
                 "prompt".to_string(),
                 None,
                 Some(token_tx),
+                None,
             )
             .await
             .unwrap();

--- a/src/inference/openai_client.rs
+++ b/src/inference/openai_client.rs
@@ -47,6 +47,8 @@ struct ChatCompletionRequest<'a> {
     stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     response_format: Option<ResponseFormat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u32>,
 }
 
 /// Controls structured output format.
@@ -129,14 +131,16 @@ impl OpenAiClient {
     ///
     /// Builds a messages array from the prompt and optional system message,
     /// posts to `/v1/chat/completions` with `stream: false`, and extracts
-    /// `choices[0].message.content`.
+    /// `choices[0].message.content`. An optional `max_tokens` cap prevents
+    /// excessively long responses.
     pub async fn generate(
         &self,
         model: &str,
         prompt: &str,
         system: Option<&str>,
+        max_tokens: Option<u32>,
     ) -> Result<String, ParishError> {
-        let body = self.build_request(model, prompt, system, false, false);
+        let body = self.build_request(model, prompt, system, false, false, max_tokens);
         let resp = self.send_request(&body).await?;
         let completion: ChatCompletionResponse = resp.json().await?;
         Ok(extract_content(&completion))
@@ -147,15 +151,17 @@ impl OpenAiClient {
     /// Posts to `/v1/chat/completions` with `stream: true`. Parses SSE
     /// (Server-Sent Events) data lines, extracts delta content, and sends
     /// each token through `token_tx`. Returns the full accumulated text
-    /// after the stream completes. Uses a 5-minute timeout.
+    /// after the stream completes. Uses a 5-minute timeout. An optional
+    /// `max_tokens` cap prevents excessively long responses.
     pub async fn generate_stream(
         &self,
         model: &str,
         prompt: &str,
         system: Option<&str>,
         token_tx: mpsc::UnboundedSender<String>,
+        max_tokens: Option<u32>,
     ) -> Result<String, ParishError> {
-        let body = self.build_request(model, prompt, system, true, false);
+        let body = self.build_request(model, prompt, system, true, false, max_tokens);
 
         // Use a longer timeout for streaming
         let streaming_client = reqwest::Client::builder()
@@ -203,14 +209,16 @@ impl OpenAiClient {
     ///
     /// Requests JSON output via `response_format: {"type": "json_object"}` and
     /// parses the response content into the target type `T`. Use
-    /// `#[serde(default)]` on optional fields in `T` for robustness.
+    /// `#[serde(default)]` on optional fields in `T` for robustness. An
+    /// optional `max_tokens` cap prevents excessively long responses.
     pub async fn generate_json<T: DeserializeOwned>(
         &self,
         model: &str,
         prompt: &str,
         system: Option<&str>,
+        max_tokens: Option<u32>,
     ) -> Result<T, ParishError> {
-        let body = self.build_request(model, prompt, system, false, true);
+        let body = self.build_request(model, prompt, system, false, true, max_tokens);
         let resp = self.send_request(&body).await?;
         let completion: ChatCompletionResponse = resp.json().await?;
         let content = extract_content(&completion);
@@ -226,6 +234,7 @@ impl OpenAiClient {
         system: Option<&'a str>,
         stream: bool,
         json_mode: bool,
+        max_tokens: Option<u32>,
     ) -> ChatCompletionRequest<'a> {
         let mut messages = Vec::new();
         if let Some(sys) = system {
@@ -252,6 +261,7 @@ impl OpenAiClient {
             messages,
             stream,
             response_format,
+            max_tokens,
         }
     }
 
@@ -403,7 +413,14 @@ mod tests {
     #[test]
     fn test_build_request_with_system() {
         let client = OpenAiClient::new("http://localhost:11434", None);
-        let req = client.build_request("model", "hello", Some("you are helpful"), false, false);
+        let req = client.build_request(
+            "model",
+            "hello",
+            Some("you are helpful"),
+            false,
+            false,
+            None,
+        );
         assert_eq!(req.model, "model");
         assert_eq!(req.messages.len(), 2);
         assert_eq!(req.messages[0].role, "system");
@@ -417,7 +434,7 @@ mod tests {
     #[test]
     fn test_build_request_without_system() {
         let client = OpenAiClient::new("http://localhost:11434", None);
-        let req = client.build_request("model", "hello", None, false, false);
+        let req = client.build_request("model", "hello", None, false, false, None);
         assert_eq!(req.messages.len(), 1);
         assert_eq!(req.messages[0].role, "user");
     }
@@ -425,7 +442,7 @@ mod tests {
     #[test]
     fn test_build_request_json_mode() {
         let client = OpenAiClient::new("http://localhost:11434", None);
-        let req = client.build_request("model", "hello", None, false, true);
+        let req = client.build_request("model", "hello", None, false, true, None);
         let fmt = req.response_format.unwrap();
         assert_eq!(fmt.format_type, "json_object");
     }
@@ -433,7 +450,7 @@ mod tests {
     #[test]
     fn test_build_request_streaming() {
         let client = OpenAiClient::new("http://localhost:11434", None);
-        let req = client.build_request("model", "hello", None, true, false);
+        let req = client.build_request("model", "hello", None, true, false, None);
         assert!(req.stream);
     }
 
@@ -543,7 +560,7 @@ mod tests {
     #[test]
     fn test_request_serialization() {
         let client = OpenAiClient::new("http://localhost:11434", None);
-        let req = client.build_request("qwen3:14b", "hello", Some("be brief"), false, false);
+        let req = client.build_request("qwen3:14b", "hello", Some("be brief"), false, false, None);
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["model"], "qwen3:14b");
         assert_eq!(json["messages"][0]["role"], "system");
@@ -552,12 +569,13 @@ mod tests {
         assert_eq!(json["messages"][1]["content"], "hello");
         assert_eq!(json["stream"], false);
         assert!(json.get("response_format").is_none());
+        assert!(json.get("max_tokens").is_none());
     }
 
     #[test]
     fn test_request_serialization_json_mode() {
         let client = OpenAiClient::new("http://localhost:11434", None);
-        let req = client.build_request("qwen3:14b", "hello", None, false, true);
+        let req = client.build_request("qwen3:14b", "hello", None, false, true, None);
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["response_format"]["type"], "json_object");
     }
@@ -567,7 +585,7 @@ mod tests {
     async fn test_generate_live() {
         let client = OpenAiClient::new("http://localhost:11434", None);
         let result = client
-            .generate("qwen3:14b", "Say hello in one word.", None)
+            .generate("qwen3:14b", "Say hello in one word.", None, None)
             .await;
         assert!(result.is_ok());
         assert!(!result.unwrap().is_empty());
@@ -579,7 +597,7 @@ mod tests {
         let client = OpenAiClient::new("http://localhost:11434", None);
         let (tx, mut rx) = mpsc::unbounded_channel();
         let result = client
-            .generate_stream("qwen3:14b", "Say hello in one word.", None, tx)
+            .generate_stream("qwen3:14b", "Say hello in one word.", None, tx, None)
             .await;
         assert!(result.is_ok());
 
@@ -604,6 +622,7 @@ mod tests {
             .generate_json(
                 "qwen3:14b",
                 "Return a JSON object with a 'greeting' field containing 'hello'.",
+                None,
                 None,
             )
             .await;

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -486,7 +486,7 @@ pub async fn parse_intent(
     }
 
     let result = client
-        .generate_json::<IntentResponse>(model, raw_input, Some(INTENT_SYSTEM_PROMPT))
+        .generate_json::<IntentResponse>(model, raw_input, Some(INTENT_SYSTEM_PROMPT), None)
         .await;
 
     match result {

--- a/src/npc/mod.rs
+++ b/src/npc/mod.rs
@@ -368,7 +368,13 @@ pub fn build_tier1_system_prompt(npc: &Npc, improv: bool) -> String {
         \n\
         Current mood: {mood}\n\
         \n\
-        Respond in character as {name}. Use this EXACT format:\n\
+        Respond in character as {name}.\n\
+        \n\
+        LENGTH: Keep your dialogue to 2-4 sentences. Be natural and conversational — \
+        this is a back-and-forth exchange, not a monologue. Say what you would naturally \
+        say, then let the player respond. Do not narrate at length or give speeches.\n\
+        \n\
+        Use this EXACT format:\n\
         \n\
         1. First, write what you say or do, in plain text. Stay in character. \
         Pepper your speech naturally with the occasional Irish word or phrase. \

--- a/src/npc/ticks.rs
+++ b/src/npc/ticks.rs
@@ -224,7 +224,7 @@ pub async fn run_tier2_for_group(
     let participant_ids: Vec<NpcId> = group.npcs.iter().map(|s| s.id).collect();
 
     match client
-        .generate_json::<Tier2Response>(model, &prompt, None)
+        .generate_json::<Tier2Response>(model, &prompt, None, None)
         .await
     {
         Ok(resp) => Some(Tier2Event {


### PR DESCRIPTION
## Summary
This PR adds support for limiting the maximum number of tokens generated by LLM responses across all inference methods. This allows callers to cap response length and prevents excessively long outputs that could break chat formatting or consume unnecessary resources.

## Key Changes

- **OpenAI Client API**: Added optional `max_tokens: Option<u32>` parameter to:
  - `generate()` - non-streaming text generation
  - `generate_stream()` - streaming text generation
  - `generate_json()` - structured JSON output
  - `build_request()` - internal request builder

- **Inference Queue**: Extended `InferenceRequest` struct and `InferenceQueue::send()` method to accept and forward `max_tokens` to the LLM provider

- **NPC Dialogue**: 
  - Introduced `MAX_DIALOGUE_TOKENS` constant (300 tokens) to keep NPC responses conversational
  - Updated system prompt with explicit LENGTH guidance (2-4 sentences) to reinforce token limits
  - Applied max_tokens cap to NPC conversation requests in Tauri commands and headless mode

- **JSON Generation Calls**: Updated all `generate_json()` call sites to pass `None` for max_tokens (intent parsing, tier2 events)

- **Tests**: Updated all test cases to include the new `max_tokens` parameter; added new test `test_request_serialization_with_max_tokens()` to verify serialization

## Implementation Details

- The `max_tokens` field uses `#[serde(skip_serializing_if = "Option::is_none")]` to avoid sending it when not specified, maintaining backward compatibility
- The parameter flows through the entire inference pipeline: API → Queue → Worker → Client
- NPC dialogue responses are now capped at 300 tokens to prevent long monologues and maintain chat pacing
- System prompts now explicitly instruct models to keep responses brief (2-4 sentences)

https://claude.ai/code/session_018HVLvjavPQHkPY4H86iD9m