### PR TITLE
feat: add per-session web deployment with Dockerfile and Fly.io config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+target/
+node_modules/
+ui/dist/
+ui/.svelte-kit/
+logs/
+.git/
+.env
+parish.toml
+*.db
+*.db-wal
+*.db-shm
+docs/
+.devcontainer/
+.claude/
+.github/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,6 +2604,7 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# Stage 1: Build the Svelte frontend
+FROM node:22-slim AS frontend
+WORKDIR /app/ui
+COPY ui/package.json ui/package-lock.json ./
+RUN npm ci
+COPY ui/ ./
+RUN npm run build
+
+# Stage 2: Build the Rust backend
+FROM rust:1.87-bookworm AS backend
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+
+# Copy workspace manifests for dependency caching
+COPY Cargo.toml Cargo.lock ./
+COPY crates/parish-core/Cargo.toml crates/parish-core/Cargo.toml
+COPY crates/parish-server/Cargo.toml crates/parish-server/Cargo.toml
+COPY src-tauri/Cargo.toml src-tauri/Cargo.toml
+
+# Create minimal stubs so cargo can resolve the workspace and cache deps
+RUN mkdir -p src crates/parish-core/src crates/parish-server/src src-tauri/src \
+    && echo "fn main() {}" > src/main.rs \
+    && echo "pub fn stub() {}" > src/lib.rs \
+    && echo "pub fn stub() {}" > crates/parish-core/src/lib.rs \
+    && echo "pub fn stub() {}" > crates/parish-server/src/lib.rs \
+    && echo "pub fn stub() {}" > src-tauri/src/lib.rs \
+    && echo "fn main() {}" > src-tauri/src/main.rs \
+    && mkdir -p src/bin/geo_tool && echo "fn main() {}" > src/bin/geo_tool/main.rs \
+    && cargo build --release -p parish 2>/dev/null || true
+
+# Copy real source code and build
+COPY src/ src/
+COPY crates/ crates/
+# Touch files so cargo detects changes vs the stubs
+RUN touch src/main.rs crates/parish-core/src/lib.rs crates/parish-server/src/lib.rs
+RUN cargo build --release --bin parish
+
+# Stage 3: Minimal runtime image
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libssl3 && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+
+COPY --from=backend /app/target/release/parish ./parish
+COPY --from=frontend /app/ui/dist ./ui/dist
+COPY data/ ./data/
+
+EXPOSE 8080
+
+ENV PARISH_PROVIDER=openrouter
+ENV RUST_LOG=parish=info
+
+CMD ["./parish", "--web", "8080"]

--- a/crates/parish-server/Cargo.toml
+++ b/crates/parish-server/Cargo.toml
@@ -15,3 +15,4 @@ tracing = "0.1"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "0.15"
+uuid = { version = "1", features = ["v4"] }

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -1,8 +1,8 @@
 //! Parish web server — serves the Svelte UI in a browser via axum.
 //!
 //! Provides the same game experience as the Tauri desktop app, but over
-//! standard HTTP + WebSocket so it can run in any browser. Primarily
-//! intended for automated Chrome testing via Playwright.
+//! standard HTTP + WebSocket so it can run in any browser. Each visitor
+//! gets their own isolated game session.
 
 pub mod routes;
 pub mod state;
@@ -19,41 +19,45 @@ use tower_http::services::ServeDir;
 
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceQueue, new_inference_log, spawn_inference_worker};
-use parish_core::npc::manager::NpcManager;
-use parish_core::world::{LocationId, WorldState};
+use parish_core::world::LocationId;
 
-use state::{AppState, GameConfig, build_app_state};
+use state::{GameConfig, GameSession, ServerState, SessionManager};
+
+/// Default maximum concurrent sessions.
+const DEFAULT_MAX_SESSIONS: usize = 50;
+
+/// Idle session timeout (10 minutes).
+const SESSION_TIMEOUT_SECS: u64 = 600;
 
 /// Starts the Parish web server on the given port.
 ///
 /// Loads game data from `data_dir`, serves the Svelte frontend from
 /// `static_dir` (typically `ui/dist/`), and exposes REST + WebSocket
-/// endpoints for the game.
+/// endpoints for the game. Each visitor gets an isolated game session.
 pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
-    // Load world
-    let world = WorldState::from_parish_file(&data_dir.join("parish.json"), LocationId(15))
-        .unwrap_or_else(|e| {
-            tracing::warn!("Failed to load parish.json: {}. Using default world.", e);
-            WorldState::new()
-        });
+    let max_sessions: usize = std::env::var("PARISH_MAX_SESSIONS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_MAX_SESSIONS);
 
-    // Load NPCs
-    let mut npc_manager =
-        NpcManager::load_from_file(&data_dir.join("npcs.json")).unwrap_or_else(|e| {
-            tracing::warn!("Failed to load npcs.json: {}. No NPCs.", e);
-            NpcManager::new()
-        });
-    npc_manager.assign_tiers(world.player_location, &world.graph);
-
-    // Build client from env
+    // Build shared inference client from env
     let (client, config) = build_client_and_config();
     let cloud_client = build_cloud_client();
 
-    let state = build_app_state(world, npc_manager, client.clone(), config, cloud_client);
+    // Build session manager with data dir for per-session world loading
+    let session_manager = SessionManager::new(data_dir, LocationId(15), max_sessions);
 
-    // Initialize inference queue
+    let state = Arc::new(ServerState {
+        sessions: session_manager,
+        inference_queue: tokio::sync::Mutex::new(None),
+        client: tokio::sync::Mutex::new(client.clone()),
+        cloud_client: tokio::sync::Mutex::new(cloud_client),
+        config: tokio::sync::Mutex::new(config),
+    });
+
+    // Initialize shared inference queue
     if let Some(ref client) = client {
         let (tx, rx) = tokio::sync::mpsc::channel(32);
         let _worker = spawn_inference_worker(client.clone(), rx, new_inference_log());
@@ -62,11 +66,12 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         *iq = Some(queue);
     }
 
-    // Spawn background ticks
-    spawn_background_ticks(Arc::clone(&state));
+    // Spawn session cleanup task
+    spawn_session_cleanup(Arc::clone(&state));
 
     // Build router
     let app = Router::new()
+        .route("/api/session", post(routes::create_session))
         .route("/api/world-snapshot", get(routes::get_world_snapshot))
         .route("/api/map", get(routes::get_map))
         .route("/api/npcs-here", get(routes::get_npcs_here))
@@ -80,6 +85,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     let addr = format!("0.0.0.0:{}", port);
     tracing::info!("Parish web server listening on http://{}", addr);
     tracing::info!("Serving static files from {}", static_dir.display());
+    tracing::info!("Max sessions: {}", max_sessions);
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     axum::serve(listener, app).await?;
@@ -87,21 +93,26 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     Ok(())
 }
 
-/// Spawns the background tick tasks (world update + theme update).
-fn spawn_background_ticks(state: Arc<AppState>) {
-    // Idle tick: broadcast world snapshot every 5 seconds
-    let state_tick = Arc::clone(&state);
+/// Spawns per-session background tick tasks (world update + theme update).
+///
+/// Uses `Arc::downgrade` so that ticks automatically stop when the
+/// session is cleaned up (the `Weak` upgrade fails and the loop exits).
+pub fn spawn_session_ticks(session: Arc<GameSession>) {
+    let weak_tick = Arc::downgrade(&session);
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(Duration::from_secs(5)).await;
+            let Some(session) = weak_tick.upgrade() else {
+                break;
+            };
             {
-                let world = state_tick.world.lock().await;
+                let world = session.world.lock().await;
                 let snapshot = parish_core::ipc::snapshot_from_world(&world);
-                state_tick.event_bus.emit("world-update", &snapshot);
+                session.event_bus.emit("world-update", &snapshot);
             }
             {
-                let world = state_tick.world.lock().await;
-                let mut npc_mgr = state_tick.npc_manager.lock().await;
+                let world = session.world.lock().await;
+                let mut npc_mgr = session.npc_manager.lock().await;
                 let events = npc_mgr.tick_schedules(&world.clock, &world.graph);
                 if !events.is_empty() {
                     tracing::debug!("NPC schedule tick: {} events", events.len());
@@ -110,14 +121,34 @@ fn spawn_background_ticks(state: Arc<AppState>) {
         }
     });
 
-    // Theme tick: broadcast updated palette every 500 ms
-    let state_theme = Arc::clone(&state);
+    let weak_theme = Arc::downgrade(&session);
     tokio::spawn(async move {
         loop {
             tokio::time::sleep(Duration::from_millis(500)).await;
-            let world = state_theme.world.lock().await;
+            let Some(session) = weak_theme.upgrade() else {
+                break;
+            };
+            let world = session.world.lock().await;
             let palette = parish_core::ipc::build_theme(&world);
-            state_theme.event_bus.emit("theme-update", &palette);
+            session.event_bus.emit("theme-update", &palette);
+        }
+    });
+}
+
+/// Spawns a background task that cleans up idle sessions periodically.
+fn spawn_session_cleanup(state: Arc<ServerState>) {
+    tokio::spawn(async move {
+        let timeout = Duration::from_secs(SESSION_TIMEOUT_SECS);
+        loop {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            let removed = state.sessions.remove_idle(timeout).await;
+            if removed > 0 {
+                tracing::info!(
+                    "Cleaned up {} idle sessions ({} active)",
+                    removed,
+                    state.sessions.session_count().await
+                );
+            }
         }
     });
 }

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -1,13 +1,13 @@
 //! HTTP route handlers for the Parish web server.
 //!
-//! Each route maps to a Tauri command, calling the shared handlers in
-//! [`parish_core::ipc`] and returning JSON responses.
+//! Each route extracts a session ID from the query string and operates
+//! on that session's isolated game state. The inference pipeline is shared.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use axum::Json;
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use tokio::sync::mpsc;
@@ -27,42 +27,112 @@ use parish_core::world::movement::{self, MovementResult};
 
 use parish_core::debug_snapshot::{self, DebugSnapshot, InferenceDebug};
 
-use crate::state::{AppState, GameConfig};
+use crate::state::{GameConfig, GameSession, ServerState};
 
 /// Monotonically increasing request ID counter for inference requests.
 static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 
+/// Query parameter for session identification.
+#[derive(serde::Deserialize)]
+pub struct SessionQuery {
+    /// The session UUID.
+    pub session: String,
+}
+
+/// Response body for session creation.
+#[derive(serde::Serialize)]
+pub struct CreateSessionResponse {
+    /// The newly created session UUID.
+    pub session_id: String,
+}
+
+/// Helper: look up a session and touch its activity timestamp.
+async fn get_session(
+    state: &Arc<ServerState>,
+    session_id: &str,
+) -> Result<Arc<GameSession>, StatusCode> {
+    let session = state
+        .sessions
+        .get(session_id)
+        .await
+        .ok_or(StatusCode::NOT_FOUND)?;
+    session.touch().await;
+    Ok(session)
+}
+
+// ── Session management ─────────────────────────────────────────────────────
+
+/// `POST /api/session` — creates a new game session.
+pub async fn create_session(
+    State(state): State<Arc<ServerState>>,
+) -> Result<Json<CreateSessionResponse>, StatusCode> {
+    let (id, session) = state
+        .sessions
+        .create_session()
+        .await
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    // Spawn per-session background ticks
+    crate::spawn_session_ticks(Arc::clone(&session));
+
+    tracing::info!("Created session {}", id);
+    Ok(Json(CreateSessionResponse { session_id: id }))
+}
+
 // ── Query endpoints ─────────────────────────────────────────────────────────
 
 /// `GET /api/world-snapshot` — returns the current world snapshot.
-pub async fn get_world_snapshot(State(state): State<Arc<AppState>>) -> Json<WorldSnapshot> {
-    let world = state.world.lock().await;
-    Json(parish_core::ipc::snapshot_from_world(&world))
+pub async fn get_world_snapshot(
+    State(state): State<Arc<ServerState>>,
+    Query(q): Query<SessionQuery>,
+) -> Result<Json<WorldSnapshot>, StatusCode> {
+    let session = get_session(&state, &q.session).await?;
+    let world = session.world.lock().await;
+    Ok(Json(parish_core::ipc::snapshot_from_world(&world)))
 }
 
 /// `GET /api/map` — returns the map with all locations and edges.
-pub async fn get_map(State(state): State<Arc<AppState>>) -> Json<MapData> {
-    let world = state.world.lock().await;
-    Json(parish_core::ipc::build_map_data(&world))
+pub async fn get_map(
+    State(state): State<Arc<ServerState>>,
+    Query(q): Query<SessionQuery>,
+) -> Result<Json<MapData>, StatusCode> {
+    let session = get_session(&state, &q.session).await?;
+    let world = session.world.lock().await;
+    Ok(Json(parish_core::ipc::build_map_data(&world)))
 }
 
 /// `GET /api/npcs-here` — returns NPCs at the player's current location.
-pub async fn get_npcs_here(State(state): State<Arc<AppState>>) -> Json<Vec<NpcInfo>> {
-    let world = state.world.lock().await;
-    let npc_manager = state.npc_manager.lock().await;
-    Json(parish_core::ipc::build_npcs_here(&world, &npc_manager))
+pub async fn get_npcs_here(
+    State(state): State<Arc<ServerState>>,
+    Query(q): Query<SessionQuery>,
+) -> Result<Json<Vec<NpcInfo>>, StatusCode> {
+    let session = get_session(&state, &q.session).await?;
+    let world = session.world.lock().await;
+    let npc_manager = session.npc_manager.lock().await;
+    Ok(Json(parish_core::ipc::build_npcs_here(
+        &world,
+        &npc_manager,
+    )))
 }
 
 /// `GET /api/theme` — returns the current time-of-day theme palette.
-pub async fn get_theme(State(state): State<Arc<AppState>>) -> Json<ThemePalette> {
-    let world = state.world.lock().await;
-    Json(parish_core::ipc::build_theme(&world))
+pub async fn get_theme(
+    State(state): State<Arc<ServerState>>,
+    Query(q): Query<SessionQuery>,
+) -> Result<Json<ThemePalette>, StatusCode> {
+    let session = get_session(&state, &q.session).await?;
+    let world = session.world.lock().await;
+    Ok(Json(parish_core::ipc::build_theme(&world)))
 }
 
 /// `GET /api/debug-snapshot` — returns full debug state for the debug panel.
-pub async fn get_debug_snapshot(State(state): State<Arc<AppState>>) -> Json<DebugSnapshot> {
-    let world = state.world.lock().await;
-    let npc_manager = state.npc_manager.lock().await;
+pub async fn get_debug_snapshot(
+    State(state): State<Arc<ServerState>>,
+    Query(q): Query<SessionQuery>,
+) -> Result<Json<DebugSnapshot>, StatusCode> {
+    let session = get_session(&state, &q.session).await?;
+    let world = session.world.lock().await;
+    let npc_manager = session.npc_manager.lock().await;
     let config = state.config.lock().await;
     let events = std::collections::VecDeque::new();
     let inference = InferenceDebug {
@@ -75,12 +145,12 @@ pub async fn get_debug_snapshot(State(state): State<Arc<AppState>>) -> Json<Debu
         improv_enabled: config.improv_enabled,
         call_log: Vec::new(),
     };
-    Json(debug_snapshot::build_debug_snapshot(
+    Ok(Json(debug_snapshot::build_debug_snapshot(
         &world,
         &npc_manager,
         &events,
         &inference,
-    ))
+    )))
 }
 
 // ── Input endpoint ──────────────────────────────────────────────────────────
@@ -94,16 +164,18 @@ pub struct SubmitInputRequest {
 
 /// `POST /api/submit-input` — processes player text input.
 pub async fn submit_input(
-    State(state): State<Arc<AppState>>,
+    State(state): State<Arc<ServerState>>,
+    Query(q): Query<SessionQuery>,
     Json(body): Json<SubmitInputRequest>,
-) -> impl IntoResponse {
+) -> Result<impl IntoResponse, StatusCode> {
+    let session = get_session(&state, &q.session).await?;
     let text = body.text.trim().to_string();
     if text.is_empty() {
-        return StatusCode::OK;
+        return Ok(StatusCode::OK);
     }
 
     // Emit the player's own text as a log entry
-    state.event_bus.emit(
+    session.event_bus.emit(
         "text-log",
         &TextLogPayload {
             source: "player".to_string(),
@@ -113,20 +185,20 @@ pub async fn submit_input(
 
     match classify_input(&text) {
         InputResult::SystemCommand(cmd) => {
-            handle_system_command(cmd, &state).await;
+            handle_system_command(cmd, &session, &state).await;
         }
         InputResult::GameInput(raw) => {
-            handle_game_input(raw, &state).await;
+            handle_game_input(raw, &session, &state).await;
         }
     }
 
-    StatusCode::OK
+    Ok(StatusCode::OK)
 }
 
 // ── Internal helpers ────────────────────────────────────────────────────────
 
 /// Rebuilds the inference pipeline after a provider/key/client change.
-async fn rebuild_inference(state: &Arc<AppState>) {
+async fn rebuild_inference(state: &Arc<ServerState>) {
     let config = state.config.lock().await;
     let new_client = OpenAiClient::new(&config.base_url, config.api_key.as_deref());
     drop(config);
@@ -143,7 +215,11 @@ async fn rebuild_inference(state: &Arc<AppState>) {
 }
 
 /// Handles `/command` system inputs.
-async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<AppState>) {
+async fn handle_system_command(
+    cmd: parish_core::input::Command,
+    session: &Arc<GameSession>,
+    state: &Arc<ServerState>,
+) {
     use parish_core::input::Command;
     use parish_core::ipc::mask_key;
 
@@ -151,17 +227,17 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
 
     let response = match cmd {
         Command::Pause => {
-            let mut world = state.world.lock().await;
+            let mut world = session.world.lock().await;
             world.clock.pause();
             "The clocks of the parish stand still.".to_string()
         }
         Command::Resume => {
-            let mut world = state.world.lock().await;
+            let mut world = session.world.lock().await;
             world.clock.resume();
             "Time stirs again in the parish.".to_string()
         }
         Command::Status => {
-            let world = state.world.lock().await;
+            let world = session.world.lock().await;
             let tod = world.clock.time_of_day();
             let season = world.clock.season();
             let loc = world.current_location().name.clone();
@@ -185,7 +261,7 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
             "The web server cannot be quit from the game. Close your browser tab.".to_string()
         }
         Command::ShowSpeed => {
-            let world = state.world.lock().await;
+            let world = session.world.lock().await;
             let s = world
                 .clock
                 .current_speed()
@@ -194,7 +270,7 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
             format!("Speed: {}", s)
         }
         Command::SetSpeed(speed) => {
-            let mut world = state.world.lock().await;
+            let mut world = session.world.lock().await;
             world.clock.set_speed(speed);
             speed.activation_message().to_string()
         }
@@ -381,7 +457,7 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
         rebuild_inference(state).await;
     }
 
-    state.event_bus.emit(
+    session.event_bus.emit(
         "text-log",
         &TextLogPayload {
             source: "system".to_string(),
@@ -389,15 +465,15 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
         },
     );
 
-    let world = state.world.lock().await;
-    state.event_bus.emit(
+    let world = session.world.lock().await;
+    session.event_bus.emit(
         "world-update",
         &parish_core::ipc::snapshot_from_world(&world),
     );
 }
 
 /// Handles free-form game input: parses intent then dispatches.
-async fn handle_game_input(raw: String, state: &Arc<AppState>) {
+async fn handle_game_input(raw: String, session: &Arc<GameSession>, state: &Arc<ServerState>) {
     let intent = parse_intent_local(&raw);
 
     let is_move = intent
@@ -415,9 +491,9 @@ async fn handle_game_input(raw: String, state: &Arc<AppState>) {
 
     if is_move {
         if let Some(target) = move_target {
-            handle_movement(&target, state).await;
+            handle_movement(&target, session).await;
         } else {
-            state.event_bus.emit(
+            session.event_bus.emit(
                 "text-log",
                 &TextLogPayload {
                     source: "system".to_string(),
@@ -429,17 +505,17 @@ async fn handle_game_input(raw: String, state: &Arc<AppState>) {
     }
 
     if is_look {
-        handle_look(state).await;
+        handle_look(session).await;
         return;
     }
 
-    handle_npc_conversation(raw, state).await;
+    handle_npc_conversation(raw, session, state).await;
 }
 
 /// Resolves movement to a named location.
-async fn handle_movement(target: &str, state: &Arc<AppState>) {
+async fn handle_movement(target: &str, session: &Arc<GameSession>) {
     let result = {
-        let world = state.world.lock().await;
+        let world = session.world.lock().await;
         movement::resolve_movement(target, &world.graph, world.player_location)
     };
 
@@ -451,7 +527,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
             ..
         } => {
             {
-                let mut world = state.world.lock().await;
+                let mut world = session.world.lock().await;
                 world.clock.advance(minutes as i64);
                 world.player_location = destination;
 
@@ -471,7 +547,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
                 }
             }
 
-            state.event_bus.emit(
+            session.event_bus.emit(
                 "text-log",
                 &TextLogPayload {
                     source: "system".to_string(),
@@ -479,16 +555,16 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
                 },
             );
 
-            handle_look(state).await;
+            handle_look(session).await;
 
-            let world = state.world.lock().await;
-            state.event_bus.emit(
+            let world = session.world.lock().await;
+            session.event_bus.emit(
                 "world-update",
                 &parish_core::ipc::snapshot_from_world(&world),
             );
         }
         MovementResult::AlreadyHere => {
-            state.event_bus.emit(
+            session.event_bus.emit(
                 "text-log",
                 &TextLogPayload {
                     source: "system".to_string(),
@@ -497,9 +573,9 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
             );
         }
         MovementResult::NotFound(name) => {
-            let world = state.world.lock().await;
+            let world = session.world.lock().await;
             let exits = format_exits(world.player_location, &world.graph);
-            state.event_bus.emit(
+            session.event_bus.emit(
                 "text-log",
                 &TextLogPayload {
                     source: "system".to_string(),
@@ -514,9 +590,9 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
 }
 
 /// Renders the current location description and exits.
-async fn handle_look(state: &Arc<AppState>) {
-    let world = state.world.lock().await;
-    let npc_manager = state.npc_manager.lock().await;
+async fn handle_look(session: &Arc<GameSession>) {
+    let world = session.world.lock().await;
+    let npc_manager = session.npc_manager.lock().await;
 
     let desc = if let Some(loc_data) = world.current_location_data() {
         let tod = world.clock.time_of_day();
@@ -534,7 +610,7 @@ async fn handle_look(state: &Arc<AppState>) {
 
     let exits = format_exits(world.player_location, &world.graph);
 
-    state.event_bus.emit(
+    session.event_bus.emit(
         "text-log",
         &TextLogPayload {
             source: "system".to_string(),
@@ -544,10 +620,14 @@ async fn handle_look(state: &Arc<AppState>) {
 }
 
 /// Routes input to the NPC at the player's location, or shows idle message.
-async fn handle_npc_conversation(raw: String, state: &Arc<AppState>) {
+async fn handle_npc_conversation(
+    raw: String,
+    session: &Arc<GameSession>,
+    state: &Arc<ServerState>,
+) {
     let (npc_name, npc_id, system_prompt, context, queue) = {
-        let world = state.world.lock().await;
-        let mut npc_manager = state.npc_manager.lock().await;
+        let world = session.world.lock().await;
+        let mut npc_manager = session.npc_manager.lock().await;
         let queue = state.inference_queue.lock().await;
 
         let npcs_here = npc_manager.npcs_at(world.player_location);
@@ -577,7 +657,7 @@ async fn handle_npc_conversation(raw: String, state: &Arc<AppState>) {
             "The clouds shift. The parish carries on.",
         ];
         let idx = REQUEST_ID.fetch_add(1, Ordering::SeqCst) as usize % idle_messages.len();
-        state.event_bus.emit(
+        session.event_bus.emit(
             "text-log",
             &TextLogPayload {
                 source: "system".to_string(),
@@ -593,14 +673,14 @@ async fn handle_npc_conversation(raw: String, state: &Arc<AppState>) {
     };
     let req_id = REQUEST_ID.fetch_add(1, Ordering::SeqCst);
 
-    state
+    session
         .event_bus
         .emit("loading", &LoadingPayload { active: true });
 
     let (token_tx, token_rx) = mpsc::unbounded_channel::<String>();
 
     let display_label = capitalize_first(&npc_name);
-    state.event_bus.emit(
+    session.event_bus.emit(
         "text-log",
         &TextLogPayload {
             source: display_label,
@@ -620,12 +700,12 @@ async fn handle_npc_conversation(raw: String, state: &Arc<AppState>) {
         .await
     {
         Ok(mut response_rx) => {
-            let bus = &state.event_bus;
+            let bus = &session.event_bus;
 
             let stream_handle = tokio::spawn({
-                let state_clone = Arc::clone(state);
+                let session_clone = Arc::clone(session);
                 async move {
-                    crate::streaming::stream_npc_response(&state_clone.event_bus, token_rx).await
+                    crate::streaming::stream_npc_response(&session_clone.event_bus, token_rx).await
                 }
             });
 
@@ -666,7 +746,7 @@ async fn handle_npc_conversation(raw: String, state: &Arc<AppState>) {
         }
     }
 
-    state
+    session
         .event_bus
         .emit("loading", &LoadingPayload { active: false });
 }

--- a/crates/parish-server/src/state.rs
+++ b/crates/parish-server/src/state.rs
@@ -1,33 +1,161 @@
 //! Shared application state and event bus for the web server.
+//!
+//! Supports per-session game isolation: each visitor gets their own world,
+//! NPC manager, and event bus while sharing the inference pipeline.
 
+use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{Mutex, RwLock, broadcast};
 
 use parish_core::inference::InferenceQueue;
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::npc::manager::NpcManager;
-use parish_core::world::WorldState;
+use parish_core::world::{LocationId, WorldState};
 
-/// Shared mutable game state for the web server.
+/// Unique session identifier (UUID v4 string).
+pub type SessionId = String;
+
+/// Per-visitor isolated game state.
 ///
-/// Mirrors the Tauri `AppState` but uses an [`EventBus`] for push events
-/// instead of a Tauri `AppHandle`.
-pub struct AppState {
+/// Each browser session gets its own world, NPC manager, and event bus
+/// so players don't interfere with each other.
+pub struct GameSession {
     /// The game world (clock, player position, graph, weather).
     pub world: Mutex<WorldState>,
     /// NPC manager (all NPCs, tier assignment, schedule ticking).
     pub npc_manager: Mutex<NpcManager>,
-    /// Inference request queue (None if no provider configured).
+    /// Broadcast channel for pushing events to this session's WebSocket.
+    pub event_bus: EventBus,
+    /// When this session was created.
+    pub created_at: Instant,
+    /// Last time the session was accessed (for idle cleanup).
+    pub last_activity: Mutex<Instant>,
+}
+
+impl GameSession {
+    /// Updates the last activity timestamp to now.
+    pub async fn touch(&self) {
+        *self.last_activity.lock().await = Instant::now();
+    }
+}
+
+/// Manages all active game sessions and shared resources.
+///
+/// The inference pipeline (queue + clients) is shared across sessions
+/// since it's stateless. Only game state is per-session.
+pub struct SessionManager {
+    /// Active sessions keyed by UUID.
+    sessions: RwLock<HashMap<SessionId, Arc<GameSession>>>,
+    /// Path to data directory (for loading world/NPC templates).
+    data_dir: PathBuf,
+    /// Starting location ID for new sessions.
+    start_location: LocationId,
+    /// Maximum concurrent sessions allowed.
+    max_sessions: usize,
+}
+
+impl SessionManager {
+    /// Creates a new session manager.
+    pub fn new(data_dir: PathBuf, start_location: LocationId, max_sessions: usize) -> Self {
+        Self {
+            sessions: RwLock::new(HashMap::new()),
+            data_dir,
+            start_location,
+            max_sessions,
+        }
+    }
+
+    /// Creates a new game session by loading fresh state from data files.
+    ///
+    /// Returns the session ID, or `None` if the session limit is reached.
+    pub async fn create_session(&self) -> Option<(SessionId, Arc<GameSession>)> {
+        let mut sessions = self.sessions.write().await;
+        if sessions.len() >= self.max_sessions {
+            return None;
+        }
+
+        let id = uuid::Uuid::new_v4().to_string();
+
+        let world =
+            WorldState::from_parish_file(&self.data_dir.join("parish.json"), self.start_location)
+                .unwrap_or_else(|e| {
+                    tracing::warn!(
+                        "Failed to load parish.json for session: {}. Using default.",
+                        e
+                    );
+                    WorldState::new()
+                });
+
+        let mut npc_manager = NpcManager::load_from_file(&self.data_dir.join("npcs.json"))
+            .unwrap_or_else(|e| {
+                tracing::warn!("Failed to load npcs.json for session: {}. No NPCs.", e);
+                NpcManager::new()
+            });
+        npc_manager.assign_tiers(world.player_location, &world.graph);
+
+        let now = Instant::now();
+        let session = Arc::new(GameSession {
+            world: Mutex::new(world),
+            npc_manager: Mutex::new(npc_manager),
+            event_bus: EventBus::new(256),
+            created_at: now,
+            last_activity: Mutex::new(now),
+        });
+
+        sessions.insert(id.clone(), Arc::clone(&session));
+        Some((id, session))
+    }
+
+    /// Looks up a session by ID.
+    pub async fn get(&self, id: &str) -> Option<Arc<GameSession>> {
+        self.sessions.read().await.get(id).cloned()
+    }
+
+    /// Removes sessions idle longer than `timeout`.
+    ///
+    /// Returns the number of sessions removed.
+    pub async fn remove_idle(&self, timeout: std::time::Duration) -> usize {
+        let mut sessions = self.sessions.write().await;
+        let mut to_remove = Vec::new();
+
+        for (id, session) in sessions.iter() {
+            let last = *session.last_activity.lock().await;
+            if last.elapsed() > timeout {
+                to_remove.push(id.clone());
+            }
+        }
+
+        for id in &to_remove {
+            tracing::info!("Cleaning up idle session {}", id);
+            sessions.remove(id);
+        }
+
+        to_remove.len()
+    }
+
+    /// Returns the current number of active sessions.
+    pub async fn session_count(&self) -> usize {
+        self.sessions.read().await.len()
+    }
+}
+
+/// Top-level server state passed to all Axum route handlers.
+///
+/// Holds the session manager and shared inference resources.
+pub struct ServerState {
+    /// Per-session game state manager.
+    pub sessions: SessionManager,
+    /// Inference request queue shared across all sessions.
     pub inference_queue: Mutex<Option<InferenceQueue>>,
-    /// Local LLM client (None if no provider is configured).
+    /// Local LLM client (shared, stateless HTTP client).
     pub client: Mutex<Option<OpenAiClient>>,
-    /// Cloud LLM client for dialogue (None if not configured).
+    /// Cloud LLM client for dialogue (shared).
     pub cloud_client: Mutex<Option<OpenAiClient>>,
     /// Mutable runtime configuration.
     pub config: Mutex<GameConfig>,
-    /// Broadcast channel for pushing events to WebSocket clients.
-    pub event_bus: EventBus,
 }
 
 /// Mutable runtime configuration for provider, model, and cloud settings.
@@ -116,25 +244,6 @@ impl EventBus {
     }
 }
 
-/// Creates the shared [`AppState`] from game data.
-pub fn build_app_state(
-    world: WorldState,
-    npc_manager: NpcManager,
-    client: Option<OpenAiClient>,
-    config: GameConfig,
-    cloud_client: Option<OpenAiClient>,
-) -> Arc<AppState> {
-    Arc::new(AppState {
-        world: Mutex::new(world),
-        npc_manager: Mutex::new(npc_manager),
-        inference_queue: Mutex::new(None),
-        client: Mutex::new(client),
-        cloud_client: Mutex::new(cloud_client),
-        config: Mutex::new(config),
-        event_bus: EventBus::new(256),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,5 +267,23 @@ mod tests {
             payload: serde_json::Value::Null,
         });
         assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
+    async fn session_manager_create_and_get() {
+        let dir = std::env::temp_dir();
+        let mgr = SessionManager::new(dir, LocationId(1), 10);
+        let (id, _session) = mgr.create_session().await.unwrap();
+        assert!(mgr.get(&id).await.is_some());
+        assert!(mgr.get("nonexistent").await.is_none());
+        assert_eq!(mgr.session_count().await, 1);
+    }
+
+    #[tokio::test]
+    async fn session_manager_respects_limit() {
+        let dir = std::env::temp_dir();
+        let mgr = SessionManager::new(dir, LocationId(1), 1);
+        let _first = mgr.create_session().await.unwrap();
+        assert!(mgr.create_session().await.is_none());
     }
 }

--- a/crates/parish-server/src/ws.rs
+++ b/crates/parish-server/src/ws.rs
@@ -1,30 +1,40 @@
 //! WebSocket handler for server-push events.
 //!
-//! Each connected client gets a WebSocket that receives JSON-encoded
-//! [`ServerEvent`] frames from the [`EventBus`].
+//! Each connected client gets a WebSocket scoped to their session,
+//! receiving JSON-encoded [`ServerEvent`] frames from that session's
+//! [`EventBus`].
 
 use std::sync::Arc;
 
-use axum::extract::State;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
 use axum::response::IntoResponse;
 
-use crate::state::AppState;
+use crate::routes::SessionQuery;
+use crate::state::{GameSession, ServerState};
 
-/// Upgrades the HTTP connection to a WebSocket.
+/// Upgrades the HTTP connection to a WebSocket scoped to a session.
 pub async fn ws_handler(
     ws: WebSocketUpgrade,
-    State(state): State<Arc<AppState>>,
-) -> impl IntoResponse {
-    ws.on_upgrade(|socket| handle_socket(socket, state))
+    State(state): State<Arc<ServerState>>,
+    Query(q): Query<SessionQuery>,
+) -> Result<impl IntoResponse, StatusCode> {
+    let session = state
+        .sessions
+        .get(&q.session)
+        .await
+        .ok_or(StatusCode::NOT_FOUND)?;
+    session.touch().await;
+    Ok(ws.on_upgrade(move |socket| handle_socket(socket, session)))
 }
 
 /// Handles a single WebSocket connection.
 ///
-/// Subscribes to the [`EventBus`] and forwards each event as a JSON text
-/// frame until the client disconnects or the bus is dropped.
-async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
-    let mut rx = state.event_bus.subscribe();
+/// Subscribes to the session's [`EventBus`] and forwards each event as a
+/// JSON text frame until the client disconnects or the bus is dropped.
+async fn handle_socket(mut socket: WebSocket, session: Arc<GameSession>) {
+    let mut rx = session.event_bus.subscribe();
     tracing::info!("WebSocket client connected");
 
     loop {
@@ -54,7 +64,8 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
             msg = socket.recv() => {
                 match msg {
                     Some(Ok(_)) => {
-                        // Client messages are ignored (commands use REST)
+                        // Touch session on client activity
+                        session.touch().await;
                     }
                     _ => break,
                 }

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -277,6 +277,66 @@ For non-Ollama providers, none of these steps run — the user provides the endp
 
 Run `cargo run` for a plain stdin/stdout REPL. This is the default mode. Uses identical game logic (NPC inference, intent parsing, system commands). Useful for development testing and scripted interaction.
 
+## Web Server Mode & Deployment
+
+Run `cargo run -- --web [PORT]` to serve the Svelte frontend via an axum HTTP + WebSocket server. This provides the same game experience as the Tauri desktop app, accessible from any browser.
+
+### Per-Session Architecture
+
+Each browser visitor gets an isolated game session:
+
+```
+Browser → POST /api/session → SessionManager creates GameSession
+                                  ├── WorldState (cloned from data files)
+                                  ├── NpcManager (cloned from data files)
+                                  └── EventBus (per-session broadcast channel)
+```
+
+All subsequent requests include `?session=<uuid>` to route to the correct session. The inference pipeline (OpenAiClient + InferenceQueue) is shared across sessions since it's a stateless HTTP client.
+
+**Key types** (`crates/parish-server/src/state.rs`):
+
+| Struct | Scope | Purpose |
+|--------|-------|---------|
+| `ServerState` | Global | Holds `SessionManager`, shared inference queue/clients, config |
+| `SessionManager` | Global | Creates/looks up/cleans up sessions, holds data dir path |
+| `GameSession` | Per-visitor | Isolated world, NPC manager, event bus, activity timestamp |
+
+**Session lifecycle**:
+- Created via `POST /api/session` (returns UUID)
+- Activity tracked on every REST/WebSocket interaction
+- Cleaned up after 10 minutes of inactivity (background task every 60s)
+- Maximum concurrent sessions: 50 (configurable via `PARISH_MAX_SESSIONS`)
+- Background tick tasks use `Weak<GameSession>` to auto-exit when session drops
+
+**Endpoints** (`crates/parish-server/src/routes.rs`):
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | `/api/session` | Create new game session |
+| GET | `/api/world-snapshot?session=` | Current world state |
+| GET | `/api/map?session=` | Location graph |
+| GET | `/api/npcs-here?session=` | NPCs at player location |
+| GET | `/api/theme?session=` | Time-of-day color palette |
+| POST | `/api/submit-input?session=` | Player command input |
+| GET | `/api/ws?session=` | WebSocket (per-session events) |
+
+### Deployment (Fly.io)
+
+The project includes a multi-stage `Dockerfile` and `fly.toml` for Fly.io deployment:
+
+1. **Stage 1** (Node): Builds `ui/dist/` static frontend
+2. **Stage 2** (Rust): Compiles the `parish` binary
+3. **Stage 3** (Debian slim): Copies binary + frontend + data files (~30MB)
+
+Environment variables for production:
+- `PARISH_PROVIDER=openrouter` — Use cloud LLM (no local GPU needed)
+- `PARISH_MODEL=google/gemma-3-27b-it` — Model for NPC dialogue
+- `PARISH_API_KEY` — OpenRouter API key (set via `fly secrets set`)
+- `PARISH_MAX_SESSIONS=50` — Concurrent session limit
+
+The Fly.io config uses `auto_stop_machines = "stop"` with `min_machines_running = 0` for cost efficiency — the machine hibernates when idle and wakes on first request.
+
 ## Source Modules
 
 - [`src/main.rs`](../../src/main.rs) — Entry point, CLI parsing, mode routing

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,27 @@
+app = "parish-game"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PARISH_PROVIDER = "openrouter"
+  PARISH_MODEL = "google/gemma-3-27b-it"
+  RUST_LOG = "parish=info"
+  PARISH_MAX_SESSIONS = "50"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 100
+    soft_limit = 80
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/ui/src/lib/ipc.ts
+++ b/ui/src/lib/ipc.ts
@@ -4,6 +4,9 @@
  * In Tauri mode, uses `@tauri-apps/api` invoke/listen.
  * In browser mode, uses fetch for commands and WebSocket for events.
  * All exported function signatures are identical regardless of transport.
+ *
+ * Browser sessions: on first load, `initSession()` creates a server-side
+ * game session and stores the session ID for all subsequent requests.
  */
 
 import type {
@@ -26,6 +29,33 @@ import type {
 
 const IS_TAURI = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
 
+// ── Session management (browser mode) ──────────────────────────────────────
+
+let sessionId: string | null = null;
+
+/**
+ * Creates a new game session on the server.
+ * Must be called before any other commands in browser mode.
+ */
+export async function initSession(): Promise<void> {
+	if (IS_TAURI) return;
+
+	const resp = await fetch('/api/session', { method: 'POST' });
+	if (!resp.ok) {
+		throw new Error(`Failed to create session: ${resp.status} ${resp.statusText}`);
+	}
+	const data = (await resp.json()) as { session_id: string };
+	sessionId = data.session_id;
+}
+
+/**
+ * Returns the query string suffix for the current session.
+ */
+function sessionParam(): string {
+	if (!sessionId) return '';
+	return `session=${encodeURIComponent(sessionId)}`;
+}
+
 // ── Commands ────────────────────────────────────────────────────────────────
 
 async function command<T>(name: string, args?: Record<string, unknown>): Promise<T> {
@@ -35,7 +65,9 @@ async function command<T>(name: string, args?: Record<string, unknown>): Promise
 	}
 	// Web mode: REST API
 	const endpoint = `/api/${name.replace(/^get_/, '').replace(/_/g, '-')}`;
-	const resp = await fetch(endpoint, {
+	const sep = endpoint.includes('?') ? '&' : '?';
+	const url = sessionId ? `${endpoint}${sep}${sessionParam()}` : endpoint;
+	const resp = await fetch(url, {
 		method: args ? 'POST' : 'GET',
 		headers: args ? { 'Content-Type': 'application/json' } : {},
 		body: args ? JSON.stringify(args) : undefined
@@ -95,7 +127,8 @@ function ensureWebSocket(): void {
 	if (IS_TAURI || ws) return;
 
 	const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-	const url = `${protocol}//${window.location.host}/api/ws`;
+	const sp = sessionId ? `?${sessionParam()}` : '';
+	const url = `${protocol}//${window.location.host}/api/ws${sp}`;
 
 	ws = new WebSocket(url);
 

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -14,6 +14,7 @@
 	import { savePickerVisible } from '../stores/save';
 	import { palette } from '../stores/theme';
 	import {
+		initSession,
 		getWorldSnapshot,
 		getMap,
 		getNpcsHere,
@@ -49,6 +50,13 @@
 	}
 
 	onMount(async () => {
+		// Create a server-side session (no-op in Tauri mode)
+		try {
+			await initSession();
+		} catch (e) {
+			console.warn('Session init failed (expected in Tauri dev):', e);
+		}
+
 		// Initial data fetch (theme first to avoid color flash)
 		try {
 			const [snap, map, npcs, theme] = await Promise.all([


### PR DESCRIPTION
Each browser visitor now gets an isolated game session (world, NPCs,
event bus) instead of sharing a single global state. Sessions are
created via POST /api/session and cleaned up after 10 minutes of
inactivity (configurable via PARISH_MAX_SESSIONS env var, default 50).

The inference pipeline (OpenRouter/Ollama client + queue) is shared
across sessions since it's stateless, while game state is per-session.
Background tick tasks use Weak<GameSession> to auto-exit on cleanup.

Includes a multi-stage Dockerfile (Node for frontend, Rust for backend,
slim Debian runtime) and fly.toml for Fly.io deployment.

https://claude.ai/code/session_01X8GyfFtRWt7GFXjgKThXZ4