### PR TITLE
feat: season- and day-aware NPC schedules with cuaird visiting

### DIFF
--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -6,13 +6,14 @@
 
 use std::collections::VecDeque;
 
-use chrono::Timelike;
+use chrono::{Datelike, Timelike};
 use serde::Serialize;
 
 use crate::npc::manager::NpcManager;
 use crate::npc::types::{CogTier, NpcState};
 use crate::world::WorldState;
 use crate::world::graph::WorldGraph;
+use crate::world::time::{DayType, Season};
 
 /// A complete debug snapshot of all game state.
 ///
@@ -52,6 +53,10 @@ pub struct ClockDebug {
     pub paused: bool,
     /// Clock speed multiplier.
     pub speed_factor: f64,
+    /// Full day-of-week name (e.g. "Monday").
+    pub day_of_week: String,
+    /// Schedule day type label (e.g. "Weekday", "Sunday", "Market Day").
+    pub day_type: String,
 }
 
 /// World graph summary for debug display.
@@ -111,8 +116,8 @@ pub struct NpcDebug {
     pub state: String,
     /// Cognitive tier label ("Tier1", "Tier2", etc.).
     pub tier: String,
-    /// Daily schedule entries.
-    pub schedule: Vec<ScheduleEntryDebug>,
+    /// All schedule variants with active/current indicators.
+    pub schedule: Vec<ScheduleVariantDebug>,
     /// Relationships with other NPCs.
     pub relationships: Vec<RelationshipDebug>,
     /// Recent memory entries.
@@ -151,6 +156,21 @@ pub struct ScheduleEntryDebug {
     pub location_name: String,
     /// Activity description.
     pub activity: String,
+    /// Whether this is the currently active entry right now.
+    pub is_current: bool,
+}
+
+/// A schedule variant for debug display (one variant = one season/day-type combination).
+#[derive(Debug, Clone, Serialize)]
+pub struct ScheduleVariantDebug {
+    /// Season this variant applies to ("Spring", "Summer", etc.), or null for any season.
+    pub season: Option<String>,
+    /// Day type this variant applies to ("Weekday", "Sunday", "Market Day"), or null for any.
+    pub day_type: Option<String>,
+    /// Whether this variant is the one currently in use.
+    pub is_active: bool,
+    /// Schedule entries for this variant.
+    pub entries: Vec<ScheduleEntryDebug>,
 }
 
 /// A relationship for debug display.
@@ -268,7 +288,16 @@ pub fn build_debug_snapshot(
 ) -> DebugSnapshot {
     let clock = build_clock_debug(world);
     let world_debug = build_world_debug(world, npc_manager);
-    let npcs = build_npc_debug_list(npc_manager, &world.graph);
+    let current_hour = world.clock.now().hour() as u8;
+    let current_season = world.clock.season();
+    let current_day_type = world.clock.day_type();
+    let npcs = build_npc_debug_list(
+        npc_manager,
+        &world.graph,
+        current_hour,
+        current_season,
+        current_day_type,
+    );
     let tier_summary = build_tier_summary(npc_manager);
     let event_list: Vec<DebugEvent> = events.iter().cloned().collect();
 
@@ -285,6 +314,16 @@ pub fn build_debug_snapshot(
 /// Builds clock debug info from world state.
 fn build_clock_debug(world: &WorldState) -> ClockDebug {
     let now = world.clock.now();
+    let day_of_week = match now.weekday() {
+        chrono::Weekday::Mon => "Monday",
+        chrono::Weekday::Tue => "Tuesday",
+        chrono::Weekday::Wed => "Wednesday",
+        chrono::Weekday::Thu => "Thursday",
+        chrono::Weekday::Fri => "Friday",
+        chrono::Weekday::Sat => "Saturday",
+        chrono::Weekday::Sun => "Sunday",
+    }
+    .to_string();
     ClockDebug {
         game_time: format!(
             "{:02}:{:02} {}",
@@ -298,6 +337,8 @@ fn build_clock_debug(world: &WorldState) -> ClockDebug {
         weather: world.weather.to_string(),
         paused: world.clock.is_paused(),
         speed_factor: world.clock.speed_factor(),
+        day_of_week,
+        day_type: world.clock.day_type().to_string(),
     }
 }
 
@@ -346,7 +387,13 @@ fn loc_name(id: crate::world::LocationId, graph: &WorldGraph) -> String {
 }
 
 /// Builds the NPC debug list with full deep-dive data.
-fn build_npc_debug_list(npc_manager: &NpcManager, graph: &WorldGraph) -> Vec<NpcDebug> {
+fn build_npc_debug_list(
+    npc_manager: &NpcManager,
+    graph: &WorldGraph,
+    current_hour: u8,
+    current_season: Season,
+    current_day_type: DayType,
+) -> Vec<NpcDebug> {
     let mut npcs: Vec<NpcDebug> = npc_manager
         .all_npcs()
         .map(|npc| {
@@ -368,21 +415,39 @@ fn build_npc_debug_list(npc_manager: &NpcManager, graph: &WorldGraph) -> Vec<Npc
                 }
             };
 
-            let schedule: Vec<ScheduleEntryDebug> = npc
+            let schedule: Vec<ScheduleVariantDebug> = npc
                 .schedule
                 .as_ref()
                 .map(|s| {
-                    // Show the first variant's entries for debug display
+                    // Determine which variant is currently active
+                    let active_entries = s.resolve(current_season, current_day_type);
                     s.variants
-                        .first()
-                        .map(|v| &v.entries)
-                        .unwrap_or(&Vec::new())
                         .iter()
-                        .map(|e| ScheduleEntryDebug {
-                            start_hour: e.start_hour,
-                            end_hour: e.end_hour,
-                            location_name: loc_name(e.location, graph),
-                            activity: e.activity.clone(),
+                        .map(|v| {
+                            let is_active =
+                                active_entries.map_or(false, |ae| std::ptr::eq(ae, &v.entries[..]));
+                            let entries = v
+                                .entries
+                                .iter()
+                                .map(|e| {
+                                    let is_current = is_active
+                                        && current_hour >= e.start_hour
+                                        && current_hour <= e.end_hour;
+                                    ScheduleEntryDebug {
+                                        start_hour: e.start_hour,
+                                        end_hour: e.end_hour,
+                                        location_name: loc_name(e.location, graph),
+                                        activity: e.activity.clone(),
+                                        is_current,
+                                    }
+                                })
+                                .collect();
+                            ScheduleVariantDebug {
+                                season: v.season.map(|s| s.to_string()),
+                                day_type: v.day_type.map(|d| d.to_string()),
+                                is_active,
+                                entries,
+                            }
                         })
                         .collect()
                 })

--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -372,7 +372,11 @@ fn build_npc_debug_list(npc_manager: &NpcManager, graph: &WorldGraph) -> Vec<Npc
                 .schedule
                 .as_ref()
                 .map(|s| {
-                    s.entries
+                    // Show the first variant's entries for debug display
+                    s.variants
+                        .first()
+                        .map(|v| &v.entries)
+                        .unwrap_or(&Vec::new())
                         .iter()
                         .map(|e| ScheduleEntryDebug {
                             start_hour: e.start_hour,

--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashSet;
 
-use chrono::Timelike;
+use chrono::{Datelike, Timelike};
 
 use crate::npc::manager::NpcManager;
 use crate::world::description::{format_exits, render_description};
@@ -39,6 +39,17 @@ pub fn snapshot_from_world(world: &WorldState, transport: &TransportMode) -> Wor
         loc.description.clone()
     };
 
+    let day_of_week = match now.weekday() {
+        chrono::Weekday::Mon => "Monday",
+        chrono::Weekday::Tue => "Tuesday",
+        chrono::Weekday::Wed => "Wednesday",
+        chrono::Weekday::Thu => "Thursday",
+        chrono::Weekday::Fri => "Friday",
+        chrono::Weekday::Sat => "Saturday",
+        chrono::Weekday::Sun => "Sunday",
+    }
+    .to_string();
+
     WorldSnapshot {
         location_name: loc.name.clone(),
         location_description: description,
@@ -51,6 +62,7 @@ pub fn snapshot_from_world(world: &WorldState, transport: &TransportMode) -> Wor
         paused: world.clock.is_paused() || world.clock.is_inference_paused(),
         game_epoch_ms: now.timestamp_millis() as f64,
         speed_factor: world.clock.speed_factor(),
+        day_of_week,
     }
 }
 

--- a/crates/parish-core/src/ipc/types.rs
+++ b/crates/parish-core/src/ipc/types.rs
@@ -36,6 +36,8 @@ pub struct WorldSnapshot {
     pub game_epoch_ms: f64,
     /// Clock speed multiplier (1 real second = speed_factor game seconds).
     pub speed_factor: f64,
+    /// Current day of week (e.g. "Monday", "Saturday").
+    pub day_of_week: String,
 }
 
 // ── Map data ────────────────────────────────────────────────────────────────
@@ -228,6 +230,7 @@ mod tests {
             paused: false,
             game_epoch_ms: 1234567890.0,
             speed_factor: 36.0,
+            day_of_week: "Monday".to_string(),
         };
         let json = serde_json::to_string(&snap).unwrap();
         let deser: WorldSnapshot = serde_json::from_str(&json).unwrap();

--- a/crates/parish-core/src/npc/data.rs
+++ b/crates/parish-core/src/npc/data.rs
@@ -12,10 +12,12 @@ use crate::error::ParishError;
 use crate::npc::memory::{LongTermMemory, ShortTermMemory};
 use crate::npc::reactions::ReactionLog;
 use crate::npc::types::{
-    DailySchedule, Intelligence, NpcState, Relationship, RelationshipKind, ScheduleEntry,
+    Intelligence, NpcState, Relationship, RelationshipKind, ScheduleEntry, ScheduleVariant,
+    SeasonalSchedule,
 };
 use crate::npc::{Npc, NpcId};
 use crate::world::LocationId;
+use crate::world::time::{DayType, Season};
 
 /// Top-level JSON structure for the NPC data file.
 #[derive(Debug, Deserialize)]
@@ -24,6 +26,12 @@ struct NpcFile {
 }
 
 /// A single NPC entry in the data file.
+///
+/// Supports two schedule formats for backward compatibility:
+/// - Legacy: `"schedule": [...]` — flat array of entries, treated as the default variant.
+/// - New: `"seasonal_schedule": [...]` — array of variants with optional season/day_type.
+///
+/// If both are present, `seasonal_schedule` takes priority.
 #[derive(Debug, Deserialize)]
 struct NpcFileEntry {
     id: u32,
@@ -38,7 +46,12 @@ struct NpcFileEntry {
     home: u32,
     workplace: Option<u32>,
     mood: String,
-    schedule: Vec<ScheduleFileEntry>,
+    /// Legacy flat schedule (backward compat).
+    #[serde(default)]
+    schedule: Option<Vec<ScheduleFileEntry>>,
+    /// Season-aware schedule with variants.
+    #[serde(default)]
+    seasonal_schedule: Option<Vec<ScheduleVariantFileEntry>>,
     relationships: Vec<RelationshipFileEntry>,
     #[serde(default)]
     knowledge: Vec<String>,
@@ -89,6 +102,18 @@ struct ScheduleFileEntry {
     end_hour: u8,
     location: u32,
     activity: String,
+    #[serde(default)]
+    cuaird: bool,
+}
+
+/// A schedule variant in the seasonal_schedule data file format.
+#[derive(Debug, Deserialize)]
+struct ScheduleVariantFileEntry {
+    #[serde(default)]
+    season: Option<Season>,
+    #[serde(default)]
+    day_type: Option<DayType>,
+    entries: Vec<ScheduleFileEntry>,
 }
 
 /// A relationship entry in the data file.
@@ -97,6 +122,53 @@ struct RelationshipFileEntry {
     target_id: u32,
     kind: RelationshipKind,
     strength: f64,
+}
+
+/// Converts raw file schedule entries into [`ScheduleEntry`] values.
+fn convert_entries(entries: &[ScheduleFileEntry]) -> Vec<ScheduleEntry> {
+    entries
+        .iter()
+        .map(|s| ScheduleEntry {
+            start_hour: s.start_hour,
+            end_hour: s.end_hour,
+            location: LocationId(s.location),
+            activity: s.activity.clone(),
+            cuaird: s.cuaird,
+        })
+        .collect()
+}
+
+/// Builds a [`SeasonalSchedule`] from an NPC file entry.
+///
+/// Supports two formats:
+/// - `seasonal_schedule`: array of variants with optional season/day_type (preferred).
+/// - `schedule`: legacy flat array, wrapped as a single default variant.
+fn build_seasonal_schedule(entry: &NpcFileEntry) -> SeasonalSchedule {
+    if let Some(variants) = &entry.seasonal_schedule {
+        SeasonalSchedule {
+            variants: variants
+                .iter()
+                .map(|v| ScheduleVariant {
+                    season: v.season,
+                    day_type: v.day_type,
+                    entries: convert_entries(&v.entries),
+                })
+                .collect(),
+        }
+    } else if let Some(flat) = &entry.schedule {
+        // Legacy format: wrap as a single default variant (None, None)
+        SeasonalSchedule {
+            variants: vec![ScheduleVariant {
+                season: None,
+                day_type: None,
+                entries: convert_entries(flat),
+            }],
+        }
+    } else {
+        SeasonalSchedule {
+            variants: Vec::new(),
+        }
+    }
 }
 
 /// Loads NPCs from a JSON data file.
@@ -125,18 +197,7 @@ pub fn load_npcs_from_str(json: &str) -> Result<Vec<Npc>, ParishError> {
         .npcs
         .iter()
         .map(|entry| {
-            let schedule = DailySchedule {
-                entries: entry
-                    .schedule
-                    .iter()
-                    .map(|s| ScheduleEntry {
-                        start_hour: s.start_hour,
-                        end_hour: s.end_hour,
-                        location: LocationId(s.location),
-                        activity: s.activity.clone(),
-                    })
-                    .collect(),
-            };
+            let schedule = build_seasonal_schedule(entry);
 
             let relationships: HashMap<NpcId, Relationship> = entry
                 .relationships
@@ -272,7 +333,7 @@ mod tests {
             );
             let schedule = npc.schedule.as_ref().unwrap();
             assert!(
-                !schedule.entries.is_empty(),
+                !schedule.variants.is_empty(),
                 "{} schedule should not be empty",
                 npc.name
             );
@@ -381,5 +442,131 @@ mod tests {
                 npc.name
             );
         }
+    }
+
+    #[test]
+    fn test_legacy_schedule_loaded_as_default_variant() {
+        let json = r#"{
+            "npcs": [{
+                "id": 99,
+                "name": "Legacy NPC",
+                "age": 30,
+                "occupation": "Farmer",
+                "personality": "Quiet",
+                "home": 1,
+                "workplace": null,
+                "mood": "calm",
+                "schedule": [
+                    {"start_hour": 0, "end_hour": 11, "location": 1, "activity": "sleeping"},
+                    {"start_hour": 12, "end_hour": 23, "location": 2, "activity": "working"}
+                ],
+                "relationships": []
+            }]
+        }"#;
+        let npcs = load_npcs_from_str(json).unwrap();
+        let sched = npcs[0].schedule.as_ref().unwrap();
+        // Legacy format should produce a single default variant
+        assert_eq!(sched.variants.len(), 1);
+        assert!(sched.variants[0].season.is_none());
+        assert!(sched.variants[0].day_type.is_none());
+        assert_eq!(sched.variants[0].entries.len(), 2);
+        // Should resolve for any season/day combination
+        use crate::world::time::{DayType, Season};
+        let loc = sched.location_at(15, Season::Winter, DayType::Sunday);
+        assert_eq!(loc, Some(LocationId(2)));
+    }
+
+    #[test]
+    fn test_seasonal_schedule_loaded_with_variants() {
+        let json = r#"{
+            "npcs": [{
+                "id": 99,
+                "name": "Seasonal NPC",
+                "age": 30,
+                "occupation": "Farmer",
+                "personality": "Quiet",
+                "home": 1,
+                "workplace": null,
+                "mood": "calm",
+                "seasonal_schedule": [
+                    {
+                        "entries": [
+                            {"start_hour": 0, "end_hour": 23, "location": 1, "activity": "default routine"}
+                        ]
+                    },
+                    {
+                        "season": "winter",
+                        "entries": [
+                            {"start_hour": 0, "end_hour": 23, "location": 2, "activity": "winter routine"}
+                        ]
+                    },
+                    {
+                        "day_type": "sunday",
+                        "entries": [
+                            {"start_hour": 0, "end_hour": 23, "location": 3, "activity": "sunday mass"}
+                        ]
+                    }
+                ],
+                "relationships": []
+            }]
+        }"#;
+        let npcs = load_npcs_from_str(json).unwrap();
+        let sched = npcs[0].schedule.as_ref().unwrap();
+        assert_eq!(sched.variants.len(), 3);
+
+        use crate::world::time::{DayType, Season};
+        // Summer weekday -> default (location 1)
+        assert_eq!(
+            sched.location_at(12, Season::Summer, DayType::Weekday),
+            Some(LocationId(1))
+        );
+        // Winter weekday -> winter variant (location 2)
+        assert_eq!(
+            sched.location_at(12, Season::Winter, DayType::Weekday),
+            Some(LocationId(2))
+        );
+        // Summer sunday -> sunday variant (location 3)
+        assert_eq!(
+            sched.location_at(12, Season::Summer, DayType::Sunday),
+            Some(LocationId(3))
+        );
+    }
+
+    #[test]
+    fn test_cuaird_flag_loaded() {
+        let json = r#"{
+            "npcs": [{
+                "id": 99,
+                "name": "Cuaird NPC",
+                "age": 30,
+                "occupation": "Farmer",
+                "personality": "Quiet",
+                "home": 1,
+                "workplace": null,
+                "mood": "calm",
+                "seasonal_schedule": [
+                    {
+                        "entries": [
+                            {"start_hour": 0, "end_hour": 18, "location": 1, "activity": "working"},
+                            {"start_hour": 19, "end_hour": 23, "location": 2, "activity": "visiting neighbours", "cuaird": true}
+                        ]
+                    }
+                ],
+                "relationships": []
+            }]
+        }"#;
+        let npcs = load_npcs_from_str(json).unwrap();
+        let sched = npcs[0].schedule.as_ref().unwrap();
+        use crate::world::time::{DayType, Season};
+        let entry = sched
+            .entry_at(20, Season::Summer, DayType::Weekday)
+            .unwrap();
+        assert!(entry.cuaird);
+        assert_eq!(entry.activity, "visiting neighbours");
+
+        let entry = sched
+            .entry_at(10, Season::Summer, DayType::Weekday)
+            .unwrap();
+        assert!(!entry.cuaird);
     }
 }

--- a/crates/parish-core/src/npc/manager.rs
+++ b/crates/parish-core/src/npc/manager.rs
@@ -7,7 +7,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
 
-use chrono::{DateTime, Duration, Timelike, Utc};
+use chrono::{DateTime, Datelike, Duration, Timelike, Utc};
 
 use crate::config::CognitiveTierConfig;
 use crate::error::ParishError;
@@ -390,7 +390,24 @@ impl NpcManager {
     ) -> Vec<ScheduleEvent> {
         let now = clock.now();
         let current_hour = now.hour() as u8;
+        let season = clock.season();
+        let day_type = clock.day_type();
         let mut events = Vec::new();
+
+        // Pre-collect cuaird targets: for each NPC, gather friend home locations.
+        let cuaird_targets: HashMap<NpcId, Vec<LocationId>> = self
+            .npcs
+            .iter()
+            .map(|(id, npc)| {
+                let friends: Vec<LocationId> = npc
+                    .relationships
+                    .iter()
+                    .filter(|(_, r)| r.strength > 0.3)
+                    .filter_map(|(friend_id, _)| self.npcs.get(friend_id).and_then(|f| f.home))
+                    .collect();
+                (*id, friends)
+            })
+            .collect();
 
         let npc_ids: Vec<NpcId> = self.npcs.keys().copied().collect();
 
@@ -401,7 +418,17 @@ impl NpcManager {
 
             match &npc.state {
                 NpcState::Present => {
-                    if let Some(mut desired) = npc.desired_location(current_hour) {
+                    if let Some(mut desired) = npc.desired_location(current_hour, season, day_type)
+                    {
+                        // Cuaird override: rotate visiting location by day-of-year
+                        if let Some(entry) = npc.schedule_entry(current_hour, season, day_type)
+                            && entry.cuaird
+                            && let Some(friends) = cuaird_targets.get(&id)
+                            && !friends.is_empty()
+                        {
+                            let day_of_year = now.ordinal() as usize;
+                            desired = friends[day_of_year % friends.len()];
+                        }
                         // Weather shelter override: NPCs seek indoor locations in bad weather
                         let dominated_by_rain = matches!(
                             weather,
@@ -604,7 +631,7 @@ fn tier_rank(tier: CogTier) -> u8 {
 mod tests {
     use super::*;
     use crate::npc::memory::{LongTermMemory, ShortTermMemory};
-    use crate::npc::types::{DailySchedule, ScheduleEntry};
+    use crate::npc::types::{ScheduleEntry, ScheduleVariant, SeasonalSchedule};
     use chrono::TimeZone;
 
     fn make_test_npc(id: u32, location: u32) -> Npc {
@@ -633,27 +660,34 @@ mod tests {
 
     fn make_scheduled_npc(id: u32, home: u32, work: u32) -> Npc {
         let mut npc = make_test_npc(id, home);
-        npc.schedule = Some(DailySchedule {
-            entries: vec![
-                ScheduleEntry {
-                    start_hour: 0,
-                    end_hour: 7,
-                    location: LocationId(home),
-                    activity: "sleeping".to_string(),
-                },
-                ScheduleEntry {
-                    start_hour: 8,
-                    end_hour: 17,
-                    location: LocationId(work),
-                    activity: "working".to_string(),
-                },
-                ScheduleEntry {
-                    start_hour: 18,
-                    end_hour: 23,
-                    location: LocationId(home),
-                    activity: "evening rest".to_string(),
-                },
-            ],
+        npc.schedule = Some(SeasonalSchedule {
+            variants: vec![ScheduleVariant {
+                season: None,
+                day_type: None,
+                entries: vec![
+                    ScheduleEntry {
+                        start_hour: 0,
+                        end_hour: 7,
+                        location: LocationId(home),
+                        activity: "sleeping".to_string(),
+                        cuaird: false,
+                    },
+                    ScheduleEntry {
+                        start_hour: 8,
+                        end_hour: 17,
+                        location: LocationId(work),
+                        activity: "working".to_string(),
+                        cuaird: false,
+                    },
+                    ScheduleEntry {
+                        start_hour: 18,
+                        end_hour: 23,
+                        location: LocationId(home),
+                        activity: "evening rest".to_string(),
+                        cuaird: false,
+                    },
+                ],
+            }],
         });
         npc
     }

--- a/crates/parish-core/src/npc/mod.rs
+++ b/crates/parish-core/src/npc/mod.rs
@@ -18,13 +18,14 @@ pub mod types;
 
 use std::collections::HashMap;
 
+use crate::world::time::{DayType, Season};
 use crate::world::{LocationId, WorldState};
 use serde::{Deserialize, Serialize};
 
 use memory::{LongTermMemory, ShortTermMemory};
 use reactions::ReactionLog;
 use transitions::NpcSummary;
-use types::{DailySchedule, Intelligence, NpcState, Relationship};
+use types::{Intelligence, NpcState, Relationship, SeasonalSchedule};
 
 /// A pronunciation hint for a word in the setting's secondary language.
 ///
@@ -139,8 +140,8 @@ pub struct Npc {
     pub home: Option<LocationId>,
     /// Workplace location (where the NPC works).
     pub workplace: Option<LocationId>,
-    /// Daily schedule defining where the NPC goes at what time.
-    pub schedule: Option<DailySchedule>,
+    /// Season- and day-aware schedule defining where the NPC goes.
+    pub schedule: Option<SeasonalSchedule>,
     /// Relationships to other NPCs, keyed by their id.
     pub relationships: HashMap<NpcId, Relationship>,
     /// Ring buffer of recent memories.
@@ -205,11 +206,28 @@ impl Npc {
         }
     }
 
-    /// Returns the NPC's desired location based on their schedule and the current hour.
+    /// Returns the NPC's desired location based on their schedule and the current context.
     ///
     /// Returns `None` if the NPC has no schedule or no entry covers the hour.
-    pub fn desired_location(&self, hour: u8) -> Option<LocationId> {
-        self.schedule.as_ref()?.location_at(hour)
+    pub fn desired_location(
+        &self,
+        hour: u8,
+        season: Season,
+        day_type: DayType,
+    ) -> Option<LocationId> {
+        self.schedule.as_ref()?.location_at(hour, season, day_type)
+    }
+
+    /// Returns the active schedule entry for the current context.
+    ///
+    /// Returns `None` if the NPC has no schedule or no entry covers the hour.
+    pub fn schedule_entry(
+        &self,
+        hour: u8,
+        season: Season,
+        day_type: DayType,
+    ) -> Option<&types::ScheduleEntry> {
+        self.schedule.as_ref()?.entry_at(hour, season, day_type)
     }
 }
 

--- a/crates/parish-core/src/npc/types.rs
+++ b/crates/parish-core/src/npc/types.rs
@@ -10,6 +10,7 @@ use std::fmt;
 
 use crate::npc::NpcId;
 use crate::world::LocationId;
+use crate::world::time::{DayType, Season};
 
 /// Multidimensional intelligence profile for an NPC.
 ///
@@ -328,6 +329,13 @@ pub struct ScheduleEntry {
     pub location: LocationId,
     /// What the NPC does during this slot (e.g. "tending bar").
     pub activity: String,
+    /// Whether this is a cuaird (visiting round) slot.
+    ///
+    /// When true, the location rotates among the NPC's friends' homes
+    /// on different days, recreating the 1820s Irish tradition of
+    /// neighbors gathering for storytelling and music.
+    #[serde(default)]
+    pub cuaird: bool,
 }
 
 /// An NPC's daily schedule.
@@ -353,6 +361,93 @@ impl DailySchedule {
     /// Returns the desired location at the given hour.
     pub fn location_at(&self, hour: u8) -> Option<LocationId> {
         self.entry_at(hour).map(|e| e.location)
+    }
+}
+
+/// A single variant of an NPC's schedule, optionally scoped to a season and/or day type.
+///
+/// When both `season` and `day_type` are `None`, this is the default fallback schedule.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScheduleVariant {
+    /// Season this variant applies to, or `None` for any season.
+    #[serde(default)]
+    pub season: Option<Season>,
+    /// Day type this variant applies to, or `None` for any day.
+    #[serde(default)]
+    pub day_type: Option<DayType>,
+    /// The schedule entries for this variant.
+    pub entries: Vec<ScheduleEntry>,
+}
+
+/// Season- and day-aware schedule for an NPC.
+///
+/// Contains named schedule variants scoped by optional `(season, day_type)`.
+/// Resolution order when looking up the active schedule:
+///   1. Exact match: `(Some(season), Some(day_type))`
+///   2. Season only: `(Some(season), None)`
+///   3. Day type only: `(None, Some(day_type))`
+///   4. Default: `(None, None)`
+///
+/// This allows NPCs to declare only the variants that differ from their
+/// default routine. A publican might need only weekday/sunday variants,
+/// while a farmer needs summer/winter × weekday/sunday.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SeasonalSchedule {
+    /// Schedule variants in priority order (resolution searches linearly).
+    pub variants: Vec<ScheduleVariant>,
+}
+
+impl SeasonalSchedule {
+    /// Resolves the best-matching schedule entries for the given context.
+    ///
+    /// Fallback order: exact match → season-only → day-only → default.
+    pub fn resolve(&self, season: Season, day_type: DayType) -> Option<&[ScheduleEntry]> {
+        // 1. Exact match: both season and day_type
+        if let Some(v) = self
+            .variants
+            .iter()
+            .find(|v| v.season == Some(season) && v.day_type == Some(day_type))
+        {
+            return Some(&v.entries);
+        }
+        // 2. Season only (any day)
+        if let Some(v) = self
+            .variants
+            .iter()
+            .find(|v| v.season == Some(season) && v.day_type.is_none())
+        {
+            return Some(&v.entries);
+        }
+        // 3. Day type only (any season)
+        if let Some(v) = self
+            .variants
+            .iter()
+            .find(|v| v.season.is_none() && v.day_type == Some(day_type))
+        {
+            return Some(&v.entries);
+        }
+        // 4. Default (both None)
+        if let Some(v) = self
+            .variants
+            .iter()
+            .find(|v| v.season.is_none() && v.day_type.is_none())
+        {
+            return Some(&v.entries);
+        }
+        None
+    }
+
+    /// Returns the schedule entry active at the given hour for the given context.
+    pub fn entry_at(&self, hour: u8, season: Season, day_type: DayType) -> Option<&ScheduleEntry> {
+        let entries = self.resolve(season, day_type)?;
+        entries
+            .iter()
+            .find(|e| hour >= e.start_hour && hour <= e.end_hour)
+    }
+
+    /// Returns the desired location at the given hour for the given context.
+    pub fn location_at(&self, hour: u8, season: Season, day_type: DayType) -> Option<LocationId> {
+        self.entry_at(hour, season, day_type).map(|e| e.location)
     }
 }
 
@@ -494,18 +589,21 @@ mod tests {
                     end_hour: 11,
                     location: LocationId(2),
                     activity: "opening the pub".to_string(),
+                    cuaird: false,
                 },
                 ScheduleEntry {
                     start_hour: 12,
                     end_hour: 22,
                     location: LocationId(2),
                     activity: "tending bar".to_string(),
+                    cuaird: false,
                 },
                 ScheduleEntry {
                     start_hour: 23,
                     end_hour: 5,
                     location: LocationId(1),
                     activity: "sleeping".to_string(),
+                    cuaird: false,
                 },
             ],
         };
@@ -529,6 +627,7 @@ mod tests {
                 end_hour: 17,
                 location: LocationId(3),
                 activity: "teaching".to_string(),
+                cuaird: false,
             }],
         };
 
@@ -716,5 +815,184 @@ mod tests {
         let a = Intelligence::new(1, 2, 3, 4, 5, 1);
         let b = a; // Copy
         assert_eq!(a, b);
+    }
+
+    // --- SeasonalSchedule tests ---
+
+    fn make_entry(start: u8, end: u8, loc: u32, activity: &str) -> ScheduleEntry {
+        ScheduleEntry {
+            start_hour: start,
+            end_hour: end,
+            location: LocationId(loc),
+            activity: activity.to_string(),
+            cuaird: false,
+        }
+    }
+
+    fn make_variant(
+        season: Option<Season>,
+        day_type: Option<DayType>,
+        entries: Vec<ScheduleEntry>,
+    ) -> ScheduleVariant {
+        ScheduleVariant {
+            season,
+            day_type,
+            entries,
+        }
+    }
+
+    #[test]
+    fn test_seasonal_resolve_exact_match() {
+        let sched = SeasonalSchedule {
+            variants: vec![
+                make_variant(None, None, vec![make_entry(0, 23, 1, "default")]),
+                make_variant(
+                    Some(Season::Winter),
+                    Some(DayType::Sunday),
+                    vec![make_entry(0, 23, 3, "winter sunday mass")],
+                ),
+            ],
+        };
+        let entries = sched.resolve(Season::Winter, DayType::Sunday).unwrap();
+        assert_eq!(entries[0].activity, "winter sunday mass");
+    }
+
+    #[test]
+    fn test_seasonal_resolve_season_only_fallback() {
+        let sched = SeasonalSchedule {
+            variants: vec![
+                make_variant(None, None, vec![make_entry(0, 23, 1, "default")]),
+                make_variant(
+                    Some(Season::Winter),
+                    None,
+                    vec![make_entry(0, 23, 2, "winter routine")],
+                ),
+            ],
+        };
+        // Winter weekday should match season-only variant
+        let entries = sched.resolve(Season::Winter, DayType::Weekday).unwrap();
+        assert_eq!(entries[0].activity, "winter routine");
+    }
+
+    #[test]
+    fn test_seasonal_resolve_day_only_fallback() {
+        let sched = SeasonalSchedule {
+            variants: vec![
+                make_variant(None, None, vec![make_entry(0, 23, 1, "default")]),
+                make_variant(
+                    None,
+                    Some(DayType::Sunday),
+                    vec![make_entry(0, 23, 3, "sunday routine")],
+                ),
+            ],
+        };
+        // Summer sunday should match day-only variant
+        let entries = sched.resolve(Season::Summer, DayType::Sunday).unwrap();
+        assert_eq!(entries[0].activity, "sunday routine");
+    }
+
+    #[test]
+    fn test_seasonal_resolve_default_fallback() {
+        let sched = SeasonalSchedule {
+            variants: vec![make_variant(
+                None,
+                None,
+                vec![make_entry(0, 23, 1, "default")],
+            )],
+        };
+        // Any combination should match the default
+        let entries = sched.resolve(Season::Autumn, DayType::MarketDay).unwrap();
+        assert_eq!(entries[0].activity, "default");
+    }
+
+    #[test]
+    fn test_seasonal_resolve_priority_order() {
+        // Exact match should win over season-only, day-only, and default
+        let sched = SeasonalSchedule {
+            variants: vec![
+                make_variant(None, None, vec![make_entry(0, 23, 1, "default")]),
+                make_variant(
+                    Some(Season::Summer),
+                    None,
+                    vec![make_entry(0, 23, 2, "summer")],
+                ),
+                make_variant(
+                    None,
+                    Some(DayType::Sunday),
+                    vec![make_entry(0, 23, 3, "sunday")],
+                ),
+                make_variant(
+                    Some(Season::Summer),
+                    Some(DayType::Sunday),
+                    vec![make_entry(0, 23, 4, "summer sunday")],
+                ),
+            ],
+        };
+        let entries = sched.resolve(Season::Summer, DayType::Sunday).unwrap();
+        assert_eq!(entries[0].activity, "summer sunday");
+        assert_eq!(entries[0].location, LocationId(4));
+    }
+
+    #[test]
+    fn test_seasonal_resolve_none_when_empty() {
+        let sched = SeasonalSchedule {
+            variants: Vec::new(),
+        };
+        assert!(sched.resolve(Season::Spring, DayType::Weekday).is_none());
+    }
+
+    #[test]
+    fn test_seasonal_location_at() {
+        let sched = SeasonalSchedule {
+            variants: vec![
+                make_variant(
+                    None,
+                    None,
+                    vec![
+                        make_entry(0, 7, 10, "sleeping"),
+                        make_entry(8, 17, 9, "working"),
+                        make_entry(18, 23, 10, "evening"),
+                    ],
+                ),
+                make_variant(
+                    None,
+                    Some(DayType::Sunday),
+                    vec![
+                        make_entry(0, 7, 10, "sleeping"),
+                        make_entry(8, 10, 3, "mass"),
+                        make_entry(11, 23, 2, "pub"),
+                    ],
+                ),
+            ],
+        };
+        // Weekday at 10am -> working at location 9
+        assert_eq!(
+            sched.location_at(10, Season::Spring, DayType::Weekday),
+            Some(LocationId(9))
+        );
+        // Sunday at 10am -> mass at location 3
+        assert_eq!(
+            sched.location_at(10, Season::Spring, DayType::Sunday),
+            Some(LocationId(3))
+        );
+        // Sunday at 20pm -> pub at location 2
+        assert_eq!(
+            sched.location_at(20, Season::Spring, DayType::Sunday),
+            Some(LocationId(2))
+        );
+    }
+
+    #[test]
+    fn test_seasonal_entry_at_returns_cuaird() {
+        let mut entry = make_entry(19, 21, 2, "cuaird visiting");
+        entry.cuaird = true;
+        let sched = SeasonalSchedule {
+            variants: vec![make_variant(None, None, vec![entry])],
+        };
+        let resolved = sched
+            .entry_at(20, Season::Summer, DayType::Weekday)
+            .unwrap();
+        assert!(resolved.cuaird);
+        assert_eq!(resolved.activity, "cuaird visiting");
     }
 }

--- a/crates/parish-core/src/persistence/snapshot.rs
+++ b/crates/parish-core/src/persistence/snapshot.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::npc::gossip::GossipNetwork;
 use crate::npc::memory::{LongTermMemory, ShortTermMemory};
-use crate::npc::types::{DailySchedule, Intelligence, NpcState, Relationship};
+use crate::npc::types::{Intelligence, NpcState, Relationship, SeasonalSchedule};
 use crate::npc::{Npc, NpcId};
 use crate::world::LocationId;
 
@@ -60,8 +60,8 @@ pub struct NpcSnapshot {
     pub home: Option<LocationId>,
     /// Workplace location.
     pub workplace: Option<LocationId>,
-    /// Daily schedule.
-    pub schedule: Option<DailySchedule>,
+    /// Season-aware schedule.
+    pub schedule: Option<SeasonalSchedule>,
     /// Relationships to other NPCs.
     pub relationships: HashMap<NpcId, Relationship>,
     /// Short-term memory ring buffer.

--- a/crates/parish-core/src/world/time.rs
+++ b/crates/parish-core/src/world/time.rs
@@ -8,6 +8,7 @@
 //! loaded from a mod's [`FestivalDef`](crate::game_mod::FestivalDef) data.
 
 use chrono::{DateTime, Datelike, Duration, NaiveDate, Timelike, Utc};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::time::Instant;
 
@@ -49,7 +50,8 @@ impl fmt::Display for TimeOfDay {
 }
 
 /// Represents the four seasons of the year.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Season {
     /// March–May
     Spring,
@@ -86,6 +88,42 @@ impl fmt::Display for Season {
             Season::Summer => write!(f, "Summer"),
             Season::Autumn => write!(f, "Autumn"),
             Season::Winter => write!(f, "Winter"),
+        }
+    }
+}
+
+/// The type of day, affecting NPC schedules.
+///
+/// In 1820s rural Ireland, Sunday (Mass day) and market day (Saturday)
+/// had distinctly different rhythms from ordinary weekdays.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DayType {
+    /// Monday through Friday — ordinary working days.
+    Weekday,
+    /// Sunday — Mass, socializing, no field work.
+    Sunday,
+    /// Saturday — market day in the nearest town.
+    MarketDay,
+}
+
+impl DayType {
+    /// Determines the day type from a calendar date.
+    pub fn from_date(date: NaiveDate) -> Self {
+        match date.weekday() {
+            chrono::Weekday::Sun => DayType::Sunday,
+            chrono::Weekday::Sat => DayType::MarketDay,
+            _ => DayType::Weekday,
+        }
+    }
+}
+
+impl fmt::Display for DayType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DayType::Weekday => write!(f, "Weekday"),
+            DayType::Sunday => write!(f, "Sunday"),
+            DayType::MarketDay => write!(f, "Market Day"),
         }
     }
 }
@@ -285,6 +323,11 @@ impl GameClock {
     /// Returns the current season.
     pub fn season(&self) -> Season {
         Season::from_date(self.now().date_naive())
+    }
+
+    /// Returns the current day type (weekday, Sunday, or market day).
+    pub fn day_type(&self) -> DayType {
+        DayType::from_date(self.now().date_naive())
     }
 
     /// Checks if today is a festival day using the hardcoded [`Festival`] enum.

--- a/data/npcs.json
+++ b/data/npcs.json
@@ -7,21 +7,174 @@
             "age": 58,
             "occupation": "Publican",
             "personality": "A gruff but warm-hearted publican who has run Darcy's Pub for thirty years. Known for his dry wit, encyclopedic knowledge of local history, and tendency to offer unsolicited advice. He speaks with a thick Roscommon accent and peppers his speech with Irish phrases. Fiercely protective of his daughter Niamh, though he struggles to understand her restlessness.",
-            "intelligence": {"verbal": 3, "analytical": 3, "emotional": 4, "practical": 4, "wisdom": 5, "creative": 4},
+            "intelligence": {
+                "verbal": 3,
+                "analytical": 3,
+                "emotional": 4,
+                "practical": 4,
+                "wisdom": 5,
+                "creative": 4
+            },
             "home": 2,
             "workplace": 2,
             "mood": "content",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 6, "location": 2, "activity": "sleeping in the rooms above the pub"},
-                {"start_hour": 7, "end_hour": 8, "location": 1, "activity": "taking a morning walk at the crossroads"},
-                {"start_hour": 9, "end_hour": 22, "location": 2, "activity": "tending bar at the pub"},
-                {"start_hour": 23, "end_hour": 23, "location": 2, "activity": "closing up the pub"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 2,
+                            "activity": "sleeping in the rooms above the pub"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 1,
+                            "activity": "taking the morning air at the crossroads, greeting early risers"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 11,
+                            "location": 2,
+                            "activity": "opening up, sweeping the floor, rolling barrels up from the cellar"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 13,
+                            "location": 2,
+                            "activity": "serving the midday trade — farmers in from the fields for a quick pint"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 17,
+                            "location": 2,
+                            "activity": "minding the bar, quiet afternoon trade"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 22,
+                            "location": 2,
+                            "activity": "the busy evening — pouring pints, settling arguments, holding court"
+                        },
+                        {
+                            "start_hour": 23,
+                            "end_hour": 23,
+                            "location": 2,
+                            "activity": "closing up, banking the fire, locking the door"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 2,
+                            "activity": "sleeping above the pub, the fire banked low"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 8,
+                            "location": 2,
+                            "activity": "stirring the fire, a slow breakfast of stirabout and buttermilk"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 11,
+                            "location": 2,
+                            "activity": "opening up — little trade before noon in winter"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 16,
+                            "location": 2,
+                            "activity": "tending bar, the dark afternoons bring folk in early from the cold"
+                        },
+                        {
+                            "start_hour": 17,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "the evening rush — a full house by the fire, stories and song"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 2,
+                            "activity": "closing up early, the winter night pressing in"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 2,
+                            "activity": "sleeping late on the Lord's day"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "attending Mass at St. Brigid's"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 11,
+                            "location": 1,
+                            "activity": "lingering at the crossroads after Mass, catching up on the week's news"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 13,
+                            "location": 2,
+                            "activity": "the after-Mass crowd — the busiest dinner trade of the week"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 17,
+                            "location": 2,
+                            "activity": "a quieter Sunday afternoon, folk visiting family"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "Sunday evening session — music, singing, the week's stories retold"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 2,
+                            "activity": "closing up for the night"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 8, "kind": "Family", "strength": 0.9},
-                {"target_id": 5, "kind": "Friend", "strength": 0.7},
-                {"target_id": 4, "kind": "Professional", "strength": 0.5},
-                {"target_id": 7, "kind": "Friend", "strength": 0.4}
+                {
+                    "target_id": 8,
+                    "kind": "Family",
+                    "strength": 0.9
+                },
+                {
+                    "target_id": 5,
+                    "kind": "Friend",
+                    "strength": 0.7
+                },
+                {
+                    "target_id": 4,
+                    "kind": "Professional",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 7,
+                    "kind": "Friend",
+                    "strength": 0.4
+                }
             ],
             "knowledge": [
                 "Knows every family in the parish and their histories going back three generations.",
@@ -37,23 +190,259 @@
             "age": 45,
             "occupation": "Farmer",
             "personality": "A practical, no-nonsense farmer who runs Murphy's Farm with quiet efficiency after her husband's passing three years ago. Respected for her hard work and fair dealing. She has little patience for gossip or idle talk, but shows unexpected tenderness with children and animals. Speaks plainly and directly.",
-            "intelligence": {"verbal": 2, "analytical": 3, "emotional": 3, "practical": 5, "wisdom": 4, "creative": 2},
+            "intelligence": {
+                "verbal": 2,
+                "analytical": 3,
+                "emotional": 3,
+                "practical": 5,
+                "wisdom": 4,
+                "creative": 2
+            },
             "home": 9,
             "workplace": 9,
             "mood": "determined",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 4, "location": 9, "activity": "sleeping at the farmhouse"},
-                {"start_hour": 5, "end_hour": 11, "location": 9, "activity": "working the farm — feeding livestock and tending fields"},
-                {"start_hour": 12, "end_hour": 13, "location": 13, "activity": "buying supplies at Connolly's Shop"},
-                {"start_hour": 14, "end_hour": 18, "location": 9, "activity": "afternoon farm work"},
-                {"start_hour": 19, "end_hour": 20, "location": 2, "activity": "having a quiet drink at Darcy's Pub"},
-                {"start_hour": 21, "end_hour": 23, "location": 9, "activity": "evening chores and rest"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 4,
+                            "location": 9,
+                            "activity": "sleeping at the farmhouse"
+                        },
+                        {
+                            "start_hour": 5,
+                            "end_hour": 5,
+                            "location": 9,
+                            "activity": "rising at dawn — milking the cow, feeding the pigs and chickens"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 6,
+                            "location": 9,
+                            "activity": "breakfast of stirabout and buttermilk, fetching water from the well"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 11,
+                            "location": 9,
+                            "activity": "working the fields — planting, weeding, tending the potato ridges"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 12,
+                            "location": 9,
+                            "activity": "dinner — boiled potatoes and buttermilk at the farmhouse"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 15,
+                            "location": 12,
+                            "activity": "cutting turf on the bog, stacking it to dry in the summer sun"
+                        },
+                        {
+                            "start_hour": 16,
+                            "end_hour": 18,
+                            "location": 9,
+                            "activity": "evening farm work — bringing in the cattle, mending fences"
+                        },
+                        {
+                            "start_hour": 19,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "a quiet drink at Darcy's Pub after a long day",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 9,
+                            "activity": "evening chores, churning butter, then to bed"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 9,
+                            "activity": "sleeping at the farmhouse, huddled under blankets against the cold"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 7,
+                            "location": 9,
+                            "activity": "rising in the dark — milking, feeding livestock, tending the fire"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 8,
+                            "location": 9,
+                            "activity": "breakfast of stirabout by the fire"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 12,
+                            "location": 9,
+                            "activity": "indoor work — spinning wool, mending clothes, repairing tools"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 15,
+                            "location": 9,
+                            "activity": "what outdoor work the short day allows — mucking out, hauling turf"
+                        },
+                        {
+                            "start_hour": 16,
+                            "end_hour": 17,
+                            "location": 9,
+                            "activity": "bringing the animals in, securing the farmyard before dark"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 19,
+                            "location": 9,
+                            "activity": "supper of potatoes and milk by the fire"
+                        },
+                        {
+                            "start_hour": 20,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "visiting neighbours or a drink at the pub",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 9,
+                            "activity": "banking the fire and retiring for the night"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 9,
+                            "activity": "sleeping at the farmhouse"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 7,
+                            "location": 9,
+                            "activity": "rising — feeding livestock even on Sunday, they do not rest"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "walking to Mass at St. Brigid's Church"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "socialising at the crossroads after Mass, catching up on parish news"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 9,
+                            "activity": "Sunday dinner — the best meal of the week, perhaps a bit of salt fish"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 10,
+                            "activity": "visiting the O'Briens, as neighbours do on a Sunday"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "Sunday evening at Darcy's Pub"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 9,
+                            "activity": "home for the night, preparing for the week ahead"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "market_day",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 9,
+                            "activity": "sleeping at the farmhouse"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 9,
+                            "activity": "morning chores, preparing butter and eggs for market"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 11,
+                            "location": 13,
+                            "activity": "at Connolly's Shop, selling butter and eggs, buying supplies"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 12,
+                            "location": 15,
+                            "activity": "dinner in Kilteevan Village on market day"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 17,
+                            "location": 9,
+                            "activity": "afternoon farm work"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "a drink at the pub after market day"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 9,
+                            "activity": "home for the evening"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 5, "kind": "Neighbor", "strength": 0.6},
-                {"target_id": 4, "kind": "Professional", "strength": 0.4},
-                {"target_id": 6, "kind": "Friend", "strength": 0.5},
-                {"target_id": 3, "kind": "Professional", "strength": 0.3}
+                {
+                    "target_id": 5,
+                    "kind": "Neighbor",
+                    "strength": 0.6
+                },
+                {
+                    "target_id": 4,
+                    "kind": "Professional",
+                    "strength": 0.4
+                },
+                {
+                    "target_id": 6,
+                    "kind": "Friend",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 3,
+                    "kind": "Professional",
+                    "strength": 0.3
+                }
             ],
             "knowledge": [
                 "Knows the land better than anyone — which fields drain well, which are prone to blight.",
@@ -69,25 +458,204 @@
             "age": 62,
             "occupation": "Parish Priest",
             "personality": "A kind, thoughtful priest who has served the parish for twenty-five years. Educated at Maynooth, he walks the line between Church doctrine and the practical realities of his flock's lives. Known for his gentle sermons, his fondness for poetry, and his habit of quoting scripture in both Irish and Latin. He turns a diplomatic blind eye to hedge-school teaching and old customs.",
-            "intelligence": {"verbal": 5, "analytical": 4, "emotional": 4, "practical": 3, "wisdom": 5, "creative": 3},
+            "intelligence": {
+                "verbal": 5,
+                "analytical": 4,
+                "emotional": 4,
+                "practical": 3,
+                "wisdom": 5,
+                "creative": 3
+            },
             "home": 3,
             "workplace": 3,
             "mood": "contemplative",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 5, "location": 3, "activity": "sleeping in the parish house beside the church"},
-                {"start_hour": 6, "end_hour": 7, "location": 3, "activity": "saying morning Mass"},
-                {"start_hour": 8, "end_hour": 10, "location": 15, "activity": "visiting parishioners in Kilteevan Village"},
-                {"start_hour": 11, "end_hour": 13, "location": 3, "activity": "reading and parish correspondence"},
-                {"start_hour": 14, "end_hour": 16, "location": 1, "activity": "walking the parish roads, checking on the elderly"},
-                {"start_hour": 17, "end_hour": 18, "location": 3, "activity": "evening prayers"},
-                {"start_hour": 19, "end_hour": 21, "location": 2, "activity": "a quiet evening at Darcy's Pub"},
-                {"start_hour": 22, "end_hour": 23, "location": 3, "activity": "reading by candlelight"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 4,
+                            "location": 3,
+                            "activity": "sleeping in the parish house beside the church"
+                        },
+                        {
+                            "start_hour": 5,
+                            "end_hour": 6,
+                            "location": 3,
+                            "activity": "rising early, morning prayers and breviary"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 8,
+                            "location": 3,
+                            "activity": "saying morning Mass for the few who attend on weekdays"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 11,
+                            "location": 15,
+                            "activity": "visiting parishioners in Kilteevan Village — the sick, the elderly, the troubled"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 13,
+                            "location": 3,
+                            "activity": "dinner at the parish house, reading correspondence from the diocese"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 16,
+                            "location": 1,
+                            "activity": "walking the parish roads in the long summer light, checking on outlying families"
+                        },
+                        {
+                            "start_hour": 17,
+                            "end_hour": 18,
+                            "location": 3,
+                            "activity": "evening prayers and parish accounts"
+                        },
+                        {
+                            "start_hour": 19,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "a quiet evening at Darcy's Pub — pastoral duty, he would say"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 3,
+                            "activity": "reading by candlelight — poetry, theology, letters from Maynooth"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 3,
+                            "activity": "sleeping in the parish house"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 3,
+                            "activity": "morning prayers by candlelight, the church cold as a tomb"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 9,
+                            "location": 3,
+                            "activity": "saying morning Mass"
+                        },
+                        {
+                            "start_hour": 10,
+                            "end_hour": 12,
+                            "location": 3,
+                            "activity": "reading, writing letters, parish correspondence by the fire"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 15,
+                            "activity": "visiting the sick in Kilteevan — shorter rounds in winter"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 3,
+                            "activity": "afternoon prayers, preparing Sunday's sermon"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "an evening at Darcy's Pub, warming himself by the fire"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 3,
+                            "activity": "reading and prayer before bed"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 3,
+                            "activity": "sleeping in the parish house"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 3,
+                            "activity": "preparing for the Sunday Mass — vestments, sermon notes, the altar"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "celebrating Sunday Mass — the whole parish gathered together"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "at the crossroads after Mass, speaking with parishioners, settling small disputes"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 3,
+                            "activity": "Sunday dinner at the parish house"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 11,
+                            "activity": "a contemplative walk to the fairy fort — he prays there, though he would not call it that"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "Sunday evening at the pub, the most social night of the week"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 3,
+                            "activity": "evening prayers and early to bed"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 1, "kind": "Friend", "strength": 0.6},
-                {"target_id": 6, "kind": "Professional", "strength": 0.5},
-                {"target_id": 7, "kind": "Friend", "strength": 0.3},
-                {"target_id": 2, "kind": "Professional", "strength": 0.4}
+                {
+                    "target_id": 1,
+                    "kind": "Friend",
+                    "strength": 0.6
+                },
+                {
+                    "target_id": 6,
+                    "kind": "Professional",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 7,
+                    "kind": "Friend",
+                    "strength": 0.3
+                },
+                {
+                    "target_id": 2,
+                    "kind": "Professional",
+                    "strength": 0.4
+                }
             ],
             "knowledge": [
                 "Receives letters from other parishes about the political situation in Dublin.",
@@ -103,23 +671,239 @@
             "age": 38,
             "occupation": "Shopkeeper",
             "personality": "An ambitious and sharp-minded shopkeeper who runs Connolly's Shop with her mother. She dreams of expanding the business and establishing a proper trading post. Roisin has a talent for negotiation, a keen eye for opportunity, and a warm smile that masks a calculating mind. She collects news and gossip as currency.",
-            "intelligence": {"verbal": 4, "analytical": 5, "emotional": 3, "practical": 4, "wisdom": 3, "creative": 4},
+            "intelligence": {
+                "verbal": 4,
+                "analytical": 5,
+                "emotional": 3,
+                "practical": 4,
+                "wisdom": 3,
+                "creative": 4
+            },
             "home": 13,
             "workplace": 13,
             "mood": "alert",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 6, "location": 13, "activity": "sleeping above the shop"},
-                {"start_hour": 7, "end_hour": 8, "location": 13, "activity": "opening up and arranging stock"},
-                {"start_hour": 9, "end_hour": 17, "location": 13, "activity": "minding the shop"},
-                {"start_hour": 18, "end_hour": 19, "location": 1, "activity": "taking the evening air at the crossroads"},
-                {"start_hour": 20, "end_hour": 21, "location": 2, "activity": "socialising at Darcy's Pub"},
-                {"start_hour": 22, "end_hour": 23, "location": 13, "activity": "doing the accounts"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 13,
+                            "activity": "sleeping above the shop"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 13,
+                            "activity": "opening up, arranging stock, sweeping the doorstep"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 12,
+                            "location": 13,
+                            "activity": "minding the shop — summer brings more trade, tinkers and travellers"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 13,
+                            "location": 13,
+                            "activity": "a quick dinner of potatoes behind the counter"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 17,
+                            "location": 13,
+                            "activity": "afternoon trade, weighing flour, measuring cloth, tallying debts"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 19,
+                            "location": 1,
+                            "activity": "taking the evening air at the crossroads, collecting the day's news"
+                        },
+                        {
+                            "start_hour": 20,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "socialising at Darcy's Pub"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 13,
+                            "activity": "doing the accounts by candlelight"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 13,
+                            "activity": "sleeping above the shop"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 8,
+                            "location": 13,
+                            "activity": "opening up, lighting the lamp — dark mornings"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 12,
+                            "location": 13,
+                            "activity": "minding the shop — slower trade in winter, but folk need candles and meal"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 16,
+                            "location": 13,
+                            "activity": "afternoon in the shop, mending stock, writing orders for the Athlone merchants"
+                        },
+                        {
+                            "start_hour": 17,
+                            "end_hour": 18,
+                            "location": 13,
+                            "activity": "closing up early in the winter dark"
+                        },
+                        {
+                            "start_hour": 19,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "an evening at Darcy's Pub by the fire"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 13,
+                            "activity": "accounts and correspondence, then to bed"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 13,
+                            "activity": "sleeping late — the shop is closed on the Lord's day"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "attending Mass at St. Brigid's — wearing her best shawl"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "the crossroads after Mass — prime territory for news and negotiation"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 13,
+                            "activity": "Sunday dinner with her mother above the shop"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 15,
+                            "activity": "visiting in Kilteevan Village, trading gossip and favours"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "Sunday evening at the pub — the social highlight of the week"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 13,
+                            "activity": "home to bed"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "market_day",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 13,
+                            "activity": "sleeping above the shop"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 6,
+                            "location": 13,
+                            "activity": "up early, preparing the shop for the busiest day of the week"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 12,
+                            "location": 13,
+                            "activity": "market day trade — farmers selling butter and eggs, buying supplies"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 13,
+                            "location": 13,
+                            "activity": "a quick dinner between customers"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 17,
+                            "location": 13,
+                            "activity": "afternoon market trade, settling accounts, extending credit"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 19,
+                            "location": 1,
+                            "activity": "at the crossroads, winding down from market day"
+                        },
+                        {
+                            "start_hour": 20,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "a well-earned drink at the pub"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 13,
+                            "activity": "counting the day's takings"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 1, "kind": "Professional", "strength": 0.5},
-                {"target_id": 2, "kind": "Professional", "strength": 0.4},
-                {"target_id": 8, "kind": "Friend", "strength": 0.6},
-                {"target_id": 6, "kind": "Neighbor", "strength": 0.3}
+                {
+                    "target_id": 1,
+                    "kind": "Professional",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 2,
+                    "kind": "Professional",
+                    "strength": 0.4
+                },
+                {
+                    "target_id": 8,
+                    "kind": "Friend",
+                    "strength": 0.6
+                },
+                {
+                    "target_id": 6,
+                    "kind": "Neighbor",
+                    "strength": 0.3
+                }
             ],
             "knowledge": [
                 "Keeps track of every debt owed in the parish — knows who can pay and who cannot.",
@@ -135,24 +919,188 @@
             "age": 70,
             "occupation": "Retired Farmer",
             "personality": "A legendary storyteller and the oldest man in the parish. Tommy has farmed O'Brien's land his whole life, now largely leaving the work to his sons. He holds the oral history of the parish in his memory — every ghost story, fairy tale, and family scandal. His mind is sharp even as his body slows. He speaks in long, winding stories that always have a point, eventually.",
-            "intelligence": {"verbal": 5, "analytical": 2, "emotional": 3, "practical": 3, "wisdom": 5, "creative": 5},
+            "intelligence": {
+                "verbal": 5,
+                "analytical": 2,
+                "emotional": 3,
+                "practical": 3,
+                "wisdom": 5,
+                "creative": 5
+            },
             "home": 10,
             "workplace": null,
             "mood": "reflective",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 6, "location": 10, "activity": "sleeping at the farmhouse"},
-                {"start_hour": 7, "end_hour": 9, "location": 10, "activity": "a slow breakfast and morning pipe"},
-                {"start_hour": 10, "end_hour": 12, "location": 1, "activity": "sitting at the crossroads watching the world go by"},
-                {"start_hour": 13, "end_hour": 14, "location": 2, "activity": "a midday pint and conversation at the pub"},
-                {"start_hour": 15, "end_hour": 17, "location": 11, "activity": "walking to the fairy fort, as he has done since boyhood"},
-                {"start_hour": 18, "end_hour": 20, "location": 2, "activity": "evening storytelling at Darcy's Pub"},
-                {"start_hour": 21, "end_hour": 23, "location": 10, "activity": "settling in for the night"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 10,
+                            "activity": "sleeping at the farmhouse"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 8,
+                            "location": 10,
+                            "activity": "a slow breakfast and morning pipe on the half-door"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 11,
+                            "location": 1,
+                            "activity": "sitting at the crossroads watching the world go by, greeting passers-by"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 13,
+                            "location": 2,
+                            "activity": "a midday pint and conversation at the pub"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 16,
+                            "location": 11,
+                            "activity": "walking to the fairy fort, as he has done since boyhood"
+                        },
+                        {
+                            "start_hour": 17,
+                            "end_hour": 18,
+                            "location": 7,
+                            "activity": "sitting by Lough Ree, watching the light on the water"
+                        },
+                        {
+                            "start_hour": 19,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "evening storytelling at Darcy's Pub — the seanchai holds court",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 10,
+                            "activity": "settling in for the night at the farmhouse"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 10,
+                            "activity": "sleeping at the farmhouse, old bones aching in the cold"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 9,
+                            "location": 10,
+                            "activity": "a slow breakfast by the fire, pipe and tea"
+                        },
+                        {
+                            "start_hour": 10,
+                            "end_hour": 12,
+                            "location": 2,
+                            "activity": "to the pub for warmth and company — too cold for the crossroads"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 10,
+                            "activity": "home for dinner, a rest by the fire"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 10,
+                            "activity": "dozing by the fire, whittling, telling stories to the grandchildren"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "the evening cuaird — storytelling by firelight at the pub",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 10,
+                            "activity": "home early, the winter dark presses close"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 10,
+                            "activity": "sleeping at the farmhouse"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "attending Mass — he sits in the same spot he has sat for sixty years"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "holding court at the crossroads after Mass, everyone stops to hear Tommy"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 2,
+                            "activity": "Sunday dinner pint at the pub"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 11,
+                            "activity": "his Sunday walk to the fairy fort — a lifelong ritual"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "Sunday evening session at the pub — the best stories of the week"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 10,
+                            "activity": "home for the night"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 1, "kind": "Friend", "strength": 0.7},
-                {"target_id": 2, "kind": "Neighbor", "strength": 0.6},
-                {"target_id": 7, "kind": "Friend", "strength": 0.5},
-                {"target_id": 3, "kind": "Friend", "strength": 0.4}
+                {
+                    "target_id": 1,
+                    "kind": "Friend",
+                    "strength": 0.7
+                },
+                {
+                    "target_id": 2,
+                    "kind": "Neighbor",
+                    "strength": 0.6
+                },
+                {
+                    "target_id": 7,
+                    "kind": "Friend",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 3,
+                    "kind": "Friend",
+                    "strength": 0.4
+                }
             ],
             "knowledge": [
                 "Knows every fairy story and ghost tale in the parish — where the banshee was last heard, where the pooka runs.",
@@ -168,24 +1116,188 @@
             "age": 29,
             "occupation": "Hedge School Teacher",
             "personality": "An idealistic young teacher who runs the hedge school with fierce dedication. Educated by her father (a schoolmaster before her), she teaches reading, writing, arithmetic, and Irish to the children of the parish — all technically illegal under the Penal Laws. She is passionate about preserving Irish language and culture, brave to the point of recklessness, and carries a quiet anger about the injustices she sees.",
-            "intelligence": {"verbal": 5, "analytical": 4, "emotional": 4, "practical": 2, "wisdom": 3, "creative": 4},
+            "intelligence": {
+                "verbal": 5,
+                "analytical": 4,
+                "emotional": 4,
+                "practical": 2,
+                "wisdom": 3,
+                "creative": 4
+            },
             "home": 15,
             "workplace": 6,
             "mood": "passionate",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 5, "location": 15, "activity": "sleeping at her lodgings in Kilteevan"},
-                {"start_hour": 6, "end_hour": 7, "location": 15, "activity": "preparing lessons"},
-                {"start_hour": 8, "end_hour": 14, "location": 6, "activity": "teaching at the hedge school"},
-                {"start_hour": 15, "end_hour": 16, "location": 7, "activity": "walking by Lough Ree to clear her head"},
-                {"start_hour": 17, "end_hour": 18, "location": 15, "activity": "marking work and preparing for tomorrow"},
-                {"start_hour": 19, "end_hour": 20, "location": 2, "activity": "an evening at Darcy's Pub"},
-                {"start_hour": 21, "end_hour": 23, "location": 15, "activity": "reading by the fire"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 15,
+                            "activity": "sleeping at her lodgings in Kilteevan"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 15,
+                            "activity": "preparing lessons by the morning light, copying texts"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 13,
+                            "location": 6,
+                            "activity": "teaching at the hedge school — the long summer days allow more lessons"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 14,
+                            "location": 6,
+                            "activity": "dinner with the children before they scatter home"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 16,
+                            "location": 7,
+                            "activity": "walking by Lough Ree to clear her head and compose her thoughts"
+                        },
+                        {
+                            "start_hour": 17,
+                            "end_hour": 18,
+                            "location": 15,
+                            "activity": "marking work and preparing for tomorrow"
+                        },
+                        {
+                            "start_hour": 19,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "an evening at Darcy's Pub, debating with anyone who will listen",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 15,
+                            "activity": "reading by the fire — poetry, pamphlets, whatever she can find"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 15,
+                            "activity": "sleeping at her lodgings in Kilteevan"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 8,
+                            "location": 15,
+                            "activity": "preparing lessons by rushlight, the mornings dark and bitter"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 13,
+                            "location": 6,
+                            "activity": "teaching at the hedge school — shorter hours in winter, the children shivering"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 15,
+                            "location": 15,
+                            "activity": "home for dinner and marking work"
+                        },
+                        {
+                            "start_hour": 16,
+                            "end_hour": 18,
+                            "location": 15,
+                            "activity": "reading and writing by the fire, too dark for walking"
+                        },
+                        {
+                            "start_hour": 19,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "the evening cuaird — visiting or the pub",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 15,
+                            "activity": "reading late into the night, her one indulgence"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 15,
+                            "activity": "sleeping late — no school on the Lord's day"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "attending Mass at St. Brigid's Church"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "at the crossroads after Mass, speaking with parents about their children"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 15,
+                            "activity": "Sunday dinner at her lodgings"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 7,
+                            "activity": "a long Sunday walk by Lough Ree, composing poetry in Irish"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "Sunday evening at the pub — music and conversation"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 15,
+                            "activity": "home to bed, the week ahead in her mind"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 8, "kind": "Friend", "strength": 0.7},
-                {"target_id": 3, "kind": "Professional", "strength": 0.5},
-                {"target_id": 2, "kind": "Friend", "strength": 0.5},
-                {"target_id": 4, "kind": "Neighbor", "strength": 0.3}
+                {
+                    "target_id": 8,
+                    "kind": "Friend",
+                    "strength": 0.7
+                },
+                {
+                    "target_id": 3,
+                    "kind": "Professional",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 2,
+                    "kind": "Friend",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 4,
+                    "kind": "Neighbor",
+                    "strength": 0.3
+                }
             ],
             "knowledge": [
                 "Knows the hedge school could be shut down at any time by the authorities.",
@@ -201,24 +1313,187 @@
             "age": 65,
             "occupation": "Retired Constable",
             "personality": "A retired constable who served in the local barracks for thirty years. Mick walks a careful line — he was a Catholic man enforcing Protestant law, and not everyone has forgiven him for it. He is deeply observant, notices everything, and keeps his own counsel. Despite his past role, he is fundamentally decent and now spends his days watching, walking, and occasionally offering cryptic warnings to those he trusts.",
-            "intelligence": {"verbal": 2, "analytical": 4, "emotional": 2, "practical": 4, "wisdom": 4, "creative": 2},
+            "intelligence": {
+                "verbal": 2,
+                "analytical": 4,
+                "emotional": 2,
+                "practical": 4,
+                "wisdom": 4,
+                "creative": 2
+            },
             "home": 15,
             "workplace": null,
             "mood": "watchful",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 6, "location": 15, "activity": "sleeping at his cottage in Kilteevan"},
-                {"start_hour": 7, "end_hour": 9, "location": 15, "activity": "morning routine and breakfast"},
-                {"start_hour": 10, "end_hour": 12, "location": 12, "activity": "walking the Bog Road, old patrol habit"},
-                {"start_hour": 13, "end_hour": 14, "location": 14, "activity": "sitting by the lime kiln, thinking"},
-                {"start_hour": 15, "end_hour": 17, "location": 1, "activity": "watching the crossroads from the wall"},
-                {"start_hour": 18, "end_hour": 20, "location": 2, "activity": "nursing a pint at Darcy's Pub"},
-                {"start_hour": 21, "end_hour": 23, "location": 15, "activity": "home for the evening"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 15,
+                            "activity": "sleeping at his cottage in Kilteevan"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 15,
+                            "activity": "morning routine — tea, pipe, watching the lane from his half-door"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 12,
+                            "activity": "walking the Bog Road — old patrol routes die hard"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 14,
+                            "activity": "sitting by the lime kiln, watching who comes and goes"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 15,
+                            "activity": "home for dinner"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 1,
+                            "activity": "watching the crossroads from the wall, the habit of a lifetime"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "nursing a pint at Darcy's Pub, listening more than talking"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 15,
+                            "activity": "home for the evening, a last pipe at the door in the long twilight"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 15,
+                            "activity": "sleeping at his cottage, the fire kept alive through the night"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 9,
+                            "location": 15,
+                            "activity": "morning routine — slow in winter, the cold in his joints"
+                        },
+                        {
+                            "start_hour": 10,
+                            "end_hour": 12,
+                            "location": 2,
+                            "activity": "to the pub for warmth — walks are shorter in the cold months"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 15,
+                            "activity": "home for dinner"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 1,
+                            "activity": "a short watch at the crossroads if the weather allows, otherwise the pub"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "the evening at the pub, listening to the talk",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 15,
+                            "activity": "home early, the dark pressing in"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 15,
+                            "activity": "sleeping at his cottage"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "attending Mass — he sits near the back, old habit"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "at the crossroads after Mass, observing the gathered parish"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 2,
+                            "activity": "Sunday dinner pint at the pub"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 12,
+                            "activity": "his Sunday walk along the Bog Road, thinking of old cases"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "Sunday evening at the pub"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 15,
+                            "activity": "home for the night"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 1, "kind": "Friend", "strength": 0.4},
-                {"target_id": 5, "kind": "Friend", "strength": 0.5},
-                {"target_id": 3, "kind": "Friend", "strength": 0.3},
-                {"target_id": 4, "kind": "Rival", "strength": -0.2}
+                {
+                    "target_id": 1,
+                    "kind": "Friend",
+                    "strength": 0.4
+                },
+                {
+                    "target_id": 5,
+                    "kind": "Friend",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 3,
+                    "kind": "Friend",
+                    "strength": 0.3
+                },
+                {
+                    "target_id": 4,
+                    "kind": "Rival",
+                    "strength": -0.2
+                }
             ],
             "knowledge": [
                 "Knows every smuggling route, poteen still, and hidden meeting place in the parish.",
@@ -234,24 +1509,186 @@
             "age": 22,
             "occupation": "Publican's Daughter",
             "personality": "Padraig's daughter, restless and bright, torn between duty to her father and a longing for the wider world. She helps at the pub but dreams of Dublin, or even America. She reads everything she can get her hands on, asks too many questions, and chafes at the limitations of parish life. Beneath her frustration is a deep love for the land and its people that she has not yet recognised in herself.",
-            "intelligence": {"verbal": 4, "analytical": 3, "emotional": 4, "practical": 2, "wisdom": 2, "creative": 5},
+            "intelligence": {
+                "verbal": 4,
+                "analytical": 3,
+                "emotional": 4,
+                "practical": 2,
+                "wisdom": 2,
+                "creative": 5
+            },
             "home": 2,
             "workplace": 2,
             "mood": "restless",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 6, "location": 2, "activity": "sleeping at the pub"},
-                {"start_hour": 7, "end_hour": 8, "location": 8, "activity": "walking by Hodson Bay, watching the boats"},
-                {"start_hour": 9, "end_hour": 12, "location": 2, "activity": "helping her father at the pub"},
-                {"start_hour": 13, "end_hour": 15, "location": 6, "activity": "visiting the hedge school to borrow books"},
-                {"start_hour": 16, "end_hour": 17, "location": 7, "activity": "reading by Lough Ree"},
-                {"start_hour": 18, "end_hour": 21, "location": 2, "activity": "serving at the pub in the evening"},
-                {"start_hour": 22, "end_hour": 23, "location": 2, "activity": "reading upstairs after closing"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 2,
+                            "activity": "sleeping at the pub"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 8,
+                            "activity": "walking by Hodson Bay in the early light, watching the boats on the Shannon"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 11,
+                            "location": 2,
+                            "activity": "helping her father open up — sweeping, stocking, the morning chores"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 12,
+                            "location": 2,
+                            "activity": "serving the midday trade"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 15,
+                            "location": 6,
+                            "activity": "visiting the hedge school to borrow books from Aoife"
+                        },
+                        {
+                            "start_hour": 16,
+                            "end_hour": 17,
+                            "location": 7,
+                            "activity": "reading by Lough Ree, the one place she feels free"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 22,
+                            "location": 2,
+                            "activity": "serving at the pub through the long summer evening"
+                        },
+                        {
+                            "start_hour": 23,
+                            "end_hour": 23,
+                            "location": 2,
+                            "activity": "reading upstairs by rushlight after closing"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 2,
+                            "activity": "sleeping at the pub"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 8,
+                            "location": 2,
+                            "activity": "helping with breakfast and morning chores — no walk in the winter dark"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 12,
+                            "location": 2,
+                            "activity": "minding the pub through the quiet winter morning"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 6,
+                            "activity": "visiting Aoife at the hedge school to return and borrow books"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 16,
+                            "location": 13,
+                            "activity": "browsing at Connolly's Shop, chatting with Roisin"
+                        },
+                        {
+                            "start_hour": 17,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "serving at the pub — the early dark brings folk in sooner"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 2,
+                            "activity": "reading upstairs, dreaming of elsewhere"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 2,
+                            "activity": "sleeping late on Sunday"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "attending Mass with her father"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "at the crossroads after Mass, talking with Aoife and Roisin"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 2,
+                            "activity": "helping with the after-Mass dinner rush"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 7,
+                            "activity": "a long Sunday walk by Lough Ree, her favourite escape"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "Sunday evening at the pub — the liveliest night of the week"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 2,
+                            "activity": "reading upstairs after closing"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 1, "kind": "Family", "strength": 0.9},
-                {"target_id": 6, "kind": "Friend", "strength": 0.7},
-                {"target_id": 4, "kind": "Friend", "strength": 0.6},
-                {"target_id": 5, "kind": "Friend", "strength": 0.3}
+                {
+                    "target_id": 1,
+                    "kind": "Family",
+                    "strength": 0.9
+                },
+                {
+                    "target_id": 6,
+                    "kind": "Friend",
+                    "strength": 0.7
+                },
+                {
+                    "target_id": 4,
+                    "kind": "Friend",
+                    "strength": 0.6
+                },
+                {
+                    "target_id": 5,
+                    "kind": "Friend",
+                    "strength": 0.3
+                }
             ],
             "knowledge": [
                 "Has read pamphlets about Catholic Emancipation smuggled in from Dublin.",

--- a/mods/kilteevan-1820/npcs.json
+++ b/mods/kilteevan-1820/npcs.json
@@ -7,21 +7,174 @@
             "age": 58,
             "occupation": "Publican",
             "personality": "A gruff but warm-hearted publican who has run Darcy's Pub for thirty years. Known for his dry wit, encyclopedic knowledge of local history, and tendency to offer unsolicited advice. He speaks with a thick Roscommon accent and peppers his speech with Irish phrases. Fiercely protective of his daughter Niamh, though he struggles to understand her restlessness.",
-            "intelligence": {"verbal": 3, "analytical": 3, "emotional": 4, "practical": 4, "wisdom": 5, "creative": 4},
+            "intelligence": {
+                "verbal": 3,
+                "analytical": 3,
+                "emotional": 4,
+                "practical": 4,
+                "wisdom": 5,
+                "creative": 4
+            },
             "home": 2,
             "workplace": 2,
             "mood": "content",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 6, "location": 2, "activity": "sleeping in the rooms above the pub"},
-                {"start_hour": 7, "end_hour": 8, "location": 1, "activity": "taking a morning walk at the crossroads"},
-                {"start_hour": 9, "end_hour": 22, "location": 2, "activity": "tending bar at the pub"},
-                {"start_hour": 23, "end_hour": 23, "location": 2, "activity": "closing up the pub"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 2,
+                            "activity": "sleeping in the rooms above the pub"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 1,
+                            "activity": "taking the morning air at the crossroads, greeting early risers"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 11,
+                            "location": 2,
+                            "activity": "opening up, sweeping the floor, rolling barrels up from the cellar"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 13,
+                            "location": 2,
+                            "activity": "serving the midday trade — farmers in from the fields for a quick pint"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 17,
+                            "location": 2,
+                            "activity": "minding the bar, quiet afternoon trade"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 22,
+                            "location": 2,
+                            "activity": "the busy evening — pouring pints, settling arguments, holding court"
+                        },
+                        {
+                            "start_hour": 23,
+                            "end_hour": 23,
+                            "location": 2,
+                            "activity": "closing up, banking the fire, locking the door"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 2,
+                            "activity": "sleeping above the pub, the fire banked low"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 8,
+                            "location": 2,
+                            "activity": "stirring the fire, a slow breakfast of stirabout and buttermilk"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 11,
+                            "location": 2,
+                            "activity": "opening up — little trade before noon in winter"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 16,
+                            "location": 2,
+                            "activity": "tending bar, the dark afternoons bring folk in early from the cold"
+                        },
+                        {
+                            "start_hour": 17,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "the evening rush — a full house by the fire, stories and song"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 2,
+                            "activity": "closing up early, the winter night pressing in"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 2,
+                            "activity": "sleeping late on the Lord's day"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "attending Mass at St. Brigid's"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 11,
+                            "location": 1,
+                            "activity": "lingering at the crossroads after Mass, catching up on the week's news"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 13,
+                            "location": 2,
+                            "activity": "the after-Mass crowd — the busiest dinner trade of the week"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 17,
+                            "location": 2,
+                            "activity": "a quieter Sunday afternoon, folk visiting family"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "Sunday evening session — music, singing, the week's stories retold"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 2,
+                            "activity": "closing up for the night"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 8, "kind": "Family", "strength": 0.9},
-                {"target_id": 5, "kind": "Friend", "strength": 0.7},
-                {"target_id": 4, "kind": "Professional", "strength": 0.5},
-                {"target_id": 7, "kind": "Friend", "strength": 0.4}
+                {
+                    "target_id": 8,
+                    "kind": "Family",
+                    "strength": 0.9
+                },
+                {
+                    "target_id": 5,
+                    "kind": "Friend",
+                    "strength": 0.7
+                },
+                {
+                    "target_id": 4,
+                    "kind": "Professional",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 7,
+                    "kind": "Friend",
+                    "strength": 0.4
+                }
             ],
             "knowledge": [
                 "Knows every family in the parish and their histories going back three generations.",
@@ -37,23 +190,259 @@
             "age": 45,
             "occupation": "Farmer",
             "personality": "A practical, no-nonsense farmer who runs Murphy's Farm with quiet efficiency after her husband's passing three years ago. Respected for her hard work and fair dealing. She has little patience for gossip or idle talk, but shows unexpected tenderness with children and animals. Speaks plainly and directly.",
-            "intelligence": {"verbal": 2, "analytical": 3, "emotional": 3, "practical": 5, "wisdom": 4, "creative": 2},
+            "intelligence": {
+                "verbal": 2,
+                "analytical": 3,
+                "emotional": 3,
+                "practical": 5,
+                "wisdom": 4,
+                "creative": 2
+            },
             "home": 9,
             "workplace": 9,
             "mood": "determined",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 4, "location": 9, "activity": "sleeping at the farmhouse"},
-                {"start_hour": 5, "end_hour": 11, "location": 9, "activity": "working the farm — feeding livestock and tending fields"},
-                {"start_hour": 12, "end_hour": 13, "location": 13, "activity": "buying supplies at Connolly's Shop"},
-                {"start_hour": 14, "end_hour": 18, "location": 9, "activity": "afternoon farm work"},
-                {"start_hour": 19, "end_hour": 20, "location": 2, "activity": "having a quiet drink at Darcy's Pub"},
-                {"start_hour": 21, "end_hour": 23, "location": 9, "activity": "evening chores and rest"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 4,
+                            "location": 9,
+                            "activity": "sleeping at the farmhouse"
+                        },
+                        {
+                            "start_hour": 5,
+                            "end_hour": 5,
+                            "location": 9,
+                            "activity": "rising at dawn — milking the cow, feeding the pigs and chickens"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 6,
+                            "location": 9,
+                            "activity": "breakfast of stirabout and buttermilk, fetching water from the well"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 11,
+                            "location": 9,
+                            "activity": "working the fields — planting, weeding, tending the potato ridges"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 12,
+                            "location": 9,
+                            "activity": "dinner — boiled potatoes and buttermilk at the farmhouse"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 15,
+                            "location": 12,
+                            "activity": "cutting turf on the bog, stacking it to dry in the summer sun"
+                        },
+                        {
+                            "start_hour": 16,
+                            "end_hour": 18,
+                            "location": 9,
+                            "activity": "evening farm work — bringing in the cattle, mending fences"
+                        },
+                        {
+                            "start_hour": 19,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "a quiet drink at Darcy's Pub after a long day",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 9,
+                            "activity": "evening chores, churning butter, then to bed"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 9,
+                            "activity": "sleeping at the farmhouse, huddled under blankets against the cold"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 7,
+                            "location": 9,
+                            "activity": "rising in the dark — milking, feeding livestock, tending the fire"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 8,
+                            "location": 9,
+                            "activity": "breakfast of stirabout by the fire"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 12,
+                            "location": 9,
+                            "activity": "indoor work — spinning wool, mending clothes, repairing tools"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 15,
+                            "location": 9,
+                            "activity": "what outdoor work the short day allows — mucking out, hauling turf"
+                        },
+                        {
+                            "start_hour": 16,
+                            "end_hour": 17,
+                            "location": 9,
+                            "activity": "bringing the animals in, securing the farmyard before dark"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 19,
+                            "location": 9,
+                            "activity": "supper of potatoes and milk by the fire"
+                        },
+                        {
+                            "start_hour": 20,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "visiting neighbours or a drink at the pub",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 9,
+                            "activity": "banking the fire and retiring for the night"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 9,
+                            "activity": "sleeping at the farmhouse"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 7,
+                            "location": 9,
+                            "activity": "rising — feeding livestock even on Sunday, they do not rest"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "walking to Mass at St. Brigid's Church"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "socialising at the crossroads after Mass, catching up on parish news"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 9,
+                            "activity": "Sunday dinner — the best meal of the week, perhaps a bit of salt fish"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 10,
+                            "activity": "visiting the O'Briens, as neighbours do on a Sunday"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "Sunday evening at Darcy's Pub"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 9,
+                            "activity": "home for the night, preparing for the week ahead"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "market_day",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 9,
+                            "activity": "sleeping at the farmhouse"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 9,
+                            "activity": "morning chores, preparing butter and eggs for market"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 11,
+                            "location": 13,
+                            "activity": "at Connolly's Shop, selling butter and eggs, buying supplies"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 12,
+                            "location": 15,
+                            "activity": "dinner in Kilteevan Village on market day"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 17,
+                            "location": 9,
+                            "activity": "afternoon farm work"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "a drink at the pub after market day"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 9,
+                            "activity": "home for the evening"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 5, "kind": "Neighbor", "strength": 0.6},
-                {"target_id": 4, "kind": "Professional", "strength": 0.4},
-                {"target_id": 6, "kind": "Friend", "strength": 0.5},
-                {"target_id": 3, "kind": "Professional", "strength": 0.3}
+                {
+                    "target_id": 5,
+                    "kind": "Neighbor",
+                    "strength": 0.6
+                },
+                {
+                    "target_id": 4,
+                    "kind": "Professional",
+                    "strength": 0.4
+                },
+                {
+                    "target_id": 6,
+                    "kind": "Friend",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 3,
+                    "kind": "Professional",
+                    "strength": 0.3
+                }
             ],
             "knowledge": [
                 "Knows the land better than anyone — which fields drain well, which are prone to blight.",
@@ -69,25 +458,204 @@
             "age": 62,
             "occupation": "Parish Priest",
             "personality": "A kind, thoughtful priest who has served the parish for twenty-five years. Educated at Maynooth, he walks the line between Church doctrine and the practical realities of his flock's lives. Known for his gentle sermons, his fondness for poetry, and his habit of quoting scripture in both Irish and Latin. He turns a diplomatic blind eye to hedge-school teaching and old customs.",
-            "intelligence": {"verbal": 5, "analytical": 4, "emotional": 4, "practical": 3, "wisdom": 5, "creative": 3},
+            "intelligence": {
+                "verbal": 5,
+                "analytical": 4,
+                "emotional": 4,
+                "practical": 3,
+                "wisdom": 5,
+                "creative": 3
+            },
             "home": 3,
             "workplace": 3,
             "mood": "contemplative",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 5, "location": 3, "activity": "sleeping in the parish house beside the church"},
-                {"start_hour": 6, "end_hour": 7, "location": 3, "activity": "saying morning Mass"},
-                {"start_hour": 8, "end_hour": 10, "location": 15, "activity": "visiting parishioners in Kilteevan Village"},
-                {"start_hour": 11, "end_hour": 13, "location": 3, "activity": "reading and parish correspondence"},
-                {"start_hour": 14, "end_hour": 16, "location": 1, "activity": "walking the parish roads, checking on the elderly"},
-                {"start_hour": 17, "end_hour": 18, "location": 3, "activity": "evening prayers"},
-                {"start_hour": 19, "end_hour": 21, "location": 2, "activity": "a quiet evening at Darcy's Pub"},
-                {"start_hour": 22, "end_hour": 23, "location": 3, "activity": "reading by candlelight"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 4,
+                            "location": 3,
+                            "activity": "sleeping in the parish house beside the church"
+                        },
+                        {
+                            "start_hour": 5,
+                            "end_hour": 6,
+                            "location": 3,
+                            "activity": "rising early, morning prayers and breviary"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 8,
+                            "location": 3,
+                            "activity": "saying morning Mass for the few who attend on weekdays"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 11,
+                            "location": 15,
+                            "activity": "visiting parishioners in Kilteevan Village — the sick, the elderly, the troubled"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 13,
+                            "location": 3,
+                            "activity": "dinner at the parish house, reading correspondence from the diocese"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 16,
+                            "location": 1,
+                            "activity": "walking the parish roads in the long summer light, checking on outlying families"
+                        },
+                        {
+                            "start_hour": 17,
+                            "end_hour": 18,
+                            "location": 3,
+                            "activity": "evening prayers and parish accounts"
+                        },
+                        {
+                            "start_hour": 19,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "a quiet evening at Darcy's Pub — pastoral duty, he would say"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 3,
+                            "activity": "reading by candlelight — poetry, theology, letters from Maynooth"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 3,
+                            "activity": "sleeping in the parish house"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 3,
+                            "activity": "morning prayers by candlelight, the church cold as a tomb"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 9,
+                            "location": 3,
+                            "activity": "saying morning Mass"
+                        },
+                        {
+                            "start_hour": 10,
+                            "end_hour": 12,
+                            "location": 3,
+                            "activity": "reading, writing letters, parish correspondence by the fire"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 15,
+                            "activity": "visiting the sick in Kilteevan — shorter rounds in winter"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 3,
+                            "activity": "afternoon prayers, preparing Sunday's sermon"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "an evening at Darcy's Pub, warming himself by the fire"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 3,
+                            "activity": "reading and prayer before bed"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 3,
+                            "activity": "sleeping in the parish house"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 3,
+                            "activity": "preparing for the Sunday Mass — vestments, sermon notes, the altar"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "celebrating Sunday Mass — the whole parish gathered together"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "at the crossroads after Mass, speaking with parishioners, settling small disputes"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 3,
+                            "activity": "Sunday dinner at the parish house"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 11,
+                            "activity": "a contemplative walk to the fairy fort — he prays there, though he would not call it that"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "Sunday evening at the pub, the most social night of the week"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 3,
+                            "activity": "evening prayers and early to bed"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 1, "kind": "Friend", "strength": 0.6},
-                {"target_id": 6, "kind": "Professional", "strength": 0.5},
-                {"target_id": 7, "kind": "Friend", "strength": 0.3},
-                {"target_id": 2, "kind": "Professional", "strength": 0.4}
+                {
+                    "target_id": 1,
+                    "kind": "Friend",
+                    "strength": 0.6
+                },
+                {
+                    "target_id": 6,
+                    "kind": "Professional",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 7,
+                    "kind": "Friend",
+                    "strength": 0.3
+                },
+                {
+                    "target_id": 2,
+                    "kind": "Professional",
+                    "strength": 0.4
+                }
             ],
             "knowledge": [
                 "Receives letters from other parishes about the political situation in Dublin.",
@@ -103,23 +671,239 @@
             "age": 38,
             "occupation": "Shopkeeper",
             "personality": "An ambitious and sharp-minded shopkeeper who runs Connolly's Shop with her mother. She dreams of expanding the business and establishing a proper trading post. Roisin has a talent for negotiation, a keen eye for opportunity, and a warm smile that masks a calculating mind. She collects news and gossip as currency.",
-            "intelligence": {"verbal": 4, "analytical": 5, "emotional": 3, "practical": 4, "wisdom": 3, "creative": 4},
+            "intelligence": {
+                "verbal": 4,
+                "analytical": 5,
+                "emotional": 3,
+                "practical": 4,
+                "wisdom": 3,
+                "creative": 4
+            },
             "home": 13,
             "workplace": 13,
             "mood": "alert",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 6, "location": 13, "activity": "sleeping above the shop"},
-                {"start_hour": 7, "end_hour": 8, "location": 13, "activity": "opening up and arranging stock"},
-                {"start_hour": 9, "end_hour": 17, "location": 13, "activity": "minding the shop"},
-                {"start_hour": 18, "end_hour": 19, "location": 1, "activity": "taking the evening air at the crossroads"},
-                {"start_hour": 20, "end_hour": 21, "location": 2, "activity": "socialising at Darcy's Pub"},
-                {"start_hour": 22, "end_hour": 23, "location": 13, "activity": "doing the accounts"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 13,
+                            "activity": "sleeping above the shop"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 13,
+                            "activity": "opening up, arranging stock, sweeping the doorstep"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 12,
+                            "location": 13,
+                            "activity": "minding the shop — summer brings more trade, tinkers and travellers"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 13,
+                            "location": 13,
+                            "activity": "a quick dinner of potatoes behind the counter"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 17,
+                            "location": 13,
+                            "activity": "afternoon trade, weighing flour, measuring cloth, tallying debts"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 19,
+                            "location": 1,
+                            "activity": "taking the evening air at the crossroads, collecting the day's news"
+                        },
+                        {
+                            "start_hour": 20,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "socialising at Darcy's Pub"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 13,
+                            "activity": "doing the accounts by candlelight"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 13,
+                            "activity": "sleeping above the shop"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 8,
+                            "location": 13,
+                            "activity": "opening up, lighting the lamp — dark mornings"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 12,
+                            "location": 13,
+                            "activity": "minding the shop — slower trade in winter, but folk need candles and meal"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 16,
+                            "location": 13,
+                            "activity": "afternoon in the shop, mending stock, writing orders for the Athlone merchants"
+                        },
+                        {
+                            "start_hour": 17,
+                            "end_hour": 18,
+                            "location": 13,
+                            "activity": "closing up early in the winter dark"
+                        },
+                        {
+                            "start_hour": 19,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "an evening at Darcy's Pub by the fire"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 13,
+                            "activity": "accounts and correspondence, then to bed"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 13,
+                            "activity": "sleeping late — the shop is closed on the Lord's day"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "attending Mass at St. Brigid's — wearing her best shawl"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "the crossroads after Mass — prime territory for news and negotiation"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 13,
+                            "activity": "Sunday dinner with her mother above the shop"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 15,
+                            "activity": "visiting in Kilteevan Village, trading gossip and favours"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "Sunday evening at the pub — the social highlight of the week"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 13,
+                            "activity": "home to bed"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "market_day",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 13,
+                            "activity": "sleeping above the shop"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 6,
+                            "location": 13,
+                            "activity": "up early, preparing the shop for the busiest day of the week"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 12,
+                            "location": 13,
+                            "activity": "market day trade — farmers selling butter and eggs, buying supplies"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 13,
+                            "location": 13,
+                            "activity": "a quick dinner between customers"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 17,
+                            "location": 13,
+                            "activity": "afternoon market trade, settling accounts, extending credit"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 19,
+                            "location": 1,
+                            "activity": "at the crossroads, winding down from market day"
+                        },
+                        {
+                            "start_hour": 20,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "a well-earned drink at the pub"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 13,
+                            "activity": "counting the day's takings"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 1, "kind": "Professional", "strength": 0.5},
-                {"target_id": 2, "kind": "Professional", "strength": 0.4},
-                {"target_id": 8, "kind": "Friend", "strength": 0.6},
-                {"target_id": 6, "kind": "Neighbor", "strength": 0.3}
+                {
+                    "target_id": 1,
+                    "kind": "Professional",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 2,
+                    "kind": "Professional",
+                    "strength": 0.4
+                },
+                {
+                    "target_id": 8,
+                    "kind": "Friend",
+                    "strength": 0.6
+                },
+                {
+                    "target_id": 6,
+                    "kind": "Neighbor",
+                    "strength": 0.3
+                }
             ],
             "knowledge": [
                 "Keeps track of every debt owed in the parish — knows who can pay and who cannot.",
@@ -135,24 +919,188 @@
             "age": 70,
             "occupation": "Retired Farmer",
             "personality": "A legendary storyteller and the oldest man in the parish. Tommy has farmed O'Brien's land his whole life, now largely leaving the work to his sons. He holds the oral history of the parish in his memory — every ghost story, fairy tale, and family scandal. His mind is sharp even as his body slows. He speaks in long, winding stories that always have a point, eventually.",
-            "intelligence": {"verbal": 5, "analytical": 2, "emotional": 3, "practical": 3, "wisdom": 5, "creative": 5},
+            "intelligence": {
+                "verbal": 5,
+                "analytical": 2,
+                "emotional": 3,
+                "practical": 3,
+                "wisdom": 5,
+                "creative": 5
+            },
             "home": 10,
             "workplace": null,
             "mood": "reflective",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 6, "location": 10, "activity": "sleeping at the farmhouse"},
-                {"start_hour": 7, "end_hour": 9, "location": 10, "activity": "a slow breakfast and morning pipe"},
-                {"start_hour": 10, "end_hour": 12, "location": 1, "activity": "sitting at the crossroads watching the world go by"},
-                {"start_hour": 13, "end_hour": 14, "location": 2, "activity": "a midday pint and conversation at the pub"},
-                {"start_hour": 15, "end_hour": 17, "location": 11, "activity": "walking to the fairy fort, as he has done since boyhood"},
-                {"start_hour": 18, "end_hour": 20, "location": 2, "activity": "evening storytelling at Darcy's Pub"},
-                {"start_hour": 21, "end_hour": 23, "location": 10, "activity": "settling in for the night"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 10,
+                            "activity": "sleeping at the farmhouse"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 8,
+                            "location": 10,
+                            "activity": "a slow breakfast and morning pipe on the half-door"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 11,
+                            "location": 1,
+                            "activity": "sitting at the crossroads watching the world go by, greeting passers-by"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 13,
+                            "location": 2,
+                            "activity": "a midday pint and conversation at the pub"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 16,
+                            "location": 11,
+                            "activity": "walking to the fairy fort, as he has done since boyhood"
+                        },
+                        {
+                            "start_hour": 17,
+                            "end_hour": 18,
+                            "location": 7,
+                            "activity": "sitting by Lough Ree, watching the light on the water"
+                        },
+                        {
+                            "start_hour": 19,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "evening storytelling at Darcy's Pub — the seanchai holds court",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 10,
+                            "activity": "settling in for the night at the farmhouse"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 10,
+                            "activity": "sleeping at the farmhouse, old bones aching in the cold"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 9,
+                            "location": 10,
+                            "activity": "a slow breakfast by the fire, pipe and tea"
+                        },
+                        {
+                            "start_hour": 10,
+                            "end_hour": 12,
+                            "location": 2,
+                            "activity": "to the pub for warmth and company — too cold for the crossroads"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 10,
+                            "activity": "home for dinner, a rest by the fire"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 10,
+                            "activity": "dozing by the fire, whittling, telling stories to the grandchildren"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "the evening cuaird — storytelling by firelight at the pub",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 10,
+                            "activity": "home early, the winter dark presses close"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 10,
+                            "activity": "sleeping at the farmhouse"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "attending Mass — he sits in the same spot he has sat for sixty years"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "holding court at the crossroads after Mass, everyone stops to hear Tommy"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 2,
+                            "activity": "Sunday dinner pint at the pub"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 11,
+                            "activity": "his Sunday walk to the fairy fort — a lifelong ritual"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "Sunday evening session at the pub — the best stories of the week"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 10,
+                            "activity": "home for the night"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 1, "kind": "Friend", "strength": 0.7},
-                {"target_id": 2, "kind": "Neighbor", "strength": 0.6},
-                {"target_id": 7, "kind": "Friend", "strength": 0.5},
-                {"target_id": 3, "kind": "Friend", "strength": 0.4}
+                {
+                    "target_id": 1,
+                    "kind": "Friend",
+                    "strength": 0.7
+                },
+                {
+                    "target_id": 2,
+                    "kind": "Neighbor",
+                    "strength": 0.6
+                },
+                {
+                    "target_id": 7,
+                    "kind": "Friend",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 3,
+                    "kind": "Friend",
+                    "strength": 0.4
+                }
             ],
             "knowledge": [
                 "Knows every fairy story and ghost tale in the parish — where the banshee was last heard, where the pooka runs.",
@@ -168,24 +1116,188 @@
             "age": 29,
             "occupation": "Hedge School Teacher",
             "personality": "An idealistic young teacher who runs the hedge school with fierce dedication. Educated by her father (a schoolmaster before her), she teaches reading, writing, arithmetic, and Irish to the children of the parish — all technically illegal under the Penal Laws. She is passionate about preserving Irish language and culture, brave to the point of recklessness, and carries a quiet anger about the injustices she sees.",
-            "intelligence": {"verbal": 5, "analytical": 4, "emotional": 4, "practical": 2, "wisdom": 3, "creative": 4},
+            "intelligence": {
+                "verbal": 5,
+                "analytical": 4,
+                "emotional": 4,
+                "practical": 2,
+                "wisdom": 3,
+                "creative": 4
+            },
             "home": 15,
             "workplace": 6,
             "mood": "passionate",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 5, "location": 15, "activity": "sleeping at her lodgings in Kilteevan"},
-                {"start_hour": 6, "end_hour": 7, "location": 15, "activity": "preparing lessons"},
-                {"start_hour": 8, "end_hour": 14, "location": 6, "activity": "teaching at the hedge school"},
-                {"start_hour": 15, "end_hour": 16, "location": 7, "activity": "walking by Lough Ree to clear her head"},
-                {"start_hour": 17, "end_hour": 18, "location": 15, "activity": "marking work and preparing for tomorrow"},
-                {"start_hour": 19, "end_hour": 20, "location": 2, "activity": "an evening at Darcy's Pub"},
-                {"start_hour": 21, "end_hour": 23, "location": 15, "activity": "reading by the fire"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 15,
+                            "activity": "sleeping at her lodgings in Kilteevan"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 15,
+                            "activity": "preparing lessons by the morning light, copying texts"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 13,
+                            "location": 6,
+                            "activity": "teaching at the hedge school — the long summer days allow more lessons"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 14,
+                            "location": 6,
+                            "activity": "dinner with the children before they scatter home"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 16,
+                            "location": 7,
+                            "activity": "walking by Lough Ree to clear her head and compose her thoughts"
+                        },
+                        {
+                            "start_hour": 17,
+                            "end_hour": 18,
+                            "location": 15,
+                            "activity": "marking work and preparing for tomorrow"
+                        },
+                        {
+                            "start_hour": 19,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "an evening at Darcy's Pub, debating with anyone who will listen",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 15,
+                            "activity": "reading by the fire — poetry, pamphlets, whatever she can find"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 15,
+                            "activity": "sleeping at her lodgings in Kilteevan"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 8,
+                            "location": 15,
+                            "activity": "preparing lessons by rushlight, the mornings dark and bitter"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 13,
+                            "location": 6,
+                            "activity": "teaching at the hedge school — shorter hours in winter, the children shivering"
+                        },
+                        {
+                            "start_hour": 14,
+                            "end_hour": 15,
+                            "location": 15,
+                            "activity": "home for dinner and marking work"
+                        },
+                        {
+                            "start_hour": 16,
+                            "end_hour": 18,
+                            "location": 15,
+                            "activity": "reading and writing by the fire, too dark for walking"
+                        },
+                        {
+                            "start_hour": 19,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "the evening cuaird — visiting or the pub",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 15,
+                            "activity": "reading late into the night, her one indulgence"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 15,
+                            "activity": "sleeping late — no school on the Lord's day"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "attending Mass at St. Brigid's Church"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "at the crossroads after Mass, speaking with parents about their children"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 15,
+                            "activity": "Sunday dinner at her lodgings"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 7,
+                            "activity": "a long Sunday walk by Lough Ree, composing poetry in Irish"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "Sunday evening at the pub — music and conversation"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 15,
+                            "activity": "home to bed, the week ahead in her mind"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 8, "kind": "Friend", "strength": 0.7},
-                {"target_id": 3, "kind": "Professional", "strength": 0.5},
-                {"target_id": 2, "kind": "Friend", "strength": 0.5},
-                {"target_id": 4, "kind": "Neighbor", "strength": 0.3}
+                {
+                    "target_id": 8,
+                    "kind": "Friend",
+                    "strength": 0.7
+                },
+                {
+                    "target_id": 3,
+                    "kind": "Professional",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 2,
+                    "kind": "Friend",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 4,
+                    "kind": "Neighbor",
+                    "strength": 0.3
+                }
             ],
             "knowledge": [
                 "Knows the hedge school could be shut down at any time by the authorities.",
@@ -201,24 +1313,187 @@
             "age": 65,
             "occupation": "Retired Constable",
             "personality": "A retired constable who served in the local barracks for thirty years. Mick walks a careful line — he was a Catholic man enforcing Protestant law, and not everyone has forgiven him for it. He is deeply observant, notices everything, and keeps his own counsel. Despite his past role, he is fundamentally decent and now spends his days watching, walking, and occasionally offering cryptic warnings to those he trusts.",
-            "intelligence": {"verbal": 2, "analytical": 4, "emotional": 2, "practical": 4, "wisdom": 4, "creative": 2},
+            "intelligence": {
+                "verbal": 2,
+                "analytical": 4,
+                "emotional": 2,
+                "practical": 4,
+                "wisdom": 4,
+                "creative": 2
+            },
             "home": 15,
             "workplace": null,
             "mood": "watchful",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 6, "location": 15, "activity": "sleeping at his cottage in Kilteevan"},
-                {"start_hour": 7, "end_hour": 9, "location": 15, "activity": "morning routine and breakfast"},
-                {"start_hour": 10, "end_hour": 12, "location": 12, "activity": "walking the Bog Road, old patrol habit"},
-                {"start_hour": 13, "end_hour": 14, "location": 14, "activity": "sitting by the lime kiln, thinking"},
-                {"start_hour": 15, "end_hour": 17, "location": 1, "activity": "watching the crossroads from the wall"},
-                {"start_hour": 18, "end_hour": 20, "location": 2, "activity": "nursing a pint at Darcy's Pub"},
-                {"start_hour": 21, "end_hour": 23, "location": 15, "activity": "home for the evening"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 15,
+                            "activity": "sleeping at his cottage in Kilteevan"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 15,
+                            "activity": "morning routine — tea, pipe, watching the lane from his half-door"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 12,
+                            "activity": "walking the Bog Road — old patrol routes die hard"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 14,
+                            "activity": "sitting by the lime kiln, watching who comes and goes"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 15,
+                            "activity": "home for dinner"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 1,
+                            "activity": "watching the crossroads from the wall, the habit of a lifetime"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "nursing a pint at Darcy's Pub, listening more than talking"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 15,
+                            "activity": "home for the evening, a last pipe at the door in the long twilight"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 15,
+                            "activity": "sleeping at his cottage, the fire kept alive through the night"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 9,
+                            "location": 15,
+                            "activity": "morning routine — slow in winter, the cold in his joints"
+                        },
+                        {
+                            "start_hour": 10,
+                            "end_hour": 12,
+                            "location": 2,
+                            "activity": "to the pub for warmth — walks are shorter in the cold months"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 15,
+                            "activity": "home for dinner"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 1,
+                            "activity": "a short watch at the crossroads if the weather allows, otherwise the pub"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "the evening at the pub, listening to the talk",
+                            "cuaird": true
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 15,
+                            "activity": "home early, the dark pressing in"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 15,
+                            "activity": "sleeping at his cottage"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "attending Mass — he sits near the back, old habit"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "at the crossroads after Mass, observing the gathered parish"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 2,
+                            "activity": "Sunday dinner pint at the pub"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 12,
+                            "activity": "his Sunday walk along the Bog Road, thinking of old cases"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 20,
+                            "location": 2,
+                            "activity": "Sunday evening at the pub"
+                        },
+                        {
+                            "start_hour": 21,
+                            "end_hour": 23,
+                            "location": 15,
+                            "activity": "home for the night"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 1, "kind": "Friend", "strength": 0.4},
-                {"target_id": 5, "kind": "Friend", "strength": 0.5},
-                {"target_id": 3, "kind": "Friend", "strength": 0.3},
-                {"target_id": 4, "kind": "Rival", "strength": -0.2}
+                {
+                    "target_id": 1,
+                    "kind": "Friend",
+                    "strength": 0.4
+                },
+                {
+                    "target_id": 5,
+                    "kind": "Friend",
+                    "strength": 0.5
+                },
+                {
+                    "target_id": 3,
+                    "kind": "Friend",
+                    "strength": 0.3
+                },
+                {
+                    "target_id": 4,
+                    "kind": "Rival",
+                    "strength": -0.2
+                }
             ],
             "knowledge": [
                 "Knows every smuggling route, poteen still, and hidden meeting place in the parish.",
@@ -234,24 +1509,186 @@
             "age": 22,
             "occupation": "Publican's Daughter",
             "personality": "Padraig's daughter, restless and bright, torn between duty to her father and a longing for the wider world. She helps at the pub but dreams of Dublin, or even America. She reads everything she can get her hands on, asks too many questions, and chafes at the limitations of parish life. Beneath her frustration is a deep love for the land and its people that she has not yet recognised in herself.",
-            "intelligence": {"verbal": 4, "analytical": 3, "emotional": 4, "practical": 2, "wisdom": 2, "creative": 5},
+            "intelligence": {
+                "verbal": 4,
+                "analytical": 3,
+                "emotional": 4,
+                "practical": 2,
+                "wisdom": 2,
+                "creative": 5
+            },
             "home": 2,
             "workplace": 2,
             "mood": "restless",
-            "schedule": [
-                {"start_hour": 0, "end_hour": 6, "location": 2, "activity": "sleeping at the pub"},
-                {"start_hour": 7, "end_hour": 8, "location": 8, "activity": "walking by Hodson Bay, watching the boats"},
-                {"start_hour": 9, "end_hour": 12, "location": 2, "activity": "helping her father at the pub"},
-                {"start_hour": 13, "end_hour": 15, "location": 6, "activity": "visiting the hedge school to borrow books"},
-                {"start_hour": 16, "end_hour": 17, "location": 7, "activity": "reading by Lough Ree"},
-                {"start_hour": 18, "end_hour": 21, "location": 2, "activity": "serving at the pub in the evening"},
-                {"start_hour": 22, "end_hour": 23, "location": 2, "activity": "reading upstairs after closing"}
+            "seasonal_schedule": [
+                {
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 5,
+                            "location": 2,
+                            "activity": "sleeping at the pub"
+                        },
+                        {
+                            "start_hour": 6,
+                            "end_hour": 7,
+                            "location": 8,
+                            "activity": "walking by Hodson Bay in the early light, watching the boats on the Shannon"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 11,
+                            "location": 2,
+                            "activity": "helping her father open up — sweeping, stocking, the morning chores"
+                        },
+                        {
+                            "start_hour": 12,
+                            "end_hour": 12,
+                            "location": 2,
+                            "activity": "serving the midday trade"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 15,
+                            "location": 6,
+                            "activity": "visiting the hedge school to borrow books from Aoife"
+                        },
+                        {
+                            "start_hour": 16,
+                            "end_hour": 17,
+                            "location": 7,
+                            "activity": "reading by Lough Ree, the one place she feels free"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 22,
+                            "location": 2,
+                            "activity": "serving at the pub through the long summer evening"
+                        },
+                        {
+                            "start_hour": 23,
+                            "end_hour": 23,
+                            "location": 2,
+                            "activity": "reading upstairs by rushlight after closing"
+                        }
+                    ]
+                },
+                {
+                    "season": "winter",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 6,
+                            "location": 2,
+                            "activity": "sleeping at the pub"
+                        },
+                        {
+                            "start_hour": 7,
+                            "end_hour": 8,
+                            "location": 2,
+                            "activity": "helping with breakfast and morning chores — no walk in the winter dark"
+                        },
+                        {
+                            "start_hour": 9,
+                            "end_hour": 12,
+                            "location": 2,
+                            "activity": "minding the pub through the quiet winter morning"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 6,
+                            "activity": "visiting Aoife at the hedge school to return and borrow books"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 16,
+                            "location": 13,
+                            "activity": "browsing at Connolly's Shop, chatting with Roisin"
+                        },
+                        {
+                            "start_hour": 17,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "serving at the pub — the early dark brings folk in sooner"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 2,
+                            "activity": "reading upstairs, dreaming of elsewhere"
+                        }
+                    ]
+                },
+                {
+                    "day_type": "sunday",
+                    "entries": [
+                        {
+                            "start_hour": 0,
+                            "end_hour": 7,
+                            "location": 2,
+                            "activity": "sleeping late on Sunday"
+                        },
+                        {
+                            "start_hour": 8,
+                            "end_hour": 10,
+                            "location": 3,
+                            "activity": "attending Mass with her father"
+                        },
+                        {
+                            "start_hour": 11,
+                            "end_hour": 12,
+                            "location": 1,
+                            "activity": "at the crossroads after Mass, talking with Aoife and Roisin"
+                        },
+                        {
+                            "start_hour": 13,
+                            "end_hour": 14,
+                            "location": 2,
+                            "activity": "helping with the after-Mass dinner rush"
+                        },
+                        {
+                            "start_hour": 15,
+                            "end_hour": 17,
+                            "location": 7,
+                            "activity": "a long Sunday walk by Lough Ree, her favourite escape"
+                        },
+                        {
+                            "start_hour": 18,
+                            "end_hour": 21,
+                            "location": 2,
+                            "activity": "Sunday evening at the pub — the liveliest night of the week"
+                        },
+                        {
+                            "start_hour": 22,
+                            "end_hour": 23,
+                            "location": 2,
+                            "activity": "reading upstairs after closing"
+                        }
+                    ]
+                }
             ],
             "relationships": [
-                {"target_id": 1, "kind": "Family", "strength": 0.9},
-                {"target_id": 6, "kind": "Friend", "strength": 0.7},
-                {"target_id": 4, "kind": "Friend", "strength": 0.6},
-                {"target_id": 5, "kind": "Friend", "strength": 0.3}
+                {
+                    "target_id": 1,
+                    "kind": "Family",
+                    "strength": 0.9
+                },
+                {
+                    "target_id": 6,
+                    "kind": "Friend",
+                    "strength": 0.7
+                },
+                {
+                    "target_id": 4,
+                    "kind": "Friend",
+                    "strength": 0.6
+                },
+                {
+                    "target_id": 5,
+                    "kind": "Friend",
+                    "strength": 0.3
+                }
             ],
             "knowledge": [
                 "Has read pamphlets about Catholic Emancipation smuggled in from Dublin.",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -76,7 +76,7 @@ fn snapshot_from_world(
     world: &parish_core::world::WorldState,
     transport: &TransportMode,
 ) -> WorldSnapshot {
-    use chrono::Timelike;
+    use chrono::{Datelike, Timelike};
     use parish_core::world::description::{format_exits, render_description};
 
     let now = world.clock.now();
@@ -102,6 +102,17 @@ fn snapshot_from_world(
         loc.description.clone()
     };
 
+    let day_of_week = match now.weekday() {
+        chrono::Weekday::Mon => "Monday",
+        chrono::Weekday::Tue => "Tuesday",
+        chrono::Weekday::Wed => "Wednesday",
+        chrono::Weekday::Thu => "Thursday",
+        chrono::Weekday::Fri => "Friday",
+        chrono::Weekday::Sat => "Saturday",
+        chrono::Weekday::Sun => "Sunday",
+    }
+    .to_string();
+
     WorldSnapshot {
         location_name: loc.name.clone(),
         location_description: description,
@@ -115,6 +126,7 @@ fn snapshot_from_world(
         game_epoch_ms: now.timestamp_millis() as f64,
         speed_factor: world.clock.speed_factor(),
         name_hints: vec![],
+        day_of_week,
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,6 +54,8 @@ pub struct WorldSnapshot {
     pub speed_factor: f64,
     /// Pronunciation hints for Irish names relevant to the current location.
     pub name_hints: Vec<parish_core::npc::LanguageHint>,
+    /// Current day of week (e.g. "Monday", "Saturday").
+    pub day_of_week: String,
 }
 
 /// A location node in the map data.

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -263,12 +263,19 @@ fn debug_schedule(app: &App, name: Option<&str>) -> Vec<String> {
 
     match &npc.schedule {
         Some(schedule) => {
-            for entry in &schedule.entries {
-                let loc = location_name(entry.location, &app.world.graph);
-                lines.push(format!(
-                    "  {:02}:00-{:02}:00  {}  ({})",
-                    entry.start_hour, entry.end_hour, loc, entry.activity
-                ));
+            let season = app.world.clock.season();
+            let day_type = app.world.clock.day_type();
+            if let Some(entries) = schedule.resolve(season, day_type) {
+                lines.push(format!("  (resolved for {}, {})", season, day_type));
+                for entry in entries {
+                    let loc = location_name(entry.location, &app.world.graph);
+                    lines.push(format!(
+                        "  {:02}:00-{:02}:00  {}  ({})",
+                        entry.start_hour, entry.end_hour, loc, entry.activity
+                    ));
+                }
+            } else {
+                lines.push("  (no matching schedule variant)".to_string());
             }
         }
         None => lines.push("  (no schedule)".to_string()),

--- a/ui/src/components/DebugPanel.svelte
+++ b/ui/src/components/DebugPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { debugVisible, debugSnapshot, debugTab, selectedNpcId } from '../stores/debug';
-	import type { NpcDebug } from '$lib/types';
+	import type { NpcDebug, ScheduleVariantDebug } from '$lib/types';
 
 	const tabs = ['Overview', 'NPCs', 'World', 'Events', 'Inference'];
 
@@ -67,7 +67,8 @@
 				<div class="section">
 					<h4>Clock</h4>
 					<div class="field">{snap.clock.game_time}</div>
-					<div class="field">{snap.clock.time_of_day} | {snap.clock.season}</div>
+					<div class="field">{snap.clock.time_of_day} | {snap.clock.day_of_week} | {snap.clock.season}</div>
+					<div class="field muted">Schedule day: {snap.clock.day_type}</div>
 					<div class="field">Weather: {snap.clock.weather}</div>
 					<div class="field">Speed: {snap.clock.speed_factor}x {snap.clock.paused ? '(PAUSED)' : ''}</div>
 					{#if snap.clock.festival}
@@ -121,8 +122,22 @@
 						{#if selectedNpc.schedule.length > 0}
 							<div class="section">
 								<h5>Schedule</h5>
-								{#each selectedNpc.schedule as entry}
-									<div class="field">{String(entry.start_hour).padStart(2, '0')}:00-{String(entry.end_hour).padStart(2, '0')}:00 {entry.location_name} ({entry.activity})</div>
+								{#each selectedNpc.schedule as variant}
+									{@const variantLabel = [variant.season ?? 'All seasons', variant.day_type ?? 'All days'].join(' · ')}
+									<div class="schedule-variant" class:variant-active={variant.is_active}>
+										<div class="variant-label">
+											{variantLabel}
+											{#if variant.is_active}<span class="active-badge">ACTIVE</span>{/if}
+										</div>
+										{#each variant.entries as entry}
+											<div class="schedule-entry" class:entry-current={entry.is_current}>
+												{String(entry.start_hour).padStart(2, '0')}:00–{String(entry.end_hour).padStart(2, '0')}:00
+												{entry.location_name}
+												<span class="muted">({entry.activity})</span>
+												{#if entry.is_current}<span class="now-badge">NOW</span>{/if}
+											</div>
+										{/each}
+									</div>
 								{/each}
 							</div>
 						{/if}
@@ -606,5 +621,61 @@
 		font-size: 0.65rem;
 		margin-top: 0.1rem;
 		word-break: break-word;
+	}
+
+	.schedule-variant {
+		margin-bottom: 0.4rem;
+		border-left: 2px solid var(--color-border);
+		padding-left: 0.4rem;
+	}
+
+	.schedule-variant.variant-active {
+		border-left-color: var(--color-accent);
+	}
+
+	.variant-label {
+		font-size: 0.65rem;
+		color: var(--color-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		margin-bottom: 0.15rem;
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.schedule-variant.variant-active .variant-label {
+		color: var(--color-accent);
+	}
+
+	.active-badge {
+		font-size: 0.55rem;
+		padding: 0.05rem 0.25rem;
+		background: color-mix(in srgb, var(--color-accent) 20%, transparent);
+		color: var(--color-accent);
+		border-radius: 2px;
+		font-weight: 700;
+	}
+
+	.schedule-entry {
+		font-size: 0.72rem;
+		line-height: 1.4;
+		color: var(--color-fg);
+		padding: 0.05rem 0;
+	}
+
+	.schedule-entry.entry-current {
+		color: var(--color-accent);
+		font-weight: 600;
+	}
+
+	.now-badge {
+		font-size: 0.55rem;
+		padding: 0.05rem 0.25rem;
+		background: color-mix(in srgb, #44cc44 20%, transparent);
+		color: #44cc44;
+		border-radius: 2px;
+		font-weight: 700;
+		margin-left: 0.25rem;
 	}
 </style>

--- a/ui/src/components/StatusBar.svelte
+++ b/ui/src/components/StatusBar.svelte
@@ -63,6 +63,8 @@
 		<span class="sep">|</span>
 		<span class="time-label">{displayTimeLabel}</span>
 		<span class="sep">|</span>
+		<span class="day-of-week">{$worldState.day_of_week}</span>
+		<span class="sep">|</span>
 		<span class="weather">{$worldState.weather}</span>
 		<span class="sep">|</span>
 		<span class="season">{$worldState.season}</span>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -13,6 +13,7 @@ export interface WorldSnapshot {
 	game_epoch_ms: number;
 	speed_factor: number;
 	name_hints: LanguageHint[];
+	day_of_week: string;
 }
 
 export interface MapLocation {
@@ -130,6 +131,8 @@ export interface ClockDebug {
 	weather: string;
 	paused: boolean;
 	speed_factor: number;
+	day_of_week: string;
+	day_type: string;
 }
 
 export interface WorldDebug {
@@ -161,11 +164,18 @@ export interface NpcDebug {
 	mood: string;
 	state: string;
 	tier: string;
-	schedule: ScheduleEntryDebug[];
+	schedule: ScheduleVariantDebug[];
 	relationships: RelationshipDebug[];
 	memories: MemoryDebug[];
 	knowledge: string[];
 	intelligence: IntelligenceDebug;
+}
+
+export interface ScheduleVariantDebug {
+	season: string | null;
+	day_type: string | null;
+	is_active: boolean;
+	entries: ScheduleEntryDebug[];
 }
 
 export interface IntelligenceDebug {
@@ -182,6 +192,7 @@ export interface ScheduleEntryDebug {
 	end_hour: number;
 	location_name: string;
 	activity: string;
+	is_current: boolean;
 }
 
 export interface RelationshipDebug {


### PR DESCRIPTION
Replace flat hour-based NPC schedules with a SeasonalSchedule system
that varies by season (summer/winter) and day type (weekday/sunday/
market day), reflecting historically accurate 1820s Irish rural life.

Key changes:
- Add DayType enum (Weekday, Sunday, MarketDay) and Serialize/
  Deserialize on Season
- Add SeasonalSchedule with ScheduleVariant types and fallback
  resolution: exact match > season-only > day-only > default
- Add cuaird flag on ScheduleEntry for evening visiting rounds,
  rotating among friends' homes by day-of-year
- Backward-compatible data loading: old flat "schedule" arrays load
  as a single default variant
- Rewrite all 8 NPC schedules with seasonal variants:
  * Summer/default: long days (5am rise), outdoor work, bog turf-cutting
  * Winter: compressed days (7am rise), indoor spinning/repairs
  * Sunday: Mass at church, crossroads socializing, no field work
  * Market day (Siobhan, Roisin): trade at shop/village

https://claude.ai/code/session_01A8GjRauiixVDzXxoHztWFN