### PR TITLE
feat: add bidirectional emoji reactions between player and NPCs

### DIFF
--- a/crates/parish-core/src/config/engine.rs
+++ b/crates/parish-core/src/config/engine.rs
@@ -251,6 +251,9 @@ pub struct NpcConfig {
     /// Relationship strength label thresholds.
     #[serde(default)]
     pub relationship_labels: RelationshipLabelConfig,
+    /// Number of recent player reactions included in dialogue context.
+    #[serde(default = "default_reaction_context_count")]
+    pub reaction_context_count: usize,
 }
 
 impl Default for NpcConfig {
@@ -265,8 +268,13 @@ impl Default for NpcConfig {
             event_summary_debug_truncation: 50,
             cognitive_tiers: CognitiveTierConfig::default(),
             relationship_labels: RelationshipLabelConfig::default(),
+            reaction_context_count: 5,
         }
     }
+}
+
+fn default_reaction_context_count() -> usize {
+    5
 }
 
 fn default_memory_capacity() -> usize {

--- a/crates/parish-core/src/ipc/types.rs
+++ b/crates/parish-core/src/ipc/types.rs
@@ -152,10 +152,36 @@ pub struct StreamEndPayload {
 /// Payload for `text-log` events.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TextLogPayload {
+    /// Unique message ID for reaction targeting.
+    #[serde(default)]
+    pub id: String,
     /// Who produced this text: "player", "system", or the NPC's name.
     pub source: String,
     /// The log entry text.
     pub content: String,
+}
+
+/// Payload for `npc-reaction` events.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct NpcReactionPayload {
+    /// ID of the message being reacted to.
+    pub message_id: String,
+    /// The reaction emoji.
+    pub emoji: String,
+    /// Who reacted (NPC name).
+    pub source: String,
+}
+
+/// Request body for the react-to-message endpoint.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ReactRequest {
+    /// Name of the NPC whose message is being reacted to.
+    pub npc_name: String,
+    /// First ~80 chars of the message being reacted to.
+    pub message_snippet: String,
+    /// The reaction emoji.
+    pub emoji: String,
 }
 
 /// Payload for `loading` events.
@@ -252,6 +278,7 @@ mod tests {
         assert!(json.contains("hello"));
 
         let log = TextLogPayload {
+            id: "msg-1".to_string(),
             source: "system".to_string(),
             content: "Welcome".to_string(),
         };

--- a/crates/parish-core/src/npc/data.rs
+++ b/crates/parish-core/src/npc/data.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 
 use crate::error::ParishError;
 use crate::npc::memory::ShortTermMemory;
+use crate::npc::reactions::ReactionLog;
 use crate::npc::types::{
     DailySchedule, Intelligence, NpcState, Relationship, RelationshipKind, ScheduleEntry,
 };
@@ -179,6 +180,7 @@ pub fn load_npcs_from_str(json: &str) -> Result<Vec<Npc>, ParishError> {
                 knowledge: entry.knowledge.clone(),
                 state: NpcState::default(),
                 deflated_summary: None,
+                reaction_log: ReactionLog::default(),
             }
         })
         .collect();

--- a/crates/parish-core/src/npc/manager.rs
+++ b/crates/parish-core/src/npc/manager.rs
@@ -207,6 +207,16 @@ impl NpcManager {
             .copied()
     }
 
+    /// Finds an NPC by exact name (case-insensitive), searching all NPCs.
+    ///
+    /// Returns a mutable reference for updating reaction logs, mood, etc.
+    pub fn find_by_name_mut(&mut self, name: &str) -> Option<&mut Npc> {
+        let lower = name.to_lowercase();
+        self.npcs
+            .values_mut()
+            .find(|n| n.name.to_lowercase() == lower)
+    }
+
     /// Returns an iterator over all NPCs.
     pub fn all_npcs(&self) -> impl Iterator<Item = &Npc> {
         self.npcs.values()
@@ -616,6 +626,7 @@ mod tests {
             knowledge: Vec::new(),
             state: NpcState::Present,
             deflated_summary: None,
+            reaction_log: crate::npc::reactions::ReactionLog::default(),
         }
     }
 

--- a/crates/parish-core/src/npc/mod.rs
+++ b/crates/parish-core/src/npc/mod.rs
@@ -10,6 +10,7 @@ pub mod manager;
 pub mod memory;
 pub mod mood;
 pub mod overhear;
+pub mod reactions;
 pub mod ticks;
 pub mod transitions;
 pub mod types;
@@ -20,6 +21,7 @@ use crate::world::{LocationId, WorldState};
 use serde::{Deserialize, Serialize};
 
 use memory::ShortTermMemory;
+use reactions::ReactionLog;
 use transitions::NpcSummary;
 use types::{DailySchedule, Intelligence, NpcState, Relationship};
 
@@ -151,6 +153,8 @@ pub struct Npc {
     /// Set when the NPC drops to a lower cognitive tier; cleared when
     /// they are inflated back to a higher tier.
     pub deflated_summary: Option<NpcSummary>,
+    /// Log of recent player reactions (emoji) toward this NPC.
+    pub reaction_log: ReactionLog,
 }
 
 impl Npc {
@@ -181,6 +185,7 @@ impl Npc {
             knowledge: Vec::new(),
             state: NpcState::default(),
             deflated_summary: None,
+            reaction_log: ReactionLog::default(),
         }
     }
 

--- a/crates/parish-core/src/npc/reactions.rs
+++ b/crates/parish-core/src/npc/reactions.rs
@@ -1,0 +1,323 @@
+//! Player–NPC emoji reaction system.
+//!
+//! Supports three flows:
+//! 1. Player reacts to NPC messages (stored in [`ReactionLog`], injected into prompts)
+//! 2. NPCs react to player messages (rule-based keyword matching)
+//! 3. NPC-to-NPC reactions (future, via Tier 2 ticks)
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// The canonical reaction palette mapping emoji to natural-language descriptions.
+///
+/// Period-appropriate gestures for an 1820s Irish parish. The UI shows emoji;
+/// NPC context receives the description string.
+pub const REACTION_PALETTE: &[(&str, &str)] = &[
+    ("😊", "smiled warmly"),
+    ("😠", "looked angry"),
+    ("😢", "looked sorrowful"),
+    ("😳", "looked startled"),
+    ("🤔", "looked thoughtful"),
+    ("😏", "smirked knowingly"),
+    ("👀", "raised an eyebrow"),
+    ("🤫", "made a hushing gesture"),
+    ("😂", "laughed heartily"),
+    ("🙄", "rolled their eyes"),
+    ("🍺", "raised a glass"),
+    ("✝️", "crossed themselves"),
+];
+
+/// Look up the natural-language description for a reaction emoji.
+///
+/// Returns `None` if the emoji is not in the palette.
+pub fn reaction_description(emoji: &str) -> Option<&'static str> {
+    REACTION_PALETTE
+        .iter()
+        .find(|(e, _)| *e == emoji)
+        .map(|(_, desc)| *desc)
+}
+
+/// A single reaction entry recording a player's nonverbal response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReactionEntry {
+    /// The emoji used.
+    pub emoji: String,
+    /// Natural-language description (e.g. "looked angry").
+    pub description: String,
+    /// Truncated context — what the NPC said that was reacted to.
+    pub context: String,
+    /// When the reaction occurred.
+    pub timestamp: DateTime<Utc>,
+}
+
+/// Ring buffer of recent player reactions toward an NPC.
+///
+/// Stores the last [`MAX_ENTRIES`] reactions and formats them as prompt
+/// context so the NPC is aware of the player's nonverbal feedback.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReactionLog {
+    entries: Vec<ReactionEntry>,
+}
+
+/// Maximum number of reaction entries to retain.
+const MAX_ENTRIES: usize = 10;
+
+impl ReactionLog {
+    /// Adds a player reaction, evicting the oldest if at capacity.
+    ///
+    /// Only adds the reaction if the emoji is in the canonical palette.
+    pub fn add(&mut self, emoji: &str, context: &str, timestamp: DateTime<Utc>) {
+        if let Some(desc) = reaction_description(emoji) {
+            self.entries.push(ReactionEntry {
+                emoji: emoji.to_string(),
+                description: desc.to_string(),
+                context: context.chars().take(80).collect(),
+                timestamp,
+            });
+            if self.entries.len() > MAX_ENTRIES {
+                self.entries.remove(0);
+            }
+        }
+    }
+
+    /// Formats the `n` most recent reactions as prompt context.
+    ///
+    /// Returns an empty string if there are no reactions.
+    pub fn context_string(&self, n: usize) -> String {
+        if self.entries.is_empty() {
+            return String::new();
+        }
+        let lines: Vec<String> = self
+            .entries
+            .iter()
+            .rev()
+            .take(n)
+            .map(|e| {
+                format!(
+                    "- The player {} when you said \"{}\"",
+                    e.description, e.context
+                )
+            })
+            .collect();
+        format!(
+            "Recent nonverbal reactions from the player:\n{}",
+            lines.join("\n")
+        )
+    }
+
+    /// Returns the number of stored entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns true if there are no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Keyword groups that trigger NPC reactions, with the corresponding emoji.
+const KEYWORD_REACTIONS: &[(&[&str], &str)] = &[
+    (&["death", "died", "killed", "murder"], "😢"),
+    (&["fairy", "fairies", "púca", "banshee", "sidhe"], "✝️"),
+    (&["drink", "whiskey", "poitín", "ale", "stout"], "🍺"),
+    (&["joke", "funny", "laugh", "haha"], "😂"),
+    (&["secret", "don't tell", "between us", "confidence"], "🤫"),
+    (&["rent", "evict", "landlord", "agent", "tithe"], "😠"),
+    (&["gold", "treasure", "fortune", "money", "reward"], "👀"),
+    (&["strange", "ghost", "haunted", "spirit"], "😳"),
+];
+
+/// Generates a rule-based NPC reaction to player input.
+///
+/// Returns `Some(emoji)` if a keyword match triggers a reaction (60% chance),
+/// or `None` if no reaction is generated.
+pub fn generate_rule_reaction(player_input: &str) -> Option<String> {
+    let input_lower = player_input.to_lowercase();
+
+    for (keywords, emoji) in KEYWORD_REACTIONS {
+        if keywords.iter().any(|kw| input_lower.contains(kw)) {
+            // 60% chance to react — not every NPC reacts every time
+            if rand::random::<f64>() < 0.6 {
+                return Some((*emoji).to_string());
+            }
+        }
+    }
+
+    None
+}
+
+/// Deterministic variant for testing — always returns a reaction if keywords match.
+#[cfg(test)]
+fn generate_rule_reaction_deterministic(player_input: &str) -> Option<String> {
+    let input_lower = player_input.to_lowercase();
+
+    for (keywords, emoji) in KEYWORD_REACTIONS {
+        if keywords.iter().any(|kw| input_lower.contains(kw)) {
+            return Some((*emoji).to_string());
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn reaction_description_known_emoji() {
+        assert_eq!(reaction_description("😊"), Some("smiled warmly"));
+        assert_eq!(reaction_description("😠"), Some("looked angry"));
+        assert_eq!(reaction_description("✝️"), Some("crossed themselves"));
+    }
+
+    #[test]
+    fn reaction_description_unknown_emoji() {
+        assert_eq!(reaction_description("💀"), None);
+        assert_eq!(reaction_description("hello"), None);
+    }
+
+    #[test]
+    fn reaction_log_add_and_len() {
+        let mut log = ReactionLog::default();
+        assert!(log.is_empty());
+        assert_eq!(log.len(), 0);
+
+        log.add(
+            "😊",
+            "Hello there",
+            Utc.with_ymd_and_hms(1820, 3, 20, 10, 0, 0).unwrap(),
+        );
+        assert_eq!(log.len(), 1);
+        assert!(!log.is_empty());
+    }
+
+    #[test]
+    fn reaction_log_ignores_unknown_emoji() {
+        let mut log = ReactionLog::default();
+        log.add(
+            "💀",
+            "test",
+            Utc.with_ymd_and_hms(1820, 3, 20, 10, 0, 0).unwrap(),
+        );
+        assert!(log.is_empty());
+    }
+
+    #[test]
+    fn reaction_log_caps_at_max_entries() {
+        let mut log = ReactionLog::default();
+        for i in 0..15 {
+            log.add(
+                "😊",
+                &format!("message {}", i),
+                Utc.with_ymd_and_hms(1820, 3, 20, 10, 0, 0).unwrap(),
+            );
+        }
+        assert_eq!(log.len(), MAX_ENTRIES);
+        // Oldest entries should be evicted
+        assert!(log.entries[0].context.contains("message 5"));
+    }
+
+    #[test]
+    fn reaction_log_truncates_context() {
+        let mut log = ReactionLog::default();
+        let long_context = "a".repeat(200);
+        log.add(
+            "😊",
+            &long_context,
+            Utc.with_ymd_and_hms(1820, 3, 20, 10, 0, 0).unwrap(),
+        );
+        assert_eq!(log.entries[0].context.len(), 80);
+    }
+
+    #[test]
+    fn reaction_log_context_string_empty() {
+        let log = ReactionLog::default();
+        assert_eq!(log.context_string(5), "");
+    }
+
+    #[test]
+    fn reaction_log_context_string_formats_correctly() {
+        let mut log = ReactionLog::default();
+        log.add(
+            "😠",
+            "The rent was raised",
+            Utc.with_ymd_and_hms(1820, 3, 20, 10, 0, 0).unwrap(),
+        );
+        log.add(
+            "😊",
+            "Welcome to the pub",
+            Utc.with_ymd_and_hms(1820, 3, 20, 11, 0, 0).unwrap(),
+        );
+
+        let ctx = log.context_string(5);
+        assert!(ctx.contains("Recent nonverbal reactions from the player:"));
+        assert!(ctx.contains("smiled warmly"));
+        assert!(ctx.contains("looked angry"));
+        assert!(ctx.contains("The rent was raised"));
+    }
+
+    #[test]
+    fn reaction_log_context_string_respects_limit() {
+        let mut log = ReactionLog::default();
+        for i in 0..5 {
+            log.add(
+                "😊",
+                &format!("msg {}", i),
+                Utc.with_ymd_and_hms(1820, 3, 20, 10, 0, 0).unwrap(),
+            );
+        }
+        let ctx = log.context_string(2);
+        // Should only contain the 2 most recent
+        assert!(ctx.contains("msg 4"));
+        assert!(ctx.contains("msg 3"));
+        assert!(!ctx.contains("msg 2"));
+    }
+
+    #[test]
+    fn reaction_log_serde_round_trip() {
+        let mut log = ReactionLog::default();
+        log.add(
+            "😊",
+            "test message",
+            Utc.with_ymd_and_hms(1820, 3, 20, 10, 0, 0).unwrap(),
+        );
+
+        let json = serde_json::to_string(&log).unwrap();
+        let deser: ReactionLog = serde_json::from_str(&json).unwrap();
+        assert_eq!(deser.len(), 1);
+        assert_eq!(deser.entries[0].emoji, "😊");
+    }
+
+    #[test]
+    fn generate_rule_reaction_keyword_match() {
+        // Deterministic variant always returns on match
+        assert_eq!(
+            generate_rule_reaction_deterministic("The fairy fort is cursed"),
+            Some("✝️".to_string())
+        );
+        assert_eq!(
+            generate_rule_reaction_deterministic("Let's have a drink of poitín"),
+            Some("🍺".to_string())
+        );
+        assert_eq!(
+            generate_rule_reaction_deterministic("The rent is too high"),
+            Some("😠".to_string())
+        );
+    }
+
+    #[test]
+    fn generate_rule_reaction_no_match() {
+        assert_eq!(
+            generate_rule_reaction_deterministic("Good morning to you"),
+            None
+        );
+    }
+
+    #[test]
+    fn palette_has_expected_size() {
+        assert_eq!(REACTION_PALETTE.len(), 12);
+    }
+}

--- a/crates/parish-core/src/npc/ticks.rs
+++ b/crates/parish-core/src/npc/ticks.rs
@@ -137,6 +137,15 @@ pub fn build_enhanced_context_with_config(
         context.push_str(&memory_ctx);
     }
 
+    // Add recent player reactions (emoji feedback)
+    let reaction_ctx = npc
+        .reaction_log
+        .context_string(config.reaction_context_count);
+    if !reaction_ctx.is_empty() {
+        context.push_str("\n\n");
+        context.push_str(&reaction_ctx);
+    }
+
     context
 }
 
@@ -427,6 +436,7 @@ mod tests {
             knowledge: Vec::new(),
             state: NpcState::default(),
             deflated_summary: None,
+            reaction_log: crate::npc::reactions::ReactionLog::default(),
         }
     }
 

--- a/crates/parish-core/src/npc/transitions.rs
+++ b/crates/parish-core/src/npc/transitions.rs
@@ -209,6 +209,7 @@ mod tests {
             knowledge: Vec::new(),
             state: NpcState::Present,
             deflated_summary: None,
+            reaction_log: crate::npc::reactions::ReactionLog::default(),
         }
     }
 

--- a/crates/parish-core/src/persistence/journal.rs
+++ b/crates/parish-core/src/persistence/journal.rs
@@ -286,6 +286,7 @@ mod tests {
             knowledge: Vec::new(),
             state: NpcState::Present,
             deflated_summary: None,
+            reaction_log: crate::npc::reactions::ReactionLog::default(),
         });
 
         let events = vec![WorldEvent::NpcMoodChanged {

--- a/crates/parish-core/src/persistence/snapshot.rs
+++ b/crates/parish-core/src/persistence/snapshot.rs
@@ -114,6 +114,7 @@ impl NpcSnapshot {
             knowledge: self.knowledge,
             state: self.state,
             deflated_summary: None,
+            reaction_log: crate::npc::reactions::ReactionLog::default(),
         }
     }
 }
@@ -255,6 +256,7 @@ mod tests {
             knowledge: Vec::new(),
             state: NpcState::Present,
             deflated_summary: None,
+            reaction_log: crate::npc::reactions::ReactionLog::default(),
         }
     }
 

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -102,6 +102,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         .route("/api/ui-config", get(routes::get_ui_config))
         .route("/api/debug-snapshot", get(routes::get_debug_snapshot))
         .route("/api/submit-input", post(routes::submit_input))
+        .route("/api/react-to-message", post(routes::react_to_message))
         .route("/api/ws", get(ws::ws_handler))
         .fallback_service(ServeDir::new(&static_dir).append_index_html_on_directories(true))
         .with_state(state);

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -17,10 +17,11 @@ use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceQueue, new_inference_log, spawn_inference_worker};
 use parish_core::input::{InputResult, classify_input, parse_intent_local};
 use parish_core::ipc::{
-    LoadingPayload, MapData, NpcInfo, StreamEndPayload, TextLogPayload, ThemePalette,
-    WorldSnapshot, capitalize_first,
+    LoadingPayload, MapData, NpcInfo, NpcReactionPayload, ReactRequest, StreamEndPayload,
+    TextLogPayload, ThemePalette, WorldSnapshot, capitalize_first,
 };
 use parish_core::npc::parse_npc_stream_response;
+use parish_core::npc::reactions;
 use parish_core::npc::ticks;
 use parish_core::world::description::{format_exits, render_description};
 use parish_core::world::movement::{self, MovementResult};
@@ -31,6 +32,18 @@ use crate::state::{AppState, GameConfig};
 
 /// Monotonically increasing request ID counter for inference requests.
 static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Monotonically increasing message ID counter for text-log entries.
+static MESSAGE_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Creates a [`TextLogPayload`] with an auto-generated unique message ID.
+fn text_log(source: impl Into<String>, content: impl Into<String>) -> TextLogPayload {
+    TextLogPayload {
+        id: format!("msg-{}", MESSAGE_ID.fetch_add(1, Ordering::SeqCst)),
+        source: source.into(),
+        content: content.into(),
+    }
+}
 
 // ── Query endpoints ─────────────────────────────────────────────────────────
 
@@ -118,20 +131,19 @@ pub async fn submit_input(
     }
 
     // Emit the player's own text as a log entry
-    state.event_bus.emit(
-        "text-log",
-        &TextLogPayload {
-            source: "player".to_string(),
-            content: format!("> {}", text),
-        },
-    );
+    let player_msg = text_log("player", format!("> {}", text));
+    let player_msg_id = player_msg.id.clone();
+    state.event_bus.emit("text-log", &player_msg);
 
     match classify_input(&text) {
         InputResult::SystemCommand(cmd) => {
             handle_system_command(cmd, &state).await;
         }
         InputResult::GameInput(raw) => {
+            let raw_for_reactions = raw.clone();
             handle_game_input(raw, &state).await;
+            // Generate rule-based NPC reactions to the player's message
+            emit_npc_reactions(&player_msg_id, &raw_for_reactions, &state).await;
         }
     }
 
@@ -490,13 +502,9 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
     }
 
     if !response.is_empty() {
-        state.event_bus.emit(
-            "text-log",
-            &TextLogPayload {
-                source: "system".to_string(),
-                content: response,
-            },
-        );
+        state
+            .event_bus
+            .emit("text-log", &text_log("system", response));
     }
 
     let world = state.world.lock().await;
@@ -530,10 +538,7 @@ async fn handle_game_input(raw: String, state: &Arc<AppState>) {
         } else {
             state.event_bus.emit(
                 "text-log",
-                &TextLogPayload {
-                    source: "system".to_string(),
-                    content: "And where would ye be off to?".to_string(),
-                },
+                &text_log("system", "And where would ye be off to?"),
             );
         }
         return;
@@ -584,13 +589,9 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
 
     match result {
         MovementResult::Arrived { narration, .. } => {
-            state.event_bus.emit(
-                "text-log",
-                &TextLogPayload {
-                    source: "system".to_string(),
-                    content: narration,
-                },
-            );
+            state
+                .event_bus
+                .emit("text-log", &text_log("system", narration));
 
             handle_look(state).await;
 
@@ -604,10 +605,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
         MovementResult::AlreadyHere => {
             state.event_bus.emit(
                 "text-log",
-                &TextLogPayload {
-                    source: "system".to_string(),
-                    content: "Sure, you're already standing right here.".to_string(),
-                },
+                &text_log("system", "Sure, you're already standing right here."),
             );
         }
         MovementResult::NotFound(name) => {
@@ -621,13 +619,13 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
             );
             state.event_bus.emit(
                 "text-log",
-                &TextLogPayload {
-                    source: "system".to_string(),
-                    content: format!(
+                &text_log(
+                    "system",
+                    format!(
                         "You haven't the faintest notion how to reach \"{}\". {}",
                         name, exits
                     ),
-                },
+                ),
             );
         }
     }
@@ -662,10 +660,7 @@ async fn handle_look(state: &Arc<AppState>) {
 
     state.event_bus.emit(
         "text-log",
-        &TextLogPayload {
-            source: "system".to_string(),
-            content: format!("{}\n{}", desc, exits),
-        },
+        &text_log("system", format!("{}\n{}", desc, exits)),
     );
 }
 
@@ -720,13 +715,9 @@ async fn handle_npc_conversation(raw: String, state: &Arc<AppState>) {
             let idx = REQUEST_ID.fetch_add(1, Ordering::SeqCst) as usize % idle_messages.len();
             idle_messages[idx].to_string()
         };
-        state.event_bus.emit(
-            "text-log",
-            &TextLogPayload {
-                source: "system".to_string(),
-                content,
-            },
-        );
+        state
+            .event_bus
+            .emit("text-log", &text_log("system", content));
         return;
     };
 
@@ -743,13 +734,9 @@ async fn handle_npc_conversation(raw: String, state: &Arc<AppState>) {
     let (token_tx, token_rx) = mpsc::unbounded_channel::<String>();
 
     let display_label = capitalize_first(&npc_name);
-    state.event_bus.emit(
-        "text-log",
-        &TextLogPayload {
-            source: display_label,
-            content: String::new(),
-        },
-    );
+    state
+        .event_bus
+        .emit("text-log", &text_log(display_label, String::new()));
 
     match queue
         .send(
@@ -812,6 +799,58 @@ async fn handle_npc_conversation(raw: String, state: &Arc<AppState>) {
     state
         .event_bus
         .emit("loading", &LoadingPayload { active: false });
+}
+
+// ── Reaction endpoint ──────────────────────────────────────────────────────
+
+/// `POST /api/react-to-message` — player reacts to an NPC message with an emoji.
+pub async fn react_to_message(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<ReactRequest>,
+) -> impl IntoResponse {
+    // Validate emoji is in the palette
+    if reactions::reaction_description(&body.emoji).is_none() {
+        return StatusCode::BAD_REQUEST;
+    }
+
+    // Store the reaction in the target NPC's reaction log
+    let mut npc_manager = state.npc_manager.lock().await;
+    if let Some(npc) = npc_manager.find_by_name_mut(&body.npc_name) {
+        let now = chrono::Utc::now();
+        npc.reaction_log
+            .add(&body.emoji, &body.message_snippet, now);
+    }
+
+    StatusCode::OK
+}
+
+/// Generates rule-based NPC reactions to a player message and emits events.
+///
+/// Called after processing player input. Each NPC at the player's location
+/// has a chance to react with an emoji based on keyword matching.
+async fn emit_npc_reactions(player_msg_id: &str, player_input: &str, state: &Arc<AppState>) {
+    let npc_names: Vec<String> = {
+        let world = state.world.lock().await;
+        let npc_manager = state.npc_manager.lock().await;
+        npc_manager
+            .npcs_at(world.player_location)
+            .iter()
+            .map(|n| n.name.clone())
+            .collect()
+    };
+
+    for name in npc_names {
+        if let Some(emoji) = reactions::generate_rule_reaction(player_input) {
+            state.event_bus.emit(
+                "npc-reaction",
+                &NpcReactionPayload {
+                    message_id: player_msg_id.to_string(),
+                    emoji,
+                    source: capitalize_first(&name),
+                },
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -914,5 +953,21 @@ mod tests {
             start_time,
             "clock should not advance for unknown destination"
         );
+    }
+
+    #[test]
+    fn text_log_generates_unique_ids() {
+        let a = text_log("system", "hello");
+        let b = text_log("system", "world");
+        assert_ne!(a.id, b.id);
+        assert!(a.id.starts_with("msg-"));
+    }
+
+    #[test]
+    fn react_request_deserialization() {
+        let json = r#"{"npcName": "Padraig", "messageSnippet": "Hello", "emoji": "😊"}"#;
+        let req: ReactRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.npc_name, "Padraig");
+        assert_eq!(req.emoji, "😊");
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1082,14 +1082,7 @@ async fn handle_npc_conversation(
 
     // Emit NPC name prefix as the start of the streaming entry
     let display_label = capitalize_first(&npc_name);
-    let _ = app.emit(
-        EVENT_TEXT_LOG,
-        TextLogPayload {
-            id: String::new(),
-            source: display_label,
-            content: String::new(),
-        },
-    );
+    let _ = app.emit(EVENT_TEXT_LOG, text_log(display_label, String::new()));
 
     // Pause the game clock while waiting for the inference response
     // and immediately notify the frontend so it stops interpolating.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15,6 +15,7 @@ use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceQueue, spawn_inference_worker};
 use parish_core::input::{InputResult, classify_input, extract_mention, parse_intent_local};
 use parish_core::npc::parse_npc_stream_response;
+use parish_core::npc::reactions;
 use parish_core::npc::ticks;
 use parish_core::world::description::{format_exits, render_description};
 use parish_core::world::movement::{self, MovementResult};
@@ -22,8 +23,8 @@ use parish_core::world::palette::compute_palette;
 use parish_core::world::transport::TransportMode;
 
 use crate::events::{
-    EVENT_SAVE_PICKER, EVENT_STREAM_END, EVENT_TEXT_LOG, EVENT_WORLD_UPDATE, StreamEndPayload,
-    TextLogPayload, spawn_loading_animation,
+    EVENT_SAVE_PICKER, EVENT_STREAM_END, EVENT_TEXT_LOG, EVENT_WORLD_UPDATE, NpcReactionPayload,
+    StreamEndPayload, TextLogPayload, spawn_loading_animation,
 };
 use crate::{AppState, MapData, MapLocation, NpcInfo, SaveState, ThemePalette, WorldSnapshot};
 
@@ -38,6 +39,18 @@ fn capitalize_first(s: &str) -> String {
 
 /// Monotonically increasing request ID counter for inference requests.
 static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Monotonically increasing message ID counter for text-log entries.
+static MESSAGE_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Creates a [`TextLogPayload`] with an auto-generated unique message ID.
+fn text_log(source: impl Into<String>, content: impl Into<String>) -> TextLogPayload {
+    TextLogPayload {
+        id: format!("msg-{}", MESSAGE_ID.fetch_add(1, Ordering::SeqCst)),
+        source: source.into(),
+        content: content.into(),
+    }
+}
 
 // ── Helper: build a WorldSnapshot from locked world state ────────────────────
 
@@ -300,20 +313,19 @@ pub async fn submit_input(
     }
 
     // Emit the player's own text as a log entry
-    let _ = app.emit(
-        EVENT_TEXT_LOG,
-        TextLogPayload {
-            source: "player".to_string(),
-            content: format!("> {}", text),
-        },
-    );
+    let player_msg = text_log("player", format!("> {}", text));
+    let player_msg_id = player_msg.id.clone();
+    let _ = app.emit(EVENT_TEXT_LOG, player_msg);
 
     match classify_input(&text) {
         InputResult::SystemCommand(cmd) => {
             handle_system_command(cmd, &state, &app).await;
         }
         InputResult::GameInput(raw) => {
-            handle_game_input(raw, state, app).await;
+            let raw_for_reactions = raw.clone();
+            handle_game_input(raw, state.clone(), app.clone()).await;
+            // Generate rule-based NPC reactions to the player's message
+            emit_npc_reactions(&player_msg_id, &raw_for_reactions, &state, &app).await;
         }
     }
 
@@ -763,6 +775,7 @@ async fn handle_system_command(
     let _ = app.emit(
         EVENT_TEXT_LOG,
         TextLogPayload {
+            id: String::new(),
             source: "system".to_string(),
             content: response,
         },
@@ -808,6 +821,7 @@ async fn handle_game_input(
             let _ = app.emit(
                 EVENT_TEXT_LOG,
                 TextLogPayload {
+                    id: String::new(),
                     source: "system".to_string(),
                     content: "And where would ye be off to?".to_string(),
                 },
@@ -876,6 +890,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
             let _ = app.emit(
                 EVENT_TEXT_LOG,
                 TextLogPayload {
+                    id: String::new(),
                     source: "system".to_string(),
                     content: narration,
                 },
@@ -922,6 +937,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
             let _ = app.emit(
                 EVENT_TEXT_LOG,
                 TextLogPayload {
+                    id: String::new(),
                     source: "system".to_string(),
                     content: "Sure, you're already standing right here.".to_string(),
                 },
@@ -938,6 +954,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
             let _ = app.emit(
                 EVENT_TEXT_LOG,
                 TextLogPayload {
+                    id: String::new(),
                     source: "system".to_string(),
                     content: format!(
                         "You haven't the faintest notion how to reach \"{}\". {}",
@@ -979,6 +996,7 @@ async fn handle_look(state: &Arc<AppState>, app: &tauri::AppHandle) {
     let _ = app.emit(
         EVENT_TEXT_LOG,
         TextLogPayload {
+            id: String::new(),
             source: "system".to_string(),
             content: format!("{}\n{}", desc, exits),
         },
@@ -1042,6 +1060,7 @@ async fn handle_npc_conversation(
         let _ = app.emit(
             EVENT_TEXT_LOG,
             TextLogPayload {
+                id: String::new(),
                 source: "system".to_string(),
                 content: idle_messages[idx].to_string(),
             },
@@ -1066,6 +1085,7 @@ async fn handle_npc_conversation(
     let _ = app.emit(
         EVENT_TEXT_LOG,
         TextLogPayload {
+            id: String::new(),
             source: display_label,
             content: String::new(),
         },
@@ -1157,6 +1177,7 @@ async fn handle_npc_conversation(
                     let _ = app.emit(
                         EVENT_TEXT_LOG,
                         TextLogPayload {
+                            id: String::new(),
                             source: "system".to_string(),
                             content: canned[idx].to_string(),
                         },
@@ -1193,6 +1214,7 @@ async fn handle_npc_conversation(
             let _ = app.emit(
                 EVENT_TEXT_LOG,
                 TextLogPayload {
+                    id: String::new(),
                     source: "system".to_string(),
                     content: "The parish storyteller has wandered off. Try again in a moment."
                         .to_string(),
@@ -1357,6 +1379,7 @@ pub async fn load_branch(
     let _ = app.emit(
         EVENT_TEXT_LOG,
         TextLogPayload {
+            id: String::new(),
             source: "system".to_string(),
             content: format!("Loaded {} (branch: {}).", filename, branch_name),
         },
@@ -1511,6 +1534,7 @@ pub async fn new_game(
     let _ = app.emit(
         EVENT_TEXT_LOG,
         TextLogPayload {
+            id: String::new(),
             source: "system".to_string(),
             content: "A new chapter begins in the parish...".to_string(),
         },
@@ -1593,4 +1617,59 @@ async fn do_branch_log_text(state: &Arc<AppState>) -> Result<String, String> {
         lines.push(format!("  {}. {} (game: {})", i + 1, time, info.game_time));
     }
     Ok(lines.join("\n"))
+}
+
+// ── Reaction commands ──────────────────────────────────────────────────────
+
+/// Player reacts to an NPC message with an emoji.
+#[tauri::command]
+pub async fn react_to_message(
+    npc_name: String,
+    message_snippet: String,
+    emoji: String,
+    state: tauri::State<'_, Arc<AppState>>,
+) -> Result<(), String> {
+    // Validate emoji is in the palette
+    if reactions::reaction_description(&emoji).is_none() {
+        return Err("Unknown reaction emoji.".to_string());
+    }
+
+    let mut npc_manager = state.npc_manager.lock().await;
+    if let Some(npc) = npc_manager.find_by_name_mut(&npc_name) {
+        let now = chrono::Utc::now();
+        npc.reaction_log.add(&emoji, &message_snippet, now);
+    }
+
+    Ok(())
+}
+
+/// Generates rule-based NPC reactions to a player message and emits events.
+async fn emit_npc_reactions(
+    player_msg_id: &str,
+    player_input: &str,
+    state: &Arc<AppState>,
+    app: &tauri::AppHandle,
+) {
+    let npc_names: Vec<String> = {
+        let world = state.world.lock().await;
+        let npc_manager = state.npc_manager.lock().await;
+        npc_manager
+            .npcs_at(world.player_location)
+            .iter()
+            .map(|n| n.name.clone())
+            .collect()
+    };
+
+    for name in npc_names {
+        if let Some(emoji) = reactions::generate_rule_reaction(player_input) {
+            let _ = app.emit(
+                crate::events::EVENT_NPC_REACTION,
+                NpcReactionPayload {
+                    message_id: player_msg_id.to_string(),
+                    emoji,
+                    source: capitalize_first(&name),
+                },
+            );
+        }
+    }
 }

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -27,6 +27,8 @@ pub const EVENT_DEBUG_UPDATE: &str = "debug-update";
 pub const EVENT_SAVE_PICKER: &str = "save-picker";
 /// Event emitted to toggle the full map overlay.
 pub const EVENT_TOGGLE_MAP: &str = "toggle-full-map";
+/// Event emitted when an NPC reacts to a message with an emoji.
+pub const EVENT_NPC_REACTION: &str = "npc-reaction";
 
 /// How many milliseconds to batch streaming tokens before emitting.
 pub const BATCH_MS: u64 = 16;
@@ -50,10 +52,24 @@ pub struct StreamEndPayload {
 /// Payload for `text-log` events.
 #[derive(serde::Serialize, Clone)]
 pub struct TextLogPayload {
+    /// Unique message ID for reaction targeting.
+    #[serde(default)]
+    pub id: String,
     /// Who produced this text: "player", "system", or the NPC's name.
     pub source: String,
     /// The log entry text.
     pub content: String,
+}
+
+/// Payload for `npc-reaction` events.
+#[derive(serde::Serialize, Clone)]
+pub struct NpcReactionPayload {
+    /// ID of the message being reacted to.
+    pub message_id: String,
+    /// The reaction emoji.
+    pub emoji: String,
+    /// Who reacted (NPC name).
+    pub source: String,
 }
 
 /// Payload for `loading` events.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -559,6 +559,7 @@ pub fn run() {
             commands::new_save_file,
             commands::new_game,
             commands::get_save_state,
+            commands::react_to_message,
         ])
         .setup(move |app| {
             let handle = app.handle().clone();

--- a/ui/src/components/ChatPanel.svelte
+++ b/ui/src/components/ChatPanel.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 	import { tick } from 'svelte';
-	import { textLog, streamingActive, loadingPhrase, loadingColor } from '../stores/game';
+	import { textLog, streamingActive, loadingPhrase, loadingColor, addReaction } from '../stores/game';
 	import type { TextLogEntry } from '$lib/types';
+	import { REACTION_PALETTE } from '$lib/reactions';
+	import { reactToMessage } from '$lib/ipc';
 
 	let logEl: HTMLDivElement;
+	let hoveredMessageId: string | null = $state(null);
 
 	$effect(() => {
 		// Scroll to bottom when log changes
@@ -53,6 +56,17 @@
 		}
 		return segments;
 	}
+
+	function handleReaction(entry: TextLogEntry, emoji: string) {
+		if (!entry.id) return;
+		// Optimistic UI update
+		addReaction(entry.id, emoji, 'player');
+		// Send to backend
+		const snippet = entry.content.slice(0, 80);
+		reactToMessage(entry.source, snippet, emoji).catch(() => {});
+		// Close picker
+		hoveredMessageId = null;
+	}
 </script>
 
 <div class="chat-panel" data-testid="chat-panel" bind:this={logEl} role="log" aria-live="polite" aria-label="Game chat log">
@@ -68,7 +82,12 @@
 				{/if}
 			</div>
 		{:else}
-			<div class="bubble-row {entryType(entry)}">
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<div
+				class="bubble-row {entryType(entry)}"
+				onmouseenter={() => { if (entryType(entry) === 'npc' && !entry.streaming && entry.id) hoveredMessageId = entry.id ?? null; }}
+				onmouseleave={() => { hoveredMessageId = null; }}
+			>
 				<div class="bubble-wrapper">
 					<span class="label">{displayLabel(entry)}</span>
 					<div class="bubble">
@@ -77,6 +96,35 @@
 							>{/if}</span
 						>
 					</div>
+
+					<!-- Reaction picker (on hover, NPC messages only) -->
+					{#if hoveredMessageId && hoveredMessageId === entry.id && entryType(entry) === 'npc'}
+						<div class="reaction-picker" role="toolbar" aria-label="React to message" data-testid="reaction-picker">
+							{#each REACTION_PALETTE as reaction}
+								<button
+									class="reaction-btn"
+									title={reaction.description}
+									onclick={() => handleReaction(entry, reaction.emoji)}
+								>
+									{reaction.emoji}
+								</button>
+							{/each}
+						</div>
+					{/if}
+
+					<!-- Existing reactions -->
+					{#if entry.reactions && entry.reactions.length > 0}
+						<div class="reaction-bar" data-testid="reaction-bar">
+							{#each entry.reactions as r}
+								<span class="reaction-badge" title={r.source}>
+									{r.emoji}
+									{#if r.source !== 'player'}
+										<span class="reaction-source">{r.source}</span>
+									{/if}
+								</span>
+							{/each}
+						</div>
+					{/if}
 				</div>
 			</div>
 		{/if}
@@ -202,6 +250,59 @@
 		50% {
 			opacity: 0;
 		}
+	}
+
+	/* Reaction picker */
+	.reaction-picker {
+		display: flex;
+		gap: 0.15rem;
+		padding: 0.2rem 0.25rem;
+		background: var(--color-panel-bg);
+		border: 1px solid var(--color-border);
+		border-radius: 12px;
+		box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+		width: fit-content;
+		margin-top: 0.2rem;
+	}
+
+	.reaction-btn {
+		background: none;
+		border: none;
+		padding: 0.15rem 0.2rem;
+		font-size: 0.85rem;
+		cursor: pointer;
+		border-radius: 4px;
+		line-height: 1;
+		transition: transform 0.1s, background 0.1s;
+	}
+
+	.reaction-btn:hover {
+		transform: scale(1.3);
+		background: var(--color-input-bg);
+	}
+
+	/* Reaction bar (displayed reactions) */
+	.reaction-bar {
+		display: flex;
+		gap: 0.25rem;
+		margin-top: 0.2rem;
+		flex-wrap: wrap;
+	}
+
+	.reaction-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.15rem;
+		font-size: 0.75rem;
+		background: var(--color-input-bg);
+		border: 1px solid var(--color-border);
+		border-radius: 10px;
+		padding: 0.1rem 0.35rem;
+	}
+
+	.reaction-source {
+		font-size: 0.65rem;
+		color: var(--color-muted);
 	}
 
 	.loading-row {

--- a/ui/src/components/ChatPanel.svelte
+++ b/ui/src/components/ChatPanel.svelte
@@ -82,35 +82,37 @@
 				{/if}
 			</div>
 		{:else}
-			<!-- svelte-ignore a11y_no_static_element_interactions -->
-			<div
-				class="bubble-row {entryType(entry)}"
-				onmouseenter={() => { if (entryType(entry) === 'npc' && !entry.streaming && entry.id) hoveredMessageId = entry.id ?? null; }}
-				onmouseleave={() => { hoveredMessageId = null; }}
-			>
+			<div class="bubble-row {entryType(entry)}">
 				<div class="bubble-wrapper">
 					<span class="label">{displayLabel(entry)}</span>
-					<div class="bubble">
-						<span class="content"
-							>{#each parseEmotes(entry.content) as seg}{#if seg.isAction}<span class="emote">{seg.text}</span>{:else}{seg.text}{/if}{/each}{#if entry.streaming}<span class="cursor">▋</span
-							>{/if}</span
-						>
-					</div>
-
-					<!-- Reaction picker (on hover, NPC messages only) -->
-					{#if hoveredMessageId && hoveredMessageId === entry.id && entryType(entry) === 'npc'}
-						<div class="reaction-picker" role="toolbar" aria-label="React to message" data-testid="reaction-picker">
-							{#each REACTION_PALETTE as reaction}
-								<button
-									class="reaction-btn"
-									title={reaction.description}
-									onclick={() => handleReaction(entry, reaction.emoji)}
-								>
-									{reaction.emoji}
-								</button>
-							{/each}
+					<!-- svelte-ignore a11y_no_static_element_interactions -->
+					<div
+						class="bubble-anchor"
+						onmouseenter={() => { if (entryType(entry) === 'npc' && !entry.streaming && entry.id) hoveredMessageId = entry.id ?? null; }}
+						onmouseleave={() => { hoveredMessageId = null; }}
+					>
+						<div class="bubble">
+							<span class="content"
+								>{#each parseEmotes(entry.content) as seg}{#if seg.isAction}<span class="emote">{seg.text}</span>{:else}{seg.text}{/if}{/each}{#if entry.streaming}<span class="cursor">▋</span
+								>{/if}</span
+							>
 						</div>
-					{/if}
+
+						<!-- Reaction picker (floats over bubble, NPC messages only) -->
+						{#if hoveredMessageId && hoveredMessageId === entry.id && entryType(entry) === 'npc'}
+							<div class="reaction-picker" role="toolbar" aria-label="React to message" data-testid="reaction-picker">
+								{#each REACTION_PALETTE as reaction}
+									<button
+										class="reaction-btn"
+										title={reaction.description}
+										onclick={() => handleReaction(entry, reaction.emoji)}
+									>
+										{reaction.emoji}
+									</button>
+								{/each}
+							</div>
+						{/if}
+					</div>
 
 					<!-- Existing reactions -->
 					{#if entry.reactions && entry.reactions.length > 0}
@@ -252,17 +254,26 @@
 		}
 	}
 
-	/* Reaction picker */
+	/* Bubble anchor: positioning context for the floating reaction picker */
+	.bubble-anchor {
+		position: relative;
+		width: fit-content;
+	}
+
+	/* Reaction picker: floats over the bottom edge of the bubble */
 	.reaction-picker {
+		position: absolute;
+		top: calc(100% - 10px);
+		left: 0;
+		z-index: 10;
 		display: flex;
 		gap: 0.15rem;
 		padding: 0.2rem 0.25rem;
 		background: var(--color-panel-bg);
 		border: 1px solid var(--color-border);
 		border-radius: 12px;
-		box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 		width: fit-content;
-		margin-top: 0.2rem;
 	}
 
 	.reaction-btn {

--- a/ui/src/components/ChatPanel.test.ts
+++ b/ui/src/components/ChatPanel.test.ts
@@ -137,10 +137,10 @@ describe('ChatPanel', () => {
 			textLog.set([{ id: 'msg-1', source: 'Padraig', content: 'Good morning!' }]);
 			const { container } = render(ChatPanel);
 
-			const bubbleRow = container.querySelector('.bubble-row.npc') as HTMLElement;
-			expect(bubbleRow).toBeTruthy();
+			const anchor = container.querySelector('.bubble-row.npc .bubble-anchor') as HTMLElement;
+			expect(anchor).toBeTruthy();
 
-			await fireEvent.mouseEnter(bubbleRow);
+			await fireEvent.mouseEnter(anchor);
 			expect(container.querySelector('[data-testid="reaction-picker"]')).toBeTruthy();
 		});
 
@@ -148,11 +148,11 @@ describe('ChatPanel', () => {
 			textLog.set([{ id: 'msg-1', source: 'Padraig', content: 'Good morning!' }]);
 			const { container } = render(ChatPanel);
 
-			const bubbleRow = container.querySelector('.bubble-row.npc') as HTMLElement;
-			await fireEvent.mouseEnter(bubbleRow);
+			const anchor = container.querySelector('.bubble-row.npc .bubble-anchor') as HTMLElement;
+			await fireEvent.mouseEnter(anchor);
 			expect(container.querySelector('[data-testid="reaction-picker"]')).toBeTruthy();
 
-			await fireEvent.mouseLeave(bubbleRow);
+			await fireEvent.mouseLeave(anchor);
 			expect(container.querySelector('[data-testid="reaction-picker"]')).toBeFalsy();
 		});
 
@@ -160,8 +160,8 @@ describe('ChatPanel', () => {
 			textLog.set([{ id: 'msg-1', source: 'player', content: 'Hello' }]);
 			const { container } = render(ChatPanel);
 
-			const bubbleRow = container.querySelector('.bubble-row.player') as HTMLElement;
-			await fireEvent.mouseEnter(bubbleRow);
+			const anchor = container.querySelector('.bubble-row.player .bubble-anchor') as HTMLElement;
+			await fireEvent.mouseEnter(anchor);
 			expect(container.querySelector('[data-testid="reaction-picker"]')).toBeFalsy();
 		});
 
@@ -169,8 +169,8 @@ describe('ChatPanel', () => {
 			textLog.set([{ id: 'msg-1', source: 'Padraig', content: 'Hello...', streaming: true }]);
 			const { container } = render(ChatPanel);
 
-			const bubbleRow = container.querySelector('.bubble-row.npc') as HTMLElement;
-			await fireEvent.mouseEnter(bubbleRow);
+			const anchor = container.querySelector('.bubble-row.npc .bubble-anchor') as HTMLElement;
+			await fireEvent.mouseEnter(anchor);
 			expect(container.querySelector('[data-testid="reaction-picker"]')).toBeFalsy();
 		});
 
@@ -178,8 +178,8 @@ describe('ChatPanel', () => {
 			textLog.set([{ source: 'Padraig', content: 'Hello' }]);
 			const { container } = render(ChatPanel);
 
-			const bubbleRow = container.querySelector('.bubble-row.npc') as HTMLElement;
-			await fireEvent.mouseEnter(bubbleRow);
+			const anchor = container.querySelector('.bubble-row.npc .bubble-anchor') as HTMLElement;
+			await fireEvent.mouseEnter(anchor);
 			expect(container.querySelector('[data-testid="reaction-picker"]')).toBeFalsy();
 		});
 
@@ -189,8 +189,8 @@ describe('ChatPanel', () => {
 			const { container } = render(ChatPanel);
 
 			// Hover to show picker
-			const bubbleRow = container.querySelector('.bubble-row.npc') as HTMLElement;
-			await fireEvent.mouseEnter(bubbleRow);
+			const anchor = container.querySelector('.bubble-row.npc .bubble-anchor') as HTMLElement;
+			await fireEvent.mouseEnter(anchor);
 
 			// Click the first reaction button (😊)
 			const buttons = container.querySelectorAll('.reaction-btn');

--- a/ui/src/components/ChatPanel.test.ts
+++ b/ui/src/components/ChatPanel.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { render } from '@testing-library/svelte';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
 import { textLog, streamingActive, loadingSpinner, loadingPhrase, loadingColor } from '../stores/game';
 import ChatPanel from './ChatPanel.svelte';
+
+// Mock the IPC layer
+vi.mock('$lib/ipc', () => ({
+	reactToMessage: vi.fn(() => Promise.resolve())
+}));
 
 describe('ChatPanel', () => {
 	beforeEach(() => {
@@ -124,6 +129,116 @@ describe('ChatPanel', () => {
 			const emote = container.querySelector('.emote');
 			expect(emote).toBeTruthy();
 			expect(emote?.textContent).toBe('tip your hat');
+		});
+	});
+
+	describe('emoji reactions', () => {
+		it('shows reaction picker on NPC message hover', async () => {
+			textLog.set([{ id: 'msg-1', source: 'Padraig', content: 'Good morning!' }]);
+			const { container } = render(ChatPanel);
+
+			const bubbleRow = container.querySelector('.bubble-row.npc') as HTMLElement;
+			expect(bubbleRow).toBeTruthy();
+
+			await fireEvent.mouseEnter(bubbleRow);
+			expect(container.querySelector('[data-testid="reaction-picker"]')).toBeTruthy();
+		});
+
+		it('hides reaction picker on mouseleave', async () => {
+			textLog.set([{ id: 'msg-1', source: 'Padraig', content: 'Good morning!' }]);
+			const { container } = render(ChatPanel);
+
+			const bubbleRow = container.querySelector('.bubble-row.npc') as HTMLElement;
+			await fireEvent.mouseEnter(bubbleRow);
+			expect(container.querySelector('[data-testid="reaction-picker"]')).toBeTruthy();
+
+			await fireEvent.mouseLeave(bubbleRow);
+			expect(container.querySelector('[data-testid="reaction-picker"]')).toBeFalsy();
+		});
+
+		it('does not show reaction picker on player messages', async () => {
+			textLog.set([{ id: 'msg-1', source: 'player', content: 'Hello' }]);
+			const { container } = render(ChatPanel);
+
+			const bubbleRow = container.querySelector('.bubble-row.player') as HTMLElement;
+			await fireEvent.mouseEnter(bubbleRow);
+			expect(container.querySelector('[data-testid="reaction-picker"]')).toBeFalsy();
+		});
+
+		it('does not show reaction picker on streaming messages', async () => {
+			textLog.set([{ id: 'msg-1', source: 'Padraig', content: 'Hello...', streaming: true }]);
+			const { container } = render(ChatPanel);
+
+			const bubbleRow = container.querySelector('.bubble-row.npc') as HTMLElement;
+			await fireEvent.mouseEnter(bubbleRow);
+			expect(container.querySelector('[data-testid="reaction-picker"]')).toBeFalsy();
+		});
+
+		it('does not show reaction picker on messages without id', async () => {
+			textLog.set([{ source: 'Padraig', content: 'Hello' }]);
+			const { container } = render(ChatPanel);
+
+			const bubbleRow = container.querySelector('.bubble-row.npc') as HTMLElement;
+			await fireEvent.mouseEnter(bubbleRow);
+			expect(container.querySelector('[data-testid="reaction-picker"]')).toBeFalsy();
+		});
+
+		it('clicking reaction adds to entry reactions and calls IPC', async () => {
+			const { reactToMessage } = await import('$lib/ipc');
+			textLog.set([{ id: 'msg-1', source: 'Padraig', content: 'The rent was raised.' }]);
+			const { container } = render(ChatPanel);
+
+			// Hover to show picker
+			const bubbleRow = container.querySelector('.bubble-row.npc') as HTMLElement;
+			await fireEvent.mouseEnter(bubbleRow);
+
+			// Click the first reaction button (😊)
+			const buttons = container.querySelectorAll('.reaction-btn');
+			expect(buttons.length).toBe(12);
+			await fireEvent.click(buttons[0]);
+
+			// Reaction bar should appear with the badge
+			expect(container.querySelector('[data-testid="reaction-bar"]')).toBeTruthy();
+			const badge = container.querySelector('.reaction-badge');
+			expect(badge?.textContent).toContain('😊');
+
+			// IPC should be called
+			expect(reactToMessage).toHaveBeenCalledWith('Padraig', 'The rent was raised.', '😊');
+		});
+
+		it('renders reaction bar when entry has reactions', () => {
+			textLog.set([{
+				id: 'msg-1',
+				source: 'Padraig',
+				content: 'Hello',
+				reactions: [
+					{ emoji: '😊', source: 'player' },
+					{ emoji: '😂', source: 'Siobhan' }
+				]
+			}]);
+			const { container } = render(ChatPanel);
+
+			const bar = container.querySelector('[data-testid="reaction-bar"]');
+			expect(bar).toBeTruthy();
+
+			const badges = container.querySelectorAll('.reaction-badge');
+			expect(badges.length).toBe(2);
+
+			// NPC reactions show source name
+			const source = container.querySelector('.reaction-source');
+			expect(source?.textContent).toBe('Siobhan');
+		});
+
+		it('player reactions do not show source label', () => {
+			textLog.set([{
+				id: 'msg-1',
+				source: 'Padraig',
+				content: 'Hello',
+				reactions: [{ emoji: '😊', source: 'player' }]
+			}]);
+			const { container } = render(ChatPanel);
+
+			expect(container.querySelector('.reaction-source')).toBeFalsy();
 		});
 	});
 });

--- a/ui/src/lib/ipc.ts
+++ b/ui/src/lib/ipc.ts
@@ -15,6 +15,7 @@ import type {
 	StreamTokenPayload,
 	StreamEndPayload,
 	TextLogPayload,
+	NpcReactionPayload,
 	WorldUpdatePayload,
 	LoadingPayload,
 	DebugSnapshot,
@@ -80,6 +81,11 @@ export const newSaveFile = () => command<void>('new_save_file');
 export const newGame = () => command<void>('new_game');
 
 export const getSaveState = () => command<SaveState>('get_save_state');
+
+// ── Reaction commands ──────────────────────────────────────────────────────
+
+export const reactToMessage = (npcName: string, messageSnippet: string, emoji: string) =>
+	command<void>('react_to_message', { npcName, messageSnippet, emoji });
 
 // ── Events ──────────────────────────────────────────────────────────────────
 
@@ -181,3 +187,6 @@ export const onSavePicker = (cb: () => void) =>
 
 export const onToggleFullMap = (cb: () => void) =>
 	onEvent<void>('toggle-full-map', () => cb());
+
+export const onNpcReaction = (cb: (payload: NpcReactionPayload) => void) =>
+	onEvent<NpcReactionPayload>('npc-reaction', cb);

--- a/ui/src/lib/reactions.ts
+++ b/ui/src/lib/reactions.ts
@@ -1,0 +1,24 @@
+/** Reaction palette definition for player↔NPC emoji reactions. */
+
+export interface ReactionDef {
+	emoji: string;
+	description: string;
+	key: string;
+}
+
+/** Period-appropriate gestures mapped to emoji.
+ *  UI shows the emoji; NPC context receives the description string. */
+export const REACTION_PALETTE: ReactionDef[] = [
+	{ emoji: '😊', description: 'smiled warmly', key: '1' },
+	{ emoji: '😠', description: 'looked angry', key: '2' },
+	{ emoji: '😢', description: 'looked sorrowful', key: '3' },
+	{ emoji: '😳', description: 'looked startled', key: '4' },
+	{ emoji: '🤔', description: 'looked thoughtful', key: '5' },
+	{ emoji: '😏', description: 'smirked knowingly', key: '6' },
+	{ emoji: '👀', description: 'raised an eyebrow', key: '7' },
+	{ emoji: '🤫', description: 'made a hushing gesture', key: '8' },
+	{ emoji: '😂', description: 'laughed heartily', key: '9' },
+	{ emoji: '🙄', description: 'rolled their eyes', key: '0' },
+	{ emoji: '🍺', description: 'raised a glass', key: '-' },
+	{ emoji: '✝️', description: 'crossed themselves', key: '=' }
+];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -69,10 +69,17 @@ export interface UiConfig {
 	splash_text: string;
 }
 
+export interface Reaction {
+	emoji: string;
+	source: string;
+}
+
 export interface TextLogEntry {
+	id?: string;
 	source: string;
 	content: string;
 	streaming?: boolean;
+	reactions?: Reaction[];
 }
 
 export interface StreamTokenPayload {
@@ -84,8 +91,15 @@ export interface StreamEndPayload {
 }
 
 export interface TextLogPayload {
+	id?: string;
 	source: string;
 	content: string;
+}
+
+export interface NpcReactionPayload {
+	message_id: string;
+	emoji: string;
+	source: string;
 }
 
 export type WorldUpdatePayload = WorldSnapshot;

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -10,7 +10,7 @@
 	import DebugPanel from '../components/DebugPanel.svelte';
 	import SavePicker from '../components/SavePicker.svelte';
 
-	import { worldState, mapData, npcsHere, textLog, streamingActive, loadingSpinner, loadingPhrase, loadingColor, languageHints, nameHints, uiConfig, fullMapOpen } from '../stores/game';
+	import { worldState, mapData, npcsHere, textLog, streamingActive, loadingSpinner, loadingPhrase, loadingColor, languageHints, nameHints, uiConfig, fullMapOpen, addReaction } from '../stores/game';
 	import { debugVisible, debugSnapshot } from '../stores/debug';
 	import { savePickerVisible } from '../stores/save';
 	import { palette } from '../stores/theme';
@@ -29,7 +29,8 @@
 		onThemeUpdate,
 		onDebugUpdate,
 		onSavePicker,
-		onToggleFullMap
+		onToggleFullMap,
+		onNpcReaction
 	} from '$lib/ipc';
 
 	// F5 toggle for save picker, F12 toggle for debug panel, M toggle for map
@@ -116,7 +117,11 @@
 					payload.source === 'player' && payload.content.startsWith('> ')
 						? payload.content.slice(2)
 						: payload.content;
-				textLog.update((log) => [...log, { source: payload.source, content }]);
+				textLog.update((log) => [...log, { id: payload.id, source: payload.source, content }]);
+			}),
+
+			onNpcReaction((payload) => {
+				addReaction(payload.message_id, payload.emoji, payload.source);
 			}),
 
 			onStreamToken((payload) => {

--- a/ui/src/stores/game.ts
+++ b/ui/src/stores/game.ts
@@ -31,3 +31,26 @@ export const uiConfig = writable<UiConfig>({
 });
 
 export const fullMapOpen = writable<boolean>(false);
+
+/** Adds a reaction to a message in the text log by message ID. */
+export function addReaction(messageId: string, emoji: string, source: string): void {
+	textLog.update((log) => {
+		const entry = log.find((e) => e.id === messageId);
+		if (!entry) return log;
+
+		const reactions = entry.reactions ?? [];
+		// Player: one reaction per message (replace existing)
+		if (source === 'player') {
+			const existing = reactions.findIndex((r) => r.source === 'player');
+			if (existing >= 0) {
+				reactions[existing] = { emoji, source };
+			} else {
+				reactions.push({ emoji, source });
+			}
+		} else {
+			reactions.push({ emoji, source });
+		}
+		entry.reactions = reactions;
+		return [...log];
+	});
+}


### PR DESCRIPTION
Player can hover over NPC messages to reveal a 12-emoji reaction picker
(period-appropriate gestures for 1820s Ireland). Clicking a reaction
stores it in the NPC's ReactionLog and injects it as context in the
NPC's next conversation prompt, so NPCs become aware of the player's
nonverbal feedback over time.

NPCs also react to player messages via rule-based keyword matching
(60% probability), emitting reactions as events that appear as badges
below the player's message bubbles.

Key changes:
- New reactions module (ReactionLog, reaction palette, rule-based generation)
- Message IDs on all text-log events for reaction targeting
- react-to-message endpoint (web) and Tauri command (desktop)
- Reaction context injection into NPC Tier 1 conversation prompts
- ChatPanel hover picker, reaction bar, and optimistic UI
- 8 new frontend tests, comprehensive backend unit tests

https://claude.ai/code/session_01UnPt4bwDuEgsXtMFZmsX9P