### PR TITLE
feat: add CLI-GUI parity commands and play-test skill

### DIFF
--- a/.claude/skills/play/SKILL.md
+++ b/.claude/skills/play/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: play
+description: Play-test the Parish game using the script harness. Sends commands, reads JSON output, and evaluates the gameplay experience.
+disable-model-invocation: false
+argument-hint: [scenario or script-file]
+---
+
+Play-test the Parish game via the `--script` mode, which outputs structured JSON per command.
+
+## Steps
+
+1. **Build first**: Run `cargo build` to ensure the project compiles.
+
+2. **Determine what to test**:
+   - If `$ARGUMENTS` is a `.txt` file path, use it directly as the script file.
+   - If `$ARGUMENTS` is a scenario description (e.g., "explore all locations", "talk to every NPC", "test time passage"), generate an appropriate test script file at `tests/fixtures/play_session.txt`.
+   - If no arguments, generate a comprehensive exploration script that:
+     - Checks `/status`, `/time`, `/map`, `/npcs`
+     - Visits every reachable location via movement commands
+     - Uses `/wait` to advance time and observe NPC schedule changes
+     - Uses `/tick` to test manual schedule advancement
+     - Tests `/save`, `/fork`, `/branches`, `/log` for persistence
+     - Tests `/speed fast` and `/speed normal`
+
+3. **Run the script**: `cargo run -- --script <script-file>`
+
+4. **Analyze the JSON output** line by line. For each line, check:
+   - **Movement**: `"result": "moved"` entries have valid `to` locations and reasonable `minutes`
+   - **System commands**: Responses are non-empty and contain expected data
+   - **Map**: Contains locations and connections
+   - **NPCs**: Shows NPC details when present at a location
+   - **Time**: Shows hour, minute, season, weather
+   - **Wait**: Time advances correctly (compare before/after)
+   - **Errors**: No panics, no empty responses, no unexpected `"result": "unknown_input"`
+
+5. **Report findings**: Provide a play-test summary including:
+   - Locations visited and whether descriptions were generated
+   - NPCs encountered and at which locations
+   - Time/season progression observed
+   - Any anomalies, bugs, or missing features
+   - Overall assessment of the gameplay experience
+
+## Tips for Script Generation
+
+Available commands in scripts:
+- Movement: `go to <location>`, `walk to <location>`
+- Look: `look`, `look around`
+- System: `/status`, `/time`, `/map`, `/npcs`, `/wait [N]`, `/tick`
+- Persistence: `/save`, `/fork <name>`, `/load <name>`, `/branches`, `/log`
+- Speed: `/speed fast`, `/speed normal`, `/speed slow`
+- Control: `/pause`, `/resume`, `/new`
+- Debug: `/debug`, `/debug npcs`, `/debug clock`, `/debug here`, `/debug schedule`
+
+Location names can be found by running `/map` first or checking `mods/kilteevan-1820/world.json`.

--- a/crates/parish-core/src/input/mod.rs
+++ b/crates/parish-core/src/input/mod.rs
@@ -88,8 +88,18 @@ pub enum Command {
     SetCategoryKey(InferenceCategory, String),
     /// Show about / credits information.
     About,
-    /// Toggle the full map overlay.
+    /// Toggle the full map overlay / show text-based map in CLI.
     Map,
+    /// Show NPCs at the current location with details.
+    NpcsHere,
+    /// Show detailed time, weather, and season info.
+    Time,
+    /// Wait in place for a number of game minutes, advancing time.
+    Wait(u32),
+    /// Start a fresh new game, resetting world and NPCs.
+    NewGame,
+    /// Manually tick NPC schedules without advancing time.
+    Tick,
 }
 
 /// The kind of player action parsed from natural language input.
@@ -179,6 +189,21 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
         Some(Command::About)
     } else if lower == "/map" {
         Some(Command::Map)
+    } else if lower == "/npcs" {
+        Some(Command::NpcsHere)
+    } else if lower == "/time" {
+        Some(Command::Time)
+    } else if lower == "/where" {
+        Some(Command::Status)
+    } else if lower == "/wait" {
+        Some(Command::Wait(15))
+    } else if lower.starts_with("/wait ") {
+        let mins = trimmed[6..].trim().parse::<u32>().unwrap_or(15);
+        Some(Command::Wait(mins))
+    } else if lower == "/new" {
+        Some(Command::NewGame)
+    } else if lower == "/tick" {
+        Some(Command::Tick)
     } else if let Some(cmd) = parse_category_command(trimmed, &lower) {
         Some(cmd)
     } else if lower == "/provider" {
@@ -1091,6 +1116,38 @@ mod tests {
     fn test_classify_map_command() {
         let result = classify_input("/map");
         assert_eq!(result, InputResult::SystemCommand(Command::Map));
+    }
+
+    #[test]
+    fn test_parse_npcs_command() {
+        assert_eq!(parse_system_command("/npcs"), Some(Command::NpcsHere));
+    }
+
+    #[test]
+    fn test_parse_time_command() {
+        assert_eq!(parse_system_command("/time"), Some(Command::Time));
+    }
+
+    #[test]
+    fn test_parse_where_command() {
+        assert_eq!(parse_system_command("/where"), Some(Command::Status));
+    }
+
+    #[test]
+    fn test_parse_wait_command() {
+        assert_eq!(parse_system_command("/wait"), Some(Command::Wait(15)));
+        assert_eq!(parse_system_command("/wait 60"), Some(Command::Wait(60)));
+        assert_eq!(parse_system_command("/wait abc"), Some(Command::Wait(15)));
+    }
+
+    #[test]
+    fn test_parse_new_command() {
+        assert_eq!(parse_system_command("/new"), Some(Command::NewGame));
+    }
+
+    #[test]
+    fn test_parse_tick_command() {
+        assert_eq!(parse_system_command("/tick"), Some(Command::Tick));
     }
 
     #[test]

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -392,6 +392,36 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
             String::new()
         }
         Command::About => "Parish — An Irish Living World Text Adventure (web mode).".to_string(),
+        Command::NpcsHere => {
+            let world = state.world.lock().await;
+            let npc_mgr = state.npc_manager.lock().await;
+            let npcs = npc_mgr.npcs_at(world.player_location);
+            if npcs.is_empty() {
+                "No one else is here.".to_string()
+            } else {
+                let mut lines = vec!["NPCs here:".to_string()];
+                for npc in &npcs {
+                    let display = npc_mgr.display_name(npc);
+                    lines.push(format!("  {} — {}", display, npc.occupation));
+                }
+                lines.join("\n")
+            }
+        }
+        Command::Time => {
+            use chrono::Timelike;
+            let world = state.world.lock().await;
+            let now = world.clock.now();
+            format!(
+                "{:02}:{:02} {} — {}",
+                now.hour(),
+                now.minute(),
+                world.clock.time_of_day(),
+                world.clock.season()
+            )
+        }
+        Command::Wait(_) | Command::NewGame | Command::Tick => {
+            "This command is only available in CLI/headless mode.".to_string()
+        }
     };
 
     if needs_rebuild {

--- a/docs/design/testing.md
+++ b/docs/design/testing.md
@@ -76,6 +76,66 @@ $ cargo run -- --script test.txt
 
 Lines starting with `#` are comments. Empty lines are skipped.
 
+## CLI-GUI Parity Commands
+
+The headless CLI (`src/headless.rs`) and test harness (`src/testing.rs`) support
+commands that mirror GUI-only features, enabling full play-testing without Tauri:
+
+| Command | Description | Handler Source |
+|---------|-------------|----------------|
+| `/map` | Text-based map: lists all locations with connections, marks player with `*` | `WorldGraph::location_ids()` + `neighbors()` |
+| `/npcs` | NPCs at current location: name, occupation, mood, introduced status | `NpcManager::npcs_at()` + `display_name()` |
+| `/time` | Detailed time info: hour:minute, time_of_day, season, weather, speed, festival | `GameClock::now()` + `.season()` + `.check_festival()` |
+| `/wait [N]` | Advance time by N game minutes (default 15), tick NPC schedules | `GameClock::advance()` + `tick_schedules()` |
+| `/tick` | Manually tick NPC schedules without advancing time | `assign_tiers()` + `tick_schedules()` |
+| `/new` | Start a fresh game: reload world/NPCs from mod files, reset persistence | Same init path as `GameTestHarness::new()` |
+| `/where` | Alias for `/status` | Parsed as `Command::Status` |
+
+### Time Advancement Design
+
+The GUI advances time via background tick loops (`tokio::spawn` in Tauri and
+the Axum web server). The CLI cannot do this because `reader.lines()` blocks
+synchronously on stdin — adding background ticks would require switching to
+async stdin with `tokio::select!`, which is a significant refactor.
+
+Instead, the CLI uses **explicit time control**:
+- `/wait N` advances the game clock by N minutes and ticks NPC schedules
+- `/tick` runs NPC schedule assignment without advancing time
+- The game clock still runs in real-time between commands (via `speed_factor`)
+
+This is actually better UX for a text adventure — the player controls time
+explicitly rather than having NPCs move unpredictably during input.
+
+### Command Enum Variants
+
+Added to `Command` in `src/input/mod.rs`:
+
+```rust
+Map,           // /map
+NpcsHere,      // /npcs
+Time,          // /time
+Wait(u32),     // /wait [N] — default 15
+NewGame,       // /new
+Tick,          // /tick
+```
+
+`/where` is parsed as `Command::Status` (no new variant).
+
+## Claude Code Play-Testing Skill
+
+The `/play` skill (`.claude/skills/play/SKILL.md`) enables Claude Code to
+autonomously play-test the game via `--script` mode:
+
+1. Build the project with `cargo build`
+2. Generate or use a script file with game commands
+3. Run `cargo run -- --script <file>` to get structured JSON output
+4. Analyze each JSON line for correctness (movement, NPCs, time, errors)
+5. Report a play-test summary with findings
+
+This leverages the CLI-parity commands so the AI can exercise the same
+features available in the GUI: checking the map, observing NPCs, advancing
+time, and verifying schedule-driven NPC behavior.
+
 ## Test Fixtures
 
 Test scripts live in `tests/fixtures/`:
@@ -100,6 +160,7 @@ Test scripts live in `tests/fixtures/`:
 | `test_look_variants.txt` | `look`, `l`, `look around` at multiple locations |
 | `test_grand_tour.txt` | Visit all 15 locations with look + status at each |
 | `test_speed_assertions.txt` | Speed preset changes with status verification |
+| `test_new_commands.txt` | CLI-parity commands: `/map`, `/npcs`, `/time`, `/wait`, `/tick`, `/where` |
 
 ## Captured Script Mode (`run_script_captured`)
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -685,6 +685,11 @@ async fn handle_system_command(
 
         // ── Debug ────────────────────────────────────────────────────────
         Command::Debug(_) => "Debug commands are not available in the GUI.".to_string(),
+        Command::NpcsHere => "Use the sidebar to see NPCs here.".to_string(),
+        Command::Time => "Time info is shown in the status bar.".to_string(),
+        Command::Wait(_) | Command::NewGame | Command::Tick => {
+            "This command is only available in CLI/headless mode.".to_string()
+        }
     };
 
     if needs_rebuild {

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -19,6 +19,7 @@ use crate::npc::{
 use crate::world::description::{format_exits, render_description};
 use crate::world::movement::{self, MovementResult};
 use anyhow::Result;
+use chrono::Timelike;
 use parish_core::world::transport::TransportMode;
 use std::collections::HashMap;
 use std::io::{BufRead, Write};
@@ -390,6 +391,13 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
                 "  /speed    - Show or change game speed (slow/normal/fast/fastest/ludicrous)"
             );
             println!("  /status   - Where am I?");
+            println!("  /where    - Alias for /status");
+            println!("  /map      - Show the parish map");
+            println!("  /npcs     - Who's here?");
+            println!("  /time     - Detailed time and weather");
+            println!("  /wait [n] - Wait in place (default 15 minutes)");
+            println!("  /tick     - Advance NPC schedules");
+            println!("  /new      - Start a fresh game");
             println!("  /irish    - Toggle Irish words sidebar (TUI only)");
             println!("  /improv   - Toggle improv craft for NPC dialogue");
             println!("  /provider - Show or change base LLM provider");
@@ -803,7 +811,152 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             println!("Showing spinner for {} seconds (GUI only).", secs);
         }
         Command::Map => {
-            println!("The map overlay is only available in the GUI (Tauri) mode.");
+            println!("=== Parish Map ===");
+            let player_loc = app.world.player_location;
+            for node_id in app.world.graph.location_ids() {
+                if let Some(data) = app.world.graph.get(node_id) {
+                    let marker = if node_id == player_loc { " * " } else { "   " };
+                    println!("{}{}", marker, data.name);
+                }
+            }
+            println!();
+            println!("Connections:");
+            for node_id in app.world.graph.location_ids() {
+                if let Some(data) = app.world.graph.get(node_id) {
+                    for (neighbor_id, _) in app.world.graph.neighbors(node_id) {
+                        // Print each edge once (only when from < to)
+                        if node_id.0 < neighbor_id.0 {
+                            let neighbor_name = app
+                                .world
+                                .graph
+                                .get(neighbor_id)
+                                .map(|d| d.name.as_str())
+                                .unwrap_or("???");
+                            println!("  {} — {}", data.name, neighbor_name);
+                        }
+                    }
+                }
+            }
+        }
+        Command::NpcsHere => {
+            let npcs = app.npc_manager.npcs_at(app.world.player_location);
+            if npcs.is_empty() {
+                println!("No one else is here.");
+            } else {
+                println!("NPCs here:");
+                for npc in &npcs {
+                    let display = app.npc_manager.display_name(npc);
+                    let intro = if app.npc_manager.is_introduced(npc.id) {
+                        " [introduced]"
+                    } else {
+                        ""
+                    };
+                    println!("  {} — {} ({}){}", display, npc.occupation, npc.mood, intro);
+                }
+            }
+        }
+        Command::Time => {
+            let now = app.world.clock.now();
+            let hour = now.hour();
+            let minute = now.minute();
+            let tod = app.world.clock.time_of_day();
+            let season = app.world.clock.season();
+            let festival = app
+                .world
+                .clock
+                .check_festival()
+                .map(|f| f.to_string())
+                .unwrap_or_else(|| "none".to_string());
+            let paused = if app.world.clock.is_paused() {
+                " (PAUSED)"
+            } else {
+                ""
+            };
+            println!("{:02}:{:02} {} — {}{}", hour, minute, tod, season, paused);
+            println!("Weather: {}", app.world.weather);
+            println!("Speed: {}x", app.world.clock.speed_factor());
+            println!("Festival: {}", festival);
+        }
+        Command::Wait(minutes) => {
+            println!("You wait for {} minutes...", minutes);
+            app.world.clock.advance(minutes as i64);
+            app.npc_manager.assign_tiers(&app.world, &[]);
+            let schedule_events = app
+                .npc_manager
+                .tick_schedules(&app.world.clock, &app.world.graph);
+            process_headless_schedule_events(app, &schedule_events);
+            let now = app.world.clock.now();
+            let tod = app.world.clock.time_of_day();
+            println!("It is now {:02}:{:02} {}.", now.hour(), now.minute(), tod);
+        }
+        Command::NewGame => {
+            // Re-initialize world from mod or data files
+            if let Some(ref gm) = app.game_mod {
+                match crate::world::WorldState::from_mod(gm) {
+                    Ok(world) => app.world = world,
+                    Err(e) => {
+                        eprintln!("Failed to reset world: {}", e);
+                        return (false, false);
+                    }
+                }
+            } else {
+                let parish_path = Path::new("data/parish.json");
+                if parish_path.exists() {
+                    match crate::world::WorldState::from_parish_file(
+                        parish_path,
+                        crate::world::LocationId(15),
+                    ) {
+                        Ok(world) => app.world = world,
+                        Err(e) => {
+                            eprintln!("Failed to reset world: {}", e);
+                            return (false, false);
+                        }
+                    }
+                }
+            }
+            // Re-initialize NPCs
+            let npcs_path = if let Some(ref gm) = app.game_mod {
+                gm.npcs_path()
+            } else {
+                std::path::PathBuf::from("data/npcs.json")
+            };
+            if npcs_path.exists() {
+                match NpcManager::load_from_file(&npcs_path) {
+                    Ok(mgr) => app.npc_manager = mgr,
+                    Err(e) => eprintln!("Warning: Failed to reload NPCs: {}", e),
+                }
+            }
+            app.npc_manager.assign_tiers(&app.world, &[]);
+
+            // Reset persistence
+            if let Some(ref db) = app.db
+                && let Ok(branch_id) = db.create_branch("main", None).await
+            {
+                let snapshot =
+                    crate::persistence::GameSnapshot::capture(&app.world, &app.npc_manager);
+                if let Ok(snap_id) = db.save_snapshot(branch_id, &snapshot).await {
+                    app.active_branch_id = branch_id;
+                    app.latest_snapshot_id = snap_id;
+                    app.last_autosave = Some(std::time::Instant::now());
+                }
+            }
+
+            println!("A new day dawns in the parish.");
+            println!();
+            print_location_arrival(app);
+        }
+        Command::Tick => {
+            app.npc_manager.assign_tiers(&app.world, &[]);
+            let schedule_events = app
+                .npc_manager
+                .tick_schedules(&app.world.clock, &app.world.graph);
+            let count = schedule_events.len();
+            process_headless_schedule_events(app, &schedule_events);
+            if count == 0 {
+                println!("No NPC activity.");
+            } else {
+                println!("{} schedule event(s) processed.", count);
+            }
         }
     }
     (false, rebuild)

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -737,7 +737,152 @@ impl GameTestHarness {
                 ActionResult::SystemCommand { response: msg }
             }
             Command::Map => {
-                let msg = "Map overlay is only available in the GUI.".to_string();
+                let player_loc = self.app.world.player_location;
+                let mut lines = vec!["=== Parish Map ===".to_string()];
+                for node_id in self.app.world.graph.location_ids() {
+                    if let Some(data) = self.app.world.graph.get(node_id) {
+                        let marker = if node_id == player_loc { " * " } else { "   " };
+                        lines.push(format!("{}{}", marker, data.name));
+                    }
+                }
+                lines.push(String::new());
+                lines.push("Connections:".to_string());
+                for node_id in self.app.world.graph.location_ids() {
+                    if let Some(data) = self.app.world.graph.get(node_id) {
+                        for (neighbor_id, _) in self.app.world.graph.neighbors(node_id) {
+                            if node_id.0 < neighbor_id.0 {
+                                let neighbor_name = self
+                                    .app
+                                    .world
+                                    .graph
+                                    .get(neighbor_id)
+                                    .map(|d| d.name.as_str())
+                                    .unwrap_or("???");
+                                lines.push(format!("  {} — {}", data.name, neighbor_name));
+                            }
+                        }
+                    }
+                }
+                let msg = lines.join("\n");
+                self.app.world.log(msg.clone());
+                ActionResult::SystemCommand { response: msg }
+            }
+            Command::NpcsHere => {
+                let npcs = self.app.npc_manager.npcs_at(self.app.world.player_location);
+                let msg = if npcs.is_empty() {
+                    "No one else is here.".to_string()
+                } else {
+                    let mut lines = vec!["NPCs here:".to_string()];
+                    for npc in &npcs {
+                        let display = self.app.npc_manager.display_name(npc);
+                        let intro = if self.app.npc_manager.is_introduced(npc.id) {
+                            " [introduced]"
+                        } else {
+                            ""
+                        };
+                        lines.push(format!(
+                            "  {} — {} ({}){}",
+                            display, npc.occupation, npc.mood, intro
+                        ));
+                    }
+                    lines.join("\n")
+                };
+                self.app.world.log(msg.clone());
+                ActionResult::SystemCommand { response: msg }
+            }
+            Command::Time => {
+                use chrono::Timelike;
+                let now = self.app.world.clock.now();
+                let hour = now.hour();
+                let minute = now.minute();
+                let tod = self.app.world.clock.time_of_day();
+                let season = self.app.world.clock.season();
+                let festival = self
+                    .app
+                    .world
+                    .clock
+                    .check_festival()
+                    .map(|f| f.to_string())
+                    .unwrap_or_else(|| "none".to_string());
+                let paused = if self.app.world.clock.is_paused() {
+                    " (PAUSED)"
+                } else {
+                    ""
+                };
+                let lines = [
+                    format!("{:02}:{:02} {} — {}{}", hour, minute, tod, season, paused),
+                    format!("Weather: {}", self.app.world.weather),
+                    format!("Speed: {}x", self.app.world.clock.speed_factor()),
+                    format!("Festival: {}", festival),
+                ];
+                let msg = lines.join("\n");
+                self.app.world.log(msg.clone());
+                ActionResult::SystemCommand { response: msg }
+            }
+            Command::Wait(minutes) => {
+                use chrono::Timelike;
+                self.advance_time(minutes as i64);
+                let now = self.app.world.clock.now();
+                let tod = self.app.world.clock.time_of_day();
+                let msg = format!(
+                    "Waited {} minutes. Now {:02}:{:02} {}.",
+                    minutes,
+                    now.hour(),
+                    now.minute(),
+                    tod
+                );
+                self.app.world.log(msg.clone());
+                ActionResult::SystemCommand { response: msg }
+            }
+            Command::NewGame => {
+                // Re-initialize from GameTestHarness::new() logic
+                let game_mod = parish_core::game_mod::find_default_mod()
+                    .and_then(|dir| parish_core::game_mod::GameMod::load(&dir).ok());
+
+                if let Some(ref gm) = game_mod
+                    && let Ok(world) = crate::world::WorldState::from_mod(gm)
+                {
+                    self.app.world = world;
+                } else {
+                    let parish_path = Path::new("data/parish.json");
+                    if parish_path.exists()
+                        && let Ok(world) =
+                            crate::world::WorldState::from_parish_file(parish_path, LocationId(15))
+                    {
+                        self.app.world = world;
+                    }
+                }
+
+                let npcs_path = if let Some(ref gm) = game_mod {
+                    gm.npcs_path()
+                } else {
+                    std::path::PathBuf::from("data/npcs.json")
+                };
+                if npcs_path.exists()
+                    && let Ok(mgr) = NpcManager::load_from_file(&npcs_path)
+                {
+                    self.app.npc_manager = mgr;
+                }
+                self.app.game_mod = game_mod;
+                self.app.npc_manager.assign_tiers(&self.app.world, &[]);
+
+                let msg = "New game started.".to_string();
+                self.app.world.log(msg.clone());
+                ActionResult::SystemCommand { response: msg }
+            }
+            Command::Tick => {
+                self.app.npc_manager.assign_tiers(&self.app.world, &[]);
+                let events = self
+                    .app
+                    .npc_manager
+                    .tick_schedules(&self.app.world.clock, &self.app.world.graph);
+                let count = events.len();
+                self.process_schedule_events(&events);
+                let msg = if count == 0 {
+                    "No NPC activity.".to_string()
+                } else {
+                    format!("{} schedule event(s) processed.", count)
+                };
                 self.app.world.log(msg.clone());
                 ActionResult::SystemCommand { response: msg }
             }

--- a/tests/fixtures/test_new_commands.txt
+++ b/tests/fixtures/test_new_commands.txt
@@ -1,0 +1,15 @@
+/status
+/time
+/map
+/npcs
+/wait 30
+/tick
+/where
+go to crossroads
+/npcs
+/time
+/wait 60
+/tick
+/speed fast
+/wait 15
+/speed normal

--- a/ui/src/lib/slash-commands.ts
+++ b/ui/src/lib/slash-commands.ts
@@ -28,6 +28,13 @@ export const SLASH_COMMANDS: SlashCommand[] = [
 	{ command: '/cloud', description: 'Cloud provider settings', hasArgs: true },
 	{ command: '/debug', description: 'Debug panel', hasArgs: true },
 	{ command: '/spinner', description: 'Show loading spinner', hasArgs: true },
+	{ command: '/map', description: 'Show the parish map', hasArgs: false },
+	{ command: '/npcs', description: "Who's here?", hasArgs: false },
+	{ command: '/time', description: 'What time is it?', hasArgs: false },
+	{ command: '/where', description: 'Where am I? (alias for /status)', hasArgs: false },
+	{ command: '/wait', description: 'Wait N minutes (default 15)', hasArgs: true },
+	{ command: '/tick', description: 'Advance NPC schedules', hasArgs: false },
+	{ command: '/new', description: 'Start a new game', hasArgs: false },
 	{ command: '/quit', description: 'Take your leave', hasArgs: false }
 ];
 


### PR DESCRIPTION
Add 6 new CLI commands (/map, /npcs, /time, /wait, /new, /tick) and a
/where alias to bring the headless REPL to full feature parity with
the GUI. Also add a /play Claude Code skill for automated play-testing
via the --script harness.

- /map: text-based map showing all locations and connections
- /npcs: NPCs at current location with occupation, mood, intro status
- /time: detailed time, weather, season, speed, festival info
- /wait [N]: advance time N minutes (default 15) and tick NPC schedules
- /new: start a fresh game, resetting world and NPCs
- /tick: manually advance NPC schedules without time change
- /where: alias for /status

https://claude.ai/code/session_011qooiXpcYwBvxE7HRpwSmi