### PR TITLE
feat: input enrichment wave 1 — slash autocomplete, history, emotes, multi-line, travel chips

### DIFF
--- a/crates/parish-core/src/npc/mod.rs
+++ b/crates/parish-core/src/npc/mod.rs
@@ -431,19 +431,36 @@ pub fn build_tier1_context(world: &WorldState, player_input: &str) -> String {
     let time_of_day = world.clock.time_of_day();
     let season = world.clock.season();
 
+    // Detect *emote* actions: input fully wrapped in asterisks
+    let action_line = if let Some(inner) = player_input
+        .strip_prefix('*')
+        .and_then(|s| s.strip_suffix('*'))
+    {
+        if !inner.is_empty() && !inner.contains('*') {
+            format!(
+                "The player performs an action: {inner}\n\
+                (The player is emoting rather than speaking. \
+                Respond to their physical action naturally.)"
+            )
+        } else {
+            format!("The player {player_input}")
+        }
+    } else {
+        format!("The player {player_input}")
+    };
+
     format!(
         "Your Location: {loc_name} — {loc_desc}\n\
         Time: {time}\n\
         Season: {season}\n\
         Weather: {weather}\n\
         \n\
-        The player {action}",
+        {action_line}",
         loc_name = location.name,
         loc_desc = location.description,
         time = time_of_day,
         season = season,
         weather = world.weather,
-        action = player_input,
     )
 }
 
@@ -512,6 +529,49 @@ mod tests {
         assert!(context.contains("Your Location:"));
         assert!(!context.contains("is here"));
         assert!(context.contains("says hello"));
+    }
+
+    #[test]
+    fn test_build_context_emote_action() {
+        let world = WorldState::new();
+        let context = build_tier1_context(&world, "*tips hat*");
+        assert!(
+            context.contains("performs an action: tips hat"),
+            "emote should strip asterisks and use action phrasing"
+        );
+        assert!(
+            context.contains("emoting rather than speaking"),
+            "emote should include action-mode instruction"
+        );
+        assert!(
+            !context.contains("The player *tips hat*"),
+            "emote should not pass raw asterisks through"
+        );
+    }
+
+    #[test]
+    fn test_build_context_normal_input_not_emote() {
+        let world = WorldState::new();
+        let context = build_tier1_context(&world, "hello there");
+        assert!(
+            context.contains("The player hello there"),
+            "normal input should use standard phrasing"
+        );
+        assert!(
+            !context.contains("performs an action"),
+            "normal input should not trigger action phrasing"
+        );
+    }
+
+    #[test]
+    fn test_build_context_partial_asterisks_not_emote() {
+        let world = WorldState::new();
+        // Single leading asterisk — not a complete emote
+        let context = build_tier1_context(&world, "*incomplete");
+        assert!(
+            context.contains("The player *incomplete"),
+            "partial asterisks should pass through as normal input"
+        );
     }
 
     #[test]

--- a/docs/design/input-enrichment-ideas.md
+++ b/docs/design/input-enrichment-ideas.md
@@ -4,7 +4,7 @@
 
 Brainstorming ideas for making the text entry line richer and more interactive, drawing from chat apps (Slack, Discord, Telegram, iMessage, Twitch), social platforms (Twitter/X), and games with chat interfaces (Minecraft, MMOs, MUDs).
 
-**Status**: Ideation — none of these are committed. Pick and choose.
+**Status**: Wave 1 shipped. See priority table at the bottom for per-feature status.
 
 ---
 
@@ -424,16 +424,16 @@ Hold spacebar (when the input field is empty) to speak instead of type. Release 
 
 ## Priority Ranking
 
-| Idea | Effort | Impact | Recommendation |
-|------|--------|--------|----------------|
-| `/slash` command autocomplete | Low | High | **Build next** — reuses @mention infra |
-| Input history (Up/Down) | Low | High | **Build next** — table stakes UX |
-| Push-to-talk voice input | Low | High | **Build next** — Web Speech API phase first |
-| `*action*` emotes | Low | Medium | **Build soon** — enhances RP |
-| Multi-line input | Low | Medium | Build soon |
+| Idea | Effort | Impact | Status |
+|------|--------|--------|--------|
+| `/slash` command autocomplete | Low | High | **Shipped (Wave 1)** — unified dropdown with @mention |
+| Input history (Up/Down) | Low | High | **Shipped (Wave 1)** — localStorage, 50 entries |
+| Push-to-talk voice input | Low | High | Build next — Web Speech API phase first |
+| `*action*` emotes | Low | Medium | **Shipped (Wave 1)** — italic rendering + backend action context |
+| Multi-line input | Low | Medium | **Shipped (Wave 1)** — Shift+Enter for newline |
 | Typing indicator | Low-Med | Medium | Build soon — makes NPCs feel alive |
-| Location quick-travel chips | Low | Medium | Build soon |
-| Bidirectional emoji reactions | Med-High | High | **Build soon** — makes rooms feel alive |
+| Location quick-travel chips | Low | Medium | **Shipped (Wave 1)** — adjacent location pills above input |
+| Bidirectional emoji reactions | Med-High | High | Build soon — makes rooms feel alive |
 | Whisper syntax | Medium | Medium | Build later — needs context scoping |
 | Reply-to context | Medium | Medium | Build later |
 | Inline rich preview | Medium | Low-Med | Nice to have |
@@ -442,3 +442,13 @@ Hold spacebar (when the input field is empty) to speak instead of type. Release 
 | Voice range modifiers | Med-High | High | Build later — great emergent gameplay |
 | Contextual suggestions | High | High | Build later — needs LLM or rules |
 | Streamer mode | Very High | Niche | Someday/maybe |
+
+## Wave 1 Implementation Notes
+
+Shipped in a single commit. Key design decisions:
+
+- **Unified dropdown**: The `@mention` and `/slash` dropdowns share a single `dropdownMode` state (`'mention' | 'slash' | null`), reusing all markup and CSS. Command list lives in `ui/src/lib/slash-commands.ts`.
+- **History vs. dropdown**: ArrowUp/Down only triggers history when `dropdownMode === null` and the cursor is on the first/last line (compatible with multi-line editing).
+- **Emote passthrough**: `*action*` text is sent as raw text to the backend (no IPC changes). `build_tier1_context` in `npc/mod.rs` detects the `*...*` wrapping and substitutes action-mode phrasing for the NPC prompt.
+- **Multi-line**: The contenteditable div already had `white-space: pre-wrap` and `max-height: 6em`. Only change was Shift+Enter key handling and `getPlainText()` handling `<br>` / `<div>` nodes.
+- **Travel chips**: Derived from the existing `mapData` store's `adjacent` flag. Hidden during streaming.

--- a/ui/src/components/ChatPanel.svelte
+++ b/ui/src/components/ChatPanel.svelte
@@ -25,6 +25,34 @@
 		if (entry.source === 'player') return 'You';
 		return entry.source;
 	}
+
+	interface TextSegment {
+		text: string;
+		isAction: boolean;
+	}
+
+	/** Splits text on *action* markers into normal and emote segments. */
+	function parseEmotes(content: string): TextSegment[] {
+		const segments: TextSegment[] = [];
+		const regex = /\*([^*]+)\*/g;
+		let lastIndex = 0;
+		let match: RegExpExecArray | null;
+		while ((match = regex.exec(content)) !== null) {
+			if (match.index > lastIndex) {
+				segments.push({ text: content.slice(lastIndex, match.index), isAction: false });
+			}
+			segments.push({ text: match[1], isAction: true });
+			lastIndex = regex.lastIndex;
+		}
+		if (lastIndex < content.length) {
+			segments.push({ text: content.slice(lastIndex), isAction: false });
+		}
+		// If no emotes found, return the whole content as a single segment
+		if (segments.length === 0) {
+			segments.push({ text: content, isAction: false });
+		}
+		return segments;
+	}
 </script>
 
 <div class="chat-panel" data-testid="chat-panel" bind:this={logEl}>
@@ -36,7 +64,7 @@
 				{#if isSplash}
 					<span class="content"><strong>{lines[0]}</strong>{'\n' + lines.slice(1).join('\n')}</span>
 				{:else}
-					<span class="content">{entry.content}</span>
+					<span class="content">{#each parseEmotes(entry.content) as seg}{#if seg.isAction}<span class="emote">{seg.text}</span>{:else}{seg.text}{/if}{/each}</span>
 				{/if}
 			</div>
 		{:else}
@@ -45,7 +73,7 @@
 					<span class="label">{displayLabel(entry)}</span>
 					<div class="bubble">
 						<span class="content"
-							>{entry.content}{#if entry.streaming}<span class="cursor">▋</span
+							>{#each parseEmotes(entry.content) as seg}{#if seg.isAction}<span class="emote">{seg.text}</span>{:else}{seg.text}{/if}{/each}{#if entry.streaming}<span class="cursor">▋</span
 							>{/if}</span
 						>
 					</div>
@@ -154,6 +182,11 @@
 		background: var(--color-accent);
 		color: var(--color-bg);
 		border-top-right-radius: 0.25rem;
+	}
+
+	.emote {
+		font-style: italic;
+		opacity: 0.85;
 	}
 
 	.cursor {

--- a/ui/src/components/ChatPanel.test.ts
+++ b/ui/src/components/ChatPanel.test.ts
@@ -83,4 +83,47 @@ describe('ChatPanel', () => {
 		expect(container.querySelector('.bubble-row')).toBeFalsy();
 		expect(container.querySelector('.entry.system')).toBeTruthy();
 	});
+
+	describe('emote rendering', () => {
+		it('renders *action* text with emote class', () => {
+			textLog.set([{ source: 'player', content: '*waves*' }]);
+			const { container } = render(ChatPanel);
+			const emote = container.querySelector('.emote');
+			expect(emote).toBeTruthy();
+			expect(emote?.textContent).toBe('waves');
+		});
+
+		it('renders mixed text and emotes', () => {
+			textLog.set([{ source: 'Padraig', content: 'Hello *smiles warmly* how are ye?' }]);
+			const { container } = render(ChatPanel);
+			const emotes = container.querySelectorAll('.emote');
+			expect(emotes.length).toBe(1);
+			expect(emotes[0].textContent).toBe('smiles warmly');
+			// Normal text should also be present
+			const content = container.querySelector('.content');
+			expect(content?.textContent).toContain('Hello');
+			expect(content?.textContent).toContain('how are ye?');
+		});
+
+		it('renders text without asterisks normally', () => {
+			textLog.set([{ source: 'player', content: 'Just plain text' }]);
+			const { container } = render(ChatPanel);
+			expect(container.querySelector('.emote')).toBeFalsy();
+			expect(container.querySelector('.content')?.textContent).toContain('Just plain text');
+		});
+
+		it('renders unmatched asterisks as normal text', () => {
+			textLog.set([{ source: 'player', content: 'I think *this is incomplete' }]);
+			const { container } = render(ChatPanel);
+			expect(container.querySelector('.emote')).toBeFalsy();
+		});
+
+		it('renders emotes in system messages too', () => {
+			textLog.set([{ source: 'system', content: 'You *tip your hat* to the barman.' }]);
+			const { container } = render(ChatPanel);
+			const emote = container.querySelector('.emote');
+			expect(emote).toBeTruthy();
+			expect(emote?.textContent).toBe('tip your hat');
+		});
+	});
 });

--- a/ui/src/components/InputField.svelte
+++ b/ui/src/components/InputField.svelte
@@ -1,11 +1,16 @@
 <script lang="ts">
-	import { streamingActive, npcsHere } from '../stores/game';
+	import { streamingActive, npcsHere, mapData } from '../stores/game';
 	import { submitInput } from '$lib/ipc';
+	import { filterCommands, type SlashCommand } from '$lib/slash-commands';
 
 	let editorEl: HTMLDivElement;
-	let showMentions = $state(false);
+
+	// ── Unified dropdown state ──────────────────────────────────────────────
+	type DropdownMode = 'mention' | 'slash' | null;
+	let dropdownMode: DropdownMode = $state(null);
 	let selectedIndex = $state(0);
 	let mentionQuery = $state('');
+	let slashQuery = $state('');
 
 	const filteredNpcs = $derived(
 		mentionQuery === ''
@@ -15,6 +20,36 @@
 				)
 	);
 
+	const filteredCommands = $derived(filterCommands(slashQuery));
+
+	// ── Input history ───────────────────────────────────────────────────────
+	const HISTORY_KEY = 'parish-input-history';
+	const HISTORY_MAX = 50;
+
+	function loadHistory(): string[] {
+		try {
+			const raw = localStorage.getItem(HISTORY_KEY);
+			if (raw) return JSON.parse(raw);
+		} catch { /* ignore corrupt data */ }
+		return [];
+	}
+
+	function saveHistory(h: string[]) {
+		try { localStorage.setItem(HISTORY_KEY, JSON.stringify(h)); } catch { /* quota */ }
+	}
+
+	let history: string[] = $state(loadHistory());
+	let historyIndex: number = $state(-1);
+	let savedDraft: string = $state('');
+
+	// ── Adjacent locations for quick-travel ─────────────────────────────────
+	const adjacentLocations = $derived(
+		($mapData?.locations ?? []).filter(
+			(loc) => loc.adjacent && loc.id !== $mapData?.player_location
+		)
+	);
+
+	// ── Focus management ────────────────────────────────────────────────────
 	$effect(() => {
 		if (!$streamingActive && editorEl) {
 			editorEl.focus();
@@ -22,22 +57,41 @@
 	});
 
 	$effect(() => {
-		if (selectedIndex >= filteredNpcs.length) {
+		if (dropdownMode === 'mention' && selectedIndex >= filteredNpcs.length) {
 			selectedIndex = Math.max(0, filteredNpcs.length - 1);
 		}
+		if (dropdownMode === 'slash' && selectedIndex >= filteredCommands.length) {
+			selectedIndex = Math.max(0, filteredCommands.length - 1);
+		}
 	});
+
+	// ── Editor helpers ──────────────────────────────────────────────────────
 
 	/** Returns the full plain-text content of the editor, converting chips to @Name. */
 	function getPlainText(): string {
 		if (!editorEl) return '';
+		return extractText(editorEl);
+	}
+
+	/** Recursively extract text from a node, handling <br> and <div> wrappers. */
+	function extractText(node: Node): string {
 		let result = '';
-		for (const node of editorEl.childNodes) {
-			if (node.nodeType === Node.TEXT_NODE) {
-				result += node.textContent ?? '';
-			} else if (node instanceof HTMLElement && node.dataset.npc) {
-				result += `@${node.dataset.npc}`;
-			} else if (node instanceof HTMLElement) {
-				result += node.textContent ?? '';
+		for (const child of node.childNodes) {
+			if (child.nodeType === Node.TEXT_NODE) {
+				result += child.textContent ?? '';
+			} else if (child instanceof HTMLElement && child.dataset.npc) {
+				result += `@${child.dataset.npc}`;
+			} else if (child instanceof HTMLElement && child.tagName === 'BR') {
+				result += '\n';
+			} else if (child instanceof HTMLElement && child.tagName === 'DIV') {
+				// Chrome wraps new lines in <div> elements in contenteditable
+				const inner = extractText(child);
+				if (inner && result && !result.endsWith('\n')) {
+					result += '\n';
+				}
+				result += inner;
+			} else if (child instanceof HTMLElement) {
+				result += child.textContent ?? '';
 			}
 		}
 		return result.replace(/\u00A0/g, ' ');
@@ -56,10 +110,22 @@
 		}
 	}
 
+	/** Sets the editor's plain-text content and places cursor at end. */
+	function setEditorText(text: string) {
+		if (!editorEl) return;
+		editorEl.textContent = text;
+		// Place cursor at end
+		const sel = window.getSelection();
+		const range = document.createRange();
+		range.selectNodeContents(editorEl);
+		range.collapse(false);
+		sel?.removeAllRanges();
+		sel?.addRange(range);
+	}
+
 	/** Gets the plain text currently being typed (excluding chips). */
 	function getCurrentTypingText(): string {
 		if (!editorEl) return '';
-		// Get text from the text node the cursor is in, or fall back to full text
 		const sel = window.getSelection();
 		if (sel && sel.rangeCount > 0) {
 			const node = sel.getRangeAt(0).startContainer;
@@ -67,19 +133,49 @@
 				return node.textContent ?? '';
 			}
 		}
-		// Fallback: use the full plain text of the editor
 		return getPlainText();
 	}
 
-	/** Finds an @-trigger in the text currently being typed. */
+	/** Returns true if the cursor is on the first line (or editor is empty/single-line). */
+	function isCursorOnFirstLine(): boolean {
+		if (!editorEl) return true;
+		const text = getPlainText();
+		if (!text.includes('\n')) return true;
+		const sel = window.getSelection();
+		if (!sel || sel.rangeCount === 0) return true;
+		const range = sel.getRangeAt(0);
+		// Compare cursor Y to editor top — if within first line height, we're on line 1
+		const rangeRect = range.getBoundingClientRect();
+		const editorRect = editorEl.getBoundingClientRect();
+		// If range has no rect (empty), assume first line
+		if (rangeRect.top === 0 && rangeRect.bottom === 0) return true;
+		const lineHeight = parseFloat(getComputedStyle(editorEl).lineHeight) || 20;
+		return rangeRect.top - editorRect.top < lineHeight;
+	}
+
+	/** Returns true if the cursor is on the last line. */
+	function isCursorOnLastLine(): boolean {
+		if (!editorEl) return true;
+		const text = getPlainText();
+		if (!text.includes('\n')) return true;
+		const sel = window.getSelection();
+		if (!sel || sel.rangeCount === 0) return true;
+		const range = sel.getRangeAt(0);
+		const rangeRect = range.getBoundingClientRect();
+		const editorRect = editorEl.getBoundingClientRect();
+		if (rangeRect.top === 0 && rangeRect.bottom === 0) return true;
+		const lineHeight = parseFloat(getComputedStyle(editorEl).lineHeight) || 20;
+		return editorRect.bottom - rangeRect.bottom < lineHeight;
+	}
+
+	// ── Mention detection ───────────────────────────────────────────────────
+
 	function findMentionTrigger(): { query: string } | null {
 		const text = getCurrentTypingText();
 		const atIdx = text.lastIndexOf('@');
 		if (atIdx === -1) return null;
-		// @ must be at start or preceded by a space
 		if (atIdx > 0 && text[atIdx - 1] !== ' ') return null;
 		const query = text.slice(atIdx + 1);
-		// Don't trigger if there's a space in the query
 		if (query.includes(' ')) return null;
 		return { query };
 	}
@@ -88,12 +184,35 @@
 		const trigger = findMentionTrigger();
 		if (trigger !== null && $npcsHere.length > 0) {
 			mentionQuery = trigger.query;
-			showMentions = true;
+			dropdownMode = 'mention';
 			selectedIndex = 0;
-		} else {
-			showMentions = false;
+		} else if (dropdownMode === 'mention') {
+			dropdownMode = null;
 		}
 	}
+
+	// ── Slash detection ─────────────────────────────────────────────────────
+
+	function detectSlash() {
+		const text = getPlainText();
+		// Slash commands must be the first character and no space yet (still typing the command)
+		if (!text.startsWith('/')) {
+			if (dropdownMode === 'slash') dropdownMode = null;
+			return;
+		}
+		const spaceIdx = text.indexOf(' ');
+		const query = spaceIdx === -1 ? text.slice(1) : '';
+		// If user has typed a space (entering args), dismiss dropdown
+		if (spaceIdx !== -1) {
+			if (dropdownMode === 'slash') dropdownMode = null;
+			return;
+		}
+		slashQuery = query;
+		dropdownMode = 'slash';
+		selectedIndex = 0;
+	}
+
+	// ── NPC mention chip selection ──────────────────────────────────────────
 
 	function selectNpc(npcName: string) {
 		if (!editorEl) return;
@@ -102,7 +221,6 @@
 		let textNode: Text | null = null;
 		let cursorOffset = 0;
 
-		// Find the text node containing the @mention
 		if (sel && sel.rangeCount > 0) {
 			const range = sel.getRangeAt(0);
 			const node = range.startContainer;
@@ -112,7 +230,6 @@
 			}
 		}
 
-		// Fallback: find the first text node in the editor
 		if (!textNode) {
 			for (const child of editorEl.childNodes) {
 				if (child.nodeType === Node.TEXT_NODE && (child.textContent ?? '').includes('@')) {
@@ -124,7 +241,6 @@
 		}
 
 		if (!textNode) {
-			// Last resort: just replace the entire editor content
 			const chip = document.createElement('span');
 			chip.className = 'mention-chip';
 			chip.contentEditable = 'false';
@@ -139,7 +255,7 @@
 			range.collapse(true);
 			sel?.removeAllRanges();
 			sel?.addRange(range);
-			showMentions = false;
+			dropdownMode = null;
 			editorEl.focus();
 			return;
 		}
@@ -147,21 +263,19 @@
 		const text = textNode.textContent ?? '';
 		const atIdx = text.lastIndexOf('@');
 		if (atIdx === -1) {
-			showMentions = false;
+			dropdownMode = null;
 			return;
 		}
 
 		const before = text.slice(0, atIdx);
 		const after = text.slice(cursorOffset);
 
-		// Build chip
 		const chip = document.createElement('span');
 		chip.className = 'mention-chip';
 		chip.contentEditable = 'false';
 		chip.dataset.npc = npcName;
 		chip.textContent = `@${npcName}`;
 
-		// Replace text node with: [before] [chip] [nbsp + after]
 		const parent = textNode.parentNode!;
 		if (before) {
 			parent.insertBefore(document.createTextNode(before), textNode);
@@ -171,15 +285,28 @@
 		parent.insertBefore(trailing, textNode);
 		parent.removeChild(textNode);
 
-		// Place cursor after chip
 		const range = document.createRange();
 		range.setStart(trailing, 1);
 		range.collapse(true);
 		sel?.removeAllRanges();
 		sel?.addRange(range);
 
-		showMentions = false;
+		dropdownMode = null;
 		editorEl.focus();
+	}
+
+	// ── Slash command selection ──────────────────────────────────────────────
+
+	function selectSlashCommand(cmd: SlashCommand) {
+		if (cmd.hasArgs) {
+			setEditorText(cmd.command + ' ');
+			dropdownMode = null;
+			editorEl?.focus();
+		} else {
+			clearEditor();
+			dropdownMode = null;
+			submitInput(cmd.command);
+		}
 	}
 
 	/** Dissolves a mention chip back into plain text. */
@@ -187,7 +314,6 @@
 		const text = chip.textContent ?? '';
 		const textNode = document.createTextNode(text);
 		chip.parentNode?.replaceChild(textNode, chip);
-		// Place cursor at end of dissolved text
 		const sel = window.getSelection();
 		const range = document.createRange();
 		range.setStart(textNode, text.length);
@@ -196,42 +322,100 @@
 		sel?.addRange(range);
 	}
 
+	// ── Quick-travel ────────────────────────────────────────────────────────
+
+	async function quickTravel(locationName: string) {
+		if ($streamingActive) return;
+		clearEditor();
+		await submitInput(`go to ${locationName}`);
+	}
+
+	// ── Submit ──────────────────────────────────────────────────────────────
+
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
-		if (showMentions && filteredNpcs.length > 0) {
+		// If dropdown is open, select the highlighted item
+		if (dropdownMode === 'mention' && filteredNpcs.length > 0) {
 			selectNpc(filteredNpcs[selectedIndex].name);
+			return;
+		}
+		if (dropdownMode === 'slash' && filteredCommands.length > 0) {
+			selectSlashCommand(filteredCommands[selectedIndex]);
 			return;
 		}
 		const trimmed = getPlainText().trim();
 		if (!trimmed || $streamingActive) return;
 		clearEditor();
-		showMentions = false;
+		dropdownMode = null;
+
+		// Push to history (skip consecutive dupes)
+		if (history.length === 0 || history[history.length - 1] !== trimmed) {
+			history = [...history.slice(-(HISTORY_MAX - 1)), trimmed];
+			saveHistory(history);
+		}
+		historyIndex = -1;
+
 		await submitInput(trimmed);
 	}
 
+	// ── Keyboard handling ───────────────────────────────────────────────────
+
 	function handleKeydown(e: KeyboardEvent) {
-		if (showMentions && filteredNpcs.length > 0) {
-			if (e.key === 'ArrowDown') {
+		// Dropdown navigation (mention or slash)
+		if (dropdownMode !== null) {
+			const items = dropdownMode === 'mention' ? filteredNpcs : filteredCommands;
+			if (items.length > 0) {
+				if (e.key === 'ArrowDown') {
+					e.preventDefault();
+					selectedIndex = (selectedIndex + 1) % items.length;
+					return;
+				}
+				if (e.key === 'ArrowUp') {
+					e.preventDefault();
+					selectedIndex = (selectedIndex - 1 + items.length) % items.length;
+					return;
+				}
+				if (e.key === 'Tab') {
+					e.preventDefault();
+					if (dropdownMode === 'mention') {
+						selectNpc(filteredNpcs[selectedIndex].name);
+					} else {
+						selectSlashCommand(filteredCommands[selectedIndex]);
+					}
+					return;
+				}
+				if (e.key === 'Escape') {
+					e.preventDefault();
+					dropdownMode = null;
+					return;
+				}
+			}
+		}
+
+		// Input history (only when no dropdown is open)
+		if (dropdownMode === null && e.key === 'ArrowUp' && isCursorOnFirstLine()) {
+			if (history.length > 0) {
 				e.preventDefault();
-				selectedIndex = (selectedIndex + 1) % filteredNpcs.length;
+				if (historyIndex === -1) {
+					savedDraft = getPlainText();
+					historyIndex = history.length - 1;
+				} else if (historyIndex > 0) {
+					historyIndex--;
+				}
+				setEditorText(history[historyIndex]);
 				return;
 			}
-			if (e.key === 'ArrowUp') {
-				e.preventDefault();
-				selectedIndex =
-					(selectedIndex - 1 + filteredNpcs.length) % filteredNpcs.length;
-				return;
+		}
+		if (dropdownMode === null && e.key === 'ArrowDown' && historyIndex >= 0 && isCursorOnLastLine()) {
+			e.preventDefault();
+			if (historyIndex < history.length - 1) {
+				historyIndex++;
+				setEditorText(history[historyIndex]);
+			} else {
+				historyIndex = -1;
+				setEditorText(savedDraft);
 			}
-			if (e.key === 'Tab') {
-				e.preventDefault();
-				selectNpc(filteredNpcs[selectedIndex].name);
-				return;
-			}
-			if (e.key === 'Escape') {
-				e.preventDefault();
-				showMentions = false;
-				return;
-			}
+			return;
 		}
 
 		// Backspace into a chip: dissolve it
@@ -247,7 +431,6 @@
 						return;
 					}
 				}
-				// Also handle: cursor is right after chip with no text node between
 				if (range.collapsed && range.startContainer === editorEl) {
 					const idx = range.startOffset;
 					const child = editorEl.childNodes[idx - 1];
@@ -279,14 +462,26 @@
 			}
 		}
 
+		// Enter: Shift+Enter inserts newline, plain Enter submits
 		if (e.key === 'Enter') {
+			if (e.shiftKey) {
+				// Let the browser handle <br> insertion in contenteditable
+				return;
+			}
 			e.preventDefault();
 			handleSubmit(e);
 		}
 	}
 
 	function handleInput() {
+		// Reset history browsing on any typed input
+		if (historyIndex >= 0) {
+			historyIndex = -1;
+		}
 		detectMention();
+		if (dropdownMode !== 'mention') {
+			detectSlash();
+		}
 	}
 
 	// Prevent pasting rich content — only plain text
@@ -298,7 +493,7 @@
 </script>
 
 <div class="input-wrapper">
-	{#if showMentions && filteredNpcs.length > 0}
+	{#if dropdownMode === 'mention' && filteredNpcs.length > 0}
 		<ul class="mention-dropdown" role="listbox" aria-label="Mention NPC">
 			{#each filteredNpcs as npc, i}
 				<li
@@ -316,6 +511,36 @@
 				</li>
 			{/each}
 		</ul>
+	{/if}
+	{#if dropdownMode === 'slash' && filteredCommands.length > 0}
+		<ul class="mention-dropdown" role="listbox" aria-label="Slash commands">
+			{#each filteredCommands as cmd, i}
+				<li
+					role="option"
+					aria-selected={i === selectedIndex}
+					class="mention-item"
+					class:selected={i === selectedIndex}
+					onmousedown={(e) => { e.preventDefault(); selectSlashCommand(cmd); }}
+					onmouseenter={() => (selectedIndex = i)}
+				>
+					<span class="mention-name">{cmd.command}</span>
+					<span class="mention-detail">{cmd.description}</span>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+	{#if adjacentLocations.length > 0 && !$streamingActive}
+		<div class="travel-chips">
+			{#each adjacentLocations as loc}
+				<button
+					class="travel-chip"
+					onclick={() => quickTravel(loc.name)}
+					disabled={$streamingActive}
+				>
+					{loc.name}
+				</button>
+			{/each}
+		</div>
 	{/if}
 	<div class="input-form">
 		<div class="editor-wrap">
@@ -469,5 +694,38 @@
 
 	.mention-item.selected .mention-detail {
 		opacity: 0.85;
+	}
+
+	/* ── Quick-travel chips ────────────────────────────────────────────────── */
+
+	.travel-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+		padding: 0.4rem 0.75rem;
+		background: var(--color-panel-bg);
+		border-top: 1px solid var(--color-border);
+	}
+
+	.travel-chip {
+		background: var(--color-border);
+		color: var(--color-fg);
+		border: none;
+		border-radius: 12px;
+		padding: 0.25rem 0.6rem;
+		font-size: 0.8rem;
+		font-family: inherit;
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s;
+	}
+
+	.travel-chip:hover:not(:disabled) {
+		background: var(--color-accent);
+		color: var(--color-bg);
+	}
+
+	.travel-chip:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
 	}
 </style>

--- a/ui/src/components/InputField.svelte
+++ b/ui/src/components/InputField.svelte
@@ -368,11 +368,13 @@
 				if (e.key === 'ArrowDown') {
 					e.preventDefault();
 					selectedIndex = (selectedIndex + 1) % items.length;
+					scrollDropdownToSelected();
 					return;
 				}
 				if (e.key === 'ArrowUp') {
 					e.preventDefault();
 					selectedIndex = (selectedIndex - 1 + items.length) % items.length;
+					scrollDropdownToSelected();
 					return;
 				}
 				if (e.key === 'Tab') {
@@ -471,6 +473,18 @@
 			e.preventDefault();
 			handleSubmit(e);
 		}
+	}
+
+	/** Scrolls the dropdown so the selected item is visible. */
+	function scrollDropdownToSelected() {
+		// Use tick-like defer so the DOM class has updated
+		requestAnimationFrame(() => {
+			const dropdown = document.querySelector('.mention-dropdown');
+			const selected = dropdown?.querySelector('.mention-item.selected');
+			if (selected) {
+				selected.scrollIntoView({ block: 'nearest' });
+			}
+		});
 	}
 
 	function handleInput() {

--- a/ui/src/components/InputField.test.ts
+++ b/ui/src/components/InputField.test.ts
@@ -1,17 +1,21 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
-import { streamingActive, npcsHere } from '../stores/game';
+import { streamingActive, npcsHere, mapData } from '../stores/game';
 import InputField from './InputField.svelte';
 
 // Mock ipc submitInput
+const mockSubmitInput = vi.fn(async (_text: string) => {});
 vi.mock('$lib/ipc', () => ({
-	submitInput: vi.fn(async (_text: string) => {})
+	submitInput: (...args: unknown[]) => mockSubmitInput(...args)
 }));
 
 describe('InputField', () => {
 	beforeEach(() => {
 		streamingActive.set(false);
 		npcsHere.set([]);
+		mapData.set(null);
+		mockSubmitInput.mockClear();
+		localStorage.clear();
 	});
 
 	it('renders an editable input area', () => {
@@ -37,12 +41,13 @@ describe('InputField', () => {
 	it('clears editor after submit', async () => {
 		const { getByRole } = render(InputField);
 		const editor = getByRole('textbox');
-		// Type text into contenteditable
 		editor.textContent = 'hello';
 		await fireEvent.input(editor);
 		await fireEvent.keyDown(editor, { key: 'Enter' });
 		expect(editor.textContent).toBe('');
 	});
+
+	// ── NPC mention autocomplete ────────────────────────────────────────
 
 	describe('NPC mention autocomplete', () => {
 		const testNpcs = [
@@ -55,10 +60,8 @@ describe('InputField', () => {
 			npcsHere.set(testNpcs);
 		});
 
-		/** Helper to simulate typing into contenteditable with cursor position. */
 		function typeIntoEditor(editor: HTMLElement, text: string) {
 			editor.textContent = text;
-			// Set cursor at end
 			const range = document.createRange();
 			const sel = window.getSelection();
 			if (editor.firstChild) {
@@ -151,6 +154,274 @@ describe('InputField', () => {
 			expect(chip).toBeTruthy();
 			expect(chip?.textContent).toBe('@Padraig Darcy');
 			expect((chip as HTMLElement)?.dataset.npc).toBe('Padraig Darcy');
+		});
+	});
+
+	// ── Slash command autocomplete ──────────────────────────────────────
+
+	describe('slash command autocomplete', () => {
+		function typeIntoEditor(editor: HTMLElement, text: string) {
+			editor.textContent = text;
+			const range = document.createRange();
+			const sel = window.getSelection();
+			if (editor.firstChild) {
+				range.setStart(editor.firstChild, text.length);
+			} else {
+				range.setStart(editor, 0);
+			}
+			range.collapse(true);
+			sel?.removeAllRanges();
+			sel?.addRange(range);
+		}
+
+		it('shows slash dropdown when / is typed', async () => {
+			const { getByRole, queryByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/');
+			await fireEvent.input(editor);
+			const listbox = queryByRole('listbox');
+			expect(listbox).toBeTruthy();
+			expect(listbox?.getAttribute('aria-label')).toBe('Slash commands');
+		});
+
+		it('filters commands by typed text', async () => {
+			const { getByRole, queryAllByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/pa');
+			await fireEvent.input(editor);
+			const options = queryAllByRole('option');
+			expect(options.length).toBe(1);
+			expect(options[0].textContent).toContain('/pause');
+		});
+
+		it('navigates dropdown with ArrowDown/ArrowUp', async () => {
+			const { getByRole, queryAllByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/he');
+			await fireEvent.input(editor);
+			const options = queryAllByRole('option');
+			expect(options.length).toBe(1);
+			expect(options[0].getAttribute('aria-selected')).toBe('true');
+		});
+
+		it('dismisses slash dropdown on Escape', async () => {
+			const { getByRole, queryByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/');
+			await fireEvent.input(editor);
+			expect(queryByRole('listbox')).toBeTruthy();
+
+			await fireEvent.keyDown(editor, { key: 'Escape' });
+			expect(queryByRole('listbox')).toBeNull();
+		});
+
+		it('selects no-arg command via Enter and submits', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/pa');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			expect(mockSubmitInput).toHaveBeenCalledWith('/pause');
+		});
+
+		it('selects arg command via Tab and inserts with trailing space', async () => {
+			const { getByRole, queryByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/fo');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+
+			expect(queryByRole('listbox')).toBeNull();
+			expect(editor.textContent).toContain('/fork ');
+			expect(mockSubmitInput).not.toHaveBeenCalled();
+		});
+
+		it('does not show slash dropdown when / is mid-text', async () => {
+			const { getByRole, queryByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, 'go to a/b');
+			await fireEvent.input(editor);
+			expect(queryByRole('listbox')).toBeNull();
+		});
+	});
+
+	// ── Input history ───────────────────────────────────────────────────
+
+	describe('input history', () => {
+		function typeIntoEditor(editor: HTMLElement, text: string) {
+			editor.textContent = text;
+			const range = document.createRange();
+			const sel = window.getSelection();
+			if (editor.firstChild) {
+				range.setStart(editor.firstChild, text.length);
+			} else {
+				range.setStart(editor, 0);
+			}
+			range.collapse(true);
+			sel?.removeAllRanges();
+			sel?.addRange(range);
+		}
+
+		it('ArrowUp on empty editor with no history does nothing', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+			await fireEvent.keyDown(editor, { key: 'ArrowUp' });
+			expect(editor.textContent).toBe('');
+		});
+
+		it('recalls previous input with ArrowUp after submit', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, 'hello');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			typeIntoEditor(editor, 'world');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			// ArrowUp should show 'world'
+			await fireEvent.keyDown(editor, { key: 'ArrowUp' });
+			expect(editor.textContent).toBe('world');
+
+			// Another ArrowUp should show 'hello'
+			await fireEvent.keyDown(editor, { key: 'ArrowUp' });
+			expect(editor.textContent).toBe('hello');
+		});
+
+		it('ArrowDown restores draft after navigating history', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, 'first');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			// Type a draft, then ArrowUp
+			typeIntoEditor(editor, 'my draft');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'ArrowUp' });
+			expect(editor.textContent).toBe('first');
+
+			// ArrowDown should restore draft
+			await fireEvent.keyDown(editor, { key: 'ArrowDown' });
+			expect(editor.textContent).toBe('my draft');
+		});
+
+		it('persists history to localStorage', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, 'persist me');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			const stored = JSON.parse(localStorage.getItem('parish-input-history') ?? '[]');
+			expect(stored).toContain('persist me');
+		});
+
+		it('does not store consecutive duplicate inputs', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, 'same');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			typeIntoEditor(editor, 'same');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			const stored = JSON.parse(localStorage.getItem('parish-input-history') ?? '[]');
+			expect(stored.filter((s: string) => s === 'same').length).toBe(1);
+		});
+	});
+
+	// ── Multi-line input ────────────────────────────────────────────────
+
+	describe('multi-line input', () => {
+		it('Shift+Enter does not submit', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			editor.textContent = 'line one';
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter', shiftKey: true });
+
+			// Editor should NOT be cleared (submit clears the editor)
+			expect(editor.textContent).toBe('line one');
+			expect(mockSubmitInput).not.toHaveBeenCalled();
+		});
+
+		it('Enter without Shift submits', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			editor.textContent = 'submit me';
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			expect(mockSubmitInput).toHaveBeenCalledWith('submit me');
+		});
+	});
+
+	// ── Location quick-travel chips ─────────────────────────────────────
+
+	describe('quick-travel chips', () => {
+		const testMapData = {
+			locations: [
+				{ id: 'crossroads', name: 'The Crossroads', lat: 0, lon: 0, adjacent: false },
+				{ id: 'pub', name: "Darcy's Pub", lat: 0.1, lon: 0.1, adjacent: true },
+				{ id: 'church', name: 'The Church', lat: 0.2, lon: 0.2, adjacent: true }
+			],
+			edges: [['crossroads', 'pub'], ['crossroads', 'church']] as [string, string][],
+			player_location: 'crossroads'
+		};
+
+		it('renders chips for adjacent locations', () => {
+			mapData.set(testMapData);
+			const { container } = render(InputField);
+			const chips = container.querySelectorAll('.travel-chip');
+			expect(chips.length).toBe(2);
+			expect(chips[0].textContent).toContain("Darcy's Pub");
+			expect(chips[1].textContent).toContain('The Church');
+		});
+
+		it('does not show chips when mapData is null', () => {
+			mapData.set(null);
+			const { container } = render(InputField);
+			expect(container.querySelector('.travel-chips')).toBeFalsy();
+		});
+
+		it('does not show current location as a chip', () => {
+			mapData.set(testMapData);
+			const { container } = render(InputField);
+			const chipTexts = Array.from(container.querySelectorAll('.travel-chip')).map(el => el.textContent);
+			expect(chipTexts).not.toContain('The Crossroads');
+		});
+
+		it('clicking a chip submits movement command', async () => {
+			mapData.set(testMapData);
+			const { container } = render(InputField);
+			const chip = container.querySelector('.travel-chip') as HTMLButtonElement;
+			await fireEvent.click(chip);
+			expect(mockSubmitInput).toHaveBeenCalledWith("go to Darcy's Pub");
+		});
+
+		it('hides chips during streaming', () => {
+			mapData.set(testMapData);
+			streamingActive.set(true);
+			const { container } = render(InputField);
+			expect(container.querySelector('.travel-chips')).toBeFalsy();
 		});
 	});
 });

--- a/ui/src/lib/slash-commands.ts
+++ b/ui/src/lib/slash-commands.ts
@@ -1,0 +1,39 @@
+/// Static list of slash commands for autocomplete, mirroring the backend's
+/// `parse_system_command` in `crates/parish-core/src/input/mod.rs`.
+
+export interface SlashCommand {
+	command: string;
+	description: string;
+	/** If true, the command accepts an argument after a space. */
+	hasArgs: boolean;
+}
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+	{ command: '/help', description: 'Show available commands', hasArgs: false },
+	{ command: '/status', description: 'Where am I?', hasArgs: false },
+	{ command: '/save', description: 'Save game', hasArgs: false },
+	{ command: '/load', description: 'Load a saved branch', hasArgs: true },
+	{ command: '/fork', description: 'Fork a new timeline branch', hasArgs: true },
+	{ command: '/branches', description: 'List save branches', hasArgs: false },
+	{ command: '/log', description: 'Show snapshot history', hasArgs: false },
+	{ command: '/pause', description: 'Hold time still', hasArgs: false },
+	{ command: '/resume', description: 'Let time flow again', hasArgs: false },
+	{ command: '/speed', description: 'Show or change game speed', hasArgs: true },
+	{ command: '/irish', description: 'Toggle language hints sidebar', hasArgs: false },
+	{ command: '/improv', description: 'Toggle improv craft mode', hasArgs: false },
+	{ command: '/about', description: 'About the game', hasArgs: false },
+	{ command: '/provider', description: 'Show or change LLM provider', hasArgs: true },
+	{ command: '/model', description: 'Show or change LLM model', hasArgs: true },
+	{ command: '/key', description: 'Show or change API key', hasArgs: true },
+	{ command: '/cloud', description: 'Cloud provider settings', hasArgs: true },
+	{ command: '/debug', description: 'Debug panel', hasArgs: true },
+	{ command: '/spinner', description: 'Show loading spinner', hasArgs: true },
+	{ command: '/quit', description: 'Take your leave', hasArgs: false }
+];
+
+/// Filter commands by prefix query (the text after `/`).
+export function filterCommands(query: string): SlashCommand[] {
+	if (query === '') return SLASH_COMMANDS;
+	const lower = query.toLowerCase();
+	return SLASH_COMMANDS.filter((cmd) => cmd.command.slice(1).toLowerCase().startsWith(lower));
+}


### PR DESCRIPTION
Implement five low-effort, high-impact input field enhancements:

1. /slash command autocomplete: dropdown of all system commands when
   typing /, reusing the existing @mention dropdown infrastructure
2. Input history (Up/Down arrow): cycle through last 50 inputs,
   persisted to localStorage, with draft preservation
3. *action* emotes: asterisk-wrapped text rendered as italics in chat,
   backend detects emote pattern and adjusts NPC prompt context
4. Multi-line input (Shift+Enter): inserts newline instead of submitting,
   with proper <br>/<div> handling in getPlainText()
5. Location quick-travel chips: clickable pills for adjacent locations
   above the input field, using existing mapData store

https://claude.ai/code/session_0168vNqkHDZwUjAtk7RieKi1