### PR TITLE
⚡ Bolt: Reuse reqwest client pool for streaming requests

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+# Bolt's Journal - Critical Learnings Only
+
+## 2026-03-29 - HTTP Client Reuse in reqwest
+**Learning:** `reqwest::Client` maintains an internal connection pool with keep-alive. Creating a new client per request wastes that pool entirely — each new client starts fresh TCP+TLS negotiations. Both `DEFAULT_TIMEOUT_SECS` and `STREAMING_TIMEOUT_SECS` were identical (30s), making the separate streaming client completely redundant.
+**Action:** Always check if reqwest clients are being reused across the struct. A single client handles different timeout needs via per-request `.timeout()` if truly needed.

--- a/crates/parish-core/src/inference/openai_client.rs
+++ b/crates/parish-core/src/inference/openai_client.rs
@@ -10,11 +10,9 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
-/// Default timeout for non-streaming requests (30 seconds).
+/// Timeout for all requests (30 seconds).
+/// Both streaming and non-streaming share the same client and timeout.
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
-
-/// Timeout for streaming requests (30 seconds).
-const STREAMING_TIMEOUT_SECS: u64 = 30;
 
 /// HTTP client for OpenAI-compatible chat completions endpoints.
 ///
@@ -163,14 +161,11 @@ impl OpenAiClient {
     ) -> Result<String, ParishError> {
         let body = self.build_request(model, prompt, system, true, false, max_tokens);
 
-        // Use a longer timeout for streaming
-        let streaming_client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(STREAMING_TIMEOUT_SECS))
-            .build()
-            .expect("failed to build streaming reqwest client");
-
+        // Reuse the shared client to leverage its connection pool and avoid
+        // per-request TLS handshake overhead. Both streaming and non-streaming
+        // share the same timeout; reqwest's pool keeps idle connections alive.
         let url = format!("{}/v1/chat/completions", self.base_url);
-        let mut req = streaming_client.post(&url).json(&body);
+        let mut req = self.client.post(&url).json(&body);
         req = self.apply_auth_headers(req);
 
         let resp = req


### PR DESCRIPTION
## Summary

- **💡 What:** Reuse the shared `reqwest::Client` in `generate_stream()` instead of constructing a new one per request
- **🎯 Why:** `reqwest::Client` maintains an internal connection pool with TCP keep-alive and TLS session caching. Creating a new client per streaming request discarded this pool entirely, forcing fresh TCP+TLS negotiations for every LLM call
- **📊 Impact:** Eliminates ~100-300ms of TCP/TLS setup overhead per streaming request (depends on network conditions). Also reduces memory churn from allocating/dropping client internals on every call

## Details

`generate_stream()` was building a brand-new `reqwest::Client` with `STREAMING_TIMEOUT_SECS` (30s) — identical to the existing `DEFAULT_TIMEOUT_SECS` (30s) on `self.client`. The separate client was entirely redundant. Removed the per-request client construction and the unused `STREAMING_TIMEOUT_SECS` constant.

## 🔬 Measurement

- All 24 `openai_client` unit tests pass
- Full test suite (450+ tests) passes
- `cargo fmt --check` and `cargo clippy -- -D warnings` clean
- To verify in production: compare latency of first vs. subsequent streaming requests — with pool reuse, subsequent requests skip TLS handshake

https://claude.ai/code/session_01PqAvE6JTnqLwszK8VayC3D