### PR TITLE
fix: code quality — unused params, clippy warnings, screenshot cleanup, streaming source

### DIFF
--- a/crates/parish-core/src/inference/openai_client.rs
+++ b/crates/parish-core/src/inference/openai_client.rs
@@ -634,6 +634,7 @@ mod tests {
     #[ignore] // Requires Ollama running on localhost:11434
     async fn test_generate_json_live() {
         #[derive(Deserialize, Debug)]
+        #[allow(dead_code)] // used only for JSON deserialization test
         struct TestResponse {
             #[serde(default)]
             greeting: String,

--- a/crates/parish-core/src/npc/data.rs
+++ b/crates/parish-core/src/npc/data.rs
@@ -286,7 +286,7 @@ mod tests {
         let npc_map: HashMap<NpcId, &Npc> = npcs.iter().map(|n| (n.id, n)).collect();
 
         for npc in &npcs {
-            for (target_id, _rel) in &npc.relationships {
+            for target_id in npc.relationships.keys() {
                 let target = npc_map.get(target_id).unwrap_or_else(|| {
                     panic!(
                         "{} has relationship with NPC {} but that NPC doesn't exist",

--- a/crates/parish-core/src/npc/mod.rs
+++ b/crates/parish-core/src/npc/mod.rs
@@ -519,7 +519,7 @@ mod tests {
 
     #[test]
     fn test_build_context() {
-        let npc = Npc::new_test_npc();
+        let _npc = Npc::new_test_npc();
         let world = WorldState::new();
         let context = build_tier1_context(&world, "says hello");
         assert!(context.contains("The Crossroads"));
@@ -759,6 +759,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::assertions_on_constants)] // deliberate static assertion
     fn test_separator_holdback_sufficient() {
         // Holdback must be large enough to catch " --- " inline pattern
         assert!(SEPARATOR_HOLDBACK >= 20);

--- a/crates/parish-core/src/persistence/snapshot.rs
+++ b/crates/parish-core/src/persistence/snapshot.rs
@@ -342,7 +342,7 @@ mod tests {
         let mut new_world = WorldState::new();
         let mut new_npcs = NpcManager::new();
         snapshot.restore(&mut new_world, &mut new_npcs);
-        assert!(new_npcs.needs_tier2_tick(t) == false);
+        assert!(!new_npcs.needs_tier2_tick(t));
     }
 
     #[test]

--- a/docs/design/gui-design.md
+++ b/docs/design/gui-design.md
@@ -15,7 +15,7 @@ The `ChatPanel.svelte` component displays an animated **Celtic triquetra (Trinit
 - **Slow rotation**: the entire SVG rotates at 6s/revolution for organic motion
 - **Theme-adaptive**: uses `var(--color-accent)` (gold) which changes with time-of-day palette
 
-Once streaming tokens begin arriving, the spinner is replaced by a blinking cursor (`▋`) at the end of the streaming text.
+Once streaming tokens begin arriving, the spinner is replaced by a blinking cursor (`▋`) at the end of the streaming text. The streaming source label is derived from the last non-player, non-system log entry so the correct NPC name appears during token streaming.
 
 The headless and TUI modes continue to use the Rust `LoadingAnimation` (`crates/parish-core/src/loading.rs`) with Celtic cross Unicode characters and Irish-themed phrases.
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -593,12 +593,12 @@ pub fn run() {
                         // GDK must be called from the GTK main thread; dispatch and await.
                         let path = dir.join(format!("gui-{}.png", name));
                         if let Err(e) = dispatch_screenshot(path).await {
-                            eprintln!("screenshot: failed for {name}: {e}");
+                            tracing::error!(name = %name, error = %e, "screenshot capture failed");
                         }
                     }
 
                     println!("screenshot: all done, exiting");
-                    std::process::exit(0);
+                    handle_ss.exit(0);
                 });
 
                 return Ok(());

--- a/src/app.rs
+++ b/src/app.rs
@@ -50,13 +50,11 @@ impl ScrollState {
     }
 
     /// Scrolls down by the given number of lines.
-    pub fn scroll_down(&mut self, lines: u16, max_offset: u16) {
+    pub fn scroll_down(&mut self, lines: u16) {
         self.offset = self.offset.saturating_sub(lines);
         if self.offset == 0 {
             self.auto_scroll = true;
         }
-        // Clamp — offset is distance from bottom, so 0 = bottom
-        let _ = max_offset; // kept for API clarity; clamping happens in update()
     }
 
     /// Scrolls to the top of the text log.
@@ -425,7 +423,7 @@ mod tests {
         scroll.scroll_up(3);
         assert!(!scroll.auto_scroll);
 
-        scroll.scroll_down(3, 100);
+        scroll.scroll_down(3);
         assert_eq!(scroll.offset, 0);
         assert!(scroll.auto_scroll);
     }
@@ -434,7 +432,7 @@ mod tests {
     fn test_scroll_down_partial() {
         let mut scroll = ScrollState::new();
         scroll.scroll_up(10);
-        scroll.scroll_down(3, 100);
+        scroll.scroll_down(3);
         assert_eq!(scroll.offset, 7);
         assert!(!scroll.auto_scroll);
     }
@@ -443,7 +441,7 @@ mod tests {
     fn test_scroll_down_clamps_at_zero() {
         let mut scroll = ScrollState::new();
         scroll.scroll_up(2);
-        scroll.scroll_down(10, 100);
+        scroll.scroll_down(10);
         assert_eq!(scroll.offset, 0);
         assert!(scroll.auto_scroll);
     }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1495,7 +1495,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_restore_from_db_with_existing_snapshot() {
-        let mut app = App::new();
+        let app = App::new();
         let db = crate::persistence::Database::open_memory().unwrap();
         let async_db = Arc::new(crate::persistence::AsyncDatabase::new(db));
 

--- a/tests/headless_script_tests.rs
+++ b/tests/headless_script_tests.rs
@@ -425,12 +425,12 @@ fn test_pause_shows_paused_in_status() {
             is_paused = true;
         } else if r.command == "/resume" {
             is_paused = false;
-        } else if r.command == "/status" && is_paused {
-            if let ActionResult::SystemCommand { response } = &r.result {
-                if response.contains("paused") || response.contains("PAUSED") {
-                    found_paused_status = true;
-                }
-            }
+        } else if r.command == "/status"
+            && is_paused
+            && let ActionResult::SystemCommand { response } = &r.result
+            && (response.contains("paused") || response.contains("PAUSED"))
+        {
+            found_paused_status = true;
         }
     }
 
@@ -452,10 +452,10 @@ fn test_resume_clears_pause() {
         if r.command == "/resume" {
             last_was_resume = true;
         } else if r.command == "/status" && last_was_resume {
-            if let ActionResult::SystemCommand { response } = &r.result {
-                if !response.contains("paused") {
-                    found_unpaused = true;
-                }
+            if let ActionResult::SystemCommand { response } = &r.result
+                && !response.contains("paused")
+            {
+                found_unpaused = true;
             }
             last_was_resume = false;
         } else {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -141,7 +141,12 @@
 							{ ...last, content: payload.token, streaming: true }
 						];
 					}
-					return [...log, { source: 'NPC', content: payload.token, streaming: true }];
+					// Use the most recent NPC source name if available, otherwise fall back
+					const npcSource =
+						last && last.source !== 'player' && last.source !== 'system'
+							? last.source
+							: 'NPC';
+					return [...log, { source: npcSource, content: payload.token, streaming: true }];
 				});
 			}),
 


### PR DESCRIPTION
## Summary

Five related code quality and correctness fixes:

- **#125** — Remove unused `max_offset` parameter from `scroll_down()` which was explicitly discarded with `let _ = max_offset`
- **#136** — Clean up all clippy warnings in test modules: unused mut, unused variable, dead code, map key iteration, bool comparison, collapsible if-let chains
- **#114** — Use `tracing::error!` instead of `eprintln!` for screenshot failures so errors appear in structured logs
- **#61** — Replace `std::process::exit(0)` with `handle_ss.exit(0)` in screenshot mode to allow proper Tauri cleanup and destructor execution
- **#62** — Use the most recent NPC log entry's source name instead of hardcoded `'NPC'` when creating a streaming entry fallback

Closes #61, closes #62, closes #114, closes #125, closes #136.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --tests` — zero warnings
- [x] `cargo test` — all 774 tests pass
- [x] No callers of `scroll_down` outside `src/app.rs` (3 test call sites updated)

https://claude.ai/code/session_015kjP5WmELVUCFRgS4h99mQ