### PR TITLE
fix: security hardening — credential masking, input validation, path traversal, fingerprint headers

### DIFF
--- a/crates/parish-core/src/inference/openai_client.rs
+++ b/crates/parish-core/src/inference/openai_client.rs
@@ -294,13 +294,20 @@ impl OpenAiClient {
     }
 
     /// Applies authorization and provider-specific headers to a request.
+    ///
+    /// OpenRouter-specific headers (`HTTP-Referer`, `X-Title`) are only sent
+    /// when the base URL targets OpenRouter, avoiding client fingerprinting
+    /// on other providers.
     fn apply_auth_headers(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        match &self.api_key {
-            Some(key) => req
-                .header("Authorization", format!("Bearer {}", key))
-                .header("HTTP-Referer", "https://github.com/parish-game/parish")
-                .header("X-Title", "Parish"),
+        let req = match &self.api_key {
+            Some(key) => req.header("Authorization", format!("Bearer {}", key)),
             None => req,
+        };
+        if self.base_url.contains("openrouter") {
+            req.header("HTTP-Referer", "https://github.com/parish-game/parish")
+                .header("X-Title", "Parish")
+        } else {
+            req
         }
     }
 }

--- a/crates/parish-core/src/input/mod.rs
+++ b/crates/parish-core/src/input/mod.rs
@@ -100,6 +100,33 @@ pub enum Command {
     NewGame,
     /// Manually tick NPC schedules without advancing time.
     Tick,
+    /// Invalid branch name was provided.
+    InvalidBranchName(String),
+}
+
+/// Maximum allowed length for save branch names.
+const MAX_BRANCH_NAME_LEN: usize = 255;
+
+/// Validates a save branch name for length and allowed characters.
+///
+/// Branch names may contain alphanumerics, spaces, underscores, and hyphens.
+fn validate_branch_name(name: &str) -> Result<String, String> {
+    if name.len() > MAX_BRANCH_NAME_LEN {
+        return Err(format!(
+            "Branch name too long (max {} characters).",
+            MAX_BRANCH_NAME_LEN
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == ' ')
+    {
+        return Err(
+            "Branch names may only contain letters, numbers, spaces, underscores, and hyphens."
+                .to_string(),
+        );
+    }
+    Ok(name.to_string())
 }
 
 /// The kind of player action parsed from natural language input.
@@ -172,7 +199,10 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
         if name.is_empty() {
             Some(Command::Help) // bare /fork → show help
         } else {
-            Some(Command::Fork(name))
+            match validate_branch_name(&name) {
+                Ok(valid) => Some(Command::Fork(valid)),
+                Err(msg) => Some(Command::InvalidBranchName(msg)),
+            }
         }
     } else if lower == "/load" || lower.starts_with("/load ") {
         let name = trimmed
@@ -180,7 +210,14 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
             .unwrap_or("")
             .trim()
             .to_string();
-        Some(Command::Load(name)) // empty string = show save picker
+        if name.is_empty() {
+            Some(Command::Load(String::new())) // empty string = show save picker
+        } else {
+            match validate_branch_name(&name) {
+                Ok(valid) => Some(Command::Load(valid)),
+                Err(msg) => Some(Command::InvalidBranchName(msg)),
+            }
+        }
     } else if lower == "/branches" {
         Some(Command::Branches)
     } else if lower == "/log" {
@@ -1424,5 +1461,36 @@ mod tests {
         let result = extract_mention("hello @Padraig how are you").unwrap();
         assert_eq!(result.name, "Padraig");
         assert_eq!(result.remaining, "hello how are you");
+    }
+
+    #[test]
+    fn test_validate_branch_name_valid() {
+        assert!(validate_branch_name("my-save").is_ok());
+        assert!(validate_branch_name("save_1").is_ok());
+        assert!(validate_branch_name("My Save Game").is_ok());
+    }
+
+    #[test]
+    fn test_validate_branch_name_too_long() {
+        let long_name = "a".repeat(256);
+        assert!(validate_branch_name(&long_name).is_err());
+    }
+
+    #[test]
+    fn test_validate_branch_name_invalid_chars() {
+        assert!(validate_branch_name("save/game").is_err());
+        assert!(validate_branch_name("save;drop").is_err());
+        assert!(validate_branch_name("../../etc").is_err());
+    }
+
+    #[test]
+    fn test_fork_with_invalid_branch_name() {
+        assert_eq!(
+            parse_system_command("/fork ../../etc"),
+            Some(Command::InvalidBranchName(
+                "Branch names may only contain letters, numbers, spaces, underscores, and hyphens."
+                    .to_string()
+            ))
+        );
     }
 }

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -109,6 +109,9 @@ pub async fn submit_input(
     if text.is_empty() {
         return StatusCode::OK;
     }
+    if text.len() > 2000 {
+        return StatusCode::BAD_REQUEST;
+    }
 
     // Emit the player's own text as a log entry
     state.event_bus.emit(
@@ -217,6 +220,7 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
                 name
             )
         }
+        Command::InvalidBranchName(msg) => msg,
         Command::ToggleSidebar => "The Irish words panel is managed by the sidebar.".to_string(),
         Command::ToggleImprov => {
             let mut config = state.config.lock().await;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -313,6 +313,9 @@ pub async fn submit_input(
     if text.is_empty() {
         return Ok(());
     }
+    if text.len() > 2000 {
+        return Err("Input too long (max 2000 characters).".to_string());
+    }
 
     // Emit the player's own text as a log entry
     let _ = app.emit(
@@ -337,12 +340,12 @@ pub async fn submit_input(
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
-/// Helper to mask an API key for display.
+/// Helper to mask an API key for display, hiding length information for short keys.
 fn mask_key(key: &str) -> String {
     if key.len() > 8 {
         format!("{}...{}", &key[..4], &key[key.len() - 4..])
     } else {
-        "(set, too short to mask)".to_string()
+        "****".to_string()
     }
 }
 
@@ -452,6 +455,7 @@ async fn handle_system_command(
                 name
             )
         }
+        Command::InvalidBranchName(msg) => msg,
 
         Command::About => [
             "Parish — A text adventure set in 1820s rural Ireland.",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -368,22 +368,45 @@ pub fn run() {
 
     // Parse optional --screenshot <dir> flag.
     // Relative paths are resolved against the workspace root (parent of data/).
+    // Path traversal beyond the workspace root is rejected.
     let screenshot_dir: Option<PathBuf> = {
         let args: Vec<String> = std::env::args().collect();
+        let workspace_root = data_dir
+            .parent()
+            .map(|d| d.to_path_buf())
+            .unwrap_or_else(|| PathBuf::from(".."));
         args.iter()
             .position(|a| a == "--screenshot")
             .and_then(|i| args.get(i + 1))
-            .map(|s| {
+            .and_then(|s| {
                 let p = PathBuf::from(s);
-                if p.is_absolute() {
+                let resolved = if p.is_absolute() {
                     p
                 } else {
                     // src-tauri/ is one level below the workspace root
-                    let workspace_root = data_dir
-                        .parent()
-                        .map(|d| d.to_path_buf())
-                        .unwrap_or_else(|| PathBuf::from(".."));
                     workspace_root.join(p)
+                };
+                // Create the directory so canonicalize can resolve it
+                std::fs::create_dir_all(&resolved).ok();
+                let canonical = match resolved.canonicalize() {
+                    Ok(c) => c,
+                    Err(_) => {
+                        eprintln!("screenshot: could not resolve path: {}", resolved.display());
+                        return None;
+                    }
+                };
+                let ws_canonical = match workspace_root.canonicalize() {
+                    Ok(c) => c,
+                    Err(_) => return None,
+                };
+                if canonical.starts_with(&ws_canonical) {
+                    Some(canonical)
+                } else {
+                    eprintln!(
+                        "screenshot: path escapes workspace root: {}",
+                        resolved.display()
+                    );
+                    None
                 }
             })
     };

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -268,6 +268,15 @@ pub async fn run_headless(
     Ok(())
 }
 
+/// Masks an API key for display, hiding length information for short keys.
+fn mask_api_key(key: &str) -> String {
+    if key.len() > 8 {
+        format!("{}...{}", &key[..4], &key[key.len() - 4..])
+    } else {
+        "****".to_string()
+    }
+}
+
 /// Capitalizes the first character of a string slice.
 fn capitalize_first(s: &str) -> String {
     let mut chars = s.chars();
@@ -370,6 +379,9 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
                 "Unknown speed '{}'. Try: slow, normal, fast, fastest, ludicrous.",
                 name
             );
+        }
+        Command::InvalidBranchName(msg) => {
+            println!("{}", msg);
         }
         Command::Status => {
             let time = app.world.clock.time_of_day();
@@ -474,12 +486,8 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             println!("Model changed to {}.", name);
         }
         Command::ShowKey => match &app.api_key {
-            Some(key) if key.len() > 8 => {
-                let masked = format!("{}...{}", &key[..4], &key[key.len() - 4..]);
-                println!("API key: {}", masked);
-            }
-            Some(_) => {
-                println!("API key: (set, too short to mask)");
+            Some(key) => {
+                println!("API key: {}", mask_api_key(key));
             }
             None => {
                 println!("API key: (not set)");
@@ -726,12 +734,8 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             println!("Cloud model changed to {}.", name);
         }
         Command::ShowCloudKey => match &app.cloud_api_key {
-            Some(key) if key.len() > 8 => {
-                let masked = format!("{}...{}", &key[..4], &key[key.len() - 4..]);
-                println!("Cloud API key: {}", masked);
-            }
-            Some(_) => {
-                println!("Cloud API key: (set, too short to mask)");
+            Some(key) => {
+                println!("Cloud API key: {}", mask_api_key(key));
             }
             None => {
                 println!("Cloud API key: (not set)");
@@ -784,12 +788,8 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             println!("{} model changed to {}.", cat_name, name);
         }
         Command::ShowCategoryKey(cat) => match app.category_api_key(cat) {
-            Some(key) if key.len() > 8 => {
-                let masked = format!("{}...{}", &key[..4], &key[key.len() - 4..]);
-                println!("{} API key: {}", cat.name(), masked);
-            }
-            Some(_) => {
-                println!("{} API key: (set, too short to mask)", cat.name());
+            Some(key) => {
+                println!("{} API key: {}", cat.name(), mask_api_key(key));
             }
             None => {
                 println!("{} API key: (not set)", cat.name());
@@ -1671,5 +1671,23 @@ mod tests {
         let (quit, _rebuild) =
             handle_headless_command(&mut app, Command::Load(String::new())).await;
         assert!(!quit);
+    }
+
+    #[test]
+    fn test_mask_api_key_long() {
+        assert_eq!(mask_api_key("sk-1234567890abcdef"), "sk-1...cdef");
+    }
+
+    #[test]
+    fn test_mask_api_key_short_hides_length() {
+        // Short keys should not reveal length information
+        assert_eq!(mask_api_key("abc"), "****");
+        assert_eq!(mask_api_key("12345678"), "****");
+    }
+
+    #[test]
+    fn test_mask_api_key_boundary() {
+        // Exactly 9 chars — just over the threshold
+        assert_eq!(mask_api_key("123456789"), "1234...6789");
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -409,6 +409,10 @@ impl GameTestHarness {
                 self.app.world.log(msg.clone());
                 ActionResult::SystemCommand { response: msg }
             }
+            Command::InvalidBranchName(msg) => {
+                self.app.world.log(msg.clone());
+                ActionResult::SystemCommand { response: msg }
+            }
             Command::Status => {
                 let time = self.app.world.clock.time_of_day();
                 let season = self.app.world.clock.season();


### PR DESCRIPTION
## Summary

Five related security hardening fixes across the codebase:

- **#87** — API key masking no longer leaks key length; short keys show `****` instead of `(set, too short to mask)`
- **#129** — `HTTP-Referer` and `X-Title` fingerprint headers only sent to OpenRouter (which requires them), omitted for other providers
- **#130** — `--screenshot` path is canonicalized and validated against the workspace root to prevent directory traversal
- **#84** — Branch names in `/fork` and `/load` validated for length (max 255) and allowed characters (alphanumeric, space, hyphen, underscore)
- **#58** — Player input rejected if longer than 2000 characters in both Tauri IPC and web server handlers

Closes #87, closes #129, closes #130, closes #84, closes #58.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — all 780 tests pass
- [x] New unit tests for `mask_api_key` (long key, short key, boundary)
- [x] New unit tests for `validate_branch_name` (valid names, too-long, invalid chars, fork parsing)
- [x] All command handlers updated for new `InvalidBranchName` variant (headless, tauri, server, testing)

https://claude.ai/code/session_015kjP5WmELVUCFRgS4h99mQ