### PR TITLE
🎨 Palette: Add screen reader semantics to ChatPanel

### DIFF
--- a/ui/src/components/ChatPanel.svelte
+++ b/ui/src/components/ChatPanel.svelte
@@ -55,7 +55,7 @@
 	}
 </script>
 
-<div class="chat-panel" data-testid="chat-panel" bind:this={logEl}>
+<div class="chat-panel" data-testid="chat-panel" bind:this={logEl} role="log" aria-live="polite" aria-label="Game chat log">
 	{#each $textLog as entry (entry)}
 		{#if entryType(entry) === 'system'}
 			{@const isSplash = entry.content.includes('Copyright \u00A9')}
@@ -82,8 +82,8 @@
 		{/if}
 	{/each}
 	{#if $streamingActive && ($textLog.length === 0 || !$textLog[$textLog.length - 1].streaming)}
-		<div class="loading-row">
-			<svg class="triquetra-spinner" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+		<div class="loading-row" role="status" aria-label="Generating response">
+			<svg class="triquetra-spinner" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
 				<circle class="knot-circle" pathLength="120"
 					cx="50" cy="50" r="16"
 					fill="none" stroke="var(--color-accent)" stroke-width="3"


### PR DESCRIPTION
## Summary

- Add `role="log"` with `aria-live="polite"` to the chat container so screen readers announce new messages as they arrive
- Mark the loading spinner row with `role="status"` and `aria-label="Generating response"` so assistive technology users know when the AI is thinking
- Hide the decorative Celtic knot SVG spinner from screen readers with `aria-hidden="true"`

## 💡 What
Three ARIA attributes added to `ChatPanel.svelte` (3 lines changed) to make the core gameplay chat accessible to screen reader users.

## 🎯 Why
The chat log is the primary interaction surface of the game. Without `role="log"` and `aria-live`, screen reader users receive no announcement when NPC responses or system messages appear. The loading spinner was also invisible to assistive technology — users had no way to know the AI was generating a response.

## ♿ Accessibility improvements
| Before | After |
|--------|-------|
| Chat messages arrive silently for screen readers | New messages announced via `aria-live="polite"` |
| Loading state invisible to assistive tech | `role="status"` announces "Generating response" |
| Decorative SVG read aloud by some screen readers | Hidden with `aria-hidden="true"` |

## Test plan
- [x] Rust tests pass (`cargo test`)
- [x] Pre-existing frontend test failures confirmed unrelated (tests query `.loading-spinner` class that doesn't exist on base branch either)
- [ ] Manual screen reader verification (VoiceOver / NVDA)

https://claude.ai/code/session_01A6VcCzkb26kaovzgnFMr9P