### PR TITLE
fix: eliminate panic-prone operations and silent data failures (#86, #97, #116, #122, #124, #145, #146, #156)

### DIFF
--- a/crates/parish-core/src/input/mod.rs
+++ b/crates/parish-core/src/input/mod.rs
@@ -164,14 +164,22 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
     } else if lower == "/save" {
         Some(Command::Save)
     } else if lower == "/fork" || lower.starts_with("/fork ") {
-        let name = trimmed.get(5..).unwrap_or("").trim().to_string();
+        let name = trimmed
+            .get("/fork".len()..)
+            .unwrap_or("")
+            .trim()
+            .to_string();
         if name.is_empty() {
             Some(Command::Help) // bare /fork → show help
         } else {
             Some(Command::Fork(name))
         }
     } else if lower == "/load" || lower.starts_with("/load ") {
-        let name = trimmed.get(5..).unwrap_or("").trim().to_string();
+        let name = trimmed
+            .get("/load".len()..)
+            .unwrap_or("")
+            .trim()
+            .to_string();
         Some(Command::Load(name)) // empty string = show save picker
     } else if lower == "/branches" {
         Some(Command::Branches)
@@ -209,7 +217,11 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
     } else if lower == "/provider" {
         Some(Command::ShowProvider)
     } else if lower.starts_with("/provider ") {
-        let name = trimmed[10..].trim().to_string();
+        let name = trimmed
+            .get("/provider ".len()..)
+            .unwrap_or("")
+            .trim()
+            .to_string();
         if name.is_empty() {
             Some(Command::ShowProvider)
         } else {
@@ -218,7 +230,11 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
     } else if lower == "/model" {
         Some(Command::ShowModel)
     } else if lower.starts_with("/model ") {
-        let name = trimmed[7..].trim().to_string();
+        let name = trimmed
+            .get("/model ".len()..)
+            .unwrap_or("")
+            .trim()
+            .to_string();
         if name.is_empty() {
             Some(Command::ShowModel)
         } else {
@@ -227,7 +243,11 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
     } else if lower == "/key" {
         Some(Command::ShowKey)
     } else if lower.starts_with("/key ") {
-        let value = trimmed[5..].trim().to_string();
+        let value = trimmed
+            .get("/key ".len()..)
+            .unwrap_or("")
+            .trim()
+            .to_string();
         if value.is_empty() {
             Some(Command::ShowKey)
         } else {
@@ -236,12 +256,21 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
     } else if lower == "/spinner" {
         Some(Command::Spinner(30))
     } else if lower.starts_with("/spinner ") {
-        let secs = trimmed[9..].trim().parse::<u64>().unwrap_or(30);
+        let secs = trimmed
+            .get("/spinner ".len()..)
+            .unwrap_or("")
+            .trim()
+            .parse::<u64>()
+            .unwrap_or(30);
         Some(Command::Spinner(secs))
     } else if lower == "/debug" {
         Some(Command::Debug(None))
     } else if lower.starts_with("/debug ") {
-        let sub = trimmed[7..].trim().to_string();
+        let sub = trimmed
+            .get("/debug ".len()..)
+            .unwrap_or("")
+            .trim()
+            .to_string();
         if sub.is_empty() {
             Some(Command::Debug(None))
         } else {
@@ -250,7 +279,7 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
     } else if lower == "/speed" {
         Some(Command::ShowSpeed)
     } else if lower.starts_with("/speed ") {
-        let arg = trimmed[7..].trim();
+        let arg = trimmed.get("/speed ".len()..).unwrap_or("").trim();
         match GameSpeed::from_name(arg) {
             Some(speed) => Some(Command::SetSpeed(speed)),
             None if arg.is_empty() => Some(Command::ShowSpeed),
@@ -259,10 +288,14 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
     } else if lower == "/cloud" {
         Some(Command::ShowCloud)
     } else if lower.starts_with("/cloud ") {
-        let rest = trimmed[7..].trim();
+        let rest = trimmed.get("/cloud ".len()..).unwrap_or("").trim();
         let rest_lower = rest.to_lowercase();
         if rest_lower.starts_with("provider ") {
-            let name = rest[9..].trim().to_string();
+            let name = rest
+                .get("provider ".len()..)
+                .unwrap_or("")
+                .trim()
+                .to_string();
             if name.is_empty() {
                 Some(Command::ShowCloud)
             } else {
@@ -271,7 +304,7 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
         } else if rest_lower == "provider" {
             Some(Command::ShowCloud)
         } else if rest_lower.starts_with("model ") {
-            let name = rest[6..].trim().to_string();
+            let name = rest.get("model ".len()..).unwrap_or("").trim().to_string();
             if name.is_empty() {
                 Some(Command::ShowCloudModel)
             } else {
@@ -280,7 +313,7 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
         } else if rest_lower == "model" {
             Some(Command::ShowCloudModel)
         } else if rest_lower.starts_with("key ") {
-            let value = rest[4..].trim().to_string();
+            let value = rest.get("key ".len()..).unwrap_or("").trim().to_string();
             if value.is_empty() {
                 Some(Command::ShowCloudKey)
             } else {

--- a/crates/parish-core/src/npc/manager.rs
+++ b/crates/parish-core/src/npc/manager.rs
@@ -380,7 +380,9 @@ impl NpcManager {
         let npc_ids: Vec<NpcId> = self.npcs.keys().copied().collect();
 
         for id in npc_ids {
-            let npc = self.npcs.get(&id).unwrap();
+            let Some(npc) = self.npcs.get(&id) else {
+                continue;
+            };
 
             match &npc.state {
                 NpcState::Present => {
@@ -414,7 +416,9 @@ impl NpcManager {
                             minutes = travel_minutes,
                             "NPC starting transit"
                         );
-                        let npc = self.npcs.get_mut(&id).unwrap();
+                        let Some(npc) = self.npcs.get_mut(&id) else {
+                            continue;
+                        };
                         npc.state = NpcState::InTransit {
                             from,
                             to: desired,
@@ -443,7 +447,9 @@ impl NpcManager {
                             location = destination.0,
                             "NPC arrived"
                         );
-                        let npc = self.npcs.get_mut(&id).unwrap();
+                        let Some(npc) = self.npcs.get_mut(&id) else {
+                            continue;
+                        };
                         npc.location = destination;
                         npc.state = NpcState::Present;
                     }

--- a/crates/parish-core/src/npc/ticks.rs
+++ b/crates/parish-core/src/npc/ticks.rs
@@ -387,7 +387,8 @@ fn truncate_for_memory(s: &str, max_len: usize) -> String {
         s.to_string()
     } else {
         let boundary = crate::npc::floor_char_boundary(s, max_len.saturating_sub(3));
-        format!("{}...", &s[..boundary])
+        let safe_boundary = boundary.min(s.len());
+        format!("{}...", &s[..safe_boundary])
     }
 }
 

--- a/crates/parish-core/src/npc/types.rs
+++ b/crates/parish-core/src/npc/types.rs
@@ -274,9 +274,19 @@ pub struct Relationship {
     /// The type of relationship.
     pub kind: RelationshipKind,
     /// Strength from -1.0 (hostile) to 1.0 (close).
+    #[serde(deserialize_with = "deserialize_clamped_strength")]
     pub strength: f64,
     /// Append-only log of relationship events.
     pub history: Vec<RelationshipEvent>,
+}
+
+/// Deserializes a strength value, clamping it to the valid range -1.0..=1.0.
+fn deserialize_clamped_strength<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = f64::deserialize(deserializer)?;
+    Ok(value.clamp(-1.0, 1.0))
 }
 
 impl Relationship {

--- a/crates/parish-core/src/persistence/journal.rs
+++ b/crates/parish-core/src/persistence/journal.rs
@@ -129,9 +129,16 @@ pub fn replay_journal(
                     rel.adjust_strength(*delta);
                 }
             }
-            WorldEvent::WeatherChanged { new_weather } => {
-                world.weather = new_weather.parse().unwrap_or(crate::world::Weather::Clear);
-            }
+            WorldEvent::WeatherChanged { new_weather } => match new_weather.parse() {
+                Ok(w) => world.weather = w,
+                Err(_) => {
+                    tracing::warn!(
+                        "Invalid weather in journal: '{}', defaulting to Clear",
+                        new_weather
+                    );
+                    world.weather = crate::world::Weather::Clear;
+                }
+            },
             WorldEvent::MemoryAdded { npc_id, content } => {
                 if let Some(npc) = npc_manager.get_mut(*npc_id) {
                     use crate::npc::memory::MemoryEntry;

--- a/crates/parish-core/src/world/mod.rs
+++ b/crates/parish-core/src/world/mod.rs
@@ -229,7 +229,14 @@ impl WorldState {
         // Parse start date from mod manifest
         let start_dt = chrono::DateTime::parse_from_rfc3339(game_mod.start_date())
             .map(|dt| dt.with_timezone(&chrono::Utc))
-            .unwrap_or_else(|_| chrono::Utc::now());
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    start_date = game_mod.start_date(),
+                    error = %e,
+                    "Failed to parse mod start_date, falling back to current time"
+                );
+                chrono::Utc::now()
+            });
 
         let clock = GameClock::new(start_dt);
         let start_location = LocationId(game_mod.start_location());

--- a/crates/parish-core/src/world/movement.rs
+++ b/crates/parish-core/src/world/movement.rs
@@ -90,8 +90,9 @@ fn build_travel_narration(
         "travel"
     };
 
-    let dest_name = graph
-        .get(*path.last().unwrap())
+    let dest_name = path
+        .last()
+        .and_then(|id| graph.get(*id))
         .map(|l| l.name.as_str())
         .unwrap_or("your destination");
 

--- a/docs/reviews/chrome-testing-session.md
+++ b/docs/reviews/chrome-testing-session.md
@@ -98,3 +98,70 @@ every page load.
 - Chrome with Claude-in-Chrome MCP extension
 - Rust axum server (debug build)
 - Svelte 5 + SvelteKit (static adapter)
+
+---
+
+## Session 2: 2026-04-01
+
+> Branch: `claude/fix-open-issues-dfsiw` (post-rebase onto origin/main)
+> Method: Live manual testing via Claude-in-Chrome MCP extension
+> LLM Provider: Groq (llama-3.1-8b-instant) — .env not loaded by web server; NPC tests inconclusive
+
+### Overview
+
+Post-rebase smoke test to verify merge conflict resolutions in `input/mod.rs`
+and `movement.rs` didn't break the web UI. Core navigation, system commands,
+and edge cases all passed. NPC conversation was inconclusive due to the web
+server not picking up the `.env` file (LLM requests hit a dead endpoint).
+
+### Setup
+
+1. Built frontend: `cd ui && npm run build`
+2. Killed stale server on port 3001 (leftover from previous session)
+3. Started fresh server: `cargo run -- --web 3001`
+4. Navigated Chrome to `http://127.0.0.1:3001`
+
+### Features Tested
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Page load / initial render | Pass | Status bar, map, NPCs, chat, input all present |
+| Status bar | Pass | Location, time, weather, season update on travel |
+| Map rendering | Pass | SVG minimap with player dot and labels |
+| NPC sidebar updates | Pass | NPCs appear/disappear based on location and time |
+| Travel (direct hop) | Pass | Crossroads: narration + time advance |
+| Travel (multi-hop) | Pass | Village to Pub via Crossroads: 19 min narration |
+| Invalid location | Pass | "You haven't the faintest notion how to reach 'castle dracula'." |
+| Already-here detection | Pass | "Sure, you're already standing right here." |
+| Empty submit | Pass | No-op, input stays focused |
+| `/help` | Pass | Shows command list with descriptions |
+| `/status` | Pass | "Location: Darcy's Pub \| Afternoon \| Spring" |
+| `/pause` | Pass | "The clocks of the parish stand still." + status bar indicator |
+| `/resume` | Pass | "Time stirs again in the parish." + indicator removed |
+| `/wait 180` | Pass | Advances 3 hours, NPC schedules update |
+| Idle message (no NPCs) | Pass | "Only the sound of a distant crow." |
+| NPC conversation (LLM) | Inconclusive | .env not loaded; loading indicator shown but no response |
+| Console errors | Pass | No JavaScript errors throughout session |
+
+### Bugs Found
+
+None (all tests that could run passed cleanly).
+
+### Notes
+
+- The multi-hop travel narration correctly uses the new verb logic from the
+  rebase: "You set off along the road north past low fields to the crossroads
+  toward Darcy's Pub."
+- The `/fork` and `/load` commands were not explicitly tested in-browser but
+  the conflict resolution preserved both bare-command support and safe `.len()`
+  slicing.
+- The web server does not automatically load `.env` from the project root;
+  LLM-dependent tests require the provider env vars to be exported in the shell
+  or passed on the command line.
+
+### Environment
+
+- macOS Darwin 24.6.0
+- Chrome with Claude-in-Chrome MCP extension
+- Rust axum server (debug build, freshly compiled post-rebase)
+- Svelte 5 + SvelteKit (static adapter)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1050,7 +1050,7 @@ async fn handle_npc_conversation(
             "A dog barks somewhere beyond the hill.",
             "The clouds shift. The parish carries on.",
         ];
-        let idx = REQUEST_ID.fetch_add(1, Ordering::SeqCst) as usize % idle_messages.len();
+        let idx = REQUEST_ID.fetch_add(1, Ordering::Relaxed) as usize % idle_messages.len();
         let _ = app.emit(
             EVENT_TEXT_LOG,
             TextLogPayload {
@@ -1065,7 +1065,7 @@ async fn handle_npc_conversation(
         let config = state.config.lock().await;
         config.model_name.clone()
     };
-    let req_id = REQUEST_ID.fetch_add(1, Ordering::SeqCst);
+    let req_id = REQUEST_ID.fetch_add(1, Ordering::Relaxed);
 
     // Spawn the animated loading indicator (fun Irish phrases)
     let loading_cancel = tokio_util::sync::CancellationToken::new();


### PR DESCRIPTION
## Summary

Fixes 8 related issues in two categories: **panic safety** and **silent data failures**.

### Panic safety (#97, #122, #124, #156)

- **#156** — Replace 12 hardcoded byte-offset string slices (e.g. `trimmed[10..]`) in command parsing with safe `.get(PREFIX.len()..).unwrap_or("")` in both `crates/parish-core/src/input/mod.rs` and `src/input/mod.rs`
- **#122** — Add `.min(s.len())` safety clamp in `truncate_for_memory` to guard against `floor_char_boundary` returning a value beyond string length
- **#97** — Chain `path.last()` with `and_then` in `build_travel_narration` instead of fragile `.unwrap()` that relies on an early-return guard
- **#124** — Replace 3 `.get(&id).unwrap()` calls in `tick_schedules` with `let-else + continue` to handle potential NPC removal gracefully

### Silent data failures (#86, #116, #145, #146)

- **#86** — Log `tracing::warn` when weather string in journal replay fails to parse, instead of silently defaulting to Clear
- **#145** — Log `tracing::warn` with start_date and parse error when mod manifest date fails to parse, instead of silently falling back to `Utc::now()`
- **#146** — Add custom serde deserializer for `Relationship.strength` that clamps to `-1.0..=1.0` on deserialization, preventing out-of-range values from edited save files or malformed mod data
- **#116** — Use `Ordering::Relaxed` instead of `SeqCst` for the `REQUEST_ID` atomic counter since it only generates unique IDs and doesn't synchronize other shared state

Closes #86, closes #97, closes #116, closes #122, closes #124, closes #145, closes #146, closes #156.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — all tests pass unchanged (no behavioral change)
- [x] Verified no remaining `trimmed[N..]` or `rest[N..]` patterns in codebase

https://claude.ai/code/session_016Xs79nRojZoAmxfdnZBfKQ