### PR TITLE
fix: remove NPC self-reference from inference context prompt

### DIFF
--- a/crates/parish-core/src/npc/mod.rs
+++ b/crates/parish-core/src/npc/mod.rs
@@ -417,18 +417,16 @@ pub fn build_tier1_system_prompt(npc: &Npc, improv: bool) -> String {
 ///
 /// Includes the current location, time of day, weather, season,
 /// and the player's action, giving the LLM full situational context.
-pub fn build_tier1_context(npc: &Npc, world: &WorldState, player_input: &str) -> String {
+pub fn build_tier1_context(world: &WorldState, player_input: &str) -> String {
     let location = world.current_location();
     let time_of_day = world.clock.time_of_day();
     let season = world.clock.season();
 
     format!(
-        "Location: {loc_name} — {loc_desc}\n\
+        "Your Location: {loc_name} — {loc_desc}\n\
         Time: {time}\n\
         Season: {season}\n\
         Weather: {weather}\n\
-        \n\
-        {npc_name} is here.\n\
         \n\
         The player {action}",
         loc_name = location.name,
@@ -436,7 +434,6 @@ pub fn build_tier1_context(npc: &Npc, world: &WorldState, player_input: &str) ->
         time = time_of_day,
         season = season,
         weather = world.weather,
-        npc_name = npc.name,
         action = player_input,
     )
 }
@@ -498,12 +495,13 @@ mod tests {
     fn test_build_context() {
         let npc = Npc::new_test_npc();
         let world = WorldState::new();
-        let context = build_tier1_context(&npc, &world, "says hello");
+        let context = build_tier1_context(&world, "says hello");
         assert!(context.contains("The Crossroads"));
         assert!(context.contains("Morning"));
         assert!(context.contains("Spring"));
         assert!(context.contains("Clear"));
-        assert!(context.contains("Padraig O'Brien"));
+        assert!(context.contains("Your Location:"));
+        assert!(!context.contains("is here"));
         assert!(context.contains("says hello"));
     }
 

--- a/crates/parish-core/src/npc/ticks.rs
+++ b/crates/parish-core/src/npc/ticks.rs
@@ -92,7 +92,7 @@ pub fn build_enhanced_context(
     player_input: &str,
     other_npcs: &[&Npc],
 ) -> String {
-    let mut context = build_tier1_context(npc, world, player_input);
+    let mut context = build_tier1_context(world, player_input);
 
     // Add other NPCs present
     if !other_npcs.is_empty() {

--- a/mods/kilteevan-1820/prompts/tier1_context.txt
+++ b/mods/kilteevan-1820/prompts/tier1_context.txt
@@ -1,8 +1,6 @@
-Location: {location_name} — {location_description}
+Your Location: {location_name} — {location_description}
 Time: {time}
 Season: {season}
 Weather: {weather}
-
-{npc_name} is here.
 
 The player {player_action}

--- a/src/npc/mod.rs
+++ b/src/npc/mod.rs
@@ -425,18 +425,16 @@ pub fn build_tier1_system_prompt(npc: &Npc, improv: bool) -> String {
 ///
 /// Includes the current location, time of day, weather, season,
 /// and the player's action, giving the LLM full situational context.
-pub fn build_tier1_context(npc: &Npc, world: &WorldState, player_input: &str) -> String {
+pub fn build_tier1_context(world: &WorldState, player_input: &str) -> String {
     let location = world.current_location();
     let time_of_day = world.clock.time_of_day();
     let season = world.clock.season();
 
     format!(
-        "Location: {loc_name} — {loc_desc}\n\
+        "Your Location: {loc_name} — {loc_desc}\n\
         Time: {time}\n\
         Season: {season}\n\
         Weather: {weather}\n\
-        \n\
-        {npc_name} is here.\n\
         \n\
         The player {action}",
         loc_name = location.name,
@@ -444,7 +442,6 @@ pub fn build_tier1_context(npc: &Npc, world: &WorldState, player_input: &str) ->
         time = time_of_day,
         season = season,
         weather = world.weather,
-        npc_name = npc.name,
         action = player_input,
     )
 }
@@ -506,12 +503,13 @@ mod tests {
     fn test_build_context() {
         let npc = Npc::new_test_npc();
         let world = WorldState::new();
-        let context = build_tier1_context(&npc, &world, "says hello");
+        let context = build_tier1_context(&world, "says hello");
         assert!(context.contains("The Crossroads"));
         assert!(context.contains("Morning"));
         assert!(context.contains("Spring"));
         assert!(context.contains("Clear"));
-        assert!(context.contains("Padraig O'Brien"));
+        assert!(context.contains("Your Location:"));
+        assert!(!context.contains("is here"));
         assert!(context.contains("says hello"));
     }
 

--- a/src/npc/ticks.rs
+++ b/src/npc/ticks.rs
@@ -92,7 +92,7 @@ pub fn build_enhanced_context(
     player_input: &str,
     other_npcs: &[&Npc],
 ) -> String {
-    let mut context = build_tier1_context(npc, world, player_input);
+    let mut context = build_tier1_context(world, player_input);
 
     // Add other NPCs present
     if !other_npcs.is_empty() {


### PR DESCRIPTION
The context prompt included "{npc_name} is here." which caused the LLM
to sometimes address the NPC in third person as if they were another
character present. Since the system prompt already establishes NPC
identity ("You are {name}..."), this line was redundant and confusing.

Changed "Location:" to "Your Location:" to reinforce second-person
framing, and removed the npc parameter from build_tier1_context since
it is no longer needed.

https://claude.ai/code/session_01EVoj7voMMSLCnjxT9a6pyY