### PR TITLE
chore: add launch.json and update fix-issue skill

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,23 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "vite-dev",
+      "runtimeExecutable": "/bin/sh",
+      "runtimeArgs": ["-c", "cd ui && PATH=/usr/local/Cellar/node/25.8.1_1/bin:$PATH npx vite dev"],
+      "port": 5173
+    },
+    {
+      "name": "parish-web",
+      "runtimeExecutable": "/bin/sh",
+      "runtimeArgs": ["-c", "source $HOME/.cargo/env && cargo run -- --web"],
+      "port": 3001
+    },
+    {
+      "name": "parish-e2e",
+      "runtimeExecutable": "/bin/sh",
+      "runtimeArgs": ["-c", "source $HOME/.cargo/env && cargo run -- --web 3099"],
+      "port": 3099
+    }
+  ]
+}

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,13 +1,12 @@
 ---
 name: fix-issue
 description: Work through a GitHub issue end-to-end — diagnose, implement, test, and verify. Pass the issue number as an argument.
-argument-hint: <issue-number>
 ---
 
-Work through GitHub issue #$ARGUMENTS end-to-end.
 
 ## Steps
 
+0. Find one or more github issues that don't already have a pull request
 1. **Fetch the issue**: Run `gh issue view $ARGUMENTS` to read the title, body, and labels.
 2. **Understand the problem**: Research the relevant code. Identify the root cause or the feature gap.
 3. **Plan the fix**: Outline what files need to change and what tests to add. Keep it minimal — only change what's needed.


### PR DESCRIPTION
## Summary
- Add `.claude/launch.json` with dev server configurations (vite-dev, parish-web, parish-e2e) for Claude Preview's `preview_start`
- Update fix-issue skill to auto-find issues without existing PRs

## Test plan
- [x] Verified `preview_start` works with `parish-web` configuration
- [ ] Test fix-issue skill with no arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)