### PR TITLE
Add inference call logging to debug panel

### DIFF
--- a/.claude/hooks/design-doc-reminder.sh
+++ b/.claude/hooks/design-doc-reminder.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Stop hook: remind to update design docs when significant code changes are made
+# Triggers when new structs, public functions, or module-level changes appear
+# in .rs files but no docs/design/ files were touched.
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
+
+# Collect staged + unstaged .rs changes
+RS_DIFF=$(git diff HEAD --unified=0 -- '*.rs' 2>/dev/null || true)
+RS_UNSTAGED=$(git diff --unified=0 -- '*.rs' 2>/dev/null || true)
+ALL_DIFF="${RS_DIFF}${RS_UNSTAGED}"
+
+if [[ -z "$ALL_DIFF" ]]; then
+    exit 0
+fi
+
+# Look for signals of significant architectural changes:
+#   - New pub struct/enum/type definitions
+#   - New pub fn signatures
+#   - New module declarations (pub mod)
+SIGNIFICANT=$(echo "$ALL_DIFF" | grep -E '^\+.*(pub struct |pub enum |pub type |pub fn |pub mod |pub const )' || true)
+
+if [[ -z "$SIGNIFICANT" ]]; then
+    exit 0
+fi
+
+# Check if any design docs were also updated
+DESIGN_CHANGED=$(git diff --name-only HEAD 2>/dev/null | grep 'docs/design/' || true)
+DESIGN_UNSTAGED=$(git diff --name-only 2>/dev/null | grep 'docs/design/' || true)
+
+if [[ -n "$DESIGN_CHANGED" || -n "$DESIGN_UNSTAGED" ]]; then
+    exit 0
+fi
+
+echo "=== Design Doc Reminder ==="
+echo "Significant new public API detected (structs, functions, modules) but"
+echo "no docs/design/ files were updated."
+echo ""
+echo "Before finishing, update the relevant design doc(s) in docs/design/ with:"
+echo "  - Data structures and their fields"
+echo "  - Architecture (data flow, shared state, IPC)"
+echo "  - Capacity/limits and design rationale"
+echo ""
+echo "Key design docs: inference-pipeline.md, debug-ui.md, npc-system.md,"
+echo "  cognitive-lod.md, gui-design.md, overview.md"
+echo "============================="
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,6 +53,10 @@
           {
             "type": "command",
             "command": ".claude/hooks/coverage-reminder.sh"
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/design-doc-reminder.sh"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,7 @@ Automated hooks configured in `.claude/settings.json` that run at lifecycle even
 | `doc-staleness.sh` | Stop | When Claude finishes responding | Warns if `.rs` files changed but no docs were updated |
 | `screenshot-reminder.sh` | Stop | When Claude finishes responding | Reminds to regenerate screenshots if `ui/` or `src-tauri/` changed |
 | `coverage-reminder.sh` | Stop | When Claude finishes responding | Reminds to check coverage when new `.rs` files are added |
+| `design-doc-reminder.sh` | Stop | When Claude finishes responding | Reminds to update `docs/design/` when new public structs/functions/modules are added |
 | `compact-context.sh` | SessionStart | After context compaction | Re-injects key project context |
 | `commit-msg-check.sh` | UserPromptSubmit | When user submits a prompt mentioning "commit" | Validates conventional commit message format |
 | `notify.sh` | Notification | When Claude needs attention | Sends desktop notification via `notify-send` |

--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -222,6 +222,29 @@ pub struct InferenceDebug {
     pub has_queue: bool,
     /// Whether improv mode is enabled.
     pub improv_enabled: bool,
+    /// Recent inference call log entries (newest last).
+    pub call_log: Vec<InferenceLogEntry>,
+}
+
+/// A single logged inference call for the debug panel.
+#[derive(Debug, Clone, Serialize)]
+pub struct InferenceLogEntry {
+    /// Unique request ID.
+    pub request_id: u64,
+    /// Wall-clock timestamp (e.g. "14:32:05").
+    pub timestamp: String,
+    /// Model name used for this request.
+    pub model: String,
+    /// Whether this was a streaming request.
+    pub streaming: bool,
+    /// Request duration in milliseconds.
+    pub duration_ms: u64,
+    /// Prompt length in characters.
+    pub prompt_len: usize,
+    /// Response length in characters.
+    pub response_len: usize,
+    /// Error message if the request failed (None = success).
+    pub error: Option<String>,
 }
 
 /// Builds a complete debug snapshot from live game state.
@@ -466,6 +489,7 @@ mod tests {
             cloud_model: None,
             has_queue: false,
             improv_enabled: false,
+            call_log: vec![],
         };
 
         let snapshot = build_debug_snapshot(&world, &npc_manager, &events, &inference);
@@ -494,6 +518,7 @@ mod tests {
             cloud_model: None,
             has_queue: true,
             improv_enabled: false,
+            call_log: vec![],
         };
 
         let snapshot = build_debug_snapshot(&world, &npc_manager, &events, &inference);
@@ -570,6 +595,73 @@ mod tests {
     }
 
     #[test]
+    fn test_inference_log_entry_serialize() {
+        let entry = InferenceLogEntry {
+            request_id: 42,
+            timestamp: "14:32:05".to_string(),
+            model: "qwen3:14b".to_string(),
+            streaming: true,
+            duration_ms: 1250,
+            prompt_len: 500,
+            response_len: 200,
+            error: None,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("qwen3:14b"));
+        assert!(json.contains("1250"));
+        assert!(json.contains("\"streaming\":true"));
+    }
+
+    #[test]
+    fn test_inference_log_entry_with_error() {
+        let entry = InferenceLogEntry {
+            request_id: 7,
+            timestamp: "09:00:00".to_string(),
+            model: "test".to_string(),
+            streaming: false,
+            duration_ms: 30000,
+            prompt_len: 100,
+            response_len: 0,
+            error: Some("timeout".to_string()),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains("timeout"));
+        assert!(json.contains("\"response_len\":0"));
+    }
+
+    #[test]
+    fn test_call_log_included_in_snapshot() {
+        let world = WorldState::new();
+        let mgr = NpcManager::new();
+        let events = VecDeque::new();
+        let entry = InferenceLogEntry {
+            request_id: 1,
+            timestamp: "10:00:00".to_string(),
+            model: "test-model".to_string(),
+            streaming: true,
+            duration_ms: 500,
+            prompt_len: 100,
+            response_len: 50,
+            error: None,
+        };
+        let inference = InferenceDebug {
+            provider_name: "test".to_string(),
+            model_name: "test".to_string(),
+            base_url: "http://localhost".to_string(),
+            cloud_provider: None,
+            cloud_model: None,
+            has_queue: false,
+            improv_enabled: false,
+            call_log: vec![entry],
+        };
+
+        let snapshot = build_debug_snapshot(&world, &mgr, &events, &inference);
+        assert_eq!(snapshot.inference.call_log.len(), 1);
+        assert_eq!(snapshot.inference.call_log[0].request_id, 1);
+        assert_eq!(snapshot.inference.call_log[0].duration_ms, 500);
+    }
+
+    #[test]
     fn test_events_included_in_snapshot() {
         let world = WorldState::new();
         let mgr = NpcManager::new();
@@ -592,6 +684,7 @@ mod tests {
             cloud_model: None,
             has_queue: false,
             improv_enabled: false,
+            call_log: vec![],
         };
 
         let snapshot = build_debug_snapshot(&world, &mgr, &events, &inference);

--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -245,6 +245,14 @@ pub struct InferenceLogEntry {
     pub response_len: usize,
     /// Error message if the request failed (None = success).
     pub error: Option<String>,
+    /// System prompt sent (if any).
+    pub system_prompt: Option<String>,
+    /// User prompt text.
+    pub prompt_text: String,
+    /// Full response text (empty on error).
+    pub response_text: String,
+    /// Max tokens limit sent to provider (if any).
+    pub max_tokens: Option<u32>,
 }
 
 /// Builds a complete debug snapshot from live game state.
@@ -605,6 +613,10 @@ mod tests {
             prompt_len: 500,
             response_len: 200,
             error: None,
+            system_prompt: Some("You are helpful.".to_string()),
+            prompt_text: "Hello world".to_string(),
+            response_text: "Hi there!".to_string(),
+            max_tokens: Some(300),
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("qwen3:14b"));
@@ -623,6 +635,10 @@ mod tests {
             prompt_len: 100,
             response_len: 0,
             error: Some("timeout".to_string()),
+            system_prompt: None,
+            prompt_text: "test prompt".to_string(),
+            response_text: String::new(),
+            max_tokens: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("timeout"));
@@ -643,6 +659,10 @@ mod tests {
             prompt_len: 100,
             response_len: 50,
             error: None,
+            system_prompt: None,
+            prompt_text: "test".to_string(),
+            response_text: "response".to_string(),
+            max_tokens: None,
         };
         let inference = InferenceDebug {
             provider_name: "test".to_string(),

--- a/crates/parish-core/src/inference/mod.rs
+++ b/crates/parish-core/src/inference/mod.rs
@@ -8,9 +8,26 @@ pub mod client;
 pub mod openai_client;
 pub mod setup;
 
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Instant;
+
 use openai_client::OpenAiClient;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinHandle;
+
+use crate::debug_snapshot::InferenceLogEntry;
+
+/// Maximum number of inference log entries to retain.
+pub const INFERENCE_LOG_CAPACITY: usize = 50;
+
+/// Shared ring buffer of inference call log entries.
+pub type InferenceLog = Arc<Mutex<VecDeque<InferenceLogEntry>>>;
+
+/// Creates a new empty inference log with pre-allocated capacity.
+pub fn new_inference_log() -> InferenceLog {
+    Arc::new(Mutex::new(VecDeque::with_capacity(INFERENCE_LOG_CAPACITY)))
+}
 
 /// A request to generate text via the inference pipeline.
 ///
@@ -143,13 +160,21 @@ impl InferenceClients {
 ///
 /// The worker pulls requests from the mpsc receiver, calls the LLM
 /// client, and sends responses back through each request's oneshot channel.
+/// Each completed call is recorded in the shared `log` ring buffer.
 /// The task runs until the sender side of the channel is dropped.
 pub fn spawn_inference_worker(
     client: OpenAiClient,
     mut rx: mpsc::Receiver<InferenceRequest>,
+    log: InferenceLog,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         while let Some(request) = rx.recv().await {
+            let streaming = request.token_tx.is_some();
+            let prompt_len = request.prompt.len();
+            let model = request.model.clone();
+            let req_id = request.id;
+            let start = Instant::now();
+
             let result = if let Some(token_tx) = request.token_tx {
                 client
                     .generate_stream(
@@ -171,18 +196,47 @@ pub fn spawn_inference_worker(
                     .await
             };
 
-            let response = match result {
-                Ok(text) => InferenceResponse {
-                    id: request.id,
-                    text,
-                    error: None,
-                },
-                Err(e) => InferenceResponse {
-                    id: request.id,
-                    text: String::new(),
-                    error: Some(e.to_string()),
-                },
+            let elapsed = start.elapsed();
+
+            let (response, entry_error, response_len) = match &result {
+                Ok(text) => (
+                    InferenceResponse {
+                        id: req_id,
+                        text: text.clone(),
+                        error: None,
+                    },
+                    None,
+                    text.len(),
+                ),
+                Err(e) => (
+                    InferenceResponse {
+                        id: req_id,
+                        text: String::new(),
+                        error: Some(e.to_string()),
+                    },
+                    Some(e.to_string()),
+                    0,
+                ),
             };
+
+            // Record log entry
+            {
+                let entry = InferenceLogEntry {
+                    request_id: req_id,
+                    timestamp: chrono::Local::now().format("%H:%M:%S").to_string(),
+                    model,
+                    streaming,
+                    duration_ms: elapsed.as_millis() as u64,
+                    prompt_len,
+                    response_len,
+                    error: entry_error,
+                };
+                let mut log = log.lock().await;
+                if log.len() >= INFERENCE_LOG_CAPACITY {
+                    log.pop_front();
+                }
+                log.push_back(entry);
+            }
 
             // Ignore send error — the caller may have dropped the receiver
             let _ = request.response_tx.send(response);

--- a/crates/parish-core/src/inference/mod.rs
+++ b/crates/parish-core/src/inference/mod.rs
@@ -172,6 +172,9 @@ pub fn spawn_inference_worker(
             let streaming = request.token_tx.is_some();
             let prompt_len = request.prompt.len();
             let model = request.model.clone();
+            let system_prompt = request.system.clone();
+            let prompt_text = request.prompt.clone();
+            let max_tokens = request.max_tokens;
             let req_id = request.id;
             let start = Instant::now();
 
@@ -198,7 +201,7 @@ pub fn spawn_inference_worker(
 
             let elapsed = start.elapsed();
 
-            let (response, entry_error, response_len) = match &result {
+            let (response, entry_error, response_len, response_text) = match &result {
                 Ok(text) => (
                     InferenceResponse {
                         id: req_id,
@@ -207,6 +210,7 @@ pub fn spawn_inference_worker(
                     },
                     None,
                     text.len(),
+                    text.clone(),
                 ),
                 Err(e) => (
                     InferenceResponse {
@@ -216,6 +220,7 @@ pub fn spawn_inference_worker(
                     },
                     Some(e.to_string()),
                     0,
+                    String::new(),
                 ),
             };
 
@@ -230,6 +235,10 @@ pub fn spawn_inference_worker(
                     prompt_len,
                     response_len,
                     error: entry_error,
+                    system_prompt,
+                    prompt_text,
+                    response_text,
+                    max_tokens,
                 };
                 let mut log = log.lock().await;
                 if log.len() >= INFERENCE_LOG_CAPACITY {

--- a/docs/design/debug-ui.md
+++ b/docs/design/debug-ui.md
@@ -70,6 +70,12 @@ pub struct DebugSnapshot {
 - `prompt_len`: usize — prompt length in characters
 - `response_len`: usize — response length in characters
 - `error`: Option\<String\> — error message if the request failed
+- `system_prompt`: Option\<String\> — system prompt sent to provider
+- `prompt_text`: String — full user prompt text
+- `response_text`: String — full response text (empty on error)
+- `max_tokens`: Option\<u32\> — token limit if set
+
+Clicking a log entry in the Inference tab opens a detail view showing the full system prompt, user prompt, and response text in scrollable `<pre>` blocks. A "Back to list" button returns to the call log list (same pattern as the NPC inspector).
 
 #### `DebugEvent`
 - `timestamp`: formatted game time

--- a/docs/design/debug-ui.md
+++ b/docs/design/debug-ui.md
@@ -59,6 +59,17 @@ pub struct DebugSnapshot {
 - `cloud_provider`, `cloud_model`: Option strings
 - `has_queue`: bool (whether inference is configured)
 - `improv_enabled`: bool
+- `call_log`: `Vec<InferenceLogEntry>` — recent inference call history
+
+#### `InferenceLogEntry`
+- `request_id`: u64 — unique request identifier
+- `timestamp`: String — wall-clock time (HH:MM:SS)
+- `model`: String — model name used
+- `streaming`: bool — whether SSE streaming was used
+- `duration_ms`: u64 — end-to-end latency in milliseconds
+- `prompt_len`: usize — prompt length in characters
+- `response_len`: usize — response length in characters
+- `error`: Option\<String\> — error message if the request failed
 
 #### `DebugEvent`
 - `timestamp`: formatted game time

--- a/docs/design/inference-pipeline.md
+++ b/docs/design/inference-pipeline.md
@@ -60,14 +60,18 @@ Every request processed by the inference worker is logged in a shared ring buffe
 
 ```rust
 pub struct InferenceLogEntry {
-    pub request_id: u64,      // Unique request ID
-    pub timestamp: String,     // Wall-clock time (HH:MM:SS)
-    pub model: String,         // Model name used
-    pub streaming: bool,       // Whether SSE streaming was used
-    pub duration_ms: u64,      // End-to-end latency
-    pub prompt_len: usize,     // Prompt length in characters
-    pub response_len: usize,   // Response length in characters
-    pub error: Option<String>, // Error message if failed
+    pub request_id: u64,            // Unique request ID
+    pub timestamp: String,           // Wall-clock time (HH:MM:SS)
+    pub model: String,               // Model name used
+    pub streaming: bool,             // Whether SSE streaming was used
+    pub duration_ms: u64,            // End-to-end latency
+    pub prompt_len: usize,           // Prompt length in characters
+    pub response_len: usize,         // Response length in characters
+    pub error: Option<String>,       // Error message if failed
+    pub system_prompt: Option<String>, // System prompt (if any)
+    pub prompt_text: String,         // Full user prompt
+    pub response_text: String,       // Full response text
+    pub max_tokens: Option<u32>,     // Token limit (if set)
 }
 ```
 

--- a/docs/design/inference-pipeline.md
+++ b/docs/design/inference-pipeline.md
@@ -40,16 +40,78 @@ Player natural language input is also sent to Ollama for intent parsing. The LLM
 
 If the LLM can't resolve intent, the game asks for clarification in-character.
 
+## Multi-Provider Support
+
+The pipeline supports any OpenAI-compatible endpoint (Ollama, LM Studio, OpenRouter, etc.) via `OpenAiClient`. Per-category provider routing allows different models for different tasks:
+
+| Category | Purpose | Default |
+|----------|---------|---------|
+| Dialogue | Player-facing NPC conversation (Tier 1) | Cloud if configured, else local |
+| Simulation | Background NPC activity (Tier 2) | Always local |
+| Intent | Player input classification | Always local |
+
+Configuration is runtime-mutable via `/provider`, `/model`, `/key`, and `/cloud` commands. Changing provider settings respawns the inference worker with a new client.
+
+## Inference Call Logging
+
+Every request processed by the inference worker is logged in a shared ring buffer (`InferenceLog`) for real-time visibility in the debug panel.
+
+### `InferenceLogEntry`
+
+```rust
+pub struct InferenceLogEntry {
+    pub request_id: u64,      // Unique request ID
+    pub timestamp: String,     // Wall-clock time (HH:MM:SS)
+    pub model: String,         // Model name used
+    pub streaming: bool,       // Whether SSE streaming was used
+    pub duration_ms: u64,      // End-to-end latency
+    pub prompt_len: usize,     // Prompt length in characters
+    pub response_len: usize,   // Response length in characters
+    pub error: Option<String>, // Error message if failed
+}
+```
+
+### Architecture
+
+```
+InferenceRequest → spawn_inference_worker() → generate()/generate_stream()
+                         │                              │
+                         │  records Instant::now()       │  measures elapsed
+                         │                              │
+                         └──── InferenceLogEntry ───────┘
+                                      │
+                              InferenceLog (Arc<Mutex<VecDeque>>)
+                                      │
+                              DebugSnapshot.inference.call_log
+                                      │
+                              Tauri IPC → Svelte DebugPanel
+```
+
+- **Capacity**: 50 entries (ring buffer, oldest evicted first)
+- **Scope**: Captures all queued requests (NPC dialogue). Direct `generate_json()` calls (Tier 2 simulation, intent parsing) are not yet logged.
+- **Shared state**: The `InferenceLog` (`Arc<Mutex<VecDeque<InferenceLogEntry>>>`) is passed to the worker at spawn time and stored on `AppState` for snapshot reads.
+- **Timing**: `std::time::Instant` measures end-to-end latency including network round-trip, model inference, and streaming delivery.
+
+### Debug Panel Display
+
+The Inference tab in the debug panel shows:
+
+1. **Config section** (top): Provider, model, URL, queue status, cloud info, improv flag
+2. **Call Log section** (below): Summary stats (avg latency, error count) followed by a scrollable list of entries (newest first) with color-coded OK/ERROR/STREAM badges
+
 ## Related
 
 - [NPC System](npc-system.md) — NPC context construction feeds the inference queue
 - [Cognitive LOD](cognitive-lod.md) — Tier determines model selection and batch strategy
 - [Player Input](player-input.md) — Natural language input parsed via this pipeline
+- [Debug UI](debug-ui.md) — Debug panel that displays inference call log
 - [ADR 005: Ollama Local Inference](../adr/005-ollama-local-inference.md)
 - [ADR 008: Structured JSON LLM Output](../adr/008-structured-json-llm-output.md)
 
 ## Source Modules
 
-- [`src/inference/`](../../src/inference/) — Ollama HTTP client, inference queue
+- [`crates/parish-core/src/inference/`](../../crates/parish-core/src/inference/) — OpenAI-compatible HTTP client, inference queue, worker, log
+- [`crates/parish-core/src/debug_snapshot.rs`](../../crates/parish-core/src/debug_snapshot.rs) — `InferenceLogEntry`, `InferenceDebug` structs
+- [`src/inference/`](../../src/inference/) — Root crate inference (headless mode)
 - [`src/input/`](../../src/input/) — Player input parsing
 - [`src/npc/`](../../src/npc/) — NPC context construction

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -191,6 +191,9 @@ pub async fn get_debug_snapshot(
     let events = state.debug_events.lock().await;
     let config = state.config.lock().await;
 
+    let call_log: Vec<parish_core::debug_snapshot::InferenceLogEntry> =
+        state.inference_log.lock().await.iter().cloned().collect();
+
     let inference = InferenceDebug {
         provider_name: config.provider_name.clone(),
         model_name: config.model_name.clone(),
@@ -199,6 +202,7 @@ pub async fn get_debug_snapshot(
         cloud_model: config.cloud_model_name.clone(),
         has_queue: state.inference_queue.lock().await.is_some(),
         improv_enabled: config.improv_enabled,
+        call_log,
     };
 
     Ok(debug_snapshot::build_debug_snapshot(
@@ -281,7 +285,7 @@ async fn rebuild_inference(state: &Arc<AppState>) {
 
     // Respawn inference worker with the new client
     let (tx, rx) = tokio::sync::mpsc::channel(32);
-    let _worker = spawn_inference_worker(new_client, rx);
+    let _worker = spawn_inference_worker(new_client, rx, state.inference_log.clone());
     let queue = InferenceQueue::new(tx);
     let mut iq = state.inference_queue.lock().await;
     *iq = Some(queue);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,7 +15,9 @@ use tokio::sync::Mutex;
 
 use parish_core::debug_snapshot::{DebugEvent, InferenceDebug};
 use parish_core::inference::openai_client::OpenAiClient;
-use parish_core::inference::{InferenceQueue, spawn_inference_worker};
+use parish_core::inference::{
+    InferenceLog, InferenceQueue, new_inference_log, spawn_inference_worker,
+};
 use parish_core::npc::manager::NpcManager;
 use parish_core::world::palette::{RawColor, RawPalette, compute_palette};
 use parish_core::world::{LocationId, WorldState};
@@ -205,6 +207,8 @@ pub struct AppState {
     pub config: Mutex<GameConfig>,
     /// Rolling debug event log for the debug panel.
     pub debug_events: Mutex<std::collections::VecDeque<DebugEvent>>,
+    /// Shared inference call log for the debug panel.
+    pub inference_log: InferenceLog,
     /// UI configuration from the loaded game mod.
     pub ui_config: UiConfigSnapshot,
 }
@@ -423,6 +427,7 @@ pub fn run() {
         debug_events: Mutex::new(std::collections::VecDeque::with_capacity(
             DEBUG_EVENT_CAPACITY,
         )),
+        inference_log: new_inference_log(),
         ui_config,
         config: Mutex::new(GameConfig {
             provider_name,
@@ -538,7 +543,11 @@ pub fn run() {
                     let client_guard = state_setup.client.lock().await;
                     if let Some(ref client) = *client_guard {
                         let (tx, rx) = tokio::sync::mpsc::channel(32);
-                        let _worker = spawn_inference_worker(client.clone(), rx);
+                        let _worker = spawn_inference_worker(
+                            client.clone(),
+                            rx,
+                            state_setup.inference_log.clone(),
+                        );
                         let queue = InferenceQueue::new(tx);
                         let mut iq = state_setup.inference_queue.lock().await;
                         *iq = Some(queue);
@@ -601,6 +610,15 @@ pub fn run() {
                         let debug_events = state_debug.debug_events.lock().await;
                         let config = state_debug.config.lock().await;
 
+                        let call_log: Vec<parish_core::debug_snapshot::InferenceLogEntry> =
+                            state_debug
+                                .inference_log
+                                .lock()
+                                .await
+                                .iter()
+                                .cloned()
+                                .collect();
+
                         let inference = InferenceDebug {
                             provider_name: config.provider_name.clone(),
                             model_name: config.model_name.clone(),
@@ -609,6 +627,7 @@ pub fn run() {
                             cloud_model: config.cloud_model_name.clone(),
                             has_queue: state_debug.inference_queue.lock().await.is_some(),
                             improv_enabled: config.improv_enabled,
+                            call_log,
                         };
 
                         let snapshot = parish_core::debug_snapshot::build_debug_snapshot(

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -58,7 +58,8 @@ pub async fn run_headless(
     let (dial_client, dial_model) = clients.dialogue_client();
     let dialogue_model = dial_model.to_string();
     let (tx, rx) = mpsc::channel(32);
-    let _worker = inference::spawn_inference_worker(dial_client.clone(), rx);
+    let inference_log = inference::new_inference_log();
+    let _worker = inference::spawn_inference_worker(dial_client.clone(), rx, inference_log.clone());
     let queue = InferenceQueue::new(tx);
 
     // Initialize app state — prefer mod data, fall back to legacy parish.json
@@ -218,7 +219,7 @@ pub async fn run_headless(
                     let dial_client = app.cloud_client.clone().or_else(|| app.client.clone());
                     if let Some(new_client) = dial_client {
                         let (tx, rx) = mpsc::channel(32);
-                        let _new_worker = inference::spawn_inference_worker(new_client, rx);
+                        let _new_worker = inference::spawn_inference_worker(new_client, rx, inference_log.clone());
                         app.inference_queue = Some(InferenceQueue::new(tx));
                     }
                 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -219,7 +219,11 @@ pub async fn run_headless(
                     let dial_client = app.cloud_client.clone().or_else(|| app.client.clone());
                     if let Some(new_client) = dial_client {
                         let (tx, rx) = mpsc::channel(32);
-                        let _new_worker = inference::spawn_inference_worker(new_client, rx, inference_log.clone());
+                        let _new_worker = inference::spawn_inference_worker(
+                            new_client,
+                            rx,
+                            inference_log.clone(),
+                        );
                         app.inference_queue = Some(InferenceQueue::new(tx));
                     }
                 }

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -8,9 +8,26 @@ pub mod client;
 pub mod openai_client;
 pub mod setup;
 
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Instant;
+
 use openai_client::OpenAiClient;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinHandle;
+
+use parish_core::debug_snapshot::InferenceLogEntry;
+
+/// Maximum number of inference log entries to retain.
+pub const INFERENCE_LOG_CAPACITY: usize = 50;
+
+/// Shared ring buffer of inference call log entries.
+pub type InferenceLog = Arc<Mutex<VecDeque<InferenceLogEntry>>>;
+
+/// Creates a new empty inference log with pre-allocated capacity.
+pub fn new_inference_log() -> InferenceLog {
+    Arc::new(Mutex::new(VecDeque::with_capacity(INFERENCE_LOG_CAPACITY)))
+}
 
 /// A request to generate text via the inference pipeline.
 ///
@@ -159,13 +176,21 @@ impl InferenceClients {
 ///
 /// The worker pulls requests from the mpsc receiver, calls the LLM
 /// client, and sends responses back through each request's oneshot channel.
+/// Each completed call is recorded in the shared `log` ring buffer.
 /// The task runs until the sender side of the channel is dropped.
 pub fn spawn_inference_worker(
     client: OpenAiClient,
     mut rx: mpsc::Receiver<InferenceRequest>,
+    log: InferenceLog,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         while let Some(request) = rx.recv().await {
+            let streaming = request.token_tx.is_some();
+            let prompt_len = request.prompt.len();
+            let model = request.model.clone();
+            let req_id = request.id;
+            let start = Instant::now();
+
             let result = if let Some(token_tx) = request.token_tx {
                 client
                     .generate_stream(
@@ -187,18 +212,47 @@ pub fn spawn_inference_worker(
                     .await
             };
 
-            let response = match result {
-                Ok(text) => InferenceResponse {
-                    id: request.id,
-                    text,
-                    error: None,
-                },
-                Err(e) => InferenceResponse {
-                    id: request.id,
-                    text: String::new(),
-                    error: Some(e.to_string()),
-                },
+            let elapsed = start.elapsed();
+
+            let (response, entry_error, response_len) = match &result {
+                Ok(text) => (
+                    InferenceResponse {
+                        id: req_id,
+                        text: text.clone(),
+                        error: None,
+                    },
+                    None,
+                    text.len(),
+                ),
+                Err(e) => (
+                    InferenceResponse {
+                        id: req_id,
+                        text: String::new(),
+                        error: Some(e.to_string()),
+                    },
+                    Some(e.to_string()),
+                    0,
+                ),
             };
+
+            // Record log entry
+            {
+                let entry = InferenceLogEntry {
+                    request_id: req_id,
+                    timestamp: chrono::Local::now().format("%H:%M:%S").to_string(),
+                    model,
+                    streaming,
+                    duration_ms: elapsed.as_millis() as u64,
+                    prompt_len,
+                    response_len,
+                    error: entry_error,
+                };
+                let mut log = log.lock().await;
+                if log.len() >= INFERENCE_LOG_CAPACITY {
+                    log.pop_front();
+                }
+                log.push_back(entry);
+            }
 
             // Ignore send error — the caller may have dropped the receiver
             let _ = request.response_tx.send(response);

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -188,6 +188,9 @@ pub fn spawn_inference_worker(
             let streaming = request.token_tx.is_some();
             let prompt_len = request.prompt.len();
             let model = request.model.clone();
+            let system_prompt = request.system.clone();
+            let prompt_text = request.prompt.clone();
+            let max_tokens = request.max_tokens;
             let req_id = request.id;
             let start = Instant::now();
 
@@ -214,7 +217,7 @@ pub fn spawn_inference_worker(
 
             let elapsed = start.elapsed();
 
-            let (response, entry_error, response_len) = match &result {
+            let (response, entry_error, response_len, response_text) = match &result {
                 Ok(text) => (
                     InferenceResponse {
                         id: req_id,
@@ -223,6 +226,7 @@ pub fn spawn_inference_worker(
                     },
                     None,
                     text.len(),
+                    text.clone(),
                 ),
                 Err(e) => (
                     InferenceResponse {
@@ -232,6 +236,7 @@ pub fn spawn_inference_worker(
                     },
                     Some(e.to_string()),
                     0,
+                    String::new(),
                 ),
             };
 
@@ -246,6 +251,10 @@ pub fn spawn_inference_worker(
                     prompt_len,
                     response_len,
                     error: entry_error,
+                    system_prompt,
+                    prompt_text,
+                    response_text,
+                    max_tokens,
                 };
                 let mut log = log.lock().await;
                 if log.len() >= INFERENCE_LOG_CAPACITY {

--- a/ui/src/components/DebugPanel.svelte
+++ b/ui/src/components/DebugPanel.svelte
@@ -213,6 +213,37 @@
 				<div class="section">
 					<div class="field">Improv: {snap.inference.improv_enabled ? 'ON' : 'OFF'}</div>
 				</div>
+				<div class="section">
+					<h4>Call Log ({snap.inference.call_log.length})</h4>
+					{#if snap.inference.call_log.length > 0}
+						{@const avgMs = Math.round(snap.inference.call_log.reduce((s, e) => s + e.duration_ms, 0) / snap.inference.call_log.length)}
+						{@const errorCount = snap.inference.call_log.filter(e => e.error).length}
+						<div class="field muted">Avg latency: {avgMs}ms | Errors: {errorCount}</div>
+						<div class="call-log">
+							{#each [...snap.inference.call_log].reverse() as entry}
+								<div class="log-entry" class:log-error={entry.error}>
+									<div class="log-header">
+										<span class="muted">[{entry.timestamp}]</span>
+										<span class="log-id">#{entry.request_id}</span>
+										<span class="log-model">{entry.model}</span>
+										{#if entry.streaming}<span class="log-badge stream">STREAM</span>{/if}
+										{#if entry.error}<span class="log-badge error">ERROR</span>{:else}<span class="log-badge ok">OK</span>{/if}
+									</div>
+									<div class="log-meta">
+										<span>{entry.duration_ms}ms</span>
+										<span class="muted">prompt: {entry.prompt_len}ch</span>
+										<span class="muted">response: {entry.response_len}ch</span>
+									</div>
+									{#if entry.error}
+										<div class="log-error-msg">{entry.error}</div>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					{:else}
+						<div class="field muted">(no calls yet)</div>
+					{/if}
+				</div>
 			{/if}
 		</div>
 	</div>
@@ -418,5 +449,76 @@
 	.event-cat {
 		color: var(--color-accent);
 		font-size: 0.65rem;
+	}
+
+	.call-log {
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+		margin-top: 0.25rem;
+	}
+
+	.log-entry {
+		padding: 0.3rem 0.5rem;
+		border-bottom: 1px solid var(--color-border);
+	}
+
+	.log-entry.log-error {
+		background: color-mix(in srgb, #ff4444 8%, transparent);
+	}
+
+	.log-header {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+		align-items: baseline;
+	}
+
+	.log-id {
+		color: var(--color-muted);
+		font-size: 0.65rem;
+	}
+
+	.log-model {
+		color: var(--color-accent);
+		font-weight: 600;
+	}
+
+	.log-badge {
+		font-size: 0.55rem;
+		padding: 0.05rem 0.3rem;
+		border-radius: 2px;
+		text-transform: uppercase;
+		font-weight: 700;
+		letter-spacing: 0.05em;
+	}
+
+	.log-badge.stream {
+		background: color-mix(in srgb, var(--color-accent) 20%, transparent);
+		color: var(--color-accent);
+	}
+
+	.log-badge.ok {
+		background: color-mix(in srgb, #44cc44 20%, transparent);
+		color: #44cc44;
+	}
+
+	.log-badge.error {
+		background: color-mix(in srgb, #ff4444 20%, transparent);
+		color: #ff4444;
+	}
+
+	.log-meta {
+		display: flex;
+		gap: 0.6rem;
+		font-size: 0.65rem;
+		margin-top: 0.1rem;
+	}
+
+	.log-error-msg {
+		color: #ff4444;
+		font-size: 0.65rem;
+		margin-top: 0.1rem;
+		word-break: break-word;
 	}
 </style>

--- a/ui/src/components/DebugPanel.svelte
+++ b/ui/src/components/DebugPanel.svelte
@@ -7,6 +7,7 @@
 	function selectTab(index: number) {
 		debugTab.set(index);
 		selectedNpcId.set(null);
+		selectedLogId = null;
 	}
 
 	function selectNpc(id: number) {
@@ -24,10 +25,21 @@
 		return '[' + '#'.repeat(filled) + '.'.repeat(empty) + ']';
 	}
 
+	let selectedLogId: number | null = null;
+
+	function selectLogEntry(id: number) {
+		selectedLogId = id;
+	}
+
+	function deselectLogEntry() {
+		selectedLogId = null;
+	}
+
 	$: snap = $debugSnapshot;
 	$: tab = $debugTab;
 	$: npcId = $selectedNpcId;
 	$: selectedNpc = snap?.npcs.find((n: NpcDebug) => n.id === npcId) ?? null;
+	$: selectedLog = snap?.inference.call_log.find(e => e.request_id === selectedLogId) ?? null;
 </script>
 
 {#if $debugVisible && snap}
@@ -194,56 +206,100 @@
 
 			{:else if tab === 4}
 				<!-- Inference -->
-				<div class="section">
-					<h4>Base Provider</h4>
-					<div class="field">Provider: {snap.inference.provider_name}</div>
-					<div class="field">Model: {snap.inference.model_name || '(auto)'}</div>
-					<div class="field">URL: {snap.inference.base_url || '(default)'}</div>
-					<div class="field">Queue: {snap.inference.has_queue ? 'active' : 'none'}</div>
-				</div>
-				<div class="section">
-					<h4>Cloud</h4>
-					{#if snap.inference.cloud_provider}
-						<div class="field">Provider: {snap.inference.cloud_provider}</div>
-						<div class="field">Model: {snap.inference.cloud_model || '(none)'}</div>
-					{:else}
-						<div class="field muted">(not configured)</div>
-					{/if}
-				</div>
-				<div class="section">
-					<div class="field">Improv: {snap.inference.improv_enabled ? 'ON' : 'OFF'}</div>
-				</div>
-				<div class="section">
-					<h4>Call Log ({snap.inference.call_log.length})</h4>
-					{#if snap.inference.call_log.length > 0}
-						{@const avgMs = Math.round(snap.inference.call_log.reduce((s, e) => s + e.duration_ms, 0) / snap.inference.call_log.length)}
-						{@const errorCount = snap.inference.call_log.filter(e => e.error).length}
-						<div class="field muted">Avg latency: {avgMs}ms | Errors: {errorCount}</div>
-						<div class="call-log">
-							{#each [...snap.inference.call_log].reverse() as entry}
-								<div class="log-entry" class:log-error={entry.error}>
-									<div class="log-header">
-										<span class="muted">[{entry.timestamp}]</span>
-										<span class="log-id">#{entry.request_id}</span>
-										<span class="log-model">{entry.model}</span>
-										{#if entry.streaming}<span class="log-badge stream">STREAM</span>{/if}
-										{#if entry.error}<span class="log-badge error">ERROR</span>{:else}<span class="log-badge ok">OK</span>{/if}
-									</div>
-									<div class="log-meta">
-										<span>{entry.duration_ms}ms</span>
-										<span class="muted">prompt: {entry.prompt_len}ch</span>
-										<span class="muted">response: {entry.response_len}ch</span>
-									</div>
-									{#if entry.error}
-										<div class="log-error-msg">{entry.error}</div>
-									{/if}
-								</div>
-							{/each}
+				{#if selectedLog}
+					<!-- Detail view for a single inference call -->
+					<div class="npc-detail">
+						<button class="back-btn" on:click={deselectLogEntry}>Back to list</button>
+						<h4>Request #{selectedLog.request_id}</h4>
+
+						<div class="section">
+							<h5>Summary</h5>
+							<div class="field">Time: {selectedLog.timestamp}</div>
+							<div class="field">Model: <span class="accent">{selectedLog.model}</span></div>
+							<div class="field">Duration: {selectedLog.duration_ms}ms</div>
+							<div class="field">Streaming: {selectedLog.streaming ? 'yes' : 'no'}</div>
+							{#if selectedLog.max_tokens}
+								<div class="field">Max tokens: {selectedLog.max_tokens}</div>
+							{/if}
+							<div class="field">Status:
+								{#if selectedLog.error}<span class="log-badge error">ERROR</span>{:else}<span class="log-badge ok">OK</span>{/if}
+							</div>
 						</div>
-					{:else}
-						<div class="field muted">(no calls yet)</div>
-					{/if}
-				</div>
+
+						{#if selectedLog.system_prompt}
+							<div class="section">
+								<h5>System Prompt ({selectedLog.system_prompt.length}ch)</h5>
+								<pre class="prompt-block">{selectedLog.system_prompt}</pre>
+							</div>
+						{/if}
+
+						<div class="section">
+							<h5>Prompt ({selectedLog.prompt_len}ch)</h5>
+							<pre class="prompt-block">{selectedLog.prompt_text}</pre>
+						</div>
+
+						<div class="section">
+							<h5>Response ({selectedLog.response_len}ch)</h5>
+							{#if selectedLog.error}
+								<div class="log-error-msg">{selectedLog.error}</div>
+							{:else}
+								<pre class="prompt-block">{selectedLog.response_text}</pre>
+							{/if}
+						</div>
+					</div>
+				{:else}
+					<!-- Config + call log list -->
+					<div class="section">
+						<h4>Base Provider</h4>
+						<div class="field">Provider: {snap.inference.provider_name}</div>
+						<div class="field">Model: {snap.inference.model_name || '(auto)'}</div>
+						<div class="field">URL: {snap.inference.base_url || '(default)'}</div>
+						<div class="field">Queue: {snap.inference.has_queue ? 'active' : 'none'}</div>
+					</div>
+					<div class="section">
+						<h4>Cloud</h4>
+						{#if snap.inference.cloud_provider}
+							<div class="field">Provider: {snap.inference.cloud_provider}</div>
+							<div class="field">Model: {snap.inference.cloud_model || '(none)'}</div>
+						{:else}
+							<div class="field muted">(not configured)</div>
+						{/if}
+					</div>
+					<div class="section">
+						<div class="field">Improv: {snap.inference.improv_enabled ? 'ON' : 'OFF'}</div>
+					</div>
+					<div class="section">
+						<h4>Call Log ({snap.inference.call_log.length})</h4>
+						{#if snap.inference.call_log.length > 0}
+							{@const avgMs = Math.round(snap.inference.call_log.reduce((s, e) => s + e.duration_ms, 0) / snap.inference.call_log.length)}
+							{@const errorCount = snap.inference.call_log.filter(e => e.error).length}
+							<div class="field muted">Avg latency: {avgMs}ms | Errors: {errorCount}</div>
+							<div class="call-log">
+								{#each [...snap.inference.call_log].reverse() as entry}
+									<button class="log-entry-btn" class:log-error={entry.error} on:click={() => selectLogEntry(entry.request_id)}>
+										<div class="log-header">
+											<span class="muted">[{entry.timestamp}]</span>
+											<span class="log-id">#{entry.request_id}</span>
+											<span class="log-model">{entry.model}</span>
+											{#if entry.streaming}<span class="log-badge stream">STREAM</span>{/if}
+											{#if entry.error}<span class="log-badge error">ERROR</span>{:else}<span class="log-badge ok">OK</span>{/if}
+										</div>
+										<div class="log-meta">
+											<span>{entry.duration_ms}ms</span>
+											<span class="muted">prompt: {entry.prompt_len}ch</span>
+											<span class="muted">response: {entry.response_len}ch</span>
+										</div>
+										{#if entry.error}
+											<div class="log-error-msg">{entry.error}</div>
+										{/if}
+									</button>
+								{/each}
+							</div>
+						{:else}
+							<div class="field muted">(no calls yet)</div>
+						{/if}
+					</div>
+				{/if}
 			{/if}
 		</div>
 	</div>
@@ -458,13 +514,43 @@
 		margin-top: 0.25rem;
 	}
 
-	.log-entry {
+	.log-entry-btn {
+		display: block;
+		width: 100%;
 		padding: 0.3rem 0.5rem;
+		border: none;
 		border-bottom: 1px solid var(--color-border);
+		background: none;
+		cursor: pointer;
+		text-align: left;
+		font-size: 0.75rem;
+		color: var(--color-fg);
 	}
 
-	.log-entry.log-error {
+	.log-entry-btn:hover {
+		background: var(--color-input-bg);
+	}
+
+	.log-entry-btn.log-error {
 		background: color-mix(in srgb, #ff4444 8%, transparent);
+	}
+
+	.log-entry-btn.log-error:hover {
+		background: color-mix(in srgb, #ff4444 14%, transparent);
+	}
+
+	.prompt-block {
+		background: var(--color-input-bg);
+		border: 1px solid var(--color-border);
+		padding: 0.4rem 0.5rem;
+		font-size: 0.65rem;
+		line-height: 1.5;
+		white-space: pre-wrap;
+		word-break: break-word;
+		max-height: 12rem;
+		overflow-y: auto;
+		color: var(--color-fg);
+		margin: 0.15rem 0 0;
 	}
 
 	.log-header {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -209,4 +209,8 @@ export interface InferenceLogEntry {
 	prompt_len: number;
 	response_len: number;
 	error: string | null;
+	system_prompt: string | null;
+	prompt_text: string;
+	response_text: string;
+	max_tokens: number | null;
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -197,4 +197,16 @@ export interface InferenceDebug {
 	cloud_model: string | null;
 	has_queue: boolean;
 	improv_enabled: boolean;
+	call_log: InferenceLogEntry[];
+}
+
+export interface InferenceLogEntry {
+	request_id: number;
+	timestamp: string;
+	model: string;
+	streaming: boolean;
+	duration_ms: number;
+	prompt_len: number;
+	response_len: number;
+	error: string | null;
 }


### PR DESCRIPTION
## Summary
This PR adds comprehensive logging of inference API calls to the debug panel, allowing developers to monitor LLM request/response metrics in real-time.

## Key Changes

- **New `InferenceLogEntry` struct** in `debug_snapshot.rs` to capture:
  - Request ID, timestamp, and model name
  - Streaming flag and call duration
  - Prompt and response lengths
  - Error messages (if any)

- **Shared inference log infrastructure**:
  - Added `InferenceLog` type (thread-safe ring buffer with 50-entry capacity)
  - `new_inference_log()` factory function for creating log instances
  - Integrated logging into `spawn_inference_worker()` to record all completed calls

- **Debug panel UI enhancements**:
  - New "Call Log" section displaying recent inference calls in reverse chronological order
  - Shows average latency and error count summary
  - Per-entry details: request ID, model, duration, prompt/response lengths
  - Visual badges for streaming and error states
  - Color-coded styling (red tint for errors, green for success)

- **Type definitions and integration**:
  - Added `InferenceLogEntry` TypeScript interface in `ui/lib/types.ts`
  - Updated `InferenceDebug` struct to include `call_log` field
  - Integrated log collection in both Tauri and headless backends

## Implementation Details

- Log entries are recorded after each inference call completes, capturing actual duration via `Instant`
- Ring buffer automatically evicts oldest entries when capacity (50) is reached
- Timestamps use local time formatted as HH:MM:SS
- Error messages are preserved and displayed in the UI
- All changes maintain backward compatibility with existing inference pipeline

https://claude.ai/code/session_01DyJW7L9y31DyDaLDt4LZWJ