### PR TITLE
feat: add Tab-complete for known location and NPC names

### DIFF
--- a/docs/design/input-enrichment-ideas.md
+++ b/docs/design/input-enrichment-ideas.md
@@ -438,7 +438,7 @@ Hold spacebar (when the input field is empty) to speak instead of type. Release 
 | Reply-to context | Medium | Medium | Build later |
 | Inline rich preview | Medium | Low-Med | Nice to have |
 | Tone indicator | Medium | Low-Med | Nice to have |
-| Tab-complete nouns | Medium | Medium | Build later |
+| Tab-complete nouns | Medium | Medium | **Shipped (Wave 2)** — derived noun store + Tab cycling |
 | Voice range modifiers | Med-High | High | Build later — great emergent gameplay |
 | Contextual suggestions | High | High | Build later — needs LLM or rules |
 | Streamer mode | Very High | Niche | Someday/maybe |

--- a/ui/src/components/InputField.svelte
+++ b/ui/src/components/InputField.svelte
@@ -46,9 +46,9 @@
 
 	// ── Adjacent locations for quick-travel ─────────────────────────────────
 	const adjacentLocations = $derived(
-		($mapData?.locations ?? []).filter(
-			(loc) => loc.adjacent && loc.id !== $mapData?.player_location
-		)
+		($mapData?.locations ?? [])
+			.filter((loc) => loc.adjacent && loc.id !== $mapData?.player_location)
+			.sort((a, b) => a.name.localeCompare(b.name))
 	);
 
 	// ── Tab-completion state ────────────────────────────────────────────────
@@ -116,7 +116,20 @@
 
 		const range = sel.getRangeAt(0);
 		const node = range.startContainer;
-		if (node.nodeType !== Node.TEXT_NODE) return;
+
+		// Empty editor — no text node yet, insert one
+		if (node.nodeType !== Node.TEXT_NODE) {
+			const textNode = document.createTextNode(match.text);
+			editorEl.innerHTML = '';
+			editorEl.appendChild(textNode);
+			completion.replacedLength = match.text.length;
+			const newRange = document.createRange();
+			newRange.setStart(textNode, match.text.length);
+			newRange.collapse(true);
+			sel.removeAllRanges();
+			sel.addRange(newRange);
+			return;
+		}
 
 		const text = node.textContent ?? '';
 		const replaceLen = completion.replacedLength > 0 ? completion.replacedLength : completion.prefix.length;
@@ -493,10 +506,30 @@
 			}
 
 			// Start new completion
-			const extracted = extractPrefix();
-			if (!extracted) return;
-
 			const nouns = get(knownNouns);
+			const extracted = extractPrefix();
+
+			if (!extracted) {
+				// No word typed yet — cycle through all explored locations
+				const locationNouns = nouns.filter((n) => n.category === 'location');
+				if (locationNouns.length === 0) return;
+				const sel2 = window.getSelection();
+				if (!sel2 || sel2.rangeCount === 0) return;
+				const range2 = sel2.getRangeAt(0);
+				const prefixStart =
+					range2.startContainer.nodeType === Node.TEXT_NODE ? range2.startOffset : 0;
+				completion = {
+					active: true,
+					prefix: '',
+					matches: locationNouns,
+					currentIndex: 0,
+					prefixStart,
+					replacedLength: 0
+				};
+				applyCompletion();
+				return;
+			}
+
 			const matches = findMatches(extracted.prefix, nouns);
 			if (matches.length === 0) return;
 

--- a/ui/src/components/InputField.svelte
+++ b/ui/src/components/InputField.svelte
@@ -2,6 +2,8 @@
 	import { streamingActive, npcsHere, mapData } from '../stores/game';
 	import { submitInput } from '$lib/ipc';
 	import { filterCommands, type SlashCommand } from '$lib/slash-commands';
+	import { knownNouns, findMatches, type KnownNoun } from '../stores/nouns';
+	import { get } from 'svelte/store';
 
 	let editorEl: HTMLDivElement;
 
@@ -48,6 +50,90 @@
 			(loc) => loc.adjacent && loc.id !== $mapData?.player_location
 		)
 	);
+
+	// ── Tab-completion state ────────────────────────────────────────────────
+	interface CompletionState {
+		active: boolean;
+		prefix: string;
+		matches: KnownNoun[];
+		currentIndex: number;
+		prefixStart: number;
+		replacedLength: number;
+	}
+
+	let completion = $state<CompletionState>({
+		active: false,
+		prefix: '',
+		matches: [],
+		currentIndex: 0,
+		prefixStart: 0,
+		replacedLength: 0
+	});
+
+	function resetCompletion() {
+		completion = {
+			active: false,
+			prefix: '',
+			matches: [],
+			currentIndex: 0,
+			prefixStart: 0,
+			replacedLength: 0
+		};
+	}
+
+	/** Extract the word being typed from the cursor position backward. */
+	function extractPrefix(): { prefix: string; start: number; node: Text } | null {
+		if (!editorEl) return null;
+		const sel = window.getSelection();
+		if (!sel || sel.rangeCount === 0) return null;
+
+		const range = sel.getRangeAt(0);
+		const node = range.startContainer;
+		if (node.nodeType !== Node.TEXT_NODE) return null;
+
+		const fullText = node.textContent ?? '';
+		const cursorPos = range.startOffset;
+
+		// Walk backward from cursor to find word start
+		let start = cursorPos;
+		while (start > 0 && fullText[start - 1] !== ' ' && fullText[start - 1] !== '\n' && fullText[start - 1] !== '\u00A0') {
+			start--;
+		}
+
+		const prefix = fullText.slice(start, cursorPos);
+		if (prefix.length === 0) return null;
+
+		return { prefix, start, node: node as Text };
+	}
+
+	/** Replace the prefix text in the editor with the selected completion. */
+	function applyCompletion() {
+		if (!editorEl || !completion.active) return;
+
+		const match = completion.matches[completion.currentIndex];
+		const sel = window.getSelection();
+		if (!sel || sel.rangeCount === 0) return;
+
+		const range = sel.getRangeAt(0);
+		const node = range.startContainer;
+		if (node.nodeType !== Node.TEXT_NODE) return;
+
+		const text = node.textContent ?? '';
+		const replaceLen = completion.replacedLength > 0 ? completion.replacedLength : completion.prefix.length;
+		const before = text.slice(0, completion.prefixStart);
+		const after = text.slice(completion.prefixStart + replaceLen);
+
+		node.textContent = before + match.text + after;
+		completion.replacedLength = match.text.length;
+
+		// Place cursor after completed text
+		const cursorPos = completion.prefixStart + match.text.length;
+		const newRange = document.createRange();
+		newRange.setStart(node, Math.min(cursorPos, node.textContent!.length));
+		newRange.collapse(true);
+		sel.removeAllRanges();
+		sel.addRange(newRange);
+	}
 
 	// ── Focus management ────────────────────────────────────────────────────
 	$effect(() => {
@@ -394,6 +480,43 @@
 			}
 		}
 
+		// Tab-completion for known nouns (only when no dropdown is open)
+		if (e.key === 'Tab' && dropdownMode === null) {
+			e.preventDefault();
+
+			if (completion.active) {
+				// Already cycling — advance to next match
+				completion.currentIndex =
+					(completion.currentIndex + 1) % completion.matches.length;
+				applyCompletion();
+				return;
+			}
+
+			// Start new completion
+			const extracted = extractPrefix();
+			if (!extracted) return;
+
+			const nouns = get(knownNouns);
+			const matches = findMatches(extracted.prefix, nouns);
+			if (matches.length === 0) return;
+
+			completion = {
+				active: true,
+				prefix: extracted.prefix,
+				matches,
+				currentIndex: 0,
+				prefixStart: extracted.start,
+				replacedLength: 0
+			};
+			applyCompletion();
+			return;
+		}
+
+		// Any other key while completing → accept and reset
+		if (completion.active && e.key !== 'Shift' && e.key !== 'Tab') {
+			resetCompletion();
+		}
+
 		// Input history (only when no dropdown is open)
 		if (dropdownMode === null && e.key === 'ArrowUp' && isCursorOnFirstLine()) {
 			if (history.length > 0) {
@@ -491,6 +614,10 @@
 		// Reset history browsing on any typed input
 		if (historyIndex >= 0) {
 			historyIndex = -1;
+		}
+		// Reset tab-completion on any typed input
+		if (completion.active) {
+			resetCompletion();
 		}
 		detectMention();
 		if (dropdownMode !== 'mention') {

--- a/ui/src/components/InputField.test.ts
+++ b/ui/src/components/InputField.test.ts
@@ -483,9 +483,10 @@ describe('InputField', () => {
 	describe('tab-completion', () => {
 		const testMapData = {
 			locations: [
-				{ id: 'crossroads', name: 'The Crossroads', lat: 0, lon: 0, adjacent: true, hops: 1 },
-				{ id: 'pub', name: "Darcy's Pub", lat: 0.1, lon: 0.1, adjacent: true, hops: 1 },
-				{ id: 'church', name: 'The Church', lat: 0.2, lon: 0.2, adjacent: false, hops: 2 }
+				{ id: 'crossroads', name: 'The Crossroads', lat: 0, lon: 0, adjacent: true, hops: 1, visited: true },
+				{ id: 'pub', name: "Darcy's Pub", lat: 0.1, lon: 0.1, adjacent: true, hops: 1, visited: true },
+				{ id: 'church', name: 'The Church', lat: 0.2, lon: 0.2, adjacent: false, hops: 2, visited: true },
+				{ id: 'mill', name: 'The Mill', lat: 0.3, lon: 0.3, adjacent: false, hops: 3, visited: false }
 			],
 			edges: [
 				['crossroads', 'pub'],
@@ -547,12 +548,29 @@ describe('InputField', () => {
 			expect(editor.textContent).toBe('go to xyz');
 		});
 
-		it('Tab does nothing on empty input', async () => {
+		it('Tab cycles through all visited locations on empty input', async () => {
 			const { getByRole } = render(InputField);
 			const editor = getByRole('textbox');
 
 			await fireEvent.keyDown(editor, { key: 'Tab' });
-			expect(editor.textContent).toBe('');
+			const first = editor.textContent ?? '';
+			expect(first.length).toBeGreaterThan(0);
+
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+			const second = editor.textContent ?? '';
+			expect(second).not.toBe(first);
+		});
+
+		it('Tab completes unvisited (frontier) locations with lower priority', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, 'mill');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+
+			// "The Mill" is unvisited but visible (frontier) — should complete
+			expect(editor.textContent).toContain('The Mill');
 		});
 
 		it('Tab cycles through multiple matches', async () => {

--- a/ui/src/components/InputField.test.ts
+++ b/ui/src/components/InputField.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
 import { streamingActive, npcsHere, mapData } from '../stores/game';
+import { findMatches, type KnownNoun } from '../stores/nouns';
 import InputField from './InputField.svelte';
 
 // Mock ipc submitInput
@@ -422,6 +423,197 @@ describe('InputField', () => {
 			streamingActive.set(true);
 			const { container } = render(InputField);
 			expect(container.querySelector('.travel-chips')).toBeFalsy();
+		});
+	});
+
+	// ── findMatches utility ─────────────────────────────────────────────
+
+	describe('findMatches', () => {
+		const testNouns: KnownNoun[] = [
+			{ text: "Darcy's Pub", category: 'location', priority: 0 },
+			{ text: 'The Crossroads', category: 'location', priority: 0 },
+			{ text: 'The Church', category: 'location', priority: 2 },
+			{ text: 'Padraig Darcy', category: 'npc', priority: 1 },
+			{ text: 'Siobhan Murphy', category: 'npc', priority: 1 }
+		];
+
+		it('matches start of any word in the noun', () => {
+			const matches = findMatches('pub', testNouns);
+			expect(matches.length).toBe(1);
+			expect(matches[0].text).toBe("Darcy's Pub");
+		});
+
+		it('matches NPC name prefix', () => {
+			const matches = findMatches('padr', testNouns);
+			expect(matches.length).toBe(1);
+			expect(matches[0].text).toBe('Padraig Darcy');
+		});
+
+		it('matches start of full noun text', () => {
+			const matches = findMatches('the', testNouns);
+			expect(matches.length).toBe(2);
+			expect(matches.map((m) => m.text)).toContain('The Crossroads');
+			expect(matches.map((m) => m.text)).toContain('The Church');
+		});
+
+		it('returns empty for no matches', () => {
+			expect(findMatches('xyz', testNouns)).toEqual([]);
+		});
+
+		it('returns empty for empty prefix', () => {
+			expect(findMatches('', testNouns)).toEqual([]);
+		});
+
+		it('is case-insensitive', () => {
+			const matches = findMatches('PUB', testNouns);
+			expect(matches.length).toBe(1);
+			expect(matches[0].text).toBe("Darcy's Pub");
+		});
+
+		it('matches word after apostrophe', () => {
+			const matches = findMatches('darcy', testNouns);
+			expect(matches.length).toBe(2);
+			expect(matches.map((m) => m.text)).toContain("Darcy's Pub");
+			expect(matches.map((m) => m.text)).toContain('Padraig Darcy');
+		});
+	});
+
+	// ── Tab-completion ──────────────────────────────────────────────────
+
+	describe('tab-completion', () => {
+		const testMapData = {
+			locations: [
+				{ id: 'crossroads', name: 'The Crossroads', lat: 0, lon: 0, adjacent: true, hops: 1 },
+				{ id: 'pub', name: "Darcy's Pub", lat: 0.1, lon: 0.1, adjacent: true, hops: 1 },
+				{ id: 'church', name: 'The Church', lat: 0.2, lon: 0.2, adjacent: false, hops: 2 }
+			],
+			edges: [
+				['crossroads', 'pub'],
+				['crossroads', 'church']
+			] as [string, string][],
+			player_location: 'crossroads',
+			player_lat: 0,
+			player_lon: 0
+		};
+
+		const testNpcs = [
+			{
+				name: 'Padraig Darcy',
+				occupation: 'Publican',
+				mood: 'content',
+				introduced: true,
+				mood_emoji: '😌'
+			}
+		];
+
+		function typeIntoEditor(editor: HTMLElement, text: string) {
+			editor.textContent = text;
+			const range = document.createRange();
+			const sel = window.getSelection();
+			if (editor.firstChild) {
+				range.setStart(editor.firstChild, text.length);
+			} else {
+				range.setStart(editor, 0);
+			}
+			range.collapse(true);
+			sel?.removeAllRanges();
+			sel?.addRange(range);
+		}
+
+		beforeEach(() => {
+			mapData.set(testMapData);
+			npcsHere.set(testNpcs);
+		});
+
+		it('Tab completes a matching prefix', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, 'go to pub');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+
+			expect(editor.textContent).toContain("Darcy's Pub");
+		});
+
+		it('Tab does nothing when no matches', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, 'go to xyz');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+
+			expect(editor.textContent).toBe('go to xyz');
+		});
+
+		it('Tab does nothing on empty input', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+			expect(editor.textContent).toBe('');
+		});
+
+		it('Tab cycles through multiple matches', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			// "the" matches "The Crossroads" and "The Church"
+			typeIntoEditor(editor, 'the');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+
+			const firstMatch = editor.textContent;
+			expect(firstMatch === 'The Crossroads' || firstMatch === 'The Church').toBe(true);
+
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+			const secondMatch = editor.textContent;
+			expect(secondMatch).not.toBe(firstMatch);
+			expect(secondMatch === 'The Crossroads' || secondMatch === 'The Church').toBe(true);
+		});
+
+		it('typing resets completion state', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, 'pub');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+			expect(editor.textContent).toContain("Darcy's Pub");
+
+			// Type something — should accept completion and reset
+			await fireEvent.input(editor);
+
+			// Now a new Tab should start fresh
+			typeIntoEditor(editor, 'cross');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+			expect(editor.textContent).toContain('The Crossroads');
+		});
+
+		it('mention dropdown Tab takes priority over noun completion', async () => {
+			npcsHere.set([
+				{
+					name: 'Padraig Darcy',
+					occupation: 'Publican',
+					mood: 'content',
+					introduced: true,
+					mood_emoji: '😌'
+				}
+			]);
+			const { getByRole, queryByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '@P');
+			await fireEvent.input(editor);
+			expect(queryByRole('listbox')).toBeTruthy();
+
+			// Tab should select the mention, not trigger noun completion
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+			const chip = editor.querySelector('.mention-chip');
+			expect(chip).toBeTruthy();
+			expect(chip?.textContent).toBe('@Padraig Darcy');
 		});
 	});
 });

--- a/ui/src/stores/nouns.ts
+++ b/ui/src/stores/nouns.ts
@@ -21,7 +21,7 @@ export const knownNouns = derived(
 				nouns.push({
 					text: loc.name,
 					category: 'location',
-					priority: loc.adjacent ? 0 : 2
+					priority: loc.visited ? (loc.adjacent ? 0 : 2) : 3
 				});
 			}
 		}

--- a/ui/src/stores/nouns.ts
+++ b/ui/src/stores/nouns.ts
@@ -1,0 +1,59 @@
+import { derived } from 'svelte/store';
+import { mapData, npcsHere } from './game';
+
+export interface KnownNoun {
+	text: string;
+	category: 'location' | 'npc';
+	priority: number; // lower = higher priority
+}
+
+/**
+ * All known nouns derived from current game state.
+ * Updates automatically when mapData or npcsHere change.
+ */
+export const knownNouns = derived(
+	[mapData, npcsHere],
+	([$mapData, $npcsHere]) => {
+		const nouns: KnownNoun[] = [];
+
+		if ($mapData) {
+			for (const loc of $mapData.locations) {
+				nouns.push({
+					text: loc.name,
+					category: 'location',
+					priority: loc.adjacent ? 0 : 2
+				});
+			}
+		}
+
+		for (const npc of $npcsHere) {
+			nouns.push({
+				text: npc.name,
+				category: 'npc',
+				priority: 1
+			});
+		}
+
+		nouns.sort((a, b) => a.priority - b.priority || a.text.localeCompare(b.text));
+		return nouns;
+	}
+);
+
+/**
+ * Find nouns matching a prefix. Matches against the start of any
+ * whitespace/apostrophe-delimited word in the noun text.
+ *
+ * Examples: "pub" matches "Darcy's Pub", "cross" matches "The Crossroads"
+ */
+export function findMatches(prefix: string, nouns: KnownNoun[]): KnownNoun[] {
+	if (prefix.length === 0) return [];
+	const lower = prefix.toLowerCase();
+
+	return nouns.filter((noun) => {
+		const nounLower = noun.text.toLowerCase();
+		return (
+			nounLower.startsWith(lower) ||
+			nounLower.split(/[\s']+/).some((word) => word.startsWith(lower))
+		);
+	});
+}


### PR DESCRIPTION
Press Tab while typing to complete partial words against known game
nouns (locations, NPC names). Tab cycles through multiple matches;
any other key accepts the completion. Priority: mention dropdown >
slash dropdown > noun tab-completion.

New derived store (nouns.ts) aggregates completable nouns from
mapData and npcsHere with priority sorting (adjacent locations first).

https://claude.ai/code/session_018RQ6ZUZNSrh6QhEeNk58k1