### PR TITLE
fix: remove max_tokens cap and surface inference errors in GUI

### DIFF
--- a/crates/parish-core/src/inference/openai_client.rs
+++ b/crates/parish-core/src/inference/openai_client.rs
@@ -13,8 +13,8 @@ use tokio::sync::mpsc;
 /// Default timeout for non-streaming requests (30 seconds).
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
-/// Timeout for streaming requests (5 minutes).
-const STREAMING_TIMEOUT_SECS: u64 = 300;
+/// Timeout for streaming requests (30 seconds).
+const STREAMING_TIMEOUT_SECS: u64 = 30;
 
 /// HTTP client for OpenAI-compatible chat completions endpoints.
 ///

--- a/crates/parish-core/src/npc/mod.rs
+++ b/crates/parish-core/src/npc/mod.rs
@@ -40,13 +40,6 @@ pub struct IrishWordHint {
 /// or `  ---\n` on its own line, even when preceded by text on the same line.
 pub const SEPARATOR_HOLDBACK: usize = 24;
 
-/// Maximum tokens for NPC dialogue responses (including the JSON metadata block).
-///
-/// Keeps responses conversational (a few sentences of dialogue plus the compact
-/// metadata JSON). Prevents models from generating excessively long monologues
-/// that break the chat formatting.
-pub const MAX_DIALOGUE_TOKENS: u32 = 300;
-
 /// Rounds a byte offset down to the nearest UTF-8 char boundary in `s`.
 ///
 /// If `pos` is already a char boundary, returns it unchanged. Otherwise

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -10,7 +10,7 @@ use tauri::Emitter;
 use tokio::sync::mpsc;
 
 use parish_core::config::Provider;
-use parish_core::debug_snapshot::{self, DebugSnapshot, InferenceDebug};
+use parish_core::debug_snapshot::{self, DebugEvent, DebugSnapshot, InferenceDebug};
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceQueue, spawn_inference_worker};
 use parish_core::input::{InputResult, classify_input, parse_intent_local};
@@ -808,7 +808,7 @@ async fn handle_npc_conversation(
             context,
             Some(system_prompt),
             Some(token_tx),
-            Some(parish_core::npc::MAX_DIALOGUE_TOKENS),
+            None,
         )
         .await
     {
@@ -847,8 +847,39 @@ async fn handle_npc_conversation(
 
             // Parse Irish word hints from the complete response
             let hints = if let Some(resp) = full_response {
-                if resp.error.is_some() {
-                    tracing::warn!("Inference error: {:?}", resp.error);
+                if let Some(ref err) = resp.error {
+                    tracing::warn!("Inference error: {:?}", err);
+
+                    // Log actual error to the debug events panel
+                    let mut events = state.debug_events.lock().await;
+                    if events.len() >= crate::DEBUG_EVENT_CAPACITY {
+                        events.pop_front();
+                    }
+                    events.push_back(DebugEvent {
+                        timestamp: String::new(),
+                        category: "inference".to_string(),
+                        message: format!("Dialogue error: {err}"),
+                    });
+
+                    // Show a funny canned message to the player
+                    let canned = [
+                        "A sudden fog rolls in and swallows the conversation whole.",
+                        "A crow lands between you, caws loudly, and the moment is lost.",
+                        "The wind picks up and carries their words clean away.",
+                        "They open their mouth to speak, but a donkey brays so loud neither of ye can hear a thing.",
+                        "A clap of thunder rattles the sky and ye both forget what ye were talking about.",
+                        "They stare at you blankly, as if the thought simply left their head.",
+                        "A strange silence falls over the parish. Even the birds have stopped.",
+                    ];
+                    let idx = resp.id as usize % canned.len();
+                    let _ = app.emit(
+                        EVENT_TEXT_LOG,
+                        TextLogPayload {
+                            source: "system".to_string(),
+                            content: canned[idx].to_string(),
+                        },
+                    );
+
                     vec![]
                 } else {
                     let parsed = parse_npc_stream_response(&resp.text);
@@ -862,6 +893,26 @@ async fn handle_npc_conversation(
         }
         Err(e) => {
             tracing::error!("Failed to submit inference request: {}", e);
+
+            // Log to debug events
+            let mut events = state.debug_events.lock().await;
+            if events.len() >= crate::DEBUG_EVENT_CAPACITY {
+                events.pop_front();
+            }
+            events.push_back(DebugEvent {
+                timestamp: String::new(),
+                category: "inference".to_string(),
+                message: format!("Queue submit failed: {e}"),
+            });
+
+            let _ = app.emit(
+                EVENT_TEXT_LOG,
+                TextLogPayload {
+                    source: "system".to_string(),
+                    content: "The parish storyteller has wandered off. Try again in a moment."
+                        .to_string(),
+                },
+            );
         }
     }
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -818,7 +818,7 @@ async fn handle_headless_game_input(
                             context,
                             Some(system_prompt),
                             Some(token_tx),
-                            Some(parish_core::npc::MAX_DIALOGUE_TOKENS),
+                            None,
                         )
                         .await
                     {

--- a/src/inference/openai_client.rs
+++ b/src/inference/openai_client.rs
@@ -13,8 +13,8 @@ use tokio::sync::mpsc;
 /// Default timeout for non-streaming requests (30 seconds).
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
-/// Timeout for streaming requests (5 minutes).
-const STREAMING_TIMEOUT_SECS: u64 = 300;
+/// Timeout for streaming requests (30 seconds).
+const STREAMING_TIMEOUT_SECS: u64 = 30;
 
 /// HTTP client for OpenAI-compatible chat completions endpoints.
 ///


### PR DESCRIPTION
## Summary
- Removed `max_tokens: 300` hard cap that was silencing dialogue on reasoning models (e.g. free-tier OpenRouter models that spend tokens on internal thinking before producing visible output)
- Inference errors now show a random flavour message to the player instead of silent failure, with the actual error logged to the debug Events panel
- Reduced streaming timeout from 5 minutes to 30 seconds
- Prompt LENGTH guidance ("2-4 sentences") retained as soft control

## Test plan
- [x] All 737 tests pass
- [x] Headless dialogue confirmed working against OpenRouter (nemotron free tier)
- [x] GUI dialogue confirmed working with multiple OpenRouter models
- [ ] Verify canned error messages appear when inference fails (e.g. bad API key)
- [ ] Verify debug Events tab shows the real error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)