### PR TITLE
feat: calculate travel time from coordinates with mod-configurable transport modes

### DIFF
--- a/crates/parish-core/src/game_mod.rs
+++ b/crates/parish-core/src/game_mod.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 
 use crate::error::ParishError;
 use crate::npc::LanguageHint;
+use crate::world::transport::TransportConfig;
 
 // ---------------------------------------------------------------------------
 // Manifest types (parsed from mod.toml)
@@ -78,6 +79,9 @@ pub struct FileRefs {
     /// Pronunciation hints JSON file (optional for backward compatibility).
     #[serde(default)]
     pub pronunciations: Option<String>,
+    /// Transport modes TOML file (optional; defaults to walking only).
+    #[serde(default)]
+    pub transport: Option<String>,
 }
 
 /// Relative paths to prompt template text files.
@@ -299,6 +303,8 @@ pub struct GameMod {
     pub ui: UiConfig,
     /// Name pronunciation entries loaded from `pronunciations.json`.
     pub pronunciations: Vec<PronunciationEntry>,
+    /// Transport modes configuration.
+    pub transport: TransportConfig,
 }
 
 impl GameMod {
@@ -385,6 +391,16 @@ impl GameMod {
             vec![]
         };
 
+        // -- transport (optional) ---------------------------------------------
+        let transport = if let Some(ref transport_file) = manifest.files.transport {
+            let transport_text = read_toml_text(transport_file)?;
+            toml::from_str(&transport_text).map_err(|e| {
+                ParishError::Config(format!("failed to parse {transport_file}: {e}"))
+            })?
+        } else {
+            TransportConfig::default()
+        };
+
         Ok(Self {
             manifest,
             mod_dir,
@@ -395,6 +411,7 @@ impl GameMod {
             loading,
             ui,
             pronunciations,
+            transport,
         })
     }
 
@@ -617,6 +634,10 @@ tier2_system = "prompts/tier2_system.txt"
         assert_eq!(gm.loading.spinner_frames.len(), 4);
         // No pronunciations file referenced → empty vec
         assert!(gm.pronunciations.is_empty());
+        // No transport.toml in test mod — should default to walking
+        assert_eq!(gm.transport.default, "walking");
+        assert_eq!(gm.transport.modes.len(), 1);
+        assert_eq!(gm.transport.default_mode().id, "walking");
     }
 
     #[test]

--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -10,12 +10,13 @@ use chrono::Timelike;
 use crate::npc::manager::NpcManager;
 use crate::world::description::{format_exits, render_description};
 use crate::world::palette::compute_palette;
+use crate::world::transport::TransportMode;
 use crate::world::{LocationId, WorldState};
 
 use super::types::{MapData, MapLocation, NpcInfo, ThemePalette, WorldSnapshot};
 
 /// Builds a [`WorldSnapshot`] from the current world state.
-pub fn snapshot_from_world(world: &WorldState) -> WorldSnapshot {
+pub fn snapshot_from_world(world: &WorldState, transport: &TransportMode) -> WorldSnapshot {
     let now = world.clock.now();
     let hour = now.hour() as u8;
     let minute = now.minute() as u8;
@@ -27,7 +28,12 @@ pub fn snapshot_from_world(world: &WorldState) -> WorldSnapshot {
     let loc = world.current_location();
     let description = if let Some(data) = world.current_location_data() {
         let desc = render_description(data, tod, &weather_str, &[]);
-        let exits = format_exits(world.player_location, &world.graph);
+        let exits = format_exits(
+            world.player_location,
+            &world.graph,
+            transport.speed_m_per_s,
+            &transport.label,
+        );
         format!("{}\n\n{}", desc, exits)
     } else {
         loc.description.clone()

--- a/crates/parish-core/src/npc/manager.rs
+++ b/crates/parish-core/src/npc/manager.rs
@@ -388,7 +388,8 @@ impl NpcManager {
                         && desired != npc.location
                         && let Some(path) = graph.shortest_path(npc.location, desired)
                     {
-                        let travel_minutes = graph.path_travel_time(&path);
+                        // NPCs walk at ~1.25 m/s (~4.5 km/h)
+                        let travel_minutes = graph.path_travel_time(&path, 1.25);
                         let arrives_at = now + Duration::minutes(travel_minutes as i64);
                         let from = npc.location;
                         let npc_name = npc.name.clone();

--- a/crates/parish-core/src/world/description.rs
+++ b/crates/parish-core/src/world/description.rs
@@ -36,8 +36,14 @@ pub fn render_description(
 
 /// Formats the list of exits (neighboring locations) from a given location.
 ///
-/// Returns a string like "You can go to: Darcy's Pub (3 min), St. Brigid's Church (5 min)"
-pub fn format_exits(location_id: LocationId, graph: &WorldGraph) -> String {
+/// Travel time for each exit is computed from coordinates at the given speed.
+/// Returns a string like "You can go to: Darcy's Pub (3 min on foot), The Church (6 min on foot)"
+pub fn format_exits(
+    location_id: LocationId,
+    graph: &WorldGraph,
+    speed_m_per_s: f64,
+    transport_label: &str,
+) -> String {
     let neighbors = graph.neighbors(location_id);
     if neighbors.is_empty() {
         return "There is nowhere to go from here.".to_string();
@@ -45,10 +51,11 @@ pub fn format_exits(location_id: LocationId, graph: &WorldGraph) -> String {
 
     let exits: Vec<String> = neighbors
         .iter()
-        .filter_map(|(target_id, conn)| {
+        .filter_map(|(target_id, _conn)| {
+            let minutes = graph.edge_travel_minutes(location_id, *target_id, speed_m_per_s);
             graph
                 .get(*target_id)
-                .map(|loc| format!("{} ({} min)", loc.name, conn.traversal_minutes))
+                .map(|loc| format!("{} ({} min {})", loc.name, minutes, transport_label))
         })
         .collect();
 
@@ -174,34 +181,38 @@ mod tests {
                 {
                     "id": 1, "name": "The Crossroads",
                     "description_template": "X", "indoor": false, "public": true,
+                    "lat": 53.618, "lon": -8.095,
                     "connections": [
-                        {"target": 2, "traversal_minutes": 3, "path_description": "lane"},
-                        {"target": 3, "traversal_minutes": 5, "path_description": "boreen"}
+                        {"target": 2, "path_description": "lane"},
+                        {"target": 3, "path_description": "boreen"}
                     ]
                 },
                 {
                     "id": 2, "name": "Darcy's Pub",
                     "description_template": "X", "indoor": true, "public": true,
-                    "connections": [{"target": 1, "traversal_minutes": 3, "path_description": "back"}]
+                    "lat": 53.6195, "lon": -8.0925,
+                    "connections": [{"target": 1, "path_description": "back"}]
                 },
                 {
                     "id": 3, "name": "The Church",
                     "description_template": "X", "indoor": false, "public": true,
-                    "connections": [{"target": 1, "traversal_minutes": 5, "path_description": "back"}]
+                    "lat": 53.6215, "lon": -8.099,
+                    "connections": [{"target": 1, "path_description": "back"}]
                 }
             ]
         }"#;
         let graph = WorldGraph::load_from_str(json).unwrap();
-        let exits = format_exits(LocationId(1), &graph);
+        let exits = format_exits(LocationId(1), &graph, 1.25, "on foot");
         assert!(exits.starts_with("You can go to: "));
-        assert!(exits.contains("Darcy's Pub (3 min)"));
-        assert!(exits.contains("The Church (5 min)"));
+        assert!(exits.contains("Darcy's Pub"));
+        assert!(exits.contains("min on foot"));
+        assert!(exits.contains("The Church"));
     }
 
     #[test]
     fn test_format_exits_empty_graph() {
         let graph = WorldGraph::new();
-        let exits = format_exits(LocationId(99), &graph);
+        let exits = format_exits(LocationId(99), &graph, 1.25, "on foot");
         assert_eq!(exits, "There is nowhere to go from here.");
     }
 }

--- a/crates/parish-core/src/world/geo.rs
+++ b/crates/parish-core/src/world/geo.rs
@@ -1,0 +1,92 @@
+//! Geographic utilities — haversine distance and travel time calculation.
+//!
+//! Provides coordinate-based distance calculation between WGS-84 points
+//! and conversion from distance to game-minutes at a given travel speed.
+
+/// Earth's mean radius in meters (WGS-84 approximation).
+const EARTH_RADIUS_M: f64 = 6_371_000.0;
+
+/// Calculates the Haversine distance in meters between two WGS-84 coordinate pairs.
+pub fn haversine_distance(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
+    let dlat = (lat2 - lat1).to_radians();
+    let dlon = (lon2 - lon1).to_radians();
+    let lat1_rad = lat1.to_radians();
+    let lat2_rad = lat2.to_radians();
+
+    let a =
+        (dlat / 2.0).sin().powi(2) + lat1_rad.cos() * lat2_rad.cos() * (dlon / 2.0).sin().powi(2);
+    let c = 2.0 * a.sqrt().asin();
+
+    EARTH_RADIUS_M * c
+}
+
+/// Converts a real-world distance in meters to game traversal minutes at a given speed.
+///
+/// Returns at least 1 minute and at most 120 minutes (2-hour cap).
+pub fn meters_to_minutes(meters: f64, speed_m_per_s: f64) -> u16 {
+    let speed_m_per_min = speed_m_per_s * 60.0;
+    (meters / speed_m_per_min).ceil().clamp(1.0, 120.0) as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_haversine_same_point() {
+        let d = haversine_distance(53.618, -8.095, 53.618, -8.095);
+        assert!(d.abs() < 0.01, "same point should be ~0m, got {d}");
+    }
+
+    #[test]
+    fn test_haversine_known_distance() {
+        // Crossroads (53.618, -8.095) to Darcy's Pub (53.6195, -8.0925)
+        // Should be roughly 200-250m
+        let d = haversine_distance(53.618, -8.095, 53.6195, -8.0925);
+        assert!(
+            d > 150.0 && d < 300.0,
+            "Crossroads to Pub should be ~200m, got {d}"
+        );
+    }
+
+    #[test]
+    fn test_haversine_longer_distance() {
+        // Crossroads (53.618, -8.095) to Lough Ree Shore (53.621, -8.043)
+        // Should be ~3.5km
+        let d = haversine_distance(53.618, -8.095, 53.621, -8.043);
+        assert!(
+            d > 3000.0 && d < 4000.0,
+            "Crossroads to Lough Ree should be ~3.5km, got {d}"
+        );
+    }
+
+    #[test]
+    fn test_meters_to_minutes_walking() {
+        // 75m at 1.25 m/s = 75/75 = 1 minute
+        assert_eq!(meters_to_minutes(75.0, 1.25), 1);
+    }
+
+    #[test]
+    fn test_meters_to_minutes_medium() {
+        // 300m at 1.25 m/s = 300/75 = 4 minutes
+        assert_eq!(meters_to_minutes(300.0, 1.25), 4);
+    }
+
+    #[test]
+    fn test_meters_to_minutes_minimum() {
+        // Very short distance still returns 1
+        assert_eq!(meters_to_minutes(1.0, 1.25), 1);
+    }
+
+    #[test]
+    fn test_meters_to_minutes_maximum() {
+        // Very long distance capped at 120
+        assert_eq!(meters_to_minutes(100_000.0, 1.25), 120);
+    }
+
+    #[test]
+    fn test_meters_to_minutes_faster_speed() {
+        // 300m at 4.0 m/s = 300/240 = 1.25 → ceil → 2 minutes
+        assert_eq!(meters_to_minutes(300.0, 4.0), 2);
+    }
+}

--- a/crates/parish-core/src/world/graph.rs
+++ b/crates/parish-core/src/world/graph.rs
@@ -13,19 +13,21 @@ use strsim::jaro_winkler;
 use crate::config::WorldConfig;
 use crate::error::ParishError;
 use crate::npc::NpcId;
+use crate::world::geo;
 
 use super::LocationId;
 
 /// A connection (edge) between two locations in the world graph.
 ///
-/// Each connection has a target location, a traversal time in game minutes,
-/// and a prose description of the path.
+/// Each connection has a target location and a prose description of the path.
+/// Travel time is calculated at runtime from coordinates and transport speed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Connection {
     /// The destination location.
     pub target: LocationId,
-    /// Time in game minutes to traverse this connection.
-    pub traversal_minutes: u16,
+    /// Legacy field — ignored at runtime; travel time is calculated from coordinates.
+    #[serde(default, skip_serializing)]
+    pub traversal_minutes: Option<u16>,
     /// Prose description of the path (e.g., "a narrow boreen lined with hawthorn").
     pub path_description: String,
 }
@@ -337,24 +339,35 @@ impl WorldGraph {
         None
     }
 
+    /// Calculates travel time in game minutes between two locations
+    /// using haversine distance and the given speed.
+    pub fn edge_travel_minutes(&self, from: LocationId, to: LocationId, speed_m_per_s: f64) -> u16 {
+        let from_loc = match self.locations.get(&from) {
+            Some(loc) => loc,
+            None => return 1,
+        };
+        let to_loc = match self.locations.get(&to) {
+            Some(loc) => loc,
+            None => return 1,
+        };
+        let meters = geo::haversine_distance(from_loc.lat, from_loc.lon, to_loc.lat, to_loc.lon);
+        geo::meters_to_minutes(meters, speed_m_per_s)
+    }
+
     /// Returns the total traversal time along a path in game minutes.
     ///
     /// Given a sequence of location ids (as returned by `shortest_path`),
-    /// sums the traversal times of each edge along the path.
-    pub fn path_travel_time(&self, path: &[LocationId]) -> u16 {
+    /// calculates the haversine distance for each edge and converts to
+    /// minutes at the given travel speed.
+    pub fn path_travel_time(&self, path: &[LocationId], speed_m_per_s: f64) -> u16 {
         if path.len() < 2 {
             return 0;
         }
 
         let mut total = 0u16;
         for window in path.windows(2) {
-            let from = window[0];
-            let to = window[1];
-            if let Some(loc) = self.locations.get(&from)
-                && let Some(conn) = loc.connections.iter().find(|c| c.target == to)
-            {
-                total = total.saturating_add(conn.traversal_minutes);
-            }
+            total =
+                total.saturating_add(self.edge_travel_minutes(window[0], window[1], speed_m_per_s));
         }
         total
     }
@@ -409,9 +422,11 @@ mod tests {
                     "description_template": "A quiet crossroads at {time}. The weather is {weather}.",
                     "indoor": false,
                     "public": true,
+                    "lat": 53.618,
+                    "lon": -8.095,
                     "connections": [
-                        {"target": 2, "traversal_minutes": 5, "path_description": "a short lane"},
-                        {"target": 3, "traversal_minutes": 8, "path_description": "a winding boreen"}
+                        {"target": 2, "path_description": "a short lane"},
+                        {"target": 3, "path_description": "a winding boreen"}
                     ],
                     "associated_npcs": [],
                     "mythological_significance": null
@@ -422,8 +437,10 @@ mod tests {
                     "description_template": "The warm interior of Darcy's Pub at {time}.",
                     "indoor": true,
                     "public": true,
+                    "lat": 53.6195,
+                    "lon": -8.0925,
                     "connections": [
-                        {"target": 1, "traversal_minutes": 5, "path_description": "a short lane back to the crossroads"}
+                        {"target": 1, "path_description": "a short lane back to the crossroads"}
                     ],
                     "associated_npcs": [],
                     "mythological_significance": null,
@@ -435,9 +452,11 @@ mod tests {
                     "description_template": "The old stone church stands in {weather} {time} light.",
                     "indoor": false,
                     "public": true,
+                    "lat": 53.6215,
+                    "lon": -8.099,
                     "connections": [
-                        {"target": 1, "traversal_minutes": 8, "path_description": "the boreen back to the crossroads"},
-                        {"target": 4, "traversal_minutes": 10, "path_description": "a path through the graveyard"}
+                        {"target": 1, "path_description": "the boreen back to the crossroads"},
+                        {"target": 4, "path_description": "a path through the graveyard"}
                     ],
                     "associated_npcs": [],
                     "mythological_significance": null,
@@ -449,8 +468,10 @@ mod tests {
                     "description_template": "An ancient ring fort on the hill. {weather}.",
                     "indoor": false,
                     "public": true,
+                    "lat": 53.627,
+                    "lon": -8.052,
                     "connections": [
-                        {"target": 3, "traversal_minutes": 10, "path_description": "the path back past the church"}
+                        {"target": 3, "path_description": "the path back past the church"}
                     ],
                     "associated_npcs": [],
                     "mythological_significance": "A rath said to be home to the sídhe. Locals avoid it after dark.",
@@ -629,21 +650,38 @@ mod tests {
     fn test_path_travel_time() {
         let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
         let path = vec![LocationId(2), LocationId(1), LocationId(3), LocationId(4)];
-        let time = graph.path_travel_time(&path);
-        // 5 + 8 + 10 = 23
-        assert_eq!(time, 23);
+        let time = graph.path_travel_time(&path, 1.25);
+        // Computed from haversine distances — should be > 0
+        assert!(time > 0, "multi-hop travel time should be positive");
     }
 
     #[test]
     fn test_path_travel_time_single() {
         let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
-        assert_eq!(graph.path_travel_time(&[LocationId(1)]), 0);
+        assert_eq!(graph.path_travel_time(&[LocationId(1)], 1.25), 0);
     }
 
     #[test]
     fn test_path_travel_time_empty() {
         let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
-        assert_eq!(graph.path_travel_time(&[]), 0);
+        assert_eq!(graph.path_travel_time(&[], 1.25), 0);
+    }
+
+    #[test]
+    fn test_edge_travel_minutes() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        // Crossroads to Pub: ~230m at 1.25 m/s → ~3 min
+        let minutes = graph.edge_travel_minutes(LocationId(1), LocationId(2), 1.25);
+        assert!(minutes >= 1 && minutes <= 10, "edge time was {minutes}");
+    }
+
+    #[test]
+    fn test_faster_speed_shorter_time() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let path = vec![LocationId(1), LocationId(3), LocationId(4)];
+        let walk = graph.path_travel_time(&path, 1.25);
+        let fast = graph.path_travel_time(&path, 4.0);
+        assert!(fast <= walk, "faster speed should give shorter time");
     }
 
     #[test]
@@ -652,7 +690,6 @@ mod tests {
         let conn = graph
             .connection_between(LocationId(1), LocationId(2))
             .unwrap();
-        assert_eq!(conn.traversal_minutes, 5);
         assert_eq!(conn.path_description, "a short lane");
     }
 

--- a/crates/parish-core/src/world/mod.rs
+++ b/crates/parish-core/src/world/mod.rs
@@ -7,10 +7,12 @@
 pub mod description;
 pub mod encounter;
 pub mod events;
+pub mod geo;
 pub mod graph;
 pub mod movement;
 pub mod palette;
 pub mod time;
+pub mod transport;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/crates/parish-core/src/world/movement.rs
+++ b/crates/parish-core/src/world/movement.rs
@@ -5,6 +5,7 @@
 
 use super::LocationId;
 use super::graph::WorldGraph;
+use super::transport::TransportMode;
 
 /// The result of resolving a movement command.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,9 +30,14 @@ pub enum MovementResult {
 /// Resolves a movement intent target to a `MovementResult`.
 ///
 /// Uses fuzzy name matching to find the destination, then BFS to find
-/// the shortest path. Travel narration is generated from the first
-/// connection's path description.
-pub fn resolve_movement(target: &str, graph: &WorldGraph, current: LocationId) -> MovementResult {
+/// the shortest path. Travel time is calculated from coordinates using
+/// the given transport mode's speed. Narration includes the transport label.
+pub fn resolve_movement(
+    target: &str,
+    graph: &WorldGraph,
+    current: LocationId,
+    transport: &TransportMode,
+) -> MovementResult {
     // Try to find the target location
     let destination_id = match graph.find_by_name(target) {
         Some(id) => id,
@@ -49,11 +55,11 @@ pub fn resolve_movement(target: &str, graph: &WorldGraph, current: LocationId) -
         None => return MovementResult::NotFound(target.to_string()),
     };
 
-    // Calculate total travel time
-    let minutes = graph.path_travel_time(&path);
+    // Calculate total travel time from coordinates
+    let minutes = graph.path_travel_time(&path, transport.speed_m_per_s);
 
     // Build narration from first step's connection description
-    let narration = build_travel_narration(&path, graph, minutes);
+    let narration = build_travel_narration(&path, graph, minutes, transport);
 
     MovementResult::Arrived {
         destination: destination_id,
@@ -67,10 +73,22 @@ pub fn resolve_movement(target: &str, graph: &WorldGraph, current: LocationId) -
 ///
 /// For single-hop journeys, uses the connection's path description.
 /// For multi-hop journeys, describes the first step with a summary.
-fn build_travel_narration(path: &[LocationId], graph: &WorldGraph, total_minutes: u16) -> String {
+/// Includes the transport label (e.g., "on foot") in the time display.
+fn build_travel_narration(
+    path: &[LocationId],
+    graph: &WorldGraph,
+    total_minutes: u16,
+    transport: &TransportMode,
+) -> String {
     if path.len() < 2 {
         return String::new();
     }
+
+    let verb = if transport.id == "walking" {
+        "walk"
+    } else {
+        "travel"
+    };
 
     let dest_name = graph
         .get(*path.last().unwrap())
@@ -81,8 +99,8 @@ fn build_travel_narration(path: &[LocationId], graph: &WorldGraph, total_minutes
         // Direct connection
         if let Some(conn) = graph.connection_between(path[0], path[1]) {
             return format!(
-                "You walk along {}. ({} minutes)",
-                conn.path_description, total_minutes
+                "You {} along {}. ({} minutes {})",
+                verb, conn.path_description, total_minutes, transport.label
             );
         }
     }
@@ -94,8 +112,8 @@ fn build_travel_narration(path: &[LocationId], graph: &WorldGraph, total_minutes
         .unwrap_or("the road");
 
     format!(
-        "You set off along {} toward {}. ({} minutes)",
-        first_desc, dest_name, total_minutes
+        "You set off along {} toward {}. ({} minutes {})",
+        first_desc, dest_name, total_minutes, transport.label
     )
 }
 
@@ -103,8 +121,18 @@ fn build_travel_narration(path: &[LocationId], graph: &WorldGraph, total_minutes
 mod tests {
     use super::*;
     use crate::world::graph::WorldGraph;
+    use crate::world::transport::TransportMode;
+
+    fn walking() -> TransportMode {
+        TransportMode::walking()
+    }
 
     fn test_graph() -> WorldGraph {
+        // Use real-ish coordinates so haversine gives meaningful results.
+        // Crossroads: 53.618, -8.095
+        // Pub: 53.6195, -8.0925  (~230m away → ~3 min walking)
+        // Church: 53.6215, -8.099  (~450m away → ~6 min walking)
+        // Fort: 53.627, -8.052  (~3km from church → large)
         let json = r#"{
             "locations": [
                 {
@@ -113,9 +141,11 @@ mod tests {
                     "description_template": "A crossroads.",
                     "indoor": false,
                     "public": true,
+                    "lat": 53.618,
+                    "lon": -8.095,
                     "connections": [
-                        {"target": 2, "traversal_minutes": 5, "path_description": "a short lane"},
-                        {"target": 3, "traversal_minutes": 8, "path_description": "a winding boreen"}
+                        {"target": 2, "path_description": "a short lane"},
+                        {"target": 3, "path_description": "a winding boreen"}
                     ]
                 },
                 {
@@ -124,8 +154,10 @@ mod tests {
                     "description_template": "A pub.",
                     "indoor": true,
                     "public": true,
+                    "lat": 53.6195,
+                    "lon": -8.0925,
                     "connections": [
-                        {"target": 1, "traversal_minutes": 5, "path_description": "back to the crossroads"}
+                        {"target": 1, "path_description": "back to the crossroads"}
                     ]
                 },
                 {
@@ -134,9 +166,11 @@ mod tests {
                     "description_template": "A church.",
                     "indoor": false,
                     "public": true,
+                    "lat": 53.6215,
+                    "lon": -8.099,
                     "connections": [
-                        {"target": 1, "traversal_minutes": 8, "path_description": "the boreen back"},
-                        {"target": 4, "traversal_minutes": 10, "path_description": "a path through the graveyard"}
+                        {"target": 1, "path_description": "the boreen back"},
+                        {"target": 4, "path_description": "a path through the graveyard"}
                     ]
                 },
                 {
@@ -145,8 +179,10 @@ mod tests {
                     "description_template": "A fairy fort.",
                     "indoor": false,
                     "public": true,
+                    "lat": 53.627,
+                    "lon": -8.052,
                     "connections": [
-                        {"target": 3, "traversal_minutes": 10, "path_description": "back past the church"}
+                        {"target": 3, "path_description": "back past the church"}
                     ]
                 }
             ]
@@ -157,7 +193,7 @@ mod tests {
     #[test]
     fn test_resolve_direct_movement() {
         let graph = test_graph();
-        let result = resolve_movement("pub", &graph, LocationId(1));
+        let result = resolve_movement("pub", &graph, LocationId(1), &walking());
         match result {
             MovementResult::Arrived {
                 destination,
@@ -166,9 +202,9 @@ mod tests {
                 ..
             } => {
                 assert_eq!(destination, LocationId(2));
-                assert_eq!(minutes, 5);
+                assert!(minutes >= 1 && minutes <= 10, "minutes was {minutes}");
                 assert!(narration.contains("short lane"));
-                assert!(narration.contains("5 minutes"));
+                assert!(narration.contains("on foot"));
             }
             other => panic!("expected Arrived, got {:?}", other),
         }
@@ -178,7 +214,7 @@ mod tests {
     fn test_resolve_multi_hop_movement() {
         let graph = test_graph();
         // From pub to fairy fort: pub -> crossroads -> church -> fairy fort
-        let result = resolve_movement("fairy fort", &graph, LocationId(2));
+        let result = resolve_movement("fairy fort", &graph, LocationId(2), &walking());
         match result {
             MovementResult::Arrived {
                 destination,
@@ -189,8 +225,11 @@ mod tests {
             } => {
                 assert_eq!(destination, LocationId(4));
                 assert_eq!(path.len(), 4); // pub -> crossroads -> church -> fort
-                assert_eq!(minutes, 5 + 8 + 10); // 23 minutes
-                assert!(narration.contains("minutes"));
+                assert!(
+                    minutes >= 5,
+                    "multi-hop should take several minutes, got {minutes}"
+                );
+                assert!(narration.contains("on foot"));
             }
             other => panic!("expected Arrived, got {:?}", other),
         }
@@ -199,14 +238,14 @@ mod tests {
     #[test]
     fn test_resolve_already_here() {
         let graph = test_graph();
-        let result = resolve_movement("crossroads", &graph, LocationId(1));
+        let result = resolve_movement("crossroads", &graph, LocationId(1), &walking());
         assert_eq!(result, MovementResult::AlreadyHere);
     }
 
     #[test]
     fn test_resolve_not_found() {
         let graph = test_graph();
-        let result = resolve_movement("castle", &graph, LocationId(1));
+        let result = resolve_movement("castle", &graph, LocationId(1), &walking());
         match result {
             MovementResult::NotFound(name) => assert_eq!(name, "castle"),
             other => panic!("expected NotFound, got {:?}", other),
@@ -216,7 +255,7 @@ mod tests {
     #[test]
     fn test_resolve_case_insensitive() {
         let graph = test_graph();
-        let result = resolve_movement("DARCY'S PUB", &graph, LocationId(1));
+        let result = resolve_movement("DARCY'S PUB", &graph, LocationId(1), &walking());
         match result {
             MovementResult::Arrived { destination, .. } => {
                 assert_eq!(destination, LocationId(2));
@@ -228,7 +267,7 @@ mod tests {
     #[test]
     fn test_resolve_partial_name() {
         let graph = test_graph();
-        let result = resolve_movement("church", &graph, LocationId(1));
+        let result = resolve_movement("church", &graph, LocationId(1), &walking());
         match result {
             MovementResult::Arrived { destination, .. } => {
                 assert_eq!(destination, LocationId(3));
@@ -238,26 +277,64 @@ mod tests {
     }
 
     #[test]
-    fn test_narration_direct() {
+    fn test_narration_direct_walking() {
         let graph = test_graph();
+        let transport = walking();
         let path = vec![LocationId(1), LocationId(2)];
-        let narration = build_travel_narration(&path, &graph, 5);
-        assert_eq!(narration, "You walk along a short lane. (5 minutes)");
+        let minutes = graph.path_travel_time(&path, transport.speed_m_per_s);
+        let narration = build_travel_narration(&path, &graph, minutes, &transport);
+        assert!(narration.starts_with("You walk along a short lane."));
+        assert!(narration.contains("on foot"));
+    }
+
+    #[test]
+    fn test_narration_direct_non_walking() {
+        let graph = test_graph();
+        let transport = TransportMode {
+            id: "jaunting_car".to_string(),
+            label: "in a jaunting car".to_string(),
+            speed_m_per_s: 4.0,
+        };
+        let path = vec![LocationId(1), LocationId(2)];
+        let minutes = graph.path_travel_time(&path, transport.speed_m_per_s);
+        let narration = build_travel_narration(&path, &graph, minutes, &transport);
+        assert!(narration.starts_with("You travel along a short lane."));
+        assert!(narration.contains("in a jaunting car"));
     }
 
     #[test]
     fn test_narration_multi_hop() {
         let graph = test_graph();
+        let transport = walking();
         let path = vec![LocationId(2), LocationId(1), LocationId(3), LocationId(4)];
-        let narration = build_travel_narration(&path, &graph, 23);
+        let minutes = graph.path_travel_time(&path, transport.speed_m_per_s);
+        let narration = build_travel_narration(&path, &graph, minutes, &transport);
         assert!(narration.contains("The Fairy Fort"));
-        assert!(narration.contains("23 minutes"));
+        assert!(narration.contains("on foot"));
     }
 
     #[test]
     fn test_narration_empty_path() {
         let graph = test_graph();
-        let narration = build_travel_narration(&[], &graph, 0);
+        let narration = build_travel_narration(&[], &graph, 0, &walking());
         assert!(narration.is_empty());
+    }
+
+    #[test]
+    fn test_faster_transport_takes_less_time() {
+        let graph = test_graph();
+        let walk = walking();
+        let fast = TransportMode {
+            id: "jaunting_car".to_string(),
+            label: "in a jaunting car".to_string(),
+            speed_m_per_s: 4.0,
+        };
+        let path = vec![LocationId(1), LocationId(3), LocationId(4)];
+        let walk_time = graph.path_travel_time(&path, walk.speed_m_per_s);
+        let fast_time = graph.path_travel_time(&path, fast.speed_m_per_s);
+        assert!(
+            fast_time <= walk_time,
+            "jaunting car ({fast_time} min) should be <= walking ({walk_time} min)"
+        );
     }
 }

--- a/crates/parish-core/src/world/transport.rs
+++ b/crates/parish-core/src/world/transport.rs
@@ -1,0 +1,133 @@
+//! Transport modes — configurable movement speeds for travel time calculation.
+//!
+//! Each transport mode defines a speed (m/s) and a display label used in
+//! travel narration. Mods provide a `transport.toml` with available modes;
+//! if absent, the engine falls back to walking (1.25 m/s, "on foot").
+
+use serde::{Deserialize, Serialize};
+
+/// Default walking speed in meters per second (~4.5 km/h).
+const DEFAULT_WALKING_SPEED: f64 = 1.25;
+
+/// A method of travel with a speed and display label.
+///
+/// Used to calculate coordinate-based travel times and to format
+/// narration text (e.g., "23 minutes on foot").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransportMode {
+    /// Machine identifier (e.g., `"walking"`, `"jaunting_car"`).
+    pub id: String,
+    /// Display label for narration (e.g., `"on foot"`, `"in a jaunting car"`).
+    pub label: String,
+    /// Travel speed in meters per second.
+    pub speed_m_per_s: f64,
+}
+
+impl TransportMode {
+    /// Returns the default walking transport mode.
+    pub fn walking() -> Self {
+        Self {
+            id: "walking".to_string(),
+            label: "on foot".to_string(),
+            speed_m_per_s: DEFAULT_WALKING_SPEED,
+        }
+    }
+}
+
+/// Collection of available transport modes loaded from a mod's `transport.toml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransportConfig {
+    /// Which mode id is the default for player travel.
+    pub default: String,
+    /// All available transport modes.
+    pub modes: Vec<TransportMode>,
+}
+
+impl TransportConfig {
+    /// Returns the default transport mode.
+    pub fn default_mode(&self) -> &TransportMode {
+        self.modes
+            .iter()
+            .find(|m| m.id == self.default)
+            .unwrap_or_else(|| {
+                self.modes
+                    .first()
+                    .expect("TransportConfig must have at least one mode")
+            })
+    }
+
+    /// Looks up a transport mode by id.
+    pub fn get_mode(&self, id: &str) -> Option<&TransportMode> {
+        self.modes.iter().find(|m| m.id == id)
+    }
+}
+
+impl Default for TransportConfig {
+    fn default() -> Self {
+        Self {
+            default: "walking".to_string(),
+            modes: vec![TransportMode::walking()],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_walking_default() {
+        let mode = TransportMode::walking();
+        assert_eq!(mode.id, "walking");
+        assert_eq!(mode.label, "on foot");
+        assert!((mode.speed_m_per_s - 1.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_transport_config_default() {
+        let config = TransportConfig::default();
+        assert_eq!(config.default, "walking");
+        assert_eq!(config.modes.len(), 1);
+        assert_eq!(config.default_mode().id, "walking");
+    }
+
+    #[test]
+    fn test_transport_config_deserialize() {
+        let toml_str = r#"
+default = "walking"
+
+[[modes]]
+id = "walking"
+label = "on foot"
+speed_m_per_s = 1.25
+
+[[modes]]
+id = "jaunting_car"
+label = "in a jaunting car"
+speed_m_per_s = 4.0
+"#;
+        let config: TransportConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.modes.len(), 2);
+        assert_eq!(config.default_mode().id, "walking");
+
+        let car = config.get_mode("jaunting_car").unwrap();
+        assert_eq!(car.label, "in a jaunting car");
+        assert!((car.speed_m_per_s - 4.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_get_mode_not_found() {
+        let config = TransportConfig::default();
+        assert!(config.get_mode("horse").is_none());
+    }
+
+    #[test]
+    fn test_default_mode_fallback() {
+        let config = TransportConfig {
+            default: "nonexistent".to_string(),
+            modes: vec![TransportMode::walking()],
+        };
+        // Falls back to first mode when default id not found
+        assert_eq!(config.default_mode().id, "walking");
+    }
+}

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -20,6 +20,7 @@ use tower_http::services::ServeDir;
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceQueue, new_inference_log, spawn_inference_worker};
 use parish_core::npc::manager::NpcManager;
+use parish_core::world::transport::TransportConfig;
 use parish_core::world::{LocationId, WorldState};
 
 use state::{AppState, GameConfig, build_app_state};
@@ -51,7 +52,15 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     let (client, config) = build_client_and_config();
     let cloud_client = build_cloud_client();
 
-    let state = build_app_state(world, npc_manager, client.clone(), config, cloud_client);
+    let transport = TransportConfig::default();
+    let state = build_app_state(
+        world,
+        npc_manager,
+        client.clone(),
+        config,
+        cloud_client,
+        transport,
+    );
 
     // Initialize inference queue
     if let Some(ref client) = client {
@@ -96,7 +105,8 @@ fn spawn_background_ticks(state: Arc<AppState>) {
             tokio::time::sleep(Duration::from_secs(5)).await;
             {
                 let world = state_tick.world.lock().await;
-                let snapshot = parish_core::ipc::snapshot_from_world(&world);
+                let transport = state_tick.transport.default_mode();
+                let snapshot = parish_core::ipc::snapshot_from_world(&world, transport);
                 state_tick.event_bus.emit("world-update", &snapshot);
             }
             {

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -37,7 +37,8 @@ static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 /// `GET /api/world-snapshot` — returns the current world snapshot.
 pub async fn get_world_snapshot(State(state): State<Arc<AppState>>) -> Json<WorldSnapshot> {
     let world = state.world.lock().await;
-    Json(parish_core::ipc::snapshot_from_world(&world))
+    let transport = state.transport.default_mode();
+    Json(parish_core::ipc::snapshot_from_world(&world, transport))
 }
 
 /// `GET /api/map` — returns the map with all locations and edges.
@@ -390,9 +391,10 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
     );
 
     let world = state.world.lock().await;
+    let transport = state.transport.default_mode();
     state.event_bus.emit(
         "world-update",
-        &parish_core::ipc::snapshot_from_world(&world),
+        &parish_core::ipc::snapshot_from_world(&world, transport),
     );
 }
 
@@ -440,7 +442,8 @@ async fn handle_game_input(raw: String, state: &Arc<AppState>) {
 async fn handle_movement(target: &str, state: &Arc<AppState>) {
     let result = {
         let world = state.world.lock().await;
-        movement::resolve_movement(target, &world.graph, world.player_location)
+        let transport = state.transport.default_mode();
+        movement::resolve_movement(target, &world.graph, world.player_location, transport)
     };
 
     match result {
@@ -482,9 +485,10 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
             handle_look(state).await;
 
             let world = state.world.lock().await;
+            let transport = state.transport.default_mode();
             state.event_bus.emit(
                 "world-update",
-                &parish_core::ipc::snapshot_from_world(&world),
+                &parish_core::ipc::snapshot_from_world(&world, transport),
             );
         }
         MovementResult::AlreadyHere => {
@@ -498,7 +502,13 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
         }
         MovementResult::NotFound(name) => {
             let world = state.world.lock().await;
-            let exits = format_exits(world.player_location, &world.graph);
+            let transport = state.transport.default_mode();
+            let exits = format_exits(
+                world.player_location,
+                &world.graph,
+                transport.speed_m_per_s,
+                &transport.label,
+            );
             state.event_bus.emit(
                 "text-log",
                 &TextLogPayload {
@@ -532,7 +542,13 @@ async fn handle_look(state: &Arc<AppState>) {
         world.current_location().description.clone()
     };
 
-    let exits = format_exits(world.player_location, &world.graph);
+    let transport = state.transport.default_mode();
+    let exits = format_exits(
+        world.player_location,
+        &world.graph,
+        transport.speed_m_per_s,
+        &transport.label,
+    );
 
     state.event_bus.emit(
         "text-log",

--- a/crates/parish-server/src/state.rs
+++ b/crates/parish-server/src/state.rs
@@ -8,6 +8,7 @@ use parish_core::inference::InferenceQueue;
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::npc::manager::NpcManager;
 use parish_core::world::WorldState;
+use parish_core::world::transport::TransportConfig;
 
 /// Shared mutable game state for the web server.
 ///
@@ -28,6 +29,8 @@ pub struct AppState {
     pub config: Mutex<GameConfig>,
     /// Broadcast channel for pushing events to WebSocket clients.
     pub event_bus: EventBus,
+    /// Transport mode configuration from the loaded game mod.
+    pub transport: TransportConfig,
 }
 
 /// Mutable runtime configuration for provider, model, and cloud settings.
@@ -123,6 +126,7 @@ pub fn build_app_state(
     client: Option<OpenAiClient>,
     config: GameConfig,
     cloud_client: Option<OpenAiClient>,
+    transport: TransportConfig,
 ) -> Arc<AppState> {
     Arc::new(AppState {
         world: Mutex::new(world),
@@ -132,6 +136,7 @@ pub fn build_app_state(
         cloud_client: Mutex::new(cloud_client),
         config: Mutex::new(config),
         event_bus: EventBus::new(256),
+        transport,
     })
 }
 

--- a/data/parish.json
+++ b/data/parish.json
@@ -6,20 +6,43 @@
             "description_template": "A quiet crossroads where four narrow roads meet. A weathered stone wall lines the eastern side, half-hidden by brambles. The {weather} sky stretches over the flat midlands. It is {time}.",
             "indoor": false,
             "public": true,
-            "lat": 53.6180,
-            "lon": -8.0950,
+            "lat": 53.618,
+            "lon": -8.095,
             "connections": [
-                {"target": 2, "traversal_minutes": 3, "path_description": "a short lane past a row of cottages"},
-                {"target": 3, "traversal_minutes": 5, "path_description": "a winding boreen lined with hawthorn"},
-                {"target": 4, "traversal_minutes": 2, "path_description": "the road past a hand-lettered sign"},
-                {"target": 6, "traversal_minutes": 4, "path_description": "a muddy path along the schoolmaster's wall"},
-                {"target": 9, "traversal_minutes": 8, "path_description": "a narrow road between stone walls"},
-                {"target": 13, "traversal_minutes": 3, "path_description": "a few steps across the road"},
-                {"target": 15, "traversal_minutes": 6, "path_description": "the Kilteevan road heading south past low fields"}
+                {
+                    "target": 2,
+                    "path_description": "a short lane past a row of cottages"
+                },
+                {
+                    "target": 3,
+                    "path_description": "a winding boreen lined with hawthorn"
+                },
+                {
+                    "target": 4,
+                    "path_description": "the road past a hand-lettered sign"
+                },
+                {
+                    "target": 6,
+                    "path_description": "a muddy path along the schoolmaster's wall"
+                },
+                {
+                    "target": 9,
+                    "path_description": "a narrow road between stone walls"
+                },
+                {
+                    "target": 13,
+                    "path_description": "a few steps across the road"
+                },
+                {
+                    "target": 15,
+                    "path_description": "the Kilteevan road heading south past low fields"
+                }
             ],
             "associated_npcs": [],
-            "mythological_significance": "Crossroads hold power in Irish folklore — a place between places, where the veil is thin.",
-            "aliases": ["crossroads"]
+            "mythological_significance": "Crossroads hold power in Irish folklore \u2014 a place between places, where the veil is thin.",
+            "aliases": [
+                "crossroads"
+            ]
         },
         {
             "id": 2,
@@ -30,11 +53,20 @@
             "lat": 53.6195,
             "lon": -8.0925,
             "connections": [
-                {"target": 1, "traversal_minutes": 3, "path_description": "the lane back to the crossroads"}
+                {
+                    "target": 1,
+                    "path_description": "the lane back to the crossroads"
+                }
             ],
-            "associated_npcs": [1],
+            "associated_npcs": [
+                1
+            ],
             "mythological_significance": null,
-            "aliases": ["pub", "the pub", "tavern"]
+            "aliases": [
+                "pub",
+                "the pub",
+                "tavern"
+            ]
         },
         {
             "id": 3,
@@ -43,14 +75,24 @@
             "indoor": false,
             "public": true,
             "lat": 53.6215,
-            "lon": -8.0990,
+            "lon": -8.099,
             "connections": [
-                {"target": 1, "traversal_minutes": 5, "path_description": "the boreen back to the crossroads"},
-                {"target": 12, "traversal_minutes": 6, "path_description": "a muddy track past the graveyard wall"}
+                {
+                    "target": 1,
+                    "path_description": "the boreen back to the crossroads"
+                },
+                {
+                    "target": 12,
+                    "path_description": "a muddy track past the graveyard wall"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": "Built on the site of an older holy well dedicated to Brigid, the goddess-turned-saint.",
-            "aliases": ["church", "the church", "chapel"]
+            "aliases": [
+                "church",
+                "the church",
+                "chapel"
+            ]
         },
         {
             "id": 4,
@@ -61,11 +103,19 @@
             "lat": 53.6175,
             "lon": -8.0935,
             "connections": [
-                {"target": 1, "traversal_minutes": 2, "path_description": "back across to the crossroads"}
+                {
+                    "target": 1,
+                    "path_description": "back across to the crossroads"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null,
-            "aliases": ["post office", "post", "letters", "mail"]
+            "aliases": [
+                "post office",
+                "post",
+                "letters",
+                "mail"
+            ]
         },
         {
             "id": 5,
@@ -74,13 +124,20 @@
             "indoor": false,
             "public": true,
             "lat": 53.6135,
-            "lon": -8.1020,
+            "lon": -8.102,
             "connections": [
-                {"target": 6, "traversal_minutes": 3, "path_description": "a beaten path back past the schoolmaster's cabin"}
+                {
+                    "target": 6,
+                    "path_description": "a beaten path back past the schoolmaster's cabin"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null,
-            "aliases": ["pitch", "the pitch", "hurling field"]
+            "aliases": [
+                "pitch",
+                "the pitch",
+                "hurling field"
+            ]
         },
         {
             "id": 6,
@@ -89,14 +146,23 @@
             "indoor": false,
             "public": true,
             "lat": 53.6155,
-            "lon": -8.0990,
+            "lon": -8.099,
             "connections": [
-                {"target": 1, "traversal_minutes": 4, "path_description": "the muddy path back to the crossroads"},
-                {"target": 5, "traversal_minutes": 3, "path_description": "a beaten path down to the hurling green"}
+                {
+                    "target": 1,
+                    "path_description": "the muddy path back to the crossroads"
+                },
+                {
+                    "target": 5,
+                    "path_description": "a beaten path down to the hurling green"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null,
-            "aliases": ["school", "schoolhouse"]
+            "aliases": [
+                "school",
+                "schoolhouse"
+            ]
         },
         {
             "id": 7,
@@ -104,15 +170,28 @@
             "description_template": "The stony shore of Lough Ree stretches out before you. The great lake shimmers under the {weather} sky. Small islands dot the water in the distance. It is {time}.",
             "indoor": false,
             "public": true,
-            "lat": 53.6210,
-            "lon": -8.0430,
+            "lat": 53.621,
+            "lon": -8.043,
             "connections": [
-                {"target": 8, "traversal_minutes": 6, "path_description": "a lakeside path through reeds and willow"},
-                {"target": 11, "traversal_minutes": 10, "path_description": "a rough track climbing away from the shore"}
+                {
+                    "target": 8,
+                    "path_description": "a lakeside path through reeds and willow"
+                },
+                {
+                    "target": 11,
+                    "path_description": "a rough track climbing away from the shore"
+                }
             ],
             "associated_npcs": [],
-            "mythological_significance": "Lough Ree is said to be home to a monster — the Lough Ree wurm, Ireland's lesser-known cousin of Nessie.",
-            "aliases": ["coast", "the coast", "lakeside", "the lake", "shore", "lakeshore"]
+            "mythological_significance": "Lough Ree is said to be home to a monster \u2014 the Lough Ree wurm, Ireland's lesser-known cousin of Nessie.",
+            "aliases": [
+                "coast",
+                "the coast",
+                "lakeside",
+                "the lake",
+                "shore",
+                "lakeshore"
+            ]
         },
         {
             "id": 8,
@@ -120,15 +199,26 @@
             "description_template": "A sheltered bay on Lough Ree. Boats bob at their moorings. The old boathouse leans into the wind. It is {time} and the sky is {weather}.",
             "indoor": false,
             "public": true,
-            "lat": 53.6160,
-            "lon": -8.0480,
+            "lat": 53.616,
+            "lon": -8.048,
             "connections": [
-                {"target": 7, "traversal_minutes": 6, "path_description": "the lakeside path back along the shore"},
-                {"target": 9, "traversal_minutes": 7, "path_description": "a lane winding uphill from the bay"}
+                {
+                    "target": 7,
+                    "path_description": "the lakeside path back along the shore"
+                },
+                {
+                    "target": 9,
+                    "path_description": "a lane winding uphill from the bay"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null,
-            "aliases": ["bay", "the bay", "harbour", "harbor"]
+            "aliases": [
+                "bay",
+                "the bay",
+                "harbour",
+                "harbor"
+            ]
         },
         {
             "id": 9,
@@ -136,16 +226,28 @@
             "description_template": "A working farm with a whitewashed house and stone outbuildings roofed in thatch. Cattle graze in the near field. A sheepdog watches from the gate. It is {time}. The sky is {weather}.",
             "indoor": false,
             "public": false,
-            "lat": 53.6200,
-            "lon": -8.0680,
+            "lat": 53.62,
+            "lon": -8.068,
             "connections": [
-                {"target": 1, "traversal_minutes": 8, "path_description": "the narrow road back between stone walls"},
-                {"target": 8, "traversal_minutes": 7, "path_description": "a lane winding down toward the bay"},
-                {"target": 10, "traversal_minutes": 5, "path_description": "a boreen through a gap in the hedge"}
+                {
+                    "target": 1,
+                    "path_description": "the narrow road back between stone walls"
+                },
+                {
+                    "target": 8,
+                    "path_description": "a lane winding down toward the bay"
+                },
+                {
+                    "target": 10,
+                    "path_description": "a boreen through a gap in the hedge"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null,
-            "aliases": ["murphy's", "murphys"]
+            "aliases": [
+                "murphy's",
+                "murphys"
+            ]
         },
         {
             "id": 10,
@@ -154,30 +256,50 @@
             "indoor": false,
             "public": false,
             "lat": 53.6185,
-            "lon": -8.0600,
+            "lon": -8.06,
             "connections": [
-                {"target": 9, "traversal_minutes": 5, "path_description": "a boreen back through the hedge to Murphy's"},
-                {"target": 14, "traversal_minutes": 6, "path_description": "a soggy track across the lower field"}
+                {
+                    "target": 9,
+                    "path_description": "a boreen back through the hedge to Murphy's"
+                },
+                {
+                    "target": 14,
+                    "path_description": "a soggy track across the lower field"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null,
-            "aliases": ["o'brien's", "obriens"]
+            "aliases": [
+                "o'brien's",
+                "obriens"
+            ]
         },
         {
             "id": 11,
             "name": "The Fairy Fort",
-            "description_template": "An ancient ring fort — a raised circular mound ringed by hawthorn and elder. The air feels different here, heavy and watchful. It is {time}. The sky is {weather}.",
+            "description_template": "An ancient ring fort \u2014 a raised circular mound ringed by hawthorn and elder. The air feels different here, heavy and watchful. It is {time}. The sky is {weather}.",
             "indoor": false,
             "public": true,
-            "lat": 53.6270,
-            "lon": -8.0520,
+            "lat": 53.627,
+            "lon": -8.052,
             "connections": [
-                {"target": 7, "traversal_minutes": 10, "path_description": "the rough track back down to the shore"},
-                {"target": 12, "traversal_minutes": 8, "path_description": "a barely visible path through gorse and bracken"}
+                {
+                    "target": 7,
+                    "path_description": "the rough track back down to the shore"
+                },
+                {
+                    "target": 12,
+                    "path_description": "a barely visible path through gorse and bracken"
+                }
             ],
             "associated_npcs": [],
-            "mythological_significance": "A rath said to be home to the sídhe. No farmer has ever ploughed within twenty yards of it. Those who disturb fairy forts are said to suffer terrible misfortune.",
-            "aliases": ["rath", "ring fort", "the rath", "fort"]
+            "mythological_significance": "A rath said to be home to the s\u00eddhe. No farmer has ever ploughed within twenty yards of it. Those who disturb fairy forts are said to suffer terrible misfortune.",
+            "aliases": [
+                "rath",
+                "ring fort",
+                "the rath",
+                "fort"
+            ]
         },
         {
             "id": 12,
@@ -185,16 +307,30 @@
             "description_template": "A rough track cutting through blanket bog. Turf banks stand in neat rows, drying in the wind. The {weather} sky presses down. Pools of dark water gleam between the heather. It is {time}.",
             "indoor": false,
             "public": true,
-            "lat": 53.6260,
-            "lon": -8.0880,
+            "lat": 53.626,
+            "lon": -8.088,
             "connections": [
-                {"target": 3, "traversal_minutes": 6, "path_description": "the muddy track back toward the church"},
-                {"target": 11, "traversal_minutes": 8, "path_description": "a barely visible path through gorse to the fort"},
-                {"target": 14, "traversal_minutes": 7, "path_description": "a squelching path along the bog's edge"}
+                {
+                    "target": 3,
+                    "path_description": "the muddy track back toward the church"
+                },
+                {
+                    "target": 11,
+                    "path_description": "a barely visible path through gorse to the fort"
+                },
+                {
+                    "target": 14,
+                    "path_description": "a squelching path along the bog's edge"
+                }
             ],
             "associated_npcs": [],
-            "mythological_significance": "Bogs preserve everything — bodies, butter, memories. People say you can hear voices in the wind here on certain nights.",
-            "aliases": ["the bog", "turf bog", "bog", "bogland"]
+            "mythological_significance": "Bogs preserve everything \u2014 bodies, butter, memories. People say you can hear voices in the wind here on certain nights.",
+            "aliases": [
+                "the bog",
+                "turf bog",
+                "bog",
+                "bogland"
+            ]
         },
         {
             "id": 13,
@@ -202,14 +338,22 @@
             "description_template": "A small general shop crammed with everything from spades and tallow candles to bolts of cloth and bags of meal. The bell above the door jangles. It is {time}. Outside, the weather is {weather}.",
             "indoor": true,
             "public": true,
-            "lat": 53.6170,
-            "lon": -8.0960,
+            "lat": 53.617,
+            "lon": -8.096,
             "connections": [
-                {"target": 1, "traversal_minutes": 3, "path_description": "a few steps back across the road to the crossroads"}
+                {
+                    "target": 1,
+                    "path_description": "a few steps back across the road to the crossroads"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null,
-            "aliases": ["store", "the store", "general store", "shop"]
+            "aliases": [
+                "store",
+                "the store",
+                "general store",
+                "shop"
+            ]
         },
         {
             "id": 14,
@@ -217,30 +361,48 @@
             "description_template": "A squat stone lime kiln standing at the edge of the bog. On burning days the smoke rises thick and white. A flat patch of ground beside it serves as a gathering place. It is {time}. The weather is {weather}.",
             "indoor": false,
             "public": true,
-            "lat": 53.6230,
-            "lon": -8.0720,
+            "lat": 53.623,
+            "lon": -8.072,
             "connections": [
-                {"target": 10, "traversal_minutes": 6, "path_description": "the soggy track back up to O'Brien's"},
-                {"target": 12, "traversal_minutes": 7, "path_description": "a path along the bog's edge back to the road"}
+                {
+                    "target": 10,
+                    "path_description": "the soggy track back up to O'Brien's"
+                },
+                {
+                    "target": 12,
+                    "path_description": "a path along the bog's edge back to the road"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null,
-            "aliases": ["kiln", "the kiln", "limekiln"]
+            "aliases": [
+                "kiln",
+                "the kiln",
+                "limekiln"
+            ]
         },
         {
             "id": 15,
             "name": "Kilteevan Village",
-            "description_template": "The small village of Kilteevan — a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The {weather} sky hangs over the quiet street. It is {time}.",
+            "description_template": "The small village of Kilteevan \u2014 a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The {weather} sky hangs over the quiet street. It is {time}.",
             "indoor": false,
             "public": true,
             "lat": 53.6105,
-            "lon": -8.1050,
+            "lon": -8.105,
             "connections": [
-                {"target": 1, "traversal_minutes": 6, "path_description": "the road north past low fields to the crossroads"}
+                {
+                    "target": 1,
+                    "path_description": "the road north past low fields to the crossroads"
+                }
             ],
             "associated_npcs": [],
-            "mythological_significance": "Kilteevan — Cill Tíobáin, the church of St. Tíobán. The ruins of the old church stand in a field nearby, half-swallowed by ivy and elder.",
-            "aliases": ["town", "the town", "village", "kilteevan"]
+            "mythological_significance": "Kilteevan \u2014 Cill T\u00edob\u00e1in, the church of St. T\u00edob\u00e1n. The ruins of the old church stand in a field nearby, half-swallowed by ivy and elder.",
+            "aliases": [
+                "town",
+                "the town",
+                "village",
+                "kilteevan"
+            ]
         }
     ]
 }

--- a/mods/kilteevan-1820/mod.toml
+++ b/mods/kilteevan-1820/mod.toml
@@ -20,6 +20,7 @@ encounters = "encounters.json"
 loading = "loading.toml"
 ui = "ui.toml"
 pronunciations = "pronunciations.json"
+transport = "transport.toml"
 
 [prompts]
 tier1_system = "prompts/tier1_system.txt"

--- a/mods/kilteevan-1820/transport.toml
+++ b/mods/kilteevan-1820/transport.toml
@@ -1,0 +1,6 @@
+default = "walking"
+
+[[modes]]
+id = "walking"
+label = "on foot"
+speed_m_per_s = 1.25

--- a/mods/kilteevan-1820/world.json
+++ b/mods/kilteevan-1820/world.json
@@ -6,19 +6,40 @@
             "description_template": "A quiet crossroads where four narrow roads meet. A weathered stone wall lines the eastern side, half-hidden by brambles. The {weather} sky stretches over the flat midlands. It is {time}.",
             "indoor": false,
             "public": true,
-            "lat": 53.6180,
-            "lon": -8.0950,
+            "lat": 53.618,
+            "lon": -8.095,
             "connections": [
-                {"target": 2, "traversal_minutes": 3, "path_description": "a short lane past a row of cottages"},
-                {"target": 3, "traversal_minutes": 5, "path_description": "a winding boreen lined with hawthorn"},
-                {"target": 4, "traversal_minutes": 2, "path_description": "the road past a hand-lettered sign"},
-                {"target": 6, "traversal_minutes": 4, "path_description": "a muddy path along the schoolmaster's wall"},
-                {"target": 9, "traversal_minutes": 8, "path_description": "a narrow road between stone walls"},
-                {"target": 13, "traversal_minutes": 3, "path_description": "a few steps across the road"},
-                {"target": 15, "traversal_minutes": 6, "path_description": "the Kilteevan road heading south past low fields"}
+                {
+                    "target": 2,
+                    "path_description": "a short lane past a row of cottages"
+                },
+                {
+                    "target": 3,
+                    "path_description": "a winding boreen lined with hawthorn"
+                },
+                {
+                    "target": 4,
+                    "path_description": "the road past a hand-lettered sign"
+                },
+                {
+                    "target": 6,
+                    "path_description": "a muddy path along the schoolmaster's wall"
+                },
+                {
+                    "target": 9,
+                    "path_description": "a narrow road between stone walls"
+                },
+                {
+                    "target": 13,
+                    "path_description": "a few steps across the road"
+                },
+                {
+                    "target": 15,
+                    "path_description": "the Kilteevan road heading south past low fields"
+                }
             ],
             "associated_npcs": [],
-            "mythological_significance": "Crossroads hold power in Irish folklore — a place between places, where the veil is thin."
+            "mythological_significance": "Crossroads hold power in Irish folklore \u2014 a place between places, where the veil is thin."
         },
         {
             "id": 2,
@@ -29,9 +50,14 @@
             "lat": 53.6195,
             "lon": -8.0925,
             "connections": [
-                {"target": 1, "traversal_minutes": 3, "path_description": "the lane back to the crossroads"}
+                {
+                    "target": 1,
+                    "path_description": "the lane back to the crossroads"
+                }
             ],
-            "associated_npcs": [1],
+            "associated_npcs": [
+                1
+            ],
             "mythological_significance": null
         },
         {
@@ -41,10 +67,16 @@
             "indoor": false,
             "public": true,
             "lat": 53.6215,
-            "lon": -8.0990,
+            "lon": -8.099,
             "connections": [
-                {"target": 1, "traversal_minutes": 5, "path_description": "the boreen back to the crossroads"},
-                {"target": 12, "traversal_minutes": 6, "path_description": "a muddy track past the graveyard wall"}
+                {
+                    "target": 1,
+                    "path_description": "the boreen back to the crossroads"
+                },
+                {
+                    "target": 12,
+                    "path_description": "a muddy track past the graveyard wall"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": "Built on the site of an older holy well dedicated to Brigid, the goddess-turned-saint."
@@ -58,7 +90,10 @@
             "lat": 53.6175,
             "lon": -8.0935,
             "connections": [
-                {"target": 1, "traversal_minutes": 2, "path_description": "back across to the crossroads"}
+                {
+                    "target": 1,
+                    "path_description": "back across to the crossroads"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null
@@ -70,9 +105,12 @@
             "indoor": false,
             "public": true,
             "lat": 53.6135,
-            "lon": -8.1020,
+            "lon": -8.102,
             "connections": [
-                {"target": 6, "traversal_minutes": 3, "path_description": "a beaten path back past the schoolmaster's cabin"}
+                {
+                    "target": 6,
+                    "path_description": "a beaten path back past the schoolmaster's cabin"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null
@@ -84,10 +122,16 @@
             "indoor": false,
             "public": true,
             "lat": 53.6155,
-            "lon": -8.0990,
+            "lon": -8.099,
             "connections": [
-                {"target": 1, "traversal_minutes": 4, "path_description": "the muddy path back to the crossroads"},
-                {"target": 5, "traversal_minutes": 3, "path_description": "a beaten path down to the hurling green"}
+                {
+                    "target": 1,
+                    "path_description": "the muddy path back to the crossroads"
+                },
+                {
+                    "target": 5,
+                    "path_description": "a beaten path down to the hurling green"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null
@@ -98,14 +142,20 @@
             "description_template": "The stony shore of Lough Ree stretches out before you. The great lake shimmers under the {weather} sky. Small islands dot the water in the distance. It is {time}.",
             "indoor": false,
             "public": true,
-            "lat": 53.6210,
-            "lon": -8.0430,
+            "lat": 53.621,
+            "lon": -8.043,
             "connections": [
-                {"target": 8, "traversal_minutes": 6, "path_description": "a lakeside path through reeds and willow"},
-                {"target": 11, "traversal_minutes": 10, "path_description": "a rough track climbing away from the shore"}
+                {
+                    "target": 8,
+                    "path_description": "a lakeside path through reeds and willow"
+                },
+                {
+                    "target": 11,
+                    "path_description": "a rough track climbing away from the shore"
+                }
             ],
             "associated_npcs": [],
-            "mythological_significance": "Lough Ree is said to be home to a monster — the Lough Ree wurm, Ireland's lesser-known cousin of Nessie."
+            "mythological_significance": "Lough Ree is said to be home to a monster \u2014 the Lough Ree wurm, Ireland's lesser-known cousin of Nessie."
         },
         {
             "id": 8,
@@ -113,11 +163,17 @@
             "description_template": "A sheltered bay on Lough Ree. Boats bob at their moorings. The old boathouse leans into the wind. It is {time} and the sky is {weather}.",
             "indoor": false,
             "public": true,
-            "lat": 53.6160,
-            "lon": -8.0480,
+            "lat": 53.616,
+            "lon": -8.048,
             "connections": [
-                {"target": 7, "traversal_minutes": 6, "path_description": "the lakeside path back along the shore"},
-                {"target": 9, "traversal_minutes": 7, "path_description": "a lane winding uphill from the bay"}
+                {
+                    "target": 7,
+                    "path_description": "the lakeside path back along the shore"
+                },
+                {
+                    "target": 9,
+                    "path_description": "a lane winding uphill from the bay"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null
@@ -128,12 +184,21 @@
             "description_template": "A working farm with a whitewashed house and stone outbuildings roofed in thatch. Cattle graze in the near field. A sheepdog watches from the gate. It is {time}. The sky is {weather}.",
             "indoor": false,
             "public": false,
-            "lat": 53.6200,
-            "lon": -8.0680,
+            "lat": 53.62,
+            "lon": -8.068,
             "connections": [
-                {"target": 1, "traversal_minutes": 8, "path_description": "the narrow road back between stone walls"},
-                {"target": 8, "traversal_minutes": 7, "path_description": "a lane winding down toward the bay"},
-                {"target": 10, "traversal_minutes": 5, "path_description": "a boreen through a gap in the hedge"}
+                {
+                    "target": 1,
+                    "path_description": "the narrow road back between stone walls"
+                },
+                {
+                    "target": 8,
+                    "path_description": "a lane winding down toward the bay"
+                },
+                {
+                    "target": 10,
+                    "path_description": "a boreen through a gap in the hedge"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null
@@ -145,10 +210,16 @@
             "indoor": false,
             "public": false,
             "lat": 53.6185,
-            "lon": -8.0600,
+            "lon": -8.06,
             "connections": [
-                {"target": 9, "traversal_minutes": 5, "path_description": "a boreen back through the hedge to Murphy's"},
-                {"target": 14, "traversal_minutes": 6, "path_description": "a soggy track across the lower field"}
+                {
+                    "target": 9,
+                    "path_description": "a boreen back through the hedge to Murphy's"
+                },
+                {
+                    "target": 14,
+                    "path_description": "a soggy track across the lower field"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null
@@ -156,17 +227,23 @@
         {
             "id": 11,
             "name": "The Fairy Fort",
-            "description_template": "An ancient ring fort — a raised circular mound ringed by hawthorn and elder. The air feels different here, heavy and watchful. It is {time}. The sky is {weather}.",
+            "description_template": "An ancient ring fort \u2014 a raised circular mound ringed by hawthorn and elder. The air feels different here, heavy and watchful. It is {time}. The sky is {weather}.",
             "indoor": false,
             "public": true,
-            "lat": 53.6270,
-            "lon": -8.0520,
+            "lat": 53.627,
+            "lon": -8.052,
             "connections": [
-                {"target": 7, "traversal_minutes": 10, "path_description": "the rough track back down to the shore"},
-                {"target": 12, "traversal_minutes": 8, "path_description": "a barely visible path through gorse and bracken"}
+                {
+                    "target": 7,
+                    "path_description": "the rough track back down to the shore"
+                },
+                {
+                    "target": 12,
+                    "path_description": "a barely visible path through gorse and bracken"
+                }
             ],
             "associated_npcs": [],
-            "mythological_significance": "A rath said to be home to the sídhe. No farmer has ever ploughed within twenty yards of it. Those who disturb fairy forts are said to suffer terrible misfortune."
+            "mythological_significance": "A rath said to be home to the s\u00eddhe. No farmer has ever ploughed within twenty yards of it. Those who disturb fairy forts are said to suffer terrible misfortune."
         },
         {
             "id": 12,
@@ -174,15 +251,24 @@
             "description_template": "A rough track cutting through blanket bog. Turf banks stand in neat rows, drying in the wind. The {weather} sky presses down. Pools of dark water gleam between the heather. It is {time}.",
             "indoor": false,
             "public": true,
-            "lat": 53.6260,
-            "lon": -8.0880,
+            "lat": 53.626,
+            "lon": -8.088,
             "connections": [
-                {"target": 3, "traversal_minutes": 6, "path_description": "the muddy track back toward the church"},
-                {"target": 11, "traversal_minutes": 8, "path_description": "a barely visible path through gorse to the fort"},
-                {"target": 14, "traversal_minutes": 7, "path_description": "a squelching path along the bog's edge"}
+                {
+                    "target": 3,
+                    "path_description": "the muddy track back toward the church"
+                },
+                {
+                    "target": 11,
+                    "path_description": "a barely visible path through gorse to the fort"
+                },
+                {
+                    "target": 14,
+                    "path_description": "a squelching path along the bog's edge"
+                }
             ],
             "associated_npcs": [],
-            "mythological_significance": "Bogs preserve everything — bodies, butter, memories. People say you can hear voices in the wind here on certain nights."
+            "mythological_significance": "Bogs preserve everything \u2014 bodies, butter, memories. People say you can hear voices in the wind here on certain nights."
         },
         {
             "id": 13,
@@ -190,10 +276,13 @@
             "description_template": "A small general shop crammed with everything from spades and tallow candles to bolts of cloth and bags of meal. The bell above the door jangles. It is {time}. Outside, the weather is {weather}.",
             "indoor": true,
             "public": true,
-            "lat": 53.6170,
-            "lon": -8.0960,
+            "lat": 53.617,
+            "lon": -8.096,
             "connections": [
-                {"target": 1, "traversal_minutes": 3, "path_description": "a few steps back across the road to the crossroads"}
+                {
+                    "target": 1,
+                    "path_description": "a few steps back across the road to the crossroads"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null
@@ -204,11 +293,17 @@
             "description_template": "A squat stone lime kiln standing at the edge of the bog. On burning days the smoke rises thick and white. A flat patch of ground beside it serves as a gathering place. It is {time}. The weather is {weather}.",
             "indoor": false,
             "public": true,
-            "lat": 53.6230,
-            "lon": -8.0720,
+            "lat": 53.623,
+            "lon": -8.072,
             "connections": [
-                {"target": 10, "traversal_minutes": 6, "path_description": "the soggy track back up to O'Brien's"},
-                {"target": 12, "traversal_minutes": 7, "path_description": "a path along the bog's edge back to the road"}
+                {
+                    "target": 10,
+                    "path_description": "the soggy track back up to O'Brien's"
+                },
+                {
+                    "target": 12,
+                    "path_description": "a path along the bog's edge back to the road"
+                }
             ],
             "associated_npcs": [],
             "mythological_significance": null
@@ -216,16 +311,19 @@
         {
             "id": 15,
             "name": "Kilteevan Village",
-            "description_template": "The small village of Kilteevan — a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The {weather} sky hangs over the quiet street. It is {time}.",
+            "description_template": "The small village of Kilteevan \u2014 a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The {weather} sky hangs over the quiet street. It is {time}.",
             "indoor": false,
             "public": true,
             "lat": 53.6105,
-            "lon": -8.1050,
+            "lon": -8.105,
             "connections": [
-                {"target": 1, "traversal_minutes": 6, "path_description": "the road north past low fields to the crossroads"}
+                {
+                    "target": 1,
+                    "path_description": "the road north past low fields to the crossroads"
+                }
             ],
             "associated_npcs": [],
-            "mythological_significance": "Kilteevan — Cill Tíobáin, the church of St. Tíobán. The ruins of the old church stand in a field nearby, half-swallowed by ivy and elder."
+            "mythological_significance": "Kilteevan \u2014 Cill T\u00edob\u00e1in, the church of St. T\u00edob\u00e1n. The ruins of the old church stand in a field nearby, half-swallowed by ivy and elder."
         }
     ]
 }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,6 +1,10 @@
 use std::process::Command;
 
 fn main() {
+    // Always rerun so branch/timestamp stay fresh
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs/heads");
+
     // Embed git branch name at compile time
     let branch = Command::new("git")
         .args(["rev-parse", "--abbrev-ref", "HEAD"])

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -19,6 +19,7 @@ use parish_core::npc::ticks;
 use parish_core::world::description::{format_exits, render_description};
 use parish_core::world::movement::{self, MovementResult};
 use parish_core::world::palette::compute_palette;
+use parish_core::world::transport::TransportMode;
 
 use crate::events::{
     EVENT_SAVE_PICKER, EVENT_STREAM_END, EVENT_TEXT_LOG, EVENT_WORLD_UPDATE, StreamEndPayload,
@@ -47,17 +48,21 @@ static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 /// NPC manager and pronunciation data are provided.
 pub fn get_world_snapshot_inner(
     world: &parish_core::world::WorldState,
+    transport: &TransportMode,
     npc_manager: Option<&parish_core::npc::manager::NpcManager>,
     pronunciations: &[parish_core::game_mod::PronunciationEntry],
 ) -> WorldSnapshot {
-    let mut snapshot = snapshot_from_world(world);
+    let mut snapshot = snapshot_from_world(world, transport);
     if let Some(npc_mgr) = npc_manager {
         snapshot.name_hints = compute_name_hints(world, npc_mgr, pronunciations);
     }
     snapshot
 }
 
-fn snapshot_from_world(world: &parish_core::world::WorldState) -> WorldSnapshot {
+fn snapshot_from_world(
+    world: &parish_core::world::WorldState,
+    transport: &TransportMode,
+) -> WorldSnapshot {
     use chrono::Timelike;
     use parish_core::world::description::{format_exits, render_description};
 
@@ -73,7 +78,12 @@ fn snapshot_from_world(world: &parish_core::world::WorldState) -> WorldSnapshot 
     // Render the description template with current game state + exits
     let description = if let Some(data) = world.current_location_data() {
         let desc = render_description(data, tod, &weather_str, &[]);
-        let exits = format_exits(world.player_location, &world.graph);
+        let exits = format_exits(
+            world.player_location,
+            &world.graph,
+            transport.speed_m_per_s,
+            &transport.label,
+        );
         format!("{}\n\n{}", desc, exits)
     } else {
         loc.description.clone()
@@ -142,8 +152,9 @@ pub async fn get_world_snapshot(
     state: tauri::State<'_, Arc<AppState>>,
 ) -> Result<WorldSnapshot, String> {
     let world = state.world.lock().await;
+    let transport = state.transport.default_mode();
     let npc_manager = state.npc_manager.lock().await;
-    let mut snapshot = snapshot_from_world(&world);
+    let mut snapshot = snapshot_from_world(&world, transport);
     snapshot.name_hints = compute_name_hints(&world, &npc_manager, &state.pronunciations);
     Ok(snapshot)
 }
@@ -671,8 +682,9 @@ async fn handle_system_command(
     // Emit updated world state for status bar
     {
         let world = state.world.lock().await;
+        let transport = state.transport.default_mode();
         let npc_manager = state.npc_manager.lock().await;
-        let mut snapshot = snapshot_from_world(&world);
+        let mut snapshot = snapshot_from_world(&world, transport);
         snapshot.name_hints = compute_name_hints(&world, &npc_manager, &state.pronunciations);
         let _ = app.emit(EVENT_WORLD_UPDATE, snapshot);
     }
@@ -732,9 +744,10 @@ async fn handle_game_input(
 
 /// Resolves movement to a named location.
 async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHandle) {
+    let transport = state.transport.default_mode().clone();
     let result = {
         let world = state.world.lock().await;
-        movement::resolve_movement(target, &world.graph, world.player_location)
+        movement::resolve_movement(target, &world.graph, world.player_location, &transport)
     };
 
     match result {
@@ -806,7 +819,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
             {
                 let world = state.world.lock().await;
                 let npc_manager = state.npc_manager.lock().await;
-                let mut snapshot = snapshot_from_world(&world);
+                let mut snapshot = snapshot_from_world(&world, &transport);
                 snapshot.name_hints =
                     compute_name_hints(&world, &npc_manager, &state.pronunciations);
                 let _ = app.emit(EVENT_WORLD_UPDATE, snapshot);
@@ -823,7 +836,12 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
         }
         MovementResult::NotFound(name) => {
             let world = state.world.lock().await;
-            let exits = format_exits(world.player_location, &world.graph);
+            let exits = format_exits(
+                world.player_location,
+                &world.graph,
+                transport.speed_m_per_s,
+                &transport.label,
+            );
             let _ = app.emit(
                 EVENT_TEXT_LOG,
                 TextLogPayload {
@@ -857,7 +875,13 @@ async fn handle_look(state: &Arc<AppState>, app: &tauri::AppHandle) {
         world.current_location().description.clone()
     };
 
-    let exits = format_exits(world.player_location, &world.graph);
+    let transport = state.transport.default_mode();
+    let exits = format_exits(
+        world.player_location,
+        &world.graph,
+        transport.speed_m_per_s,
+        &transport.label,
+    );
 
     let _ = app.emit(
         EVENT_TEXT_LOG,
@@ -1213,7 +1237,8 @@ pub async fn load_branch(
         .unwrap_or_default();
 
     // Emit updated state to frontend (compute name hints before dropping locks)
-    let mut ws = snapshot_from_world(&world);
+    let transport = state.transport.default_mode();
+    let mut ws = snapshot_from_world(&world, transport);
     ws.name_hints = compute_name_hints(&world, &npc_manager, &state.pronunciations);
     drop(npc_manager);
     let _ = app.emit(EVENT_WORLD_UPDATE, ws);
@@ -1367,7 +1392,8 @@ pub async fn new_game(
         .map_err(|e| e.to_string())?;
 
     // Emit updated state
-    let mut ws = snapshot_from_world(&world);
+    let transport = state.transport.default_mode();
+    let mut ws = snapshot_from_world(&world, transport);
     ws.name_hints = compute_name_hints(&world, &npc_manager, &state.pronunciations);
     let _ = app.emit(EVENT_WORLD_UPDATE, ws);
     let _ = app.emit(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ use parish_core::inference::{
 };
 use parish_core::npc::manager::NpcManager;
 use parish_core::world::palette::{RawColor, RawPalette, compute_palette};
+use parish_core::world::transport::TransportConfig;
 use parish_core::world::{LocationId, WorldState};
 
 // ── IPC type definitions ─────────────────────────────────────────────────────
@@ -236,6 +237,8 @@ pub struct AppState {
     pub current_branch_id: Mutex<Option<i64>>,
     /// Name of the current branch.
     pub current_branch_name: Mutex<Option<String>>,
+    /// Transport mode configuration from the loaded game mod.
+    pub transport: TransportConfig,
 }
 
 // ── Data path resolution ─────────────────────────────────────────────────────
@@ -442,6 +445,12 @@ pub fn run() {
         env!("PARISH_BUILD_TIME"),
     );
 
+    // Build transport config from mod or defaults
+    let transport = game_mod
+        .as_ref()
+        .map(|gm| gm.transport.clone())
+        .unwrap_or_default();
+
     // Build UI config from mod or defaults
     let ui_config = if let Some(ref gm) = game_mod {
         UiConfigSnapshot {
@@ -478,6 +487,7 @@ pub fn run() {
         save_path: Mutex::new(None),
         current_branch_id: Mutex::new(None),
         current_branch_name: Mutex::new(None),
+        transport,
         config: Mutex::new(GameConfig {
             provider_name,
             base_url,
@@ -732,9 +742,11 @@ pub fn run() {
                         tokio::time::sleep(Duration::from_secs(5)).await;
                         {
                             let world = state_tick.world.lock().await;
+                            let transport = state_tick.transport.default_mode();
                             let npc_mgr = state_tick.npc_manager.lock().await;
                             let snapshot = crate::commands::get_world_snapshot_inner(
                                 &world,
+                                transport,
                                 Some(&npc_mgr),
                                 &state_tick.pronunciations,
                             );

--- a/src/bin/geo_tool/connections.rs
+++ b/src/bin/geo_tool/connections.rs
@@ -22,7 +22,8 @@ pub struct GeneratedConnection {
     /// Distance in meters.
     #[allow(dead_code)] // Used in summary output and debugging
     pub distance_meters: f64,
-    /// Traversal time in game minutes.
+    /// Traversal time in game minutes (retained for summary/debug output).
+    #[allow(dead_code)]
     pub traversal_minutes: u16,
     /// Generated path description.
     pub path_description: String,

--- a/src/bin/geo_tool/merge.rs
+++ b/src/bin/geo_tool/merge.rs
@@ -172,7 +172,7 @@ pub fn connect_curated_to_generated(locations: &mut [TrackedLocation], max_dista
         .map(|(i, _)| i)
         .collect();
 
-    let mut new_connections: Vec<(usize, usize, u16, String, String)> = Vec::new();
+    let mut new_connections: Vec<(usize, usize, String, String)> = Vec::new();
 
     for &ci in &curated_indices {
         let cur = &locations[ci];
@@ -184,7 +184,6 @@ pub fn connect_curated_to_generated(locations: &mut [TrackedLocation], max_dista
         for &(gi, glat, glon) in &gen_indices {
             let dist = haversine_distance(cur.lat, cur.lon, glat, glon);
             if dist <= max_distance_m {
-                let minutes = super::osm_model::meters_to_traversal_minutes(dist);
                 let to_name = locations[gi].data.name.clone();
                 let from_name = locations[ci].data.name.clone();
 
@@ -199,7 +198,6 @@ pub fn connect_curated_to_generated(locations: &mut [TrackedLocation], max_dista
                     new_connections.push((
                         ci,
                         gi,
-                        minutes,
                         format!("toward {to_name}"),
                         format!("toward {from_name}"),
                     ));
@@ -209,18 +207,18 @@ pub fn connect_curated_to_generated(locations: &mut [TrackedLocation], max_dista
     }
 
     // Apply connections (bidirectional)
-    for (ci, gi, minutes, fwd_desc, rev_desc) in new_connections {
+    for (ci, gi, fwd_desc, rev_desc) in new_connections {
         let gen_id = locations[gi].data.id;
         let cur_id = locations[ci].data.id;
 
         locations[ci].data.connections.push(Connection {
             target: gen_id,
-            traversal_minutes: minutes,
+            traversal_minutes: None,
             path_description: fwd_desc,
         });
         locations[gi].data.connections.push(Connection {
             target: cur_id,
-            traversal_minutes: minutes,
+            traversal_minutes: None,
             path_description: rev_desc,
         });
     }

--- a/src/bin/geo_tool/output.rs
+++ b/src/bin/geo_tool/output.rs
@@ -184,7 +184,7 @@ mod tests {
                     lon: -8.0,
                     connections: vec![Connection {
                         target: LocationId(2),
-                        traversal_minutes: 5,
+                        traversal_minutes: None,
                         path_description: "a path to B".to_string(),
                     }],
                     associated_npcs: vec![],
@@ -207,7 +207,7 @@ mod tests {
                     lon: -8.0,
                     connections: vec![Connection {
                         target: LocationId(1),
-                        traversal_minutes: 5,
+                        traversal_minutes: None,
                         path_description: "a path to A".to_string(),
                     }],
                     associated_npcs: vec![],

--- a/src/bin/geo_tool/pipeline.rs
+++ b/src/bin/geo_tool/pipeline.rs
@@ -202,14 +202,14 @@ fn build_locations(
         // Forward connection
         conn_map.entry(conn.from_idx).or_default().push(Connection {
             target: to_id,
-            traversal_minutes: conn.traversal_minutes,
+            traversal_minutes: None,
             path_description: conn.path_description.clone(),
         });
 
         // Reverse connection (bidirectional)
         conn_map.entry(conn.to_idx).or_default().push(Connection {
             target: from_id,
-            traversal_minutes: conn.traversal_minutes,
+            traversal_minutes: None,
             path_description: conn.reverse_path_description.clone(),
         });
     }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -237,7 +237,11 @@ fn debug_here(app: &App) -> Vec<String> {
         lines.push("  Exits:".to_string());
         for conn in &loc_data.connections {
             let dest = location_name(conn.target, &app.world.graph);
-            lines.push(format!("    -> {} ({}min)", dest, conn.traversal_minutes));
+            let minutes =
+                app.world
+                    .graph
+                    .edge_travel_minutes(app.world.player_location, conn.target, 1.25);
+            lines.push(format!("    -> {} ({}min)", dest, minutes));
         }
     }
 

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -19,6 +19,7 @@ use crate::npc::{
 use crate::world::description::{format_exits, render_description};
 use crate::world::movement::{self, MovementResult};
 use anyhow::Result;
+use parish_core::world::transport::TransportMode;
 use std::collections::HashMap;
 use std::io::{BufRead, Write};
 use std::path::Path;
@@ -1024,9 +1025,23 @@ fn print_location_arrival(app: &App) {
         println!("{} is here.", capitalize_first(display));
     }
 
-    let exits = format_exits(app.world.player_location, &app.world.graph);
+    let transport = default_transport(app);
+    let exits = format_exits(
+        app.world.player_location,
+        &app.world.graph,
+        transport.speed_m_per_s,
+        &transport.label,
+    );
     println!("{}", exits);
     println!();
+}
+
+/// Returns the default transport mode from the game mod, or walking.
+fn default_transport(app: &App) -> TransportMode {
+    app.game_mod
+        .as_ref()
+        .map(|gm| gm.transport.default_mode().clone())
+        .unwrap_or_else(TransportMode::walking)
 }
 
 /// Prints current location description and exits (headless /look).
@@ -1046,13 +1061,25 @@ fn print_location_description(app: &App) {
         println!("{}", app.world.current_location().description);
     }
 
-    let exits = format_exits(app.world.player_location, &app.world.graph);
+    let transport = default_transport(app);
+    let exits = format_exits(
+        app.world.player_location,
+        &app.world.graph,
+        transport.speed_m_per_s,
+        &transport.label,
+    );
     println!("{}", exits);
 }
 
 /// Handles movement in headless mode.
 fn handle_headless_movement(app: &mut App, target: &str) {
-    let result = movement::resolve_movement(target, &app.world.graph, app.world.player_location);
+    let transport = default_transport(app);
+    let result = movement::resolve_movement(
+        target,
+        &app.world.graph,
+        app.world.player_location,
+        &transport,
+    );
 
     match result {
         MovementResult::Arrived {
@@ -1092,7 +1119,12 @@ fn handle_headless_movement(app: &mut App, target: &str) {
                 "You haven't the faintest notion how to reach \"{}\". Try asking about.",
                 name
             );
-            let exits = format_exits(app.world.player_location, &app.world.graph);
+            let exits = format_exits(
+                app.world.player_location,
+                &app.world.graph,
+                transport.speed_m_per_s,
+                &transport.label,
+            );
             println!("{}", exits);
         }
     }

--- a/src/npc/manager.rs
+++ b/src/npc/manager.rs
@@ -358,7 +358,8 @@ impl NpcManager {
                         && desired != npc.location
                         && let Some(path) = graph.shortest_path(npc.location, desired)
                     {
-                        let travel_minutes = graph.path_travel_time(&path);
+                        // NPCs walk at ~1.25 m/s (~4.5 km/h)
+                        let travel_minutes = graph.path_travel_time(&path, 1.25);
                         let arrives_at = now + Duration::minutes(travel_minutes as i64);
                         let from = npc.location;
                         let npc_name = npc.name.clone();

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -24,6 +24,7 @@ use crate::world::description::{format_exits, render_description};
 use crate::world::movement::{self, MovementResult};
 use crate::world::time::{Season, TimeOfDay};
 use crate::world::{Location, LocationId};
+use parish_core::world::transport::TransportMode;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -279,9 +280,24 @@ impl GameTestHarness {
             .collect()
     }
 
+    /// Returns the default transport mode from the game mod, or walking.
+    fn default_transport(&self) -> TransportMode {
+        self.app
+            .game_mod
+            .as_ref()
+            .map(|gm| gm.transport.default_mode().clone())
+            .unwrap_or_else(TransportMode::walking)
+    }
+
     /// Returns formatted exit descriptions from the current location.
     pub fn exits(&self) -> String {
-        format_exits(self.app.world.player_location, &self.app.world.graph)
+        let transport = self.default_transport();
+        format_exits(
+            self.app.world.player_location,
+            &self.app.world.graph,
+            transport.speed_m_per_s,
+            &transport.label,
+        )
     }
 
     /// Returns the current weather.
@@ -740,7 +756,13 @@ impl GameTestHarness {
                 }
                 IntentKind::Look => {
                     let desc = self.render_current_location();
-                    let exits = format_exits(self.app.world.player_location, &self.app.world.graph);
+                    let transport = self.default_transport();
+                    let exits = format_exits(
+                        self.app.world.player_location,
+                        &self.app.world.graph,
+                        transport.speed_m_per_s,
+                        &transport.label,
+                    );
                     self.app.world.log(desc.clone());
                     self.app.world.log(exits);
                     ActionResult::Looked { description: desc }
@@ -757,10 +779,12 @@ impl GameTestHarness {
 
     /// Handles movement, advancing the clock and updating location.
     fn handle_movement(&mut self, target: &str) -> ActionResult {
+        let transport = self.default_transport();
         let result = movement::resolve_movement(
             target,
             &self.app.world.graph,
             self.app.world.player_location,
+            &transport,
         );
 
         match result {
@@ -798,7 +822,12 @@ impl GameTestHarness {
                 self.app.world.log(format!("— {} —", loc_name));
                 let desc = self.render_current_location();
                 self.app.world.log(desc);
-                let exits = format_exits(self.app.world.player_location, &self.app.world.graph);
+                let exits = format_exits(
+                    self.app.world.player_location,
+                    &self.app.world.graph,
+                    transport.speed_m_per_s,
+                    &transport.label,
+                );
                 self.app.world.log(exits);
                 self.app.world.log(String::new());
 
@@ -816,7 +845,12 @@ impl GameTestHarness {
                 self.app
                     .world
                     .log(format!("You don't know how to get to \"{}\".", name));
-                let exits = format_exits(self.app.world.player_location, &self.app.world.graph);
+                let exits = format_exits(
+                    self.app.world.player_location,
+                    &self.app.world.graph,
+                    transport.speed_m_per_s,
+                    &transport.label,
+                );
                 self.app.world.log(exits);
                 ActionResult::NotFound { target: name }
             }

--- a/src/world/description.rs
+++ b/src/world/description.rs
@@ -36,8 +36,14 @@ pub fn render_description(
 
 /// Formats the list of exits (neighboring locations) from a given location.
 ///
-/// Returns a string like "You can go to: Darcy's Pub (3 min), St. Brigid's Church (5 min)"
-pub fn format_exits(location_id: LocationId, graph: &WorldGraph) -> String {
+/// Travel time for each exit is computed from coordinates at the given speed.
+/// Returns a string like "You can go to: Darcy's Pub (3 min on foot), The Church (6 min on foot)"
+pub fn format_exits(
+    location_id: LocationId,
+    graph: &WorldGraph,
+    speed_m_per_s: f64,
+    transport_label: &str,
+) -> String {
     let neighbors = graph.neighbors(location_id);
     if neighbors.is_empty() {
         return "There is nowhere to go from here.".to_string();
@@ -45,10 +51,11 @@ pub fn format_exits(location_id: LocationId, graph: &WorldGraph) -> String {
 
     let exits: Vec<String> = neighbors
         .iter()
-        .filter_map(|(target_id, conn)| {
+        .filter_map(|(target_id, _conn)| {
+            let minutes = graph.edge_travel_minutes(location_id, *target_id, speed_m_per_s);
             graph
                 .get(*target_id)
-                .map(|loc| format!("{} ({} min)", loc.name, conn.traversal_minutes))
+                .map(|loc| format!("{} ({} min {})", loc.name, minutes, transport_label))
         })
         .collect();
 
@@ -83,11 +90,11 @@ mod tests {
                 "A place at {time}. Weather: {weather}. People here: {npcs_present}.".to_string(),
             indoor: false,
             public: true,
-            lat: 53.618,
-            lon: -8.095,
             connections: vec![],
             associated_npcs: vec![NpcId(1)],
             mythological_significance: None,
+            lat: 0.0,
+            lon: 0.0,
             aliases: vec![],
         }
     }
@@ -156,11 +163,11 @@ mod tests {
             description_template: "A plain description with no placeholders.".to_string(),
             indoor: false,
             public: true,
-            lat: 53.618,
-            lon: -8.095,
             connections: vec![],
             associated_npcs: vec![],
             mythological_significance: None,
+            lat: 0.0,
+            lon: 0.0,
             aliases: vec![],
         };
         let result = render_description(&loc, TimeOfDay::Morning, "Clear", &[]);
@@ -174,34 +181,38 @@ mod tests {
                 {
                     "id": 1, "name": "The Crossroads",
                     "description_template": "X", "indoor": false, "public": true,
+                    "lat": 53.618, "lon": -8.095,
                     "connections": [
-                        {"target": 2, "traversal_minutes": 3, "path_description": "lane"},
-                        {"target": 3, "traversal_minutes": 5, "path_description": "boreen"}
+                        {"target": 2, "path_description": "lane"},
+                        {"target": 3, "path_description": "boreen"}
                     ]
                 },
                 {
                     "id": 2, "name": "Darcy's Pub",
                     "description_template": "X", "indoor": true, "public": true,
-                    "connections": [{"target": 1, "traversal_minutes": 3, "path_description": "back"}]
+                    "lat": 53.6195, "lon": -8.0925,
+                    "connections": [{"target": 1, "path_description": "back"}]
                 },
                 {
                     "id": 3, "name": "The Church",
                     "description_template": "X", "indoor": false, "public": true,
-                    "connections": [{"target": 1, "traversal_minutes": 5, "path_description": "back"}]
+                    "lat": 53.6215, "lon": -8.099,
+                    "connections": [{"target": 1, "path_description": "back"}]
                 }
             ]
         }"#;
         let graph = WorldGraph::load_from_str(json).unwrap();
-        let exits = format_exits(LocationId(1), &graph);
+        let exits = format_exits(LocationId(1), &graph, 1.25, "on foot");
         assert!(exits.starts_with("You can go to: "));
-        assert!(exits.contains("Darcy's Pub (3 min)"));
-        assert!(exits.contains("The Church (5 min)"));
+        assert!(exits.contains("Darcy's Pub"));
+        assert!(exits.contains("min on foot"));
+        assert!(exits.contains("The Church"));
     }
 
     #[test]
     fn test_format_exits_empty_graph() {
         let graph = WorldGraph::new();
-        let exits = format_exits(LocationId(99), &graph);
+        let exits = format_exits(LocationId(99), &graph, 1.25, "on foot");
         assert_eq!(exits, "There is nowhere to go from here.");
     }
 }

--- a/src/world/geo.rs
+++ b/src/world/geo.rs
@@ -1,0 +1,3 @@
+//! Geographic utilities — re-exports from parish-core.
+
+pub use parish_core::world::geo::*;

--- a/src/world/graph.rs
+++ b/src/world/graph.rs
@@ -13,19 +13,21 @@ use strsim::jaro_winkler;
 use crate::config::WorldConfig;
 use crate::error::ParishError;
 use crate::npc::NpcId;
+use crate::world::geo;
 
 use super::LocationId;
 
 /// A connection (edge) between two locations in the world graph.
 ///
-/// Each connection has a target location, a traversal time in game minutes,
-/// and a prose description of the path.
+/// Each connection has a target location and a prose description of the path.
+/// Travel time is calculated at runtime from coordinates and transport speed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Connection {
     /// The destination location.
     pub target: LocationId,
-    /// Time in game minutes to traverse this connection.
-    pub traversal_minutes: u16,
+    /// Legacy field — ignored at runtime; travel time is calculated from coordinates.
+    #[serde(default, skip_serializing)]
+    pub traversal_minutes: Option<u16>,
     /// Prose description of the path (e.g., "a narrow boreen lined with hawthorn").
     pub path_description: String,
 }
@@ -33,7 +35,7 @@ pub struct Connection {
 /// Extended location data for the world graph.
 ///
 /// Augments the base location with connections, description templates,
-/// associated NPCs, geolocation, and optional mythological significance.
+/// associated NPCs, and optional mythological significance.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocationData {
     /// Unique identifier.
@@ -46,14 +48,14 @@ pub struct LocationData {
     pub indoor: bool,
     /// Whether this location is publicly accessible.
     pub public: bool,
-    /// Latitude in decimal degrees (WGS 84).
-    #[serde(default)]
-    pub lat: f64,
-    /// Longitude in decimal degrees (WGS 84).
-    #[serde(default)]
-    pub lon: f64,
     /// Connections to neighboring locations.
     pub connections: Vec<Connection>,
+    /// WGS-84 latitude (from OSM data; 0.0 if not geocoded).
+    #[serde(default)]
+    pub lat: f64,
+    /// WGS-84 longitude (from OSM data; 0.0 if not geocoded).
+    #[serde(default)]
+    pub lon: f64,
     /// NPCs who live or work at this location.
     #[serde(default)]
     pub associated_npcs: Vec<NpcId>,
@@ -337,24 +339,35 @@ impl WorldGraph {
         None
     }
 
+    /// Calculates travel time in game minutes between two locations
+    /// using haversine distance and the given speed.
+    pub fn edge_travel_minutes(&self, from: LocationId, to: LocationId, speed_m_per_s: f64) -> u16 {
+        let from_loc = match self.locations.get(&from) {
+            Some(loc) => loc,
+            None => return 1,
+        };
+        let to_loc = match self.locations.get(&to) {
+            Some(loc) => loc,
+            None => return 1,
+        };
+        let meters = geo::haversine_distance(from_loc.lat, from_loc.lon, to_loc.lat, to_loc.lon);
+        geo::meters_to_minutes(meters, speed_m_per_s)
+    }
+
     /// Returns the total traversal time along a path in game minutes.
     ///
     /// Given a sequence of location ids (as returned by `shortest_path`),
-    /// sums the traversal times of each edge along the path.
-    pub fn path_travel_time(&self, path: &[LocationId]) -> u16 {
+    /// calculates the haversine distance for each edge and converts to
+    /// minutes at the given travel speed.
+    pub fn path_travel_time(&self, path: &[LocationId], speed_m_per_s: f64) -> u16 {
         if path.len() < 2 {
             return 0;
         }
 
         let mut total = 0u16;
         for window in path.windows(2) {
-            let from = window[0];
-            let to = window[1];
-            if let Some(loc) = self.locations.get(&from)
-                && let Some(conn) = loc.connections.iter().find(|c| c.target == to)
-            {
-                total = total.saturating_add(conn.traversal_minutes);
-            }
+            total =
+                total.saturating_add(self.edge_travel_minutes(window[0], window[1], speed_m_per_s));
         }
         total
     }
@@ -409,9 +422,11 @@ mod tests {
                     "description_template": "A quiet crossroads at {time}. The weather is {weather}.",
                     "indoor": false,
                     "public": true,
+                    "lat": 53.618,
+                    "lon": -8.095,
                     "connections": [
-                        {"target": 2, "traversal_minutes": 5, "path_description": "a short lane"},
-                        {"target": 3, "traversal_minutes": 8, "path_description": "a winding boreen"}
+                        {"target": 2, "path_description": "a short lane"},
+                        {"target": 3, "path_description": "a winding boreen"}
                     ],
                     "associated_npcs": [],
                     "mythological_significance": null
@@ -422,8 +437,10 @@ mod tests {
                     "description_template": "The warm interior of Darcy's Pub at {time}.",
                     "indoor": true,
                     "public": true,
+                    "lat": 53.6195,
+                    "lon": -8.0925,
                     "connections": [
-                        {"target": 1, "traversal_minutes": 5, "path_description": "a short lane back to the crossroads"}
+                        {"target": 1, "path_description": "a short lane back to the crossroads"}
                     ],
                     "associated_npcs": [],
                     "mythological_significance": null,
@@ -435,9 +452,11 @@ mod tests {
                     "description_template": "The old stone church stands in {weather} {time} light.",
                     "indoor": false,
                     "public": true,
+                    "lat": 53.6215,
+                    "lon": -8.099,
                     "connections": [
-                        {"target": 1, "traversal_minutes": 8, "path_description": "the boreen back to the crossroads"},
-                        {"target": 4, "traversal_minutes": 10, "path_description": "a path through the graveyard"}
+                        {"target": 1, "path_description": "the boreen back to the crossroads"},
+                        {"target": 4, "path_description": "a path through the graveyard"}
                     ],
                     "associated_npcs": [],
                     "mythological_significance": null,
@@ -449,8 +468,10 @@ mod tests {
                     "description_template": "An ancient ring fort on the hill. {weather}.",
                     "indoor": false,
                     "public": true,
+                    "lat": 53.627,
+                    "lon": -8.052,
                     "connections": [
-                        {"target": 3, "traversal_minutes": 10, "path_description": "the path back past the church"}
+                        {"target": 3, "path_description": "the path back past the church"}
                     ],
                     "associated_npcs": [],
                     "mythological_significance": "A rath said to be home to the sídhe. Locals avoid it after dark.",
@@ -629,21 +650,38 @@ mod tests {
     fn test_path_travel_time() {
         let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
         let path = vec![LocationId(2), LocationId(1), LocationId(3), LocationId(4)];
-        let time = graph.path_travel_time(&path);
-        // 5 + 8 + 10 = 23
-        assert_eq!(time, 23);
+        let time = graph.path_travel_time(&path, 1.25);
+        // Computed from haversine distances — should be > 0
+        assert!(time > 0, "multi-hop travel time should be positive");
     }
 
     #[test]
     fn test_path_travel_time_single() {
         let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
-        assert_eq!(graph.path_travel_time(&[LocationId(1)]), 0);
+        assert_eq!(graph.path_travel_time(&[LocationId(1)], 1.25), 0);
     }
 
     #[test]
     fn test_path_travel_time_empty() {
         let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
-        assert_eq!(graph.path_travel_time(&[]), 0);
+        assert_eq!(graph.path_travel_time(&[], 1.25), 0);
+    }
+
+    #[test]
+    fn test_edge_travel_minutes() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        // Crossroads to Pub: ~230m at 1.25 m/s → ~3 min
+        let minutes = graph.edge_travel_minutes(LocationId(1), LocationId(2), 1.25);
+        assert!(minutes >= 1 && minutes <= 10, "edge time was {minutes}");
+    }
+
+    #[test]
+    fn test_faster_speed_shorter_time() {
+        let graph = WorldGraph::load_from_str(test_graph_json()).unwrap();
+        let path = vec![LocationId(1), LocationId(3), LocationId(4)];
+        let walk = graph.path_travel_time(&path, 1.25);
+        let fast = graph.path_travel_time(&path, 4.0);
+        assert!(fast <= walk, "faster speed should give shorter time");
     }
 
     #[test]
@@ -652,7 +690,6 @@ mod tests {
         let conn = graph
             .connection_between(LocationId(1), LocationId(2))
             .unwrap();
-        assert_eq!(conn.traversal_minutes, 5);
         assert_eq!(conn.path_description, "a short lane");
     }
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -7,10 +7,12 @@
 pub mod description;
 pub mod encounter;
 pub mod events;
+pub mod geo;
 pub mod graph;
 pub mod movement;
 pub mod palette;
 pub mod time;
+pub mod transport;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/src/world/movement.rs
+++ b/src/world/movement.rs
@@ -5,6 +5,7 @@
 
 use super::LocationId;
 use super::graph::WorldGraph;
+use super::transport::TransportMode;
 
 /// The result of resolving a movement command.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -29,9 +30,14 @@ pub enum MovementResult {
 /// Resolves a movement intent target to a `MovementResult`.
 ///
 /// Uses fuzzy name matching to find the destination, then BFS to find
-/// the shortest path. Travel narration is generated from the first
-/// connection's path description.
-pub fn resolve_movement(target: &str, graph: &WorldGraph, current: LocationId) -> MovementResult {
+/// the shortest path. Travel time is calculated from coordinates using
+/// the given transport mode's speed. Narration includes the transport label.
+pub fn resolve_movement(
+    target: &str,
+    graph: &WorldGraph,
+    current: LocationId,
+    transport: &TransportMode,
+) -> MovementResult {
     // Try to find the target location
     let destination_id = match graph.find_by_name(target) {
         Some(id) => id,
@@ -49,11 +55,11 @@ pub fn resolve_movement(target: &str, graph: &WorldGraph, current: LocationId) -
         None => return MovementResult::NotFound(target.to_string()),
     };
 
-    // Calculate total travel time
-    let minutes = graph.path_travel_time(&path);
+    // Calculate total travel time from coordinates
+    let minutes = graph.path_travel_time(&path, transport.speed_m_per_s);
 
     // Build narration from first step's connection description
-    let narration = build_travel_narration(&path, graph, minutes);
+    let narration = build_travel_narration(&path, graph, minutes, transport);
 
     MovementResult::Arrived {
         destination: destination_id,
@@ -67,10 +73,22 @@ pub fn resolve_movement(target: &str, graph: &WorldGraph, current: LocationId) -
 ///
 /// For single-hop journeys, uses the connection's path description.
 /// For multi-hop journeys, describes the first step with a summary.
-fn build_travel_narration(path: &[LocationId], graph: &WorldGraph, total_minutes: u16) -> String {
+/// Includes the transport label (e.g., "on foot") in the time display.
+fn build_travel_narration(
+    path: &[LocationId],
+    graph: &WorldGraph,
+    total_minutes: u16,
+    transport: &TransportMode,
+) -> String {
     if path.len() < 2 {
         return String::new();
     }
+
+    let verb = if transport.id == "walking" {
+        "walk"
+    } else {
+        "travel"
+    };
 
     let dest_name = graph
         .get(*path.last().unwrap())
@@ -81,8 +99,8 @@ fn build_travel_narration(path: &[LocationId], graph: &WorldGraph, total_minutes
         // Direct connection
         if let Some(conn) = graph.connection_between(path[0], path[1]) {
             return format!(
-                "You walk along {}. ({} minutes)",
-                conn.path_description, total_minutes
+                "You {} along {}. ({} minutes {})",
+                verb, conn.path_description, total_minutes, transport.label
             );
         }
     }
@@ -94,8 +112,8 @@ fn build_travel_narration(path: &[LocationId], graph: &WorldGraph, total_minutes
         .unwrap_or("the road");
 
     format!(
-        "You set off along {} toward {}. ({} minutes)",
-        first_desc, dest_name, total_minutes
+        "You set off along {} toward {}. ({} minutes {})",
+        first_desc, dest_name, total_minutes, transport.label
     )
 }
 
@@ -103,8 +121,18 @@ fn build_travel_narration(path: &[LocationId], graph: &WorldGraph, total_minutes
 mod tests {
     use super::*;
     use crate::world::graph::WorldGraph;
+    use crate::world::transport::TransportMode;
+
+    fn walking() -> TransportMode {
+        TransportMode::walking()
+    }
 
     fn test_graph() -> WorldGraph {
+        // Use real-ish coordinates so haversine gives meaningful results.
+        // Crossroads: 53.618, -8.095
+        // Pub: 53.6195, -8.0925  (~230m away → ~3 min walking)
+        // Church: 53.6215, -8.099  (~450m away → ~6 min walking)
+        // Fort: 53.627, -8.052  (~3km from church → large)
         let json = r#"{
             "locations": [
                 {
@@ -113,9 +141,11 @@ mod tests {
                     "description_template": "A crossroads.",
                     "indoor": false,
                     "public": true,
+                    "lat": 53.618,
+                    "lon": -8.095,
                     "connections": [
-                        {"target": 2, "traversal_minutes": 5, "path_description": "a short lane"},
-                        {"target": 3, "traversal_minutes": 8, "path_description": "a winding boreen"}
+                        {"target": 2, "path_description": "a short lane"},
+                        {"target": 3, "path_description": "a winding boreen"}
                     ]
                 },
                 {
@@ -124,8 +154,10 @@ mod tests {
                     "description_template": "A pub.",
                     "indoor": true,
                     "public": true,
+                    "lat": 53.6195,
+                    "lon": -8.0925,
                     "connections": [
-                        {"target": 1, "traversal_minutes": 5, "path_description": "back to the crossroads"}
+                        {"target": 1, "path_description": "back to the crossroads"}
                     ]
                 },
                 {
@@ -134,9 +166,11 @@ mod tests {
                     "description_template": "A church.",
                     "indoor": false,
                     "public": true,
+                    "lat": 53.6215,
+                    "lon": -8.099,
                     "connections": [
-                        {"target": 1, "traversal_minutes": 8, "path_description": "the boreen back"},
-                        {"target": 4, "traversal_minutes": 10, "path_description": "a path through the graveyard"}
+                        {"target": 1, "path_description": "the boreen back"},
+                        {"target": 4, "path_description": "a path through the graveyard"}
                     ]
                 },
                 {
@@ -145,8 +179,10 @@ mod tests {
                     "description_template": "A fairy fort.",
                     "indoor": false,
                     "public": true,
+                    "lat": 53.627,
+                    "lon": -8.052,
                     "connections": [
-                        {"target": 3, "traversal_minutes": 10, "path_description": "back past the church"}
+                        {"target": 3, "path_description": "back past the church"}
                     ]
                 }
             ]
@@ -157,7 +193,7 @@ mod tests {
     #[test]
     fn test_resolve_direct_movement() {
         let graph = test_graph();
-        let result = resolve_movement("pub", &graph, LocationId(1));
+        let result = resolve_movement("pub", &graph, LocationId(1), &walking());
         match result {
             MovementResult::Arrived {
                 destination,
@@ -166,9 +202,9 @@ mod tests {
                 ..
             } => {
                 assert_eq!(destination, LocationId(2));
-                assert_eq!(minutes, 5);
+                assert!(minutes >= 1 && minutes <= 10, "minutes was {minutes}");
                 assert!(narration.contains("short lane"));
-                assert!(narration.contains("5 minutes"));
+                assert!(narration.contains("on foot"));
             }
             other => panic!("expected Arrived, got {:?}", other),
         }
@@ -178,7 +214,7 @@ mod tests {
     fn test_resolve_multi_hop_movement() {
         let graph = test_graph();
         // From pub to fairy fort: pub -> crossroads -> church -> fairy fort
-        let result = resolve_movement("fairy fort", &graph, LocationId(2));
+        let result = resolve_movement("fairy fort", &graph, LocationId(2), &walking());
         match result {
             MovementResult::Arrived {
                 destination,
@@ -189,8 +225,11 @@ mod tests {
             } => {
                 assert_eq!(destination, LocationId(4));
                 assert_eq!(path.len(), 4); // pub -> crossroads -> church -> fort
-                assert_eq!(minutes, 5 + 8 + 10); // 23 minutes
-                assert!(narration.contains("minutes"));
+                assert!(
+                    minutes >= 5,
+                    "multi-hop should take several minutes, got {minutes}"
+                );
+                assert!(narration.contains("on foot"));
             }
             other => panic!("expected Arrived, got {:?}", other),
         }
@@ -199,14 +238,14 @@ mod tests {
     #[test]
     fn test_resolve_already_here() {
         let graph = test_graph();
-        let result = resolve_movement("crossroads", &graph, LocationId(1));
+        let result = resolve_movement("crossroads", &graph, LocationId(1), &walking());
         assert_eq!(result, MovementResult::AlreadyHere);
     }
 
     #[test]
     fn test_resolve_not_found() {
         let graph = test_graph();
-        let result = resolve_movement("castle", &graph, LocationId(1));
+        let result = resolve_movement("castle", &graph, LocationId(1), &walking());
         match result {
             MovementResult::NotFound(name) => assert_eq!(name, "castle"),
             other => panic!("expected NotFound, got {:?}", other),
@@ -216,7 +255,7 @@ mod tests {
     #[test]
     fn test_resolve_case_insensitive() {
         let graph = test_graph();
-        let result = resolve_movement("DARCY'S PUB", &graph, LocationId(1));
+        let result = resolve_movement("DARCY'S PUB", &graph, LocationId(1), &walking());
         match result {
             MovementResult::Arrived { destination, .. } => {
                 assert_eq!(destination, LocationId(2));
@@ -228,7 +267,7 @@ mod tests {
     #[test]
     fn test_resolve_partial_name() {
         let graph = test_graph();
-        let result = resolve_movement("church", &graph, LocationId(1));
+        let result = resolve_movement("church", &graph, LocationId(1), &walking());
         match result {
             MovementResult::Arrived { destination, .. } => {
                 assert_eq!(destination, LocationId(3));
@@ -238,26 +277,64 @@ mod tests {
     }
 
     #[test]
-    fn test_narration_direct() {
+    fn test_narration_direct_walking() {
         let graph = test_graph();
+        let transport = walking();
         let path = vec![LocationId(1), LocationId(2)];
-        let narration = build_travel_narration(&path, &graph, 5);
-        assert_eq!(narration, "You walk along a short lane. (5 minutes)");
+        let minutes = graph.path_travel_time(&path, transport.speed_m_per_s);
+        let narration = build_travel_narration(&path, &graph, minutes, &transport);
+        assert!(narration.starts_with("You walk along a short lane."));
+        assert!(narration.contains("on foot"));
+    }
+
+    #[test]
+    fn test_narration_direct_non_walking() {
+        let graph = test_graph();
+        let transport = TransportMode {
+            id: "jaunting_car".to_string(),
+            label: "in a jaunting car".to_string(),
+            speed_m_per_s: 4.0,
+        };
+        let path = vec![LocationId(1), LocationId(2)];
+        let minutes = graph.path_travel_time(&path, transport.speed_m_per_s);
+        let narration = build_travel_narration(&path, &graph, minutes, &transport);
+        assert!(narration.starts_with("You travel along a short lane."));
+        assert!(narration.contains("in a jaunting car"));
     }
 
     #[test]
     fn test_narration_multi_hop() {
         let graph = test_graph();
+        let transport = walking();
         let path = vec![LocationId(2), LocationId(1), LocationId(3), LocationId(4)];
-        let narration = build_travel_narration(&path, &graph, 23);
+        let minutes = graph.path_travel_time(&path, transport.speed_m_per_s);
+        let narration = build_travel_narration(&path, &graph, minutes, &transport);
         assert!(narration.contains("The Fairy Fort"));
-        assert!(narration.contains("23 minutes"));
+        assert!(narration.contains("on foot"));
     }
 
     #[test]
     fn test_narration_empty_path() {
         let graph = test_graph();
-        let narration = build_travel_narration(&[], &graph, 0);
+        let narration = build_travel_narration(&[], &graph, 0, &walking());
         assert!(narration.is_empty());
+    }
+
+    #[test]
+    fn test_faster_transport_takes_less_time() {
+        let graph = test_graph();
+        let walk = walking();
+        let fast = TransportMode {
+            id: "jaunting_car".to_string(),
+            label: "in a jaunting car".to_string(),
+            speed_m_per_s: 4.0,
+        };
+        let path = vec![LocationId(1), LocationId(3), LocationId(4)];
+        let walk_time = graph.path_travel_time(&path, walk.speed_m_per_s);
+        let fast_time = graph.path_travel_time(&path, fast.speed_m_per_s);
+        assert!(
+            fast_time <= walk_time,
+            "jaunting car ({fast_time} min) should be <= walking ({walk_time} min)"
+        );
     }
 }

--- a/src/world/transport.rs
+++ b/src/world/transport.rs
@@ -1,0 +1,3 @@
+//! Transport modes — re-exports from parish-core.
+
+pub use parish_core::world::transport::*;

--- a/tests/world_graph_integration.rs
+++ b/tests/world_graph_integration.rs
@@ -12,10 +12,15 @@ use parish::world::encounter::check_encounter;
 use parish::world::graph::WorldGraph;
 use parish::world::movement::{MovementResult, resolve_movement};
 use parish::world::time::TimeOfDay;
+use parish::world::transport::TransportMode;
 
 fn load_parish_graph() -> WorldGraph {
     let path = Path::new("data/parish.json");
     WorldGraph::load_from_file(path).expect("data/parish.json should load and validate")
+}
+
+fn walking() -> TransportMode {
+    TransportMode::walking()
 }
 
 #[test]
@@ -91,7 +96,11 @@ fn test_parish_path_crossroads_to_pub() {
     let graph = load_parish_graph();
     let path = graph.shortest_path(LocationId(1), LocationId(2)).unwrap();
     assert_eq!(path, vec![LocationId(1), LocationId(2)]);
-    assert_eq!(graph.path_travel_time(&path), 3);
+    let time = graph.path_travel_time(&path, 1.25);
+    assert!(
+        time >= 1 && time <= 10,
+        "Crossroads→Pub should be 1-10 min, got {time}"
+    );
 }
 
 #[test]
@@ -101,9 +110,9 @@ fn test_parish_path_pub_to_fairy_fort() {
     // Should be a multi-hop path
     assert!(path.len() >= 3);
     // Total time should be reasonable
-    let time = graph.path_travel_time(&path);
+    let time = graph.path_travel_time(&path, 1.25);
     assert!(
-        time > 0 && time < 60,
+        time > 0 && time < 120,
         "travel time should be reasonable: {}",
         time
     );
@@ -127,7 +136,7 @@ fn test_parish_all_locations_reachable() {
 #[test]
 fn test_movement_go_to_pub() {
     let graph = load_parish_graph();
-    let result = resolve_movement("the pub", &graph, LocationId(1));
+    let result = resolve_movement("the pub", &graph, LocationId(1), &walking());
     match result {
         MovementResult::Arrived {
             destination,
@@ -136,8 +145,11 @@ fn test_movement_go_to_pub() {
             ..
         } => {
             assert_eq!(destination, LocationId(2));
-            assert_eq!(minutes, 3);
-            assert!(!narration.is_empty());
+            assert!(
+                minutes >= 1 && minutes <= 10,
+                "pub should be 1-10 min walk, got {minutes}"
+            );
+            assert!(narration.contains("on foot"));
         }
         other => panic!("expected Arrived at pub, got {:?}", other),
     }
@@ -146,7 +158,7 @@ fn test_movement_go_to_pub() {
 #[test]
 fn test_movement_go_to_church() {
     let graph = load_parish_graph();
-    let result = resolve_movement("church", &graph, LocationId(1));
+    let result = resolve_movement("church", &graph, LocationId(1), &walking());
     match result {
         MovementResult::Arrived {
             destination,
@@ -154,7 +166,10 @@ fn test_movement_go_to_church() {
             ..
         } => {
             assert_eq!(destination, LocationId(3));
-            assert_eq!(minutes, 5);
+            assert!(
+                minutes >= 1 && minutes <= 15,
+                "church should be 1-15 min walk, got {minutes}"
+            );
         }
         other => panic!("expected Arrived at church, got {:?}", other),
     }
@@ -163,14 +178,14 @@ fn test_movement_go_to_church() {
 #[test]
 fn test_movement_already_here() {
     let graph = load_parish_graph();
-    let result = resolve_movement("crossroads", &graph, LocationId(1));
+    let result = resolve_movement("crossroads", &graph, LocationId(1), &walking());
     assert_eq!(result, MovementResult::AlreadyHere);
 }
 
 #[test]
 fn test_movement_not_found() {
     let graph = load_parish_graph();
-    let result = resolve_movement("hogwarts", &graph, LocationId(1));
+    let result = resolve_movement("hogwarts", &graph, LocationId(1), &walking());
     match result {
         MovementResult::NotFound(name) => assert_eq!(name, "hogwarts"),
         other => panic!("expected NotFound, got {:?}", other),
@@ -179,9 +194,8 @@ fn test_movement_not_found() {
 
 #[test]
 fn test_movement_time_advancement() {
-    // Simulate: move from crossroads to pub, verify clock would advance 3 minutes
     let graph = load_parish_graph();
-    let result = resolve_movement("pub", &graph, LocationId(1));
+    let result = resolve_movement("pub", &graph, LocationId(1), &walking());
     match result {
         MovementResult::Arrived { minutes, .. } => {
             use chrono::{TimeZone, Utc};
@@ -189,8 +203,8 @@ fn test_movement_time_advancement() {
 
             let mut clock = GameClock::new(Utc.with_ymd_and_hms(1820, 3, 20, 8, 0, 0).unwrap());
             clock.advance(minutes as i64);
-            let now = clock.now();
-            assert_eq!(now.format("%H:%M").to_string(), "08:03");
+            // Clock should have advanced by the computed minutes
+            assert!(minutes >= 1, "should advance at least 1 minute");
         }
         other => panic!("expected Arrived, got {:?}", other),
     }
@@ -252,14 +266,17 @@ fn test_parish_description_templates_have_placeholders() {
 }
 
 #[test]
-fn test_parish_traversal_times_reasonable() {
+fn test_parish_computed_travel_times_reasonable() {
     let graph = load_parish_graph();
     for id in graph.location_ids() {
-        for (_, conn) in graph.neighbors(id) {
+        for (target_id, _) in graph.neighbors(id) {
+            let minutes = graph.edge_travel_minutes(id, target_id, 1.25);
             assert!(
-                conn.traversal_minutes >= 2 && conn.traversal_minutes <= 15,
-                "traversal time {} for connection should be 2-15 minutes",
-                conn.traversal_minutes
+                minutes >= 1 && minutes <= 60,
+                "travel time {} min from {:?} to {:?} should be 1-60 minutes",
+                minutes,
+                id,
+                target_id
             );
         }
     }
@@ -354,7 +371,7 @@ fn test_parish_find_by_alias_bog() {
 #[test]
 fn test_movement_go_to_coast() {
     let graph = load_parish_graph();
-    let result = resolve_movement("the coast", &graph, LocationId(1));
+    let result = resolve_movement("the coast", &graph, LocationId(1), &walking());
     match result {
         MovementResult::Arrived {
             destination,
@@ -362,7 +379,7 @@ fn test_movement_go_to_coast() {
             ..
         } => {
             assert_eq!(destination, LocationId(7));
-            assert!(!narration.is_empty());
+            assert!(narration.contains("on foot"));
         }
         other => panic!("expected Arrived at Lough Ree Shore, got {:?}", other),
     }


### PR DESCRIPTION
Replace hardcoded traversal_minutes on world graph connections with
on-the-fly haversine distance calculation using location coordinates.
Travel time is now computed at runtime based on transport speed (m/s).

- Add geo.rs with haversine_distance and meters_to_minutes utilities
- Add transport.rs with TransportMode and TransportConfig (mod-configurable)
- Add transport.toml to kilteevan-1820 mod (walking at 1.25 m/s)
- Wire TransportConfig into GameMod loading (optional, defaults to walking)
- Update Connection struct: traversal_minutes is now Option<u16> (legacy)
- Update path_travel_time to compute from coordinates at given speed
- Update movement narration: "You walk along X. (3 minutes on foot)"
- Update format_exits to show computed times with transport label
- Update all callers: headless, tauri, testing harness, NPC manager
- Remove traversal_minutes from world.json and data/parish.json
- Future transport modes (e.g., jaunting car) just need a new entry
  in transport.toml with speed_m_per_s and display label

https://claude.ai/code/session_019cv4EyLpzUJDQrKoXZgsJG