### PR TITLE
fix: move 'You are here' badge to bottom of save picker node

### DIFF
--- a/ui/src/components/SavePicker.svelte
+++ b/ui/src/components/SavePicker.svelte
@@ -741,7 +741,7 @@
 
 	.node-current-badge {
 		position: absolute;
-		top: -0.5rem;
+		bottom: -0.5rem;
 		right: 0.3rem;
 		font-size: 0.65rem;
 		color: var(--color-accent);


### PR DESCRIPTION
## Summary
- Repositions the "You are here" badge from the top to the bottom of the DAG node box in the save picker, improving visual clarity

## Test plan
- [ ] Open save picker and verify the badge appears at the bottom of the current node box
- [ ] Confirm it doesn't overlap with the "Branch From Here" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)