### PR TITLE
fix: smooth Celtic knot circle animation with hold at full draw

### DIFF
--- a/ui/src/components/ChatPanel.svelte
+++ b/ui/src/components/ChatPanel.svelte
@@ -203,8 +203,8 @@
 	}
 
 	.knot-circle {
-		stroke-dasharray: 120;
-		stroke-dashoffset: 120;
+		stroke-dasharray: 0 120;
+		stroke-dashoffset: 0;
 		animation: circle-draw 3s ease-in-out infinite;
 		animation-delay: 0.4s;
 	}
@@ -216,10 +216,10 @@
 	}
 
 	@keyframes circle-draw {
-		0%   { stroke-dashoffset: 120; }
-		30%  { stroke-dashoffset: 0; }
-		70%  { stroke-dashoffset: 0; }
-		100% { stroke-dashoffset: -120; }
+		0%   { stroke-dasharray: 0 120;   stroke-dashoffset: 0; }
+		30%  { stroke-dasharray: 120 120; stroke-dashoffset: 0; }
+		70%  { stroke-dasharray: 120 120; stroke-dashoffset: 0; }
+		100% { stroke-dasharray: 0 120;   stroke-dashoffset: -120; }
 	}
 
 	@keyframes triquetra-rotate {

--- a/ui/src/components/ChatPanel.svelte
+++ b/ui/src/components/ChatPanel.svelte
@@ -205,7 +205,7 @@
 	.knot-circle {
 		stroke-dasharray: 120;
 		stroke-dashoffset: 120;
-		animation: triquetra-draw 2.4s ease-in-out infinite;
+		animation: circle-draw 3s ease-in-out infinite;
 		animation-delay: 0.4s;
 	}
 
@@ -213,6 +213,13 @@
 		to {
 			stroke-dashoffset: -120;
 		}
+	}
+
+	@keyframes circle-draw {
+		0%   { stroke-dashoffset: 120; }
+		30%  { stroke-dashoffset: 0; }
+		70%  { stroke-dashoffset: 0; }
+		100% { stroke-dashoffset: -120; }
 	}
 
 	@keyframes triquetra-rotate {


### PR DESCRIPTION
The circle's stroke-dashoffset animated from 120→-120 with ease-in-out
timing, causing it to flash through its fully-drawn state at the fastest
part of the easing curve. Replace with a keyframed animation that draws
on (0-30%), holds visible (30-70%), then draws off (70-100%).

https://claude.ai/code/session_01SReTthUx24pk8eggEoYS18