### PR TITLE
feat: NPC arrival reactions and greetings system

### DIFF
--- a/crates/parish-core/src/config/engine.rs
+++ b/crates/parish-core/src/config/engine.rs
@@ -254,6 +254,9 @@ pub struct NpcConfig {
     /// Number of recent player reactions included in dialogue context.
     #[serde(default = "default_reaction_context_count")]
     pub reaction_context_count: usize,
+    /// NPC arrival reaction tuning.
+    #[serde(default)]
+    pub reactions: ReactionConfig,
 }
 
 impl Default for NpcConfig {
@@ -269,6 +272,7 @@ impl Default for NpcConfig {
             cognitive_tiers: CognitiveTierConfig::default(),
             relationship_labels: RelationshipLabelConfig::default(),
             reaction_context_count: 5,
+            reactions: ReactionConfig::default(),
         }
     }
 }
@@ -379,6 +383,72 @@ fn default_cool() -> f64 {
 }
 fn default_strained() -> f64 {
     -0.7
+}
+
+// ---------------------------------------------------------------------------
+// Reactions
+// ---------------------------------------------------------------------------
+
+/// Tuning for NPC arrival reactions (greetings, nods, introductions).
+#[derive(Debug, Deserialize, Clone)]
+pub struct ReactionConfig {
+    /// Base probability that an NPC reacts when the player arrives.
+    #[serde(default = "default_reaction_base_chance")]
+    pub base_chance: f64,
+    /// Bonus when NPC is at their workplace.
+    #[serde(default = "default_reaction_workplace_bonus")]
+    pub workplace_bonus: f64,
+    /// Bonus when location is indoors.
+    #[serde(default = "default_reaction_indoor_bonus")]
+    pub indoor_bonus: f64,
+    /// Bonus when NPC has high emotional intelligence (≥4).
+    #[serde(default = "default_reaction_empathy_bonus")]
+    pub empathy_bonus: f64,
+    /// Penalty when NPC has a negative mood.
+    #[serde(default = "default_reaction_negative_mood_penalty")]
+    pub negative_mood_penalty: f64,
+    /// Penalty at night or midnight.
+    #[serde(default = "default_reaction_night_penalty")]
+    pub night_penalty: f64,
+    /// LLM timeout for reaction greeting calls (seconds).
+    #[serde(default = "default_reaction_llm_timeout_secs")]
+    pub llm_timeout_secs: u64,
+}
+
+impl Default for ReactionConfig {
+    fn default() -> Self {
+        Self {
+            base_chance: 0.55,
+            workplace_bonus: 0.35,
+            indoor_bonus: 0.10,
+            empathy_bonus: 0.05,
+            negative_mood_penalty: 0.20,
+            night_penalty: 0.15,
+            llm_timeout_secs: 5,
+        }
+    }
+}
+
+fn default_reaction_base_chance() -> f64 {
+    0.55
+}
+fn default_reaction_workplace_bonus() -> f64 {
+    0.35
+}
+fn default_reaction_indoor_bonus() -> f64 {
+    0.10
+}
+fn default_reaction_empathy_bonus() -> f64 {
+    0.05
+}
+fn default_reaction_negative_mood_penalty() -> f64 {
+    0.20
+}
+fn default_reaction_night_penalty() -> f64 {
+    0.15
+}
+fn default_reaction_llm_timeout_secs() -> u64 {
+    5
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/parish-core/src/config/provider.rs
+++ b/crates/parish-core/src/config/provider.rs
@@ -135,14 +135,17 @@ pub enum InferenceCategory {
     Simulation,
     /// Player input intent parsing (JSON, low-latency).
     Intent,
+    /// NPC arrival reactions/greetings (short timeout, fast model).
+    Reaction,
 }
 
 impl InferenceCategory {
     /// All defined inference categories.
-    pub const ALL: [InferenceCategory; 3] = [
+    pub const ALL: [InferenceCategory; 4] = [
         InferenceCategory::Dialogue,
         InferenceCategory::Simulation,
         InferenceCategory::Intent,
+        InferenceCategory::Reaction,
     ];
 
     /// Returns the lowercase name used in TOML keys, env var prefixes, and CLI flags.
@@ -151,6 +154,7 @@ impl InferenceCategory {
             InferenceCategory::Dialogue => "dialogue",
             InferenceCategory::Simulation => "simulation",
             InferenceCategory::Intent => "intent",
+            InferenceCategory::Reaction => "reaction",
         }
     }
 
@@ -160,6 +164,7 @@ impl InferenceCategory {
             "dialogue" => Some(InferenceCategory::Dialogue),
             "simulation" => Some(InferenceCategory::Simulation),
             "intent" => Some(InferenceCategory::Intent),
+            "reaction" => Some(InferenceCategory::Reaction),
             _ => None,
         }
     }
@@ -170,6 +175,7 @@ impl InferenceCategory {
             InferenceCategory::Dialogue => "PARISH_DIALOGUE",
             InferenceCategory::Simulation => "PARISH_SIMULATION",
             InferenceCategory::Intent => "PARISH_INTENT",
+            InferenceCategory::Reaction => "PARISH_REACTION",
         }
     }
 }

--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -425,7 +425,7 @@ fn build_npc_debug_list(
                         .iter()
                         .map(|v| {
                             let is_active =
-                                active_entries.map_or(false, |ae| std::ptr::eq(ae, &v.entries[..]));
+                                active_entries.is_some_and(|ae| std::ptr::eq(ae, &v.entries[..]));
                             let entries = v
                                 .entries
                                 .iter()

--- a/crates/parish-core/src/dice.rs
+++ b/crates/parish-core/src/dice.rs
@@ -1,0 +1,176 @@
+//! Reusable dice-roll utility for probability-based game mechanics.
+//!
+//! Provides a [`DiceRoll`] wrapper around a `0.0..1.0` float that supports
+//! threshold checks, index selection, and deterministic testing via fixed
+//! values.  Higher-level helpers ([`roll_n`], [`fixed_n`]) create batches.
+
+use rand::Rng;
+
+/// A single probability roll in `0.0..1.0`.
+///
+/// Used throughout the game for threshold-based checks (encounters,
+/// NPC reactions, weather transitions, etc.).
+#[derive(Debug, Clone, Copy)]
+pub struct DiceRoll {
+    value: f64,
+}
+
+impl DiceRoll {
+    /// Creates a roll with a predetermined value (for deterministic tests).
+    ///
+    /// The value is clamped to `0.0..1.0`.
+    pub fn fixed(value: f64) -> Self {
+        Self {
+            value: value.clamp(0.0, 1.0),
+        }
+    }
+
+    /// Rolls using the thread-local RNG.
+    pub fn roll() -> Self {
+        Self {
+            value: rand::thread_rng().r#gen::<f64>(),
+        }
+    }
+
+    /// Returns `true` if this roll is below `threshold` (i.e. a "success").
+    ///
+    /// A threshold of `0.0` never succeeds; `1.0` always succeeds.
+    pub fn check(&self, threshold: f64) -> bool {
+        self.value < threshold
+    }
+
+    /// The raw `0.0..1.0` value.
+    pub fn value(&self) -> f64 {
+        self.value
+    }
+
+    /// Picks an index in `0..len` based on this roll's value.
+    ///
+    /// Panics if `len` is zero.
+    pub fn pick_index(&self, len: usize) -> usize {
+        assert!(len > 0, "pick_index called with len 0");
+        let idx = (self.value * len as f64) as usize;
+        idx.min(len - 1)
+    }
+
+    /// Picks a random element from a slice.
+    ///
+    /// Panics if the slice is empty.
+    pub fn pick<'a, T>(&self, items: &'a [T]) -> &'a T {
+        &items[self.pick_index(items.len())]
+    }
+}
+
+/// Rolls `n` dice using the thread-local RNG.
+pub fn roll_n(n: usize) -> Vec<DiceRoll> {
+    let mut rng = rand::thread_rng();
+    (0..n).map(|_| DiceRoll { value: rng.r#gen() }).collect()
+}
+
+/// Creates `n` dice with predetermined values (for deterministic tests).
+pub fn fixed_n(values: &[f64]) -> Vec<DiceRoll> {
+    values.iter().map(|&v| DiceRoll::fixed(v)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fixed_roll_value() {
+        let d = DiceRoll::fixed(0.42);
+        assert!((d.value() - 0.42).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_fixed_clamps_high() {
+        let d = DiceRoll::fixed(1.5);
+        assert!((d.value() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_fixed_clamps_low() {
+        let d = DiceRoll::fixed(-0.5);
+        assert!(d.value().abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_check_below_threshold() {
+        let d = DiceRoll::fixed(0.3);
+        assert!(d.check(0.5));
+    }
+
+    #[test]
+    fn test_check_above_threshold() {
+        let d = DiceRoll::fixed(0.7);
+        assert!(!d.check(0.5));
+    }
+
+    #[test]
+    fn test_check_at_threshold() {
+        let d = DiceRoll::fixed(0.5);
+        assert!(!d.check(0.5)); // not strictly less than
+    }
+
+    #[test]
+    fn test_check_zero_threshold_never_passes() {
+        let d = DiceRoll::fixed(0.0);
+        assert!(!d.check(0.0));
+    }
+
+    #[test]
+    fn test_check_one_threshold_always_passes() {
+        let d = DiceRoll::fixed(0.99);
+        assert!(d.check(1.0));
+    }
+
+    #[test]
+    fn test_pick_index_distributes() {
+        assert_eq!(DiceRoll::fixed(0.0).pick_index(4), 0);
+        assert_eq!(DiceRoll::fixed(0.25).pick_index(4), 1);
+        assert_eq!(DiceRoll::fixed(0.5).pick_index(4), 2);
+        assert_eq!(DiceRoll::fixed(0.75).pick_index(4), 3);
+        // Edge: value at 1.0 should clamp to last index
+        assert_eq!(DiceRoll::fixed(1.0).pick_index(4), 3);
+    }
+
+    #[test]
+    fn test_pick_single_element() {
+        let items = ["only"];
+        assert_eq!(*DiceRoll::fixed(0.0).pick(&items), "only");
+        assert_eq!(*DiceRoll::fixed(0.99).pick(&items), "only");
+    }
+
+    #[test]
+    #[should_panic(expected = "pick_index called with len 0")]
+    fn test_pick_index_panics_on_zero() {
+        DiceRoll::fixed(0.5).pick_index(0);
+    }
+
+    #[test]
+    fn test_roll_n_count() {
+        let dice = roll_n(5);
+        assert_eq!(dice.len(), 5);
+        for d in &dice {
+            assert!((0.0..1.0).contains(&d.value()));
+        }
+    }
+
+    #[test]
+    fn test_fixed_n() {
+        let dice = fixed_n(&[0.1, 0.5, 0.9]);
+        assert_eq!(dice.len(), 3);
+        assert!((dice[0].value() - 0.1).abs() < f64::EPSILON);
+        assert!((dice[1].value() - 0.5).abs() < f64::EPSILON);
+        assert!((dice[2].value() - 0.9).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_roll_produces_valid_range() {
+        // Statistical test: 100 rolls should all be in [0, 1)
+        for _ in 0..100 {
+            let d = DiceRoll::roll();
+            assert!((0.0..1.0).contains(&d.value()));
+        }
+    }
+}

--- a/crates/parish-core/src/game_mod.rs
+++ b/crates/parish-core/src/game_mod.rs
@@ -82,6 +82,9 @@ pub struct FileRefs {
     /// Transport modes TOML file (optional; defaults to walking only).
     #[serde(default)]
     pub transport: Option<String>,
+    /// NPC arrival reaction templates JSON file (optional; defaults to hardcoded bank).
+    #[serde(default)]
+    pub reactions: Option<String>,
 }
 
 /// Relative paths to prompt template text files.
@@ -305,6 +308,8 @@ pub struct GameMod {
     pub pronunciations: Vec<PronunciationEntry>,
     /// Transport modes configuration.
     pub transport: TransportConfig,
+    /// NPC arrival reaction templates (loaded from JSON or hardcoded defaults).
+    pub reactions: crate::npc::reactions::ReactionTemplates,
 }
 
 impl GameMod {
@@ -401,6 +406,16 @@ impl GameMod {
             TransportConfig::default()
         };
 
+        // -- reactions (optional) -----------------------------------------------
+        let reactions = if let Some(ref reactions_file) = manifest.files.reactions {
+            let reactions_json = read_json(reactions_file)?;
+            serde_json::from_str(&reactions_json).map_err(|e| {
+                ParishError::Config(format!("failed to parse {reactions_file}: {e}"))
+            })?
+        } else {
+            crate::npc::reactions::ReactionTemplates::default()
+        };
+
         Ok(Self {
             manifest,
             mod_dir,
@@ -412,6 +427,7 @@ impl GameMod {
             ui,
             pronunciations,
             transport,
+            reactions,
         })
     }
 

--- a/crates/parish-core/src/inference/mod.rs
+++ b/crates/parish-core/src/inference/mod.rs
@@ -168,6 +168,11 @@ impl InferenceClients {
         self.client_for(crate::config::InferenceCategory::Intent)
     }
 
+    /// Returns the client and model to use for NPC arrival reactions.
+    pub fn reaction_client(&self) -> (&OpenAiClient, &str) {
+        self.client_for(crate::config::InferenceCategory::Reaction)
+    }
+
     /// Whether the dialogue category uses a different provider than the base.
     pub fn has_custom_dialogue(&self) -> bool {
         self.overrides

--- a/crates/parish-core/src/lib.rs
+++ b/crates/parish-core/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod config;
 pub mod debug_snapshot;
+pub mod dice;
 pub mod error;
 pub mod game_mod;
 pub mod inference;

--- a/crates/parish-core/src/npc/manager.rs
+++ b/crates/parish-core/src/npc/manager.rs
@@ -127,6 +127,11 @@ impl NpcManager {
         self.introduced_npcs.contains(&id)
     }
 
+    /// Returns a clone of the set of introduced NPC ids.
+    pub fn introduced_set(&self) -> HashSet<NpcId> {
+        self.introduced_npcs.clone()
+    }
+
     /// Returns the display name for an NPC: their name if introduced,
     /// or their brief description if not yet met.
     pub fn display_name<'a>(&self, npc: &'a Npc) -> &'a str {

--- a/crates/parish-core/src/npc/reactions.rs
+++ b/crates/parish-core/src/npc/reactions.rs
@@ -1,12 +1,37 @@
-//! Player–NPC emoji reaction system.
+//! Player–NPC emoji reaction system and NPC arrival reaction system.
+//!
+//! # Emoji Reactions (player ↔ NPC)
 //!
 //! Supports three flows:
 //! 1. Player reacts to NPC messages (stored in [`ReactionLog`], injected into prompts)
 //! 2. NPCs react to player messages (rule-based keyword matching)
 //! 3. NPC-to-NPC reactions (future, via Tier 2 ticks)
+//!
+//! # Arrival Reactions (NPC → player on location entry)
+//!
+//! When the player arrives at a location, NPCs present may react —
+//! greeting, nodding, welcoming, introducing themselves, or ignoring
+//! the player entirely. Reactions are determined by dice rolls modified
+//! by NPC personality, occupation, workplace context, mood, time of day,
+//! and whether they've already been introduced.
+//!
+//! Each reaction includes canned fallback text. When `use_llm` is set,
+//! the caller can optionally fire a short-timeout LLM call for a richer
+//! greeting, falling back to the canned text on timeout or error.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::time::Duration;
+
+use crate::config::ReactionConfig;
+use crate::dice::DiceRoll;
+use crate::inference::openai_client::OpenAiClient;
+use crate::npc::{Npc, NpcId};
+use crate::world::graph::LocationData;
+use crate::world::time::TimeOfDay;
+
+// ── Emoji reaction system ────────────────────────────────────────────────────
 
 /// The canonical reaction palette mapping emoji to natural-language descriptions.
 ///
@@ -161,10 +186,756 @@ fn generate_rule_reaction_deterministic(player_input: &str) -> Option<String> {
     None
 }
 
+// ── Arrival reaction system ──────────────────────────────────────────────────
+
+/// The kind of reaction an NPC has to the player's arrival.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ReactionKind {
+    /// A silent gesture: nod, wave, glance up.
+    Gesture,
+    /// A short verbal greeting.
+    Greeting,
+    /// A role-specific welcome at the NPC's workplace.
+    Welcome,
+    /// The NPC introduces themselves by name.
+    Introduction,
+}
+
+/// A resolved reaction from one NPC.
+#[derive(Debug, Clone)]
+pub struct NpcReaction {
+    /// Which NPC reacted.
+    pub npc_id: NpcId,
+    /// Display name (full name or brief description).
+    pub npc_display_name: String,
+    /// What kind of reaction.
+    pub kind: ReactionKind,
+    /// The canned fallback text for this reaction.
+    pub canned_text: String,
+    /// Whether this reaction should mark the NPC as introduced.
+    pub introduces: bool,
+    /// Whether the caller should attempt an LLM-generated greeting.
+    pub use_llm: bool,
+}
+
+// ── Template bank ───────────────────────────────────────────────────────────
+
+/// Mod-overridable reaction text templates.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReactionTemplates {
+    /// Silent gesture descriptions.
+    #[serde(default = "default_gestures")]
+    pub gestures: Vec<String>,
+    /// Greetings by time of day.
+    #[serde(default = "default_greetings")]
+    pub greetings: GreetingsByTime,
+    /// Workplace welcome lines keyed by occupation.
+    #[serde(default = "default_welcomes")]
+    pub welcomes: WelcomesByOccupation,
+    /// Introduction lines.
+    #[serde(default = "default_introductions")]
+    pub introductions: IntroductionTemplates,
+    /// Occupation-specific greetings (non-workplace).
+    #[serde(default = "default_occupation_greetings")]
+    pub occupation_greetings: OccupationGreetings,
+}
+
+impl Default for ReactionTemplates {
+    fn default() -> Self {
+        Self {
+            gestures: default_gestures(),
+            greetings: default_greetings(),
+            welcomes: default_welcomes(),
+            introductions: default_introductions(),
+            occupation_greetings: default_occupation_greetings(),
+        }
+    }
+}
+
+/// Greetings keyed by time of day.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GreetingsByTime {
+    /// Morning greetings.
+    #[serde(default)]
+    pub morning: Vec<String>,
+    /// Afternoon greetings.
+    #[serde(default)]
+    pub afternoon: Vec<String>,
+    /// Evening / night greetings.
+    #[serde(default)]
+    pub evening: Vec<String>,
+    /// Greetings suitable for any time.
+    #[serde(default)]
+    pub any: Vec<String>,
+}
+
+/// Workplace welcome lines keyed by lowercase occupation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WelcomesByOccupation {
+    /// Publican-specific welcomes.
+    #[serde(default)]
+    pub publican: Vec<String>,
+    /// Shopkeeper-specific welcomes.
+    #[serde(default)]
+    pub shopkeeper: Vec<String>,
+    /// Priest-specific welcomes (at church).
+    #[serde(default)]
+    pub priest: Vec<String>,
+    /// Teacher-specific welcomes.
+    #[serde(default)]
+    pub teacher: Vec<String>,
+    /// Generic welcome for other occupations at workplace.
+    #[serde(default)]
+    pub generic: Vec<String>,
+}
+
+/// Introduction text templates.
+#[derive(Debug, Clone, Deserialize)]
+pub struct IntroductionTemplates {
+    /// Introductions at their workplace.
+    #[serde(default)]
+    pub workplace: Vec<String>,
+    /// Casual introductions elsewhere.
+    #[serde(default)]
+    pub casual: Vec<String>,
+}
+
+/// Occupation-specific greetings used outside the workplace.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OccupationGreetings {
+    /// Priest greetings (blessings etc.).
+    #[serde(default)]
+    pub priest: Vec<String>,
+}
+
+// ── Core algorithm ──────────────────────────────────────────────────────────
+
+/// Returns `true` if the mood string suggests a negative emotional state.
+fn is_negative_mood(mood: &str) -> bool {
+    let m = mood.to_lowercase();
+    m.contains("angry")
+        || m.contains("furious")
+        || m.contains("sad")
+        || m.contains("grief")
+        || m.contains("irritat")
+        || m.contains("frustrat")
+        || m.contains("anxious")
+        || m.contains("afraid")
+        || m.contains("hostile")
+        || m.contains("bitter")
+        || m.contains("sullen")
+        || m.contains("withdrawn")
+}
+
+/// Returns `true` if the NPC is currently at their workplace.
+fn is_at_workplace(npc: &Npc, location: &LocationData) -> bool {
+    npc.workplace.is_some_and(|wp| wp == location.id)
+}
+
+/// Computes the reaction threshold for a given NPC — the probability
+/// (0.0–1.0) that this NPC will react to the player's arrival.
+pub fn reaction_threshold(
+    npc: &Npc,
+    location: &LocationData,
+    time_of_day: TimeOfDay,
+    config: &ReactionConfig,
+) -> f64 {
+    let mut threshold = config.base_chance;
+
+    if is_at_workplace(npc, location) {
+        threshold += config.workplace_bonus;
+    }
+    if location.indoor {
+        threshold += config.indoor_bonus;
+    }
+    if npc.intelligence.emotional >= 4 {
+        threshold += config.empathy_bonus;
+    }
+    if is_negative_mood(&npc.mood) {
+        threshold -= config.negative_mood_penalty;
+    }
+    if matches!(time_of_day, TimeOfDay::Night | TimeOfDay::Midnight) {
+        threshold -= config.night_penalty;
+    }
+
+    threshold.clamp(0.0, 1.0)
+}
+
+/// Generates arrival reactions for NPCs at the player's current location.
+///
+/// Each NPC needs **two** dice rolls in `dice` (one for reaction chance,
+/// one for type/template selection). So `dice.len()` must be `≥ npcs.len() * 2`.
+///
+/// Returns only NPCs that actually react — silent NPCs are omitted.
+#[allow(clippy::too_many_arguments)]
+pub fn generate_arrival_reactions(
+    npcs: &[&Npc],
+    introduced: &HashSet<NpcId>,
+    location: &LocationData,
+    time_of_day: TimeOfDay,
+    weather: &str,
+    templates: &ReactionTemplates,
+    config: &ReactionConfig,
+    dice: &[DiceRoll],
+) -> Vec<NpcReaction> {
+    let mut reactions = Vec::new();
+
+    for (i, npc) in npcs.iter().enumerate() {
+        let roll_idx = i * 2;
+        if roll_idx + 1 >= dice.len() {
+            break;
+        }
+        let chance_roll = &dice[roll_idx];
+        let type_roll = &dice[roll_idx + 1];
+
+        let threshold = reaction_threshold(npc, location, time_of_day, config);
+        if !chance_roll.check(threshold) {
+            continue; // NPC stays silent
+        }
+
+        let is_introduced = introduced.contains(&npc.id);
+        let at_workplace = is_at_workplace(npc, location);
+        let occupation = npc.occupation.to_lowercase();
+
+        let (kind, introduces, use_llm) = if at_workplace && !is_introduced {
+            (ReactionKind::Introduction, true, true)
+        } else if at_workplace && is_introduced {
+            (ReactionKind::Welcome, false, true)
+        } else if !is_introduced && type_roll.check(0.25) {
+            (ReactionKind::Introduction, true, true)
+        } else if !is_introduced {
+            (ReactionKind::Gesture, false, false)
+        } else if is_priest_occupation(&occupation) {
+            (ReactionKind::Greeting, false, type_roll.check(0.5))
+        } else if type_roll.check(0.5) {
+            (ReactionKind::Greeting, false, false)
+        } else {
+            (ReactionKind::Gesture, false, false)
+        };
+
+        let display_name = if is_introduced || introduces {
+            npc.name.clone()
+        } else {
+            npc.brief_description.clone()
+        };
+
+        let canned_text = pick_canned_text(
+            &kind,
+            npc,
+            &display_name,
+            at_workplace,
+            &occupation,
+            time_of_day,
+            weather,
+            templates,
+            type_roll,
+        );
+
+        reactions.push(NpcReaction {
+            npc_id: npc.id,
+            npc_display_name: display_name,
+            kind,
+            canned_text,
+            introduces,
+            use_llm,
+        });
+    }
+
+    reactions
+}
+
+fn is_priest_occupation(occupation: &str) -> bool {
+    occupation.contains("priest") || occupation.contains("clergy") || occupation.contains("curate")
+}
+
+/// Picks a canned text template and substitutes placeholders.
+#[allow(clippy::too_many_arguments)]
+fn pick_canned_text(
+    kind: &ReactionKind,
+    npc: &Npc,
+    display_name: &str,
+    at_workplace: bool,
+    occupation: &str,
+    time_of_day: TimeOfDay,
+    weather: &str,
+    templates: &ReactionTemplates,
+    roll: &DiceRoll,
+) -> String {
+    let raw = match kind {
+        ReactionKind::Gesture => roll.pick(&templates.gestures).clone(),
+        ReactionKind::Greeting => {
+            if is_priest_occupation(occupation) {
+                // Try occupation-specific greetings first
+                if !templates.occupation_greetings.priest.is_empty() {
+                    roll.pick(&templates.occupation_greetings.priest).clone()
+                } else {
+                    pick_greeting_by_time(time_of_day, templates, roll)
+                }
+            } else {
+                pick_greeting_by_time(time_of_day, templates, roll)
+            }
+        }
+        ReactionKind::Welcome => {
+            let pool = match () {
+                _ if occupation.contains("publican") => &templates.welcomes.publican,
+                _ if occupation.contains("shopkeeper") => &templates.welcomes.shopkeeper,
+                _ if is_priest_occupation(occupation) => &templates.welcomes.priest,
+                _ if occupation.contains("teacher") => &templates.welcomes.teacher,
+                _ => &templates.welcomes.generic,
+            };
+            if pool.is_empty() {
+                pick_greeting_by_time(time_of_day, templates, roll)
+            } else {
+                roll.pick(pool).clone()
+            }
+        }
+        ReactionKind::Introduction => {
+            let pool = if at_workplace {
+                &templates.introductions.workplace
+            } else {
+                &templates.introductions.casual
+            };
+            if pool.is_empty() {
+                "\"I'm {},\" they say.".to_string()
+            } else {
+                roll.pick(pool).clone()
+            }
+        }
+    };
+
+    substitute_placeholders(&raw, npc, display_name, time_of_day, weather)
+}
+
+fn pick_greeting_by_time(
+    time_of_day: TimeOfDay,
+    templates: &ReactionTemplates,
+    roll: &DiceRoll,
+) -> String {
+    let time_pool = match time_of_day {
+        TimeOfDay::Dawn | TimeOfDay::Morning => &templates.greetings.morning,
+        TimeOfDay::Midday | TimeOfDay::Afternoon => &templates.greetings.afternoon,
+        TimeOfDay::Dusk | TimeOfDay::Night | TimeOfDay::Midnight => &templates.greetings.evening,
+    };
+
+    // 30% chance to use an "any time" greeting instead
+    if !templates.greetings.any.is_empty() && roll.value() < 0.3 {
+        return roll.pick(&templates.greetings.any).clone();
+    }
+
+    if time_pool.is_empty() && !templates.greetings.any.is_empty() {
+        roll.pick(&templates.greetings.any).clone()
+    } else if time_pool.is_empty() {
+        "\"Hello,\" they say.".to_string()
+    } else {
+        roll.pick(time_pool).clone()
+    }
+}
+
+/// Substitutes `{name}`, `{first_name}`, `{last_name}`, `{occupation}`,
+/// `{time}`, `{weather}` placeholders in a template string.
+fn substitute_placeholders(
+    template: &str,
+    npc: &Npc,
+    display_name: &str,
+    time_of_day: TimeOfDay,
+    weather: &str,
+) -> String {
+    let first_name = npc.name.split_whitespace().next().unwrap_or(&npc.name);
+    let last_name = npc.name.split_whitespace().last().unwrap_or(&npc.name);
+    let time_str = match time_of_day {
+        TimeOfDay::Dawn => "dawn",
+        TimeOfDay::Morning => "morning",
+        TimeOfDay::Midday => "midday",
+        TimeOfDay::Afternoon => "afternoon",
+        TimeOfDay::Dusk => "evening",
+        TimeOfDay::Night => "evening",
+        TimeOfDay::Midnight => "night",
+    };
+
+    template
+        .replace("{name}", display_name)
+        .replace("{first_name}", first_name)
+        .replace("{last_name}", last_name)
+        .replace("{occupation}", &npc.occupation)
+        .replace("{time}", time_str)
+        .replace("{weather}", weather)
+}
+
+// ── Default template banks ──────────────────────────────────────────────────
+
+fn default_gestures() -> Vec<String> {
+    vec![
+        "{name} nods in your direction.".into(),
+        "{name} glances up as you arrive.".into(),
+        "{name} gives a brief wave.".into(),
+        "{name} tips their hat without a word.".into(),
+        "{name} looks up from what they're doing.".into(),
+        "{name} shifts to make room.".into(),
+        "{name} raises a hand in greeting.".into(),
+        "{name} glances over, then goes back to what they were doing.".into(),
+        "{name} pauses mid-step and looks your way.".into(),
+        "{name} touches the brim of their hat.".into(),
+        "{name} gives a curt nod.".into(),
+        "{name} half-turns and acknowledges you with a look.".into(),
+        "{name} catches your eye for a moment.".into(),
+        "{name} straightens up as you approach.".into(),
+        "{name} steps aside to let you pass.".into(),
+        "{name} sets down what they're holding and looks up.".into(),
+        "{name} watches you arrive with quiet interest.".into(),
+        "{name} barely looks up.".into(),
+        "{name} grunts softly in acknowledgement.".into(),
+        "{name} gives the slightest nod.".into(),
+        "{name} leans against the wall and watches you enter.".into(),
+        "{name} lifts a hand from their pocket in greeting.".into(),
+    ]
+}
+
+fn default_greetings() -> GreetingsByTime {
+    GreetingsByTime {
+        morning: vec![
+            "\"Good morning to you,\" {name} says.".into(),
+            "\"Ah, morning,\" says {name}.".into(),
+            "\"God bless this fine morning,\" {name} says warmly.".into(),
+            "\"You're up early,\" {name} remarks.".into(),
+            "\"Maidin mhaith,\" says {name}.".into(),
+            "\"A fresh morning, thanks be to God,\" says {name}.".into(),
+            "\"Grand morning for it,\" {name} observes.".into(),
+            "\"Morning,\" {name} says simply.".into(),
+            "\"You're welcome this morning,\" says {name}.".into(),
+            "\"Dia dhuit ar maidin,\" {name} says.".into(),
+            "\"An early start,\" {name} remarks approvingly.".into(),
+            "\"The morning air has life in it today,\" says {name}.".into(),
+        ],
+        afternoon: vec![
+            "\"Grand day,\" says {name}.".into(),
+            "\"Good day to you,\" {name} says.".into(),
+            "\"Afternoon,\" says {name} with a nod.".into(),
+            "\"Dia dhuit,\" says {name}.".into(),
+            "\"It's yourself,\" {name} says.".into(),
+            "\"You're welcome,\" says {name}.".into(),
+            "\"God bless,\" says {name}.".into(),
+            "\"Fine afternoon,\" {name} remarks.".into(),
+            "\"You picked a good day for it,\" says {name}.".into(),
+            "\"Tráthnóna maith,\" says {name}.".into(),
+            "\"Not a bad day at all,\" says {name}.".into(),
+            "\"The day's wearing on,\" {name} observes.".into(),
+        ],
+        evening: vec![
+            "\"Good evening,\" {name} says quietly.".into(),
+            "\"Late enough to be out,\" {name} observes.".into(),
+            "\"Evening,\" {name} says.".into(),
+            "\"God bless the evening,\" says {name}.".into(),
+            "\"Oíche mhaith,\" says {name}.".into(),
+            "\"A quiet night,\" {name} says.".into(),
+            "\"You're out late,\" {name} remarks.".into(),
+            "\"Evening to you,\" says {name}.".into(),
+            "\"Not many out at this hour,\" {name} says.".into(),
+            "\"The night is drawing in,\" says {name}.".into(),
+            "\"A cold one tonight,\" {name} says with a shiver.".into(),
+            "\"The stars are out,\" {name} observes.".into(),
+        ],
+        any: vec![
+            "\"God bless,\" says {name}.".into(),
+            "\"Dia dhuit,\" {name} says.".into(),
+            "\"You're welcome,\" says {name}.".into(),
+            "\"Ah, it's yourself,\" says {name}.".into(),
+            "\"How are you keeping?\" asks {name}.".into(),
+            "\"Céad míle fáilte,\" says {name} warmly.".into(),
+            "\"Safe travels to you,\" says {name}.".into(),
+            "\"Well now,\" says {name}.".into(),
+            "\"Fair play to you for coming,\" says {name}.".into(),
+            "\"And here you are,\" says {name}.".into(),
+            "\"You're a welcome sight,\" says {name}.".into(),
+            "\"Good to see a face,\" says {name}.".into(),
+        ],
+    }
+}
+
+fn default_welcomes() -> WelcomesByOccupation {
+    WelcomesByOccupation {
+        publican: vec![
+            "\"Come in, come in! Take a seat by the fire,\" says {name}.".into(),
+            "\"Welcome! What'll it be?\" says {name}, reaching for a glass.".into(),
+            "\"Ah, you're back. The usual?\" says {name}.".into(),
+            "\"In you come out of the {weather},\" says {name}. \"What can I get you?\"".into(),
+            "\"You're welcome here,\" says {name}, wiping down the bar.".into(),
+            "\"Fáilte! Come in and rest yourself,\" says {name}.".into(),
+            "\"The fire's going well. Sit yourself down,\" says {name}.".into(),
+            "\"Sit down there and I'll bring you something,\" says {name}.".into(),
+            "\"You look like you could use a drink,\" says {name} with a grin.".into(),
+            "\"Come in out of the cold. The fire's lit,\" says {name}.".into(),
+            "\"Ah, a customer! Come in, come in,\" says {name}.".into(),
+            "\"There's a stool here with your name on it,\" says {name}.".into(),
+        ],
+        shopkeeper: vec![
+            "\"Come in, come in,\" says {name}. \"What can I get you?\"".into(),
+            "\"Ah, good {time}! Looking for anything in particular?\" says {name}.".into(),
+            "\"You're welcome,\" says {name}, looking up from the counter.".into(),
+            "\"In you come,\" says {name}. \"I've fresh stock in today.\"".into(),
+            "\"What'll it be today?\" asks {name}.".into(),
+            "\"Fáilte,\" says {name}. \"Have a look around.\"".into(),
+            "\"Come in out of the {weather},\" says {name}.".into(),
+            "\"Ah, you're here. Good timing,\" says {name}.".into(),
+            "\"Step in, step in. The door's open,\" says {name}.".into(),
+            "\"What are you after today?\" asks {name} pleasantly.".into(),
+            "\"Another fine customer,\" {name} says with a smile.".into(),
+            "\"I was just arranging the shelves. Come in,\" says {name}.".into(),
+        ],
+        priest: vec![
+            "\"Welcome to God's house,\" says {name} warmly.".into(),
+            "\"Blessings on you this {time},\" says {name}.".into(),
+            "\"Peace be with you,\" says {name}, making a small sign of the cross.".into(),
+            "\"God bless you, child,\" says {name}.".into(),
+            "\"You are always welcome here,\" says {name} gently.".into(),
+            "\"Dia dhuit. Come in, come in,\" says {name}.".into(),
+            "\"The Lord's house is open to all,\" says {name}.".into(),
+            "\"A good {time} to visit,\" says {name}. \"The church is quiet.\"".into(),
+            "\"Come in and be at peace,\" says {name}.".into(),
+            "\"Fáilte romhat. God bless,\" says {name}.".into(),
+        ],
+        teacher: vec![
+            "\"Ah, a visitor,\" says {name}, setting down a book.".into(),
+            "\"Come in quietly if you will,\" says {name}. \"The lesson's nearly done.\"".into(),
+            "\"You're welcome,\" says {name}. \"Mind the slate on the bench.\"".into(),
+            "\"Dia dhuit,\" says {name}. \"Are you here to learn?\"".into(),
+            "\"Good {time},\" says {name}, brushing chalk from their hands.".into(),
+            "\"You're welcome here,\" says {name}. \"Knowledge is for all.\"".into(),
+            "\"Step in,\" says {name}. \"We were just finishing.\"".into(),
+            "\"Ah, a new face,\" says {name} with curiosity.".into(),
+        ],
+        generic: vec![
+            "\"Come in, you're welcome,\" says {name}.".into(),
+            "\"Good {time},\" says {name}. \"Can I help you?\"".into(),
+            "\"Ah, hello there,\" says {name}.".into(),
+            "\"You're welcome,\" {name} says pleasantly.".into(),
+            "\"Come in, come in,\" says {name}.".into(),
+            "\"Fáilte,\" says {name} warmly.".into(),
+        ],
+    }
+}
+
+fn default_introductions() -> IntroductionTemplates {
+    IntroductionTemplates {
+        workplace: vec![
+            "\"I'm {name}, the {occupation} here. You're welcome,\" they say.".into(),
+            "\"The name's {first_name}. I'm the {occupation},\" they say, extending a hand.".into(),
+            "\"I don't think we've met. {first_name} {last_name}, {occupation},\" they say.".into(),
+            "\"Welcome. I'm {name} — I run this place,\" they say.".into(),
+            "\"{first_name},\" they say with a nod. \"I'm the {occupation} here.\"".into(),
+            "\"And who might you be? I'm {name}, the {occupation},\" they say.".into(),
+            "\"You must be new to the parish. I'm {name},\" they say.".into(),
+            "\"I don't believe I've seen you before. I'm {name}, {occupation},\" they say.".into(),
+            "\"Welcome to my place. {first_name} {last_name},\" they say. \"{occupation}.\"".into(),
+            "\"I'm {first_name}. This is my place of work,\" they say.".into(),
+        ],
+        casual: vec![
+            "\"I don't think we've met. I'm {name},\" they say.".into(),
+            "\"{first_name},\" they say simply, with a nod.".into(),
+            "\"The name is {name},\" they say. \"{occupation}.\"".into(),
+            "\"I'm {first_name}. Are you new to the parish?\" they ask.".into(),
+            "\"Have we met? I'm {name},\" they say.".into(),
+            "{name} extends a hand. \"{first_name}.\"".into(),
+            "\"You're a stranger to me. I'm {name},\" they say.".into(),
+            "\"New around here, are you? {first_name} {last_name},\" they say.".into(),
+            "\"I'm {name}. I don't think I've seen you about before,\" they say.".into(),
+            "\"And you are? I'm {first_name},\" they say with a friendly nod.".into(),
+        ],
+    }
+}
+
+fn default_occupation_greetings() -> OccupationGreetings {
+    OccupationGreetings {
+        priest: vec![
+            "\"God be with you,\" says {name}.".into(),
+            "\"Blessings on you this {time},\" says {name}.".into(),
+            "\"Peace of Christ be with you,\" says {name}.".into(),
+            "\"The Lord keep you,\" says {name} with a gentle nod.".into(),
+            "\"God bless, child,\" says {name}.".into(),
+            "\"Dia dhuit agus Muire dhuit,\" says {name}.".into(),
+            "\"May the road rise with you,\" says {name}.".into(),
+            "\"Go mbeannaí Dia dhuit,\" says {name} softly.".into(),
+            "\"A blessing on your journey,\" says {name}.".into(),
+            "\"The peace of God be upon you,\" says {name}.".into(),
+        ],
+    }
+}
+
+// ── LLM greeting ────────────────────────────────────────────────────────────
+
+/// Builds a short system prompt for an LLM-generated arrival greeting.
+pub fn build_reaction_prompt(
+    npc: &Npc,
+    location_name: &str,
+    time_of_day: TimeOfDay,
+    weather: &str,
+    is_introduced: bool,
+    at_workplace: bool,
+) -> (String, String) {
+    let time_str = match time_of_day {
+        TimeOfDay::Dawn => "dawn",
+        TimeOfDay::Morning => "morning",
+        TimeOfDay::Midday => "midday",
+        TimeOfDay::Afternoon => "afternoon",
+        TimeOfDay::Dusk => "dusk",
+        TimeOfDay::Night => "night",
+        TimeOfDay::Midnight => "late at night",
+    };
+
+    let personality_snippet: String = npc.personality.chars().take(200).collect();
+
+    let intro_context = if !is_introduced && at_workplace {
+        format!(
+            "You have not met this person before. You are working here as the {}. \
+             Introduce yourself briefly.",
+            npc.occupation
+        )
+    } else if !is_introduced {
+        "You have not met this person before. You may introduce yourself or simply acknowledge them."
+            .to_string()
+    } else if at_workplace {
+        format!(
+            "You know this person. You are working here as the {}.",
+            npc.occupation
+        )
+    } else {
+        "You have met this person before.".to_string()
+    };
+
+    let system = format!(
+        "You are {name}, a {age}-year-old {occupation} in rural Ireland, 1820.\n\
+         {personality}\n\
+         Current mood: {mood}\n\n\
+         Write a single brief greeting or reaction (1-2 sentences max). \
+         Dialogue only, no narration or action descriptions. \
+         Do not use any modern language.",
+        name = npc.name,
+        age = npc.age,
+        occupation = npc.occupation,
+        personality = personality_snippet,
+        mood = npc.mood,
+    );
+
+    let context = format!(
+        "A traveller has just arrived at {location}. It is {time}, {weather}.\n{intro}",
+        location = location_name,
+        time = time_str,
+        weather = weather,
+        intro = intro_context,
+    );
+
+    (system, context)
+}
+
+/// Attempts an LLM-generated greeting with a short timeout.
+///
+/// Returns the LLM text if it responds in time, or the canned fallback
+/// text from the reaction if the call times out or errors.
+#[allow(clippy::too_many_arguments)]
+pub async fn resolve_llm_greeting(
+    reaction: &NpcReaction,
+    npc: &Npc,
+    location_name: &str,
+    time_of_day: TimeOfDay,
+    weather: &str,
+    is_introduced: bool,
+    at_workplace: bool,
+    client: &OpenAiClient,
+    model: &str,
+    timeout_secs: u64,
+) -> String {
+    let (system, context) = build_reaction_prompt(
+        npc,
+        location_name,
+        time_of_day,
+        weather,
+        is_introduced,
+        at_workplace,
+    );
+
+    let timeout = Duration::from_secs(timeout_secs);
+    let result = tokio::time::timeout(
+        timeout,
+        client.generate(model, &context, Some(&system), Some(100)),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(text)) => {
+            let trimmed = text.trim();
+            if trimmed.is_empty() {
+                reaction.canned_text.clone()
+            } else {
+                // Clean up: remove any metadata block the LLM might append
+                let cleaned = trimmed.split("---").next().unwrap_or(trimmed).trim();
+                if cleaned.is_empty() {
+                    reaction.canned_text.clone()
+                } else {
+                    cleaned.to_string()
+                }
+            }
+        }
+        _ => reaction.canned_text.clone(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dice::{DiceRoll, fixed_n};
+    use crate::npc::memory::{LongTermMemory, ShortTermMemory};
+    use crate::npc::types::{Intelligence, NpcState};
+    use crate::world::LocationId;
     use chrono::TimeZone;
+    use std::collections::HashMap;
+
+    fn test_npc(id: u32, name: &str, occupation: &str, workplace: Option<LocationId>) -> Npc {
+        Npc {
+            id: NpcId(id),
+            name: name.to_string(),
+            brief_description: format!("a {}", occupation.to_lowercase()),
+            age: 40,
+            occupation: occupation.to_string(),
+            personality: "A friendly person.".to_string(),
+            intelligence: Intelligence {
+                verbal: 3,
+                analytical: 3,
+                emotional: 3,
+                practical: 3,
+                wisdom: 3,
+                creative: 3,
+            },
+            location: LocationId(1),
+            mood: "content".to_string(),
+            home: Some(LocationId(1)),
+            workplace,
+            schedule: None,
+            relationships: HashMap::new(),
+            memory: ShortTermMemory::new(),
+            long_term_memory: LongTermMemory::new(),
+            knowledge: vec![],
+            state: NpcState::Present,
+            deflated_summary: None,
+            reaction_log: ReactionLog::default(),
+        }
+    }
+
+    fn test_location(id: u32, indoor: bool) -> LocationData {
+        LocationData {
+            id: LocationId(id),
+            name: "Test Location".to_string(),
+            description_template: String::new(),
+            indoor,
+            public: true,
+            connections: vec![],
+            lat: 0.0,
+            lon: 0.0,
+            associated_npcs: vec![],
+            mythological_significance: None,
+            aliases: vec![],
+        }
+    }
+
+    // ── Emoji reaction tests ─────────────────────────────────────────────────
 
     #[test]
     fn reaction_description_known_emoji() {
@@ -319,5 +1090,358 @@ mod tests {
     #[test]
     fn palette_has_expected_size() {
         assert_eq!(REACTION_PALETTE.len(), 12);
+    }
+
+    // ── Arrival reaction tests ───────────────────────────────────────────────
+
+    #[test]
+    fn test_publican_at_pub_reacts_with_low_roll() {
+        let npc = test_npc(1, "Padraig Darcy", "Publican", Some(LocationId(2)));
+        let loc = test_location(2, true); // indoor pub, same as workplace
+        let introduced: HashSet<NpcId> = HashSet::new();
+        let templates = ReactionTemplates::default();
+        let config = ReactionConfig::default();
+        // Low rolls: will pass threshold and pick introduction
+        let dice = fixed_n(&[0.0, 0.1]);
+
+        let reactions = generate_arrival_reactions(
+            &[&npc],
+            &introduced,
+            &loc,
+            TimeOfDay::Morning,
+            "clear",
+            &templates,
+            &config,
+            &dice,
+        );
+
+        assert_eq!(reactions.len(), 1);
+        assert_eq!(reactions[0].kind, ReactionKind::Introduction);
+        assert!(reactions[0].introduces);
+        assert!(reactions[0].use_llm);
+        assert!(reactions[0].canned_text.contains("Padraig"));
+    }
+
+    #[test]
+    fn test_introduced_publican_at_pub_gives_welcome() {
+        let npc = test_npc(1, "Padraig Darcy", "Publican", Some(LocationId(2)));
+        let loc = test_location(2, true);
+        let mut introduced = HashSet::new();
+        introduced.insert(NpcId(1));
+        let templates = ReactionTemplates::default();
+        let config = ReactionConfig::default();
+        let dice = fixed_n(&[0.0, 0.5]);
+
+        let reactions = generate_arrival_reactions(
+            &[&npc],
+            &introduced,
+            &loc,
+            TimeOfDay::Afternoon,
+            "overcast",
+            &templates,
+            &config,
+            &dice,
+        );
+
+        assert_eq!(reactions.len(), 1);
+        assert_eq!(reactions[0].kind, ReactionKind::Welcome);
+        assert!(!reactions[0].introduces);
+        assert!(reactions[0].use_llm);
+    }
+
+    #[test]
+    fn test_high_roll_no_reaction() {
+        let npc = test_npc(1, "Siobhan", "Farmer", None);
+        let loc = test_location(1, false); // outdoor, not workplace
+        let introduced: HashSet<NpcId> = HashSet::new();
+        let templates = ReactionTemplates::default();
+        let config = ReactionConfig::default();
+        // Roll 0.99 will be above threshold (~0.55 base for outdoor non-workplace)
+        let dice = fixed_n(&[0.99, 0.5]);
+
+        let reactions = generate_arrival_reactions(
+            &[&npc],
+            &introduced,
+            &loc,
+            TimeOfDay::Morning,
+            "clear",
+            &templates,
+            &config,
+            &dice,
+        );
+
+        assert!(reactions.is_empty());
+    }
+
+    #[test]
+    fn test_priest_gives_blessing_greeting() {
+        let npc = test_npc(
+            3,
+            "Fr. Declan Tierney",
+            "Parish Priest",
+            Some(LocationId(3)),
+        );
+        let loc = test_location(1, false); // not at workplace
+        let mut introduced = HashSet::new();
+        introduced.insert(NpcId(3));
+        let templates = ReactionTemplates::default();
+        let config = ReactionConfig::default();
+        let dice = fixed_n(&[0.0, 0.3]); // low roll passes, type_roll < 0.5 for priest greeting
+
+        let reactions = generate_arrival_reactions(
+            &[&npc],
+            &introduced,
+            &loc,
+            TimeOfDay::Morning,
+            "clear",
+            &templates,
+            &config,
+            &dice,
+        );
+
+        assert_eq!(reactions.len(), 1);
+        assert_eq!(reactions[0].kind, ReactionKind::Greeting);
+        // Priest greetings should contain blessing/religious language
+        let text = &reactions[0].canned_text;
+        assert!(
+            text.contains("God")
+                || text.contains("Dia")
+                || text.contains("peace")
+                || text.contains("bless")
+                || text.contains("Lord"),
+            "Priest greeting should have religious content, got: {}",
+            text
+        );
+    }
+
+    #[test]
+    fn test_night_reduces_reaction_chance() {
+        let npc = test_npc(1, "Siobhan", "Farmer", None);
+        let loc = test_location(1, false);
+        let introduced: HashSet<NpcId> = HashSet::new();
+        let config = ReactionConfig::default();
+
+        // Threshold for outdoor, non-workplace, night: 0.55 - 0.15 = 0.40
+        let threshold = reaction_threshold(&npc, &loc, TimeOfDay::Night, &config);
+        assert!((threshold - 0.40).abs() < 0.01);
+
+        // Threshold for outdoor, non-workplace, morning: 0.55
+        let threshold_morning = reaction_threshold(&npc, &loc, TimeOfDay::Morning, &config);
+        assert!((threshold_morning - 0.55).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_workplace_bonus() {
+        let npc = test_npc(1, "Padraig", "Publican", Some(LocationId(2)));
+        let loc = test_location(2, true); // indoor workplace
+        let config = ReactionConfig::default();
+
+        // base 0.55 + workplace 0.35 + indoor 0.10 = 1.00 (clamped)
+        let threshold = reaction_threshold(&npc, &loc, TimeOfDay::Morning, &config);
+        assert!((threshold - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_negative_mood_penalty() {
+        let mut npc = test_npc(1, "Siobhan", "Farmer", None);
+        npc.mood = "angry and frustrated".to_string();
+        let loc = test_location(1, false);
+        let config = ReactionConfig::default();
+
+        // base 0.55 - negative_mood 0.20 = 0.35
+        let threshold = reaction_threshold(&npc, &loc, TimeOfDay::Morning, &config);
+        assert!((threshold - 0.35).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_empty_npc_list() {
+        let loc = test_location(1, false);
+        let introduced: HashSet<NpcId> = HashSet::new();
+        let templates = ReactionTemplates::default();
+        let config = ReactionConfig::default();
+        let dice: Vec<DiceRoll> = vec![];
+
+        let reactions = generate_arrival_reactions(
+            &[],
+            &introduced,
+            &loc,
+            TimeOfDay::Morning,
+            "clear",
+            &templates,
+            &config,
+            &dice,
+        );
+
+        assert!(reactions.is_empty());
+    }
+
+    #[test]
+    fn test_multiple_npcs() {
+        let npc1 = test_npc(1, "Padraig", "Publican", Some(LocationId(2)));
+        let npc2 = test_npc(2, "Siobhan", "Farmer", None);
+        let loc = test_location(2, true);
+        let introduced: HashSet<NpcId> = HashSet::new();
+        let templates = ReactionTemplates::default();
+        let config = ReactionConfig::default();
+        // NPC1: low rolls → reacts. NPC2: high chance_roll → silent
+        let dice = fixed_n(&[0.0, 0.1, 0.99, 0.5]);
+
+        let reactions = generate_arrival_reactions(
+            &[&npc1, &npc2],
+            &introduced,
+            &loc,
+            TimeOfDay::Morning,
+            "clear",
+            &templates,
+            &config,
+            &dice,
+        );
+
+        assert_eq!(reactions.len(), 1);
+        assert_eq!(reactions[0].npc_id, NpcId(1));
+    }
+
+    #[test]
+    fn test_unintroduced_npc_gesture() {
+        let npc = test_npc(1, "Siobhan Murphy", "Farmer", None);
+        let loc = test_location(1, false);
+        let introduced: HashSet<NpcId> = HashSet::new();
+        let templates = ReactionTemplates::default();
+        let config = ReactionConfig::default();
+        // type_roll 0.5 >= 0.25 → gesture for unintroduced non-workplace NPC
+        let dice = fixed_n(&[0.0, 0.5]);
+
+        let reactions = generate_arrival_reactions(
+            &[&npc],
+            &introduced,
+            &loc,
+            TimeOfDay::Morning,
+            "clear",
+            &templates,
+            &config,
+            &dice,
+        );
+
+        assert_eq!(reactions.len(), 1);
+        assert_eq!(reactions[0].kind, ReactionKind::Gesture);
+        assert!(!reactions[0].introduces);
+        assert!(!reactions[0].use_llm);
+        // Gesture for unintroduced NPC uses brief_description
+        assert!(reactions[0].npc_display_name.contains("farmer"));
+    }
+
+    #[test]
+    fn test_unintroduced_npc_casual_introduction() {
+        let npc = test_npc(1, "Siobhan Murphy", "Farmer", None);
+        let loc = test_location(1, false);
+        let introduced: HashSet<NpcId> = HashSet::new();
+        let templates = ReactionTemplates::default();
+        let config = ReactionConfig::default();
+        // type_roll 0.1 < 0.25 → casual introduction
+        let dice = fixed_n(&[0.0, 0.1]);
+
+        let reactions = generate_arrival_reactions(
+            &[&npc],
+            &introduced,
+            &loc,
+            TimeOfDay::Morning,
+            "clear",
+            &templates,
+            &config,
+            &dice,
+        );
+
+        assert_eq!(reactions.len(), 1);
+        assert_eq!(reactions[0].kind, ReactionKind::Introduction);
+        assert!(reactions[0].introduces);
+        assert!(reactions[0].use_llm);
+        // Introduction uses real name
+        assert_eq!(reactions[0].npc_display_name, "Siobhan Murphy");
+    }
+
+    #[test]
+    fn test_placeholder_substitution() {
+        let npc = test_npc(1, "Padraig Darcy", "Publican", Some(LocationId(2)));
+        let result = substitute_placeholders(
+            "\"Welcome, says {name}. It's {time}, {weather}.\"",
+            &npc,
+            "Padraig Darcy",
+            TimeOfDay::Morning,
+            "overcast",
+        );
+        assert_eq!(
+            result,
+            "\"Welcome, says Padraig Darcy. It's morning, overcast.\""
+        );
+    }
+
+    #[test]
+    fn test_reaction_templates_default_has_content() {
+        let t = ReactionTemplates::default();
+        assert!(t.gestures.len() >= 20);
+        assert!(t.greetings.morning.len() >= 10);
+        assert!(t.greetings.afternoon.len() >= 10);
+        assert!(t.greetings.evening.len() >= 10);
+        assert!(t.greetings.any.len() >= 10);
+        assert!(t.welcomes.publican.len() >= 10);
+        assert!(t.welcomes.shopkeeper.len() >= 10);
+        assert!(t.welcomes.priest.len() >= 8);
+        assert!(t.introductions.workplace.len() >= 8);
+        assert!(t.introductions.casual.len() >= 8);
+        assert!(t.occupation_greetings.priest.len() >= 8);
+    }
+
+    #[test]
+    fn test_is_negative_mood() {
+        assert!(is_negative_mood("angry"));
+        assert!(is_negative_mood("frustrated and bitter"));
+        assert!(is_negative_mood("anxious"));
+        assert!(!is_negative_mood("content"));
+        assert!(!is_negative_mood("cheerful"));
+        assert!(!is_negative_mood("contemplative"));
+    }
+
+    #[test]
+    fn test_high_emotional_intelligence_bonus() {
+        let mut npc = test_npc(1, "Padraig", "Publican", None);
+        npc.intelligence.emotional = 5;
+        let loc = test_location(1, false);
+        let config = ReactionConfig::default();
+
+        // base 0.55 + empathy 0.05 = 0.60
+        let threshold = reaction_threshold(&npc, &loc, TimeOfDay::Morning, &config);
+        assert!((threshold - 0.60).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_build_reaction_prompt_not_introduced() {
+        let npc = test_npc(1, "Padraig Darcy", "Publican", Some(LocationId(2)));
+        let (system, context) = build_reaction_prompt(
+            &npc,
+            "Darcy's Pub",
+            TimeOfDay::Morning,
+            "overcast",
+            false,
+            true,
+        );
+        assert!(system.contains("Padraig Darcy"));
+        assert!(system.contains("Publican"));
+        assert!(context.contains("Darcy's Pub"));
+        assert!(context.contains("morning"));
+        assert!(context.contains("Introduce yourself"));
+    }
+
+    #[test]
+    fn test_build_reaction_prompt_introduced() {
+        let npc = test_npc(1, "Padraig Darcy", "Publican", Some(LocationId(2)));
+        let (_, context) = build_reaction_prompt(
+            &npc,
+            "Darcy's Pub",
+            TimeOfDay::Afternoon,
+            "clear",
+            true,
+            true,
+        );
+        assert!(context.contains("You know this person"));
     }
 }

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -55,9 +55,10 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
 
     let transport = TransportConfig::default();
 
-    // Build splash text (matches Tauri's format)
-    let game_title = find_default_mod()
-        .and_then(|dir| GameMod::load(&dir).ok())
+    // Load game mod (if available) for splash text and reaction templates
+    let game_mod = find_default_mod().and_then(|dir| GameMod::load(&dir).ok());
+    let game_title = game_mod
+        .as_ref()
         .and_then(|gm| gm.manifest.meta.title.clone())
         .unwrap_or_else(|| "Parish".to_string());
     let splash_text = format!(
@@ -82,6 +83,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         ui_config,
         saves_dir,
         data_dir.clone(),
+        game_mod,
     );
 
     // Initialize inference queue
@@ -218,10 +220,10 @@ fn build_client_and_config() -> (Option<OpenAiClient>, GameConfig) {
         cloud_api_key: None,
         cloud_base_url: None,
         improv_enabled: false,
-        category_provider: [None, None, None],
-        category_model: [None, None, None],
-        category_api_key: [None, None, None],
-        category_base_url: [None, None, None],
+        category_provider: [None, None, None, None],
+        category_model: [None, None, None, None],
+        category_api_key: [None, None, None, None],
+        category_base_url: [None, None, None, None],
     };
 
     (client, config)

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -606,6 +606,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
                 .emit("text-log", &text_log("system", narration));
 
             handle_look(state).await;
+            emit_arrival_reactions(state).await;
 
             let world = state.world.lock().await;
             let transport = state.transport.default_mode();
@@ -1199,6 +1200,91 @@ pub async fn get_save_state(State(state): State<Arc<AppState>>) -> Json<SaveStat
         branch_id: *branch_id,
         branch_name: branch_name.clone(),
     })
+}
+
+/// Generates NPC arrival reactions and emits them as text-log events.
+async fn emit_arrival_reactions(state: &Arc<AppState>) {
+    use parish_core::config::ReactionConfig;
+    use parish_core::dice;
+    use parish_core::npc::reactions::{generate_arrival_reactions, resolve_llm_greeting};
+
+    let (npcs_data, loc_data, tod, weather, introduced) = {
+        let world = state.world.lock().await;
+        let npc_manager = state.npc_manager.lock().await;
+        let npcs = npc_manager.npcs_at(world.player_location);
+        if npcs.is_empty() {
+            return;
+        }
+        let loc_data = match world.current_location_data() {
+            Some(d) => d.clone(),
+            None => return,
+        };
+        let npcs_data: Vec<parish_core::npc::Npc> = npcs.into_iter().cloned().collect();
+        let tod = world.clock.time_of_day();
+        let weather = world.weather.to_string();
+        let introduced = npc_manager.introduced_set();
+        (npcs_data, loc_data, tod, weather, introduced)
+    };
+
+    let templates = state
+        .game_mod
+        .as_ref()
+        .map(|gm| gm.reactions.clone())
+        .unwrap_or_default();
+    let config = ReactionConfig::default();
+    let roll_dice = dice::roll_n(npcs_data.len() * 2);
+    let npc_refs: Vec<&parish_core::npc::Npc> = npcs_data.iter().collect();
+
+    let reactions = generate_arrival_reactions(
+        &npc_refs,
+        &introduced,
+        &loc_data,
+        tod,
+        &weather,
+        &templates,
+        &config,
+        &roll_dice,
+    );
+
+    let reaction_client = state.reaction_client.lock().await;
+    let reaction_model = state.reaction_model.lock().await;
+
+    for reaction in &reactions {
+        let text = if reaction.use_llm {
+            if let Some(client) = reaction_client.as_ref() {
+                let npc = npcs_data.iter().find(|n| n.id == reaction.npc_id);
+                if let Some(npc) = npc {
+                    let at_workplace = npc.workplace.is_some_and(|wp| wp == loc_data.id);
+                    resolve_llm_greeting(
+                        reaction,
+                        npc,
+                        &loc_data.name,
+                        tod,
+                        &weather,
+                        introduced.contains(&reaction.npc_id),
+                        at_workplace,
+                        client,
+                        &reaction_model,
+                        config.llm_timeout_secs,
+                    )
+                    .await
+                } else {
+                    reaction.canned_text.clone()
+                }
+            } else {
+                reaction.canned_text.clone()
+            }
+        } else {
+            reaction.canned_text.clone()
+        };
+
+        state.event_bus.emit("text-log", &text_log("npc", text));
+
+        if reaction.introduces {
+            let mut npc_manager = state.npc_manager.lock().await;
+            npc_manager.mark_introduced(reaction.npc_id);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/parish-server/src/state.rs
+++ b/crates/parish-server/src/state.rs
@@ -66,6 +66,12 @@ pub struct AppState {
     pub current_branch_id: Mutex<Option<i64>>,
     /// Current branch name.
     pub current_branch_name: Mutex<Option<String>>,
+    /// LLM client for NPC arrival reactions (None if not configured).
+    pub reaction_client: Mutex<Option<OpenAiClient>>,
+    /// Model name for reaction inference.
+    pub reaction_model: Mutex<String>,
+    /// Loaded game mod data (for reaction templates, etc.).
+    pub game_mod: Option<parish_core::game_mod::GameMod>,
 }
 
 /// Mutable runtime configuration for provider, model, and cloud settings.
@@ -89,13 +95,13 @@ pub struct GameConfig {
     /// Whether improv craft mode is enabled.
     pub improv_enabled: bool,
     /// Per-category provider name overrides (Dialogue=0, Simulation=1, Intent=2).
-    pub category_provider: [Option<String>; 3],
+    pub category_provider: [Option<String>; 4],
     /// Per-category model name overrides.
-    pub category_model: [Option<String>; 3],
+    pub category_model: [Option<String>; 4],
     /// Per-category API key overrides.
-    pub category_api_key: [Option<String>; 3],
+    pub category_api_key: [Option<String>; 4],
     /// Per-category base URL overrides.
-    pub category_base_url: [Option<String>; 3],
+    pub category_base_url: [Option<String>; 4],
 }
 
 impl GameConfig {
@@ -106,6 +112,7 @@ impl GameConfig {
             InferenceCategory::Dialogue => 0,
             InferenceCategory::Simulation => 1,
             InferenceCategory::Intent => 2,
+            InferenceCategory::Reaction => 3,
         }
     }
 }
@@ -179,7 +186,10 @@ pub fn build_app_state(
     ui_config: UiConfigSnapshot,
     saves_dir: PathBuf,
     data_dir: PathBuf,
+    game_mod: Option<parish_core::game_mod::GameMod>,
 ) -> Arc<AppState> {
+    // Reaction client defaults to the base client (can be overridden later).
+    let reaction_client = client.clone();
     Arc::new(AppState {
         world: Mutex::new(world),
         npc_manager: Mutex::new(npc_manager),
@@ -195,6 +205,9 @@ pub fn build_app_state(
         save_path: Mutex::new(None),
         current_branch_id: Mutex::new(None),
         current_branch_name: Mutex::new(None),
+        reaction_client: Mutex::new(reaction_client),
+        reaction_model: Mutex::new(String::new()),
+        game_mod,
     })
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -176,23 +176,24 @@ pub struct GameConfig {
     /// Whether improv craft mode is enabled for NPC dialogue.
     pub improv_enabled: bool,
     /// Per-category provider name overrides (None = inherits base).
-    pub category_provider: [Option<String>; 3],
+    pub category_provider: [Option<String>; 4],
     /// Per-category model name overrides (None = inherits base).
-    pub category_model: [Option<String>; 3],
+    pub category_model: [Option<String>; 4],
     /// Per-category API key overrides (None = inherits base).
-    pub category_api_key: [Option<String>; 3],
+    pub category_api_key: [Option<String>; 4],
     /// Per-category base URL overrides (None = inherits base).
-    pub category_base_url: [Option<String>; 3],
+    pub category_base_url: [Option<String>; 4],
 }
 
 impl GameConfig {
-    /// Returns the array index for a category (Dialogue=0, Simulation=1, Intent=2).
+    /// Returns the array index for a category (Dialogue=0, Simulation=1, Intent=2, Reaction=3).
     fn cat_idx(cat: parish_core::config::InferenceCategory) -> usize {
         use parish_core::config::InferenceCategory;
         match cat {
             InferenceCategory::Dialogue => 0,
             InferenceCategory::Simulation => 1,
             InferenceCategory::Intent => 2,
+            InferenceCategory::Reaction => 3,
         }
     }
 }
@@ -540,10 +541,10 @@ pub fn run() {
             cloud_api_key: cloud_env.api_key,
             cloud_base_url: cloud_env.base_url,
             improv_enabled: false,
-            category_provider: [None, None, None],
-            category_model: [None, None, None],
-            category_api_key: [None, None, None],
-            category_base_url: [None, None, None],
+            category_provider: [None, None, None, None],
+            category_model: [None, None, None, None],
+            category_api_key: [None, None, None, None],
+            category_base_url: [None, None, None, None],
         }),
     });
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -165,6 +165,16 @@ pub struct App {
     pub simulation_api_key: Option<String>,
     /// Base URL for simulation category.
     pub simulation_base_url: Option<String>,
+    /// The LLM client for NPC arrival reactions (may differ from base client).
+    pub reaction_client: Option<OpenAiClient>,
+    /// The model name for reactions.
+    pub reaction_model: String,
+    /// Provider name for reaction category (None = inherits base).
+    pub reaction_provider_name: Option<String>,
+    /// API key for reaction category.
+    pub reaction_api_key: Option<String>,
+    /// Base URL for reaction category.
+    pub reaction_base_url: Option<String>,
     /// Loaded game mod data (None if no mod directory was found or specified).
     pub game_mod: Option<GameMod>,
 }
@@ -215,6 +225,11 @@ impl App {
             simulation_provider_name: None,
             simulation_api_key: None,
             simulation_base_url: None,
+            reaction_client: None,
+            reaction_model: String::new(),
+            reaction_provider_name: None,
+            reaction_api_key: None,
+            reaction_base_url: None,
             game_mod: None,
         }
     }
@@ -225,6 +240,7 @@ impl App {
             InferenceCategory::Dialogue => self.cloud_provider_name.as_deref(),
             InferenceCategory::Simulation => self.simulation_provider_name.as_deref(),
             InferenceCategory::Intent => self.intent_provider_name.as_deref(),
+            InferenceCategory::Reaction => self.reaction_provider_name.as_deref(),
         }
     }
 
@@ -234,6 +250,7 @@ impl App {
             InferenceCategory::Dialogue => self.cloud_model_name.as_deref().unwrap_or(""),
             InferenceCategory::Simulation => &self.simulation_model,
             InferenceCategory::Intent => &self.intent_model,
+            InferenceCategory::Reaction => &self.reaction_model,
         }
     }
 
@@ -243,6 +260,7 @@ impl App {
             InferenceCategory::Dialogue => self.cloud_api_key.as_deref(),
             InferenceCategory::Simulation => self.simulation_api_key.as_deref(),
             InferenceCategory::Intent => self.intent_api_key.as_deref(),
+            InferenceCategory::Reaction => self.reaction_api_key.as_deref(),
         }
     }
 
@@ -252,6 +270,7 @@ impl App {
             InferenceCategory::Dialogue => self.cloud_base_url.as_deref(),
             InferenceCategory::Simulation => self.simulation_base_url.as_deref(),
             InferenceCategory::Intent => self.intent_base_url.as_deref(),
+            InferenceCategory::Reaction => self.reaction_base_url.as_deref(),
         }
     }
 
@@ -261,6 +280,7 @@ impl App {
             InferenceCategory::Dialogue => self.cloud_client.as_ref(),
             InferenceCategory::Simulation => self.simulation_client.as_ref(),
             InferenceCategory::Intent => self.intent_client.as_ref(),
+            InferenceCategory::Reaction => self.reaction_client.as_ref(),
         }
     }
 
@@ -270,6 +290,7 @@ impl App {
             InferenceCategory::Dialogue => self.cloud_provider_name = Some(name),
             InferenceCategory::Simulation => self.simulation_provider_name = Some(name),
             InferenceCategory::Intent => self.intent_provider_name = Some(name),
+            InferenceCategory::Reaction => self.reaction_provider_name = Some(name),
         }
     }
 
@@ -282,6 +303,7 @@ impl App {
             }
             InferenceCategory::Simulation => self.simulation_model = model,
             InferenceCategory::Intent => self.intent_model = model,
+            InferenceCategory::Reaction => self.reaction_model = model,
         }
     }
 
@@ -291,6 +313,7 @@ impl App {
             InferenceCategory::Dialogue => self.cloud_api_key = Some(key),
             InferenceCategory::Simulation => self.simulation_api_key = Some(key),
             InferenceCategory::Intent => self.intent_api_key = Some(key),
+            InferenceCategory::Reaction => self.reaction_api_key = Some(key),
         }
     }
 
@@ -300,6 +323,7 @@ impl App {
             InferenceCategory::Dialogue => self.cloud_base_url = Some(url),
             InferenceCategory::Simulation => self.simulation_base_url = Some(url),
             InferenceCategory::Intent => self.intent_base_url = Some(url),
+            InferenceCategory::Reaction => self.reaction_base_url = Some(url),
         }
     }
 
@@ -309,6 +333,7 @@ impl App {
             InferenceCategory::Dialogue => self.cloud_client = Some(client),
             InferenceCategory::Simulation => self.simulation_client = Some(client),
             InferenceCategory::Intent => self.intent_client = Some(client),
+            InferenceCategory::Reaction => self.reaction_client = Some(client),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,7 +60,7 @@ struct TomlConfig {
 /// parish-core and passed in as `ProviderConfig`. Serde ignores unknown keys.
 #[derive(Debug, Deserialize, Default)]
 struct TomlProvider {
-    /// Per-category overrides: `[provider.dialogue]`, `[provider.simulation]`, `[provider.intent]`.
+    /// Per-category overrides: `[provider.dialogue]`, `[provider.simulation]`, `[provider.intent]`, `[provider.reaction]`.
     #[serde(default)]
     dialogue: Option<TomlCategoryOverride>,
     /// Per-category override for simulation.
@@ -69,6 +69,9 @@ struct TomlProvider {
     /// Per-category override for intent parsing.
     #[serde(default)]
     intent: Option<TomlCategoryOverride>,
+    /// Per-category override for NPC arrival reactions.
+    #[serde(default)]
+    reaction: Option<TomlCategoryOverride>,
 }
 
 /// Per-category provider override in TOML (e.g. `[provider.dialogue]`).
@@ -124,6 +127,7 @@ pub fn resolve_category_configs(
             InferenceCategory::Dialogue => toml_cfg.provider.dialogue.clone(),
             InferenceCategory::Simulation => toml_cfg.provider.simulation.clone(),
             InferenceCategory::Intent => toml_cfg.provider.intent.clone(),
+            InferenceCategory::Reaction => toml_cfg.provider.reaction.clone(),
         };
 
         // Get CLI overrides for this category

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -103,6 +103,11 @@ pub async fn run_headless(
     app.simulation_client = Some(sim_cl.clone());
     app.simulation_model = sim_mdl.to_string();
 
+    // Set reaction client/model
+    let (react_cl, react_mdl) = clients.reaction_client();
+    app.reaction_client = Some(react_cl.clone());
+    app.reaction_model = react_mdl.to_string();
+
     // Initialize per-category provider metadata from config
     if let Some(cat_cfg) = category_configs.get(&InferenceCategory::Intent) {
         app.intent_provider_name = Some(format!("{:?}", cat_cfg.provider).to_lowercase());
@@ -113,6 +118,11 @@ pub async fn run_headless(
         app.simulation_provider_name = Some(format!("{:?}", cat_cfg.provider).to_lowercase());
         app.simulation_api_key = cat_cfg.api_key.clone();
         app.simulation_base_url = Some(cat_cfg.base_url.clone());
+    }
+    if let Some(cat_cfg) = category_configs.get(&InferenceCategory::Reaction) {
+        app.reaction_provider_name = Some(format!("{:?}", cat_cfg.provider).to_lowercase());
+        app.reaction_api_key = cat_cfg.api_key.clone();
+        app.reaction_base_url = Some(cat_cfg.base_url.clone());
     }
 
     // Set cloud/dialogue fields if configured
@@ -164,6 +174,7 @@ pub async fn run_headless(
 
     // Show initial location
     print_location_arrival(&app);
+    print_arrival_reactions(&mut app).await;
 
     let mut request_id: u64 = 0;
     let stdin = std::io::stdin();
@@ -602,6 +613,7 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
                         app.save_file_path = Some(new_path);
                         app.last_autosave = Some(std::time::Instant::now());
                         print_location_arrival(app);
+                        print_arrival_reactions(app).await;
                     }
                     Err(e) => eprintln!("Failed to open save file: {}", e),
                 }
@@ -964,6 +976,7 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             println!("A new day dawns in the parish.");
             println!();
             print_location_arrival(app);
+            print_arrival_reactions(app).await;
         }
         Command::Tick => {
             app.npc_manager.assign_tiers(&app.world, &[]);
@@ -1001,7 +1014,7 @@ async fn handle_headless_game_input(
     match intent.intent {
         crate::input::IntentKind::Move => {
             if let Some(target) = &intent.target {
-                handle_headless_movement(app, target);
+                handle_headless_movement(app, target).await;
             } else {
                 println!("And where would ye be off to?");
             }
@@ -1223,6 +1236,85 @@ fn print_location_arrival(app: &App) {
     println!();
 }
 
+/// Generates and prints NPC arrival reactions (greetings, nods, introductions).
+///
+/// For reactions flagged `use_llm`, attempts a short-timeout LLM call for a
+/// richer greeting, falling back to canned text on timeout or error.
+async fn print_arrival_reactions(app: &mut App) {
+    use parish_core::config::ReactionConfig;
+    use parish_core::dice;
+    use parish_core::npc::reactions::{generate_arrival_reactions, resolve_llm_greeting};
+
+    let npcs = app.npc_manager.npcs_at(app.world.player_location);
+    if npcs.is_empty() {
+        return;
+    }
+
+    let loc_data = match app.world.current_location_data() {
+        Some(d) => d.clone(),
+        None => return,
+    };
+
+    let tod = app.world.clock.time_of_day();
+    let weather = app.world.weather.to_string();
+    let introduced = app.npc_manager.introduced_set();
+    let templates = app
+        .game_mod
+        .as_ref()
+        .map(|gm| &gm.reactions)
+        .cloned()
+        .unwrap_or_default();
+    let config = ReactionConfig::default();
+    let roll_dice = dice::roll_n(npcs.len() * 2);
+
+    let reactions = generate_arrival_reactions(
+        &npcs,
+        &introduced,
+        &loc_data,
+        tod,
+        &weather,
+        &templates,
+        &config,
+        &roll_dice,
+    );
+
+    for reaction in &reactions {
+        let text = if reaction.use_llm {
+            if let Some(client) = &app.reaction_client {
+                let npc = app.npc_manager.get(reaction.npc_id);
+                if let Some(npc) = npc {
+                    let at_workplace = npc.workplace.is_some_and(|wp| wp == loc_data.id);
+                    resolve_llm_greeting(
+                        reaction,
+                        npc,
+                        &loc_data.name,
+                        tod,
+                        &weather,
+                        introduced.contains(&reaction.npc_id),
+                        at_workplace,
+                        client,
+                        &app.reaction_model.clone(),
+                        config.llm_timeout_secs,
+                    )
+                    .await
+                } else {
+                    reaction.canned_text.clone()
+                }
+            } else {
+                reaction.canned_text.clone()
+            }
+        } else {
+            reaction.canned_text.clone()
+        };
+
+        println!("{}", text);
+
+        if reaction.introduces {
+            app.npc_manager.mark_introduced(reaction.npc_id);
+        }
+    }
+}
+
 /// Returns the default transport mode from the game mod, or walking.
 fn default_transport(app: &App) -> TransportMode {
     app.game_mod
@@ -1259,7 +1351,7 @@ fn print_location_description(app: &App) {
 }
 
 /// Handles movement in headless mode.
-fn handle_headless_movement(app: &mut App, target: &str) {
+async fn handle_headless_movement(app: &mut App, target: &str) {
     let transport = default_transport(app);
     let result = movement::resolve_movement(
         target,
@@ -1299,6 +1391,7 @@ fn handle_headless_movement(app: &mut App, target: &str) {
             }
 
             print_location_arrival(app);
+            print_arrival_reactions(app).await;
         }
         MovementResult::AlreadyHere => {
             println!("Sure, you're already standing right here.");

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1044,6 +1044,18 @@ impl GameTestHarness {
                 self.app.world.log(exits);
                 self.app.world.log(String::new());
 
+                // Resolve any NPCs whose transit completed during travel, so
+                // emit_arrival_reactions sees them as Present rather than InTransit.
+                let schedule_events = self.app.npc_manager.tick_schedules(
+                    &self.app.world.clock,
+                    &self.app.world.graph,
+                    self.app.world.weather,
+                );
+                self.process_schedule_events(&schedule_events);
+
+                // NPC arrival reactions (canned text, no LLM)
+                self.emit_arrival_reactions();
+
                 ActionResult::Moved {
                     to: loc_name,
                     minutes,
@@ -1133,6 +1145,51 @@ impl GameTestHarness {
         }
 
         ActionResult::NpcNotAvailable
+    }
+
+    /// Generates NPC arrival reactions (canned text only, no LLM) and logs them.
+    fn emit_arrival_reactions(&mut self) {
+        use parish_core::config::ReactionConfig;
+        use parish_core::dice;
+        use parish_core::npc::reactions::generate_arrival_reactions;
+
+        let npcs = self.app.npc_manager.npcs_at(self.app.world.player_location);
+        if npcs.is_empty() {
+            return;
+        }
+        let loc_data = match self.app.world.current_location_data() {
+            Some(d) => d.clone(),
+            None => return,
+        };
+        let tod = self.app.world.clock.time_of_day();
+        let weather = self.app.world.weather.to_string();
+        let introduced = self.app.npc_manager.introduced_set();
+        let templates = self
+            .app
+            .game_mod
+            .as_ref()
+            .map(|gm| gm.reactions.clone())
+            .unwrap_or_default();
+        let config = ReactionConfig::default();
+        let roll_dice = dice::roll_n(npcs.len() * 2);
+
+        let reactions = generate_arrival_reactions(
+            &npcs,
+            &introduced,
+            &loc_data,
+            tod,
+            &weather,
+            &templates,
+            &config,
+            &roll_dice,
+        );
+
+        for reaction in &reactions {
+            self.app.world.log(reaction.canned_text.clone());
+            if reaction.introduces {
+                self.app.npc_manager.mark_introduced(reaction.npc_id);
+            }
+        }
     }
 
     /// Renders the current location description.

--- a/tests/fixtures/play_prove.txt
+++ b/tests/fixtures/play_prove.txt
@@ -1,68 +1,21 @@
-# Phase 5C Prove: NPC Long-Term Memory & Gossip Propagation
+# Prove: NPC arrival reactions and greetings system
+/status
+/wait 120
+/status
 
-# --- Go to crossroads and wait for Padraig to arrive ---
-go to crossroads
-/wait 15
+# Check NPC positions before going to pub
+/debug tiers
+
+# First pub visit — Padraig should introduce himself on arrival
+go to pub
 /npcs
 
-# --- Stub 22 canned responses (enough to overflow the 20-entry STM buffer) ---
-/stub Padraig Darcy: Ah, good morning to ye! Dia dhuit.
-/stub Padraig Darcy: The landlord was angry about the tithes, so he was.
-/stub Padraig Darcy: A stranger was seen near the fairy fort last night.
-/stub Padraig Darcy: Aye, the secret is that old Tommy buried gold under the oak.
-/stub Padraig Darcy: The weather's been fierce mild this spring.
-/stub Padraig Darcy: My daughter Niamh wants to go to Galway. I worry about her.
-/stub Padraig Darcy: Fr. Tierney gave a powerful sermon about forgiveness.
-/stub Padraig Darcy: The Murphy farm lost three sheep to the bog last week.
-/stub Padraig Darcy: There's talk of a new road being built through the parish.
-/stub Padraig Darcy: Old Tommy hasn't been well. His cough is getting worse.
-/stub Padraig Darcy: The price of grain is gone through the roof entirely.
-/stub Padraig Darcy: Roisin's shop got a delivery of cloth from Athlone.
-/stub Padraig Darcy: I remember when this pub had a thatched roof, years ago.
-/stub Padraig Darcy: The fair at Roscommon is next month. Everyone will be there.
-/stub Padraig Darcy: A tinker family passed through yesterday selling pots.
-/stub Padraig Darcy: The river flooded last autumn and took out the bridge.
-/stub Padraig Darcy: My grandfather built this pub with his own two hands.
-/stub Padraig Darcy: They say the fairy fort is cursed. I wouldn't go near it.
-/stub Padraig Darcy: The English garrison has new soldiers arrived.
-/stub Padraig Darcy: Siobhan Murphy makes the best butter in the parish.
-/stub Padraig Darcy: Sure, the old days were better. Everything's changing now.
-/stub Padraig Darcy: Did I ever tell ye about the death of old Seamus? Terrible grief.
+# Second pub visit — Padraig should give a welcome (not re-introduce)
+go to crossroads
+go to pub
+/npcs
 
-# --- 1st conversation: basic greeting ---
-Hello Padraig
-/debug memory Padraig Darcy
-
-# --- Fill the 20-entry STM buffer (conversations 2-20) ---
-Tell me about the landlord
-What news?
-Tell me a secret
-How's the weather?
-Tell me about Niamh
-What about the sermon?
-What about the sheep?
-Any talk of a road?
-How's Tommy?
-What about grain?
-Tell me about Roisin
-The roof?
-The fair?
-Tell me about the tinkers
-The flood?
-Your grandfather?
-The fairy fort?
-The soldiers?
-What about Siobhan?
-
-# --- STM should be full (20 entries). Check state ---
-/debug memory Padraig Darcy
-
-# --- Conversations 21-22: overflow the buffer, forcing evictions ---
-What's changed?
-Tell me about Seamus
-
-# --- Critical check: evicted memories should be promoted to LTM ---
-/debug memory Padraig Darcy
-
-# --- Check gossip ---
-/debug gossip
+# Shop visit — Roisin should introduce herself on first visit
+go to crossroads
+go to shop
+/npcs


### PR DESCRIPTION
NPCs now react when the player arrives at a location — publicans welcome
you into their pub, priests offer blessings, and some folks just nod.

- Add reusable DiceRoll utility (crates/parish-core/src/dice.rs)
- Add Reaction inference category for per-provider LLM routing
- Add ReactionConfig with tunable probability thresholds
- Add ~130 canned fallback templates (gestures, greetings by time of day,
  workplace welcomes by occupation, introductions, priest-specific)
- LLM greeting with short timeout, falling back to canned text
- Mod-overridable reaction templates via reactions.json
- Wire into headless mode and web server arrival flow

https://claude.ai/code/session_01QBt4LxpP2qqhVp6psHxYLS