### PR TITLE
test: improve coverage across input, NPC ticks, time, headless, and debug modules

### DIFF
--- a/crates/parish-core/src/input/mod.rs
+++ b/crates/parish-core/src/input/mod.rs
@@ -1494,4 +1494,251 @@ mod tests {
             ))
         );
     }
+
+    // --- /debug command tests ---
+
+    #[test]
+    fn test_parse_debug_bare() {
+        assert_eq!(parse_system_command("/debug"), Some(Command::Debug(None)));
+    }
+
+    #[test]
+    fn test_parse_debug_with_subcommand() {
+        assert_eq!(
+            parse_system_command("/debug npcs"),
+            Some(Command::Debug(Some("npcs".to_string())))
+        );
+        assert_eq!(
+            parse_system_command("/debug memory Padraig"),
+            Some(Command::Debug(Some("memory Padraig".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_parse_debug_with_empty_trailing_space() {
+        assert_eq!(
+            parse_system_command("/debug   "),
+            Some(Command::Debug(None))
+        );
+    }
+
+    #[test]
+    fn test_parse_debug_case_insensitive() {
+        assert_eq!(parse_system_command("/DEBUG"), Some(Command::Debug(None)));
+        assert_eq!(
+            parse_system_command("/DEBUG npcs"),
+            Some(Command::Debug(Some("npcs".to_string())))
+        );
+    }
+
+    // --- /spinner command tests ---
+
+    #[test]
+    fn test_parse_spinner_bare() {
+        assert_eq!(parse_system_command("/spinner"), Some(Command::Spinner(30)));
+    }
+
+    #[test]
+    fn test_parse_spinner_with_duration() {
+        assert_eq!(
+            parse_system_command("/spinner 10"),
+            Some(Command::Spinner(10))
+        );
+        assert_eq!(
+            parse_system_command("/spinner 120"),
+            Some(Command::Spinner(120))
+        );
+    }
+
+    #[test]
+    fn test_parse_spinner_invalid_duration() {
+        // Non-numeric falls back to 30
+        assert_eq!(
+            parse_system_command("/spinner abc"),
+            Some(Command::Spinner(30))
+        );
+    }
+
+    // --- category command tests ---
+
+    #[test]
+    fn test_parse_category_model_dialogue_show() {
+        assert_eq!(
+            parse_system_command("/model.dialogue"),
+            Some(Command::ShowCategoryModel(InferenceCategory::Dialogue))
+        );
+    }
+
+    #[test]
+    fn test_parse_category_model_dialogue_set() {
+        assert_eq!(
+            parse_system_command("/model.dialogue gpt-4"),
+            Some(Command::SetCategoryModel(
+                InferenceCategory::Dialogue,
+                "gpt-4".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_category_model_simulation() {
+        assert_eq!(
+            parse_system_command("/model.simulation"),
+            Some(Command::ShowCategoryModel(InferenceCategory::Simulation))
+        );
+        assert_eq!(
+            parse_system_command("/model.simulation qwen3:8b"),
+            Some(Command::SetCategoryModel(
+                InferenceCategory::Simulation,
+                "qwen3:8b".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_category_model_intent() {
+        assert_eq!(
+            parse_system_command("/model.intent"),
+            Some(Command::ShowCategoryModel(InferenceCategory::Intent))
+        );
+        assert_eq!(
+            parse_system_command("/model.intent qwen3:1.5b"),
+            Some(Command::SetCategoryModel(
+                InferenceCategory::Intent,
+                "qwen3:1.5b".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_category_provider_show_set() {
+        assert_eq!(
+            parse_system_command("/provider.dialogue"),
+            Some(Command::ShowCategoryProvider(InferenceCategory::Dialogue))
+        );
+        assert_eq!(
+            parse_system_command("/provider.intent openrouter"),
+            Some(Command::SetCategoryProvider(
+                InferenceCategory::Intent,
+                "openrouter".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_category_key_show_set() {
+        assert_eq!(
+            parse_system_command("/key.dialogue"),
+            Some(Command::ShowCategoryKey(InferenceCategory::Dialogue))
+        );
+        assert_eq!(
+            parse_system_command("/key.simulation sk-test"),
+            Some(Command::SetCategoryKey(
+                InferenceCategory::Simulation,
+                "sk-test".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_category_invalid_category_returns_none() {
+        // Invalid category name should not match
+        assert_eq!(parse_system_command("/model.bogus"), None);
+        assert_eq!(parse_system_command("/provider.bogus"), None);
+        assert_eq!(parse_system_command("/key.bogus"), None);
+    }
+
+    // --- /load edge cases ---
+
+    #[test]
+    fn test_parse_load_empty_shows_picker() {
+        assert_eq!(
+            parse_system_command("/load"),
+            Some(Command::Load(String::new()))
+        );
+        assert_eq!(
+            parse_system_command("/load  "),
+            Some(Command::Load(String::new()))
+        );
+    }
+
+    #[test]
+    fn test_load_with_invalid_branch_name() {
+        assert_eq!(
+            parse_system_command("/load ../../etc"),
+            Some(Command::InvalidBranchName(
+                "Branch names may only contain letters, numbers, spaces, underscores, and hyphens."
+                    .to_string()
+            ))
+        );
+    }
+
+    // --- /cloud edge cases ---
+
+    #[test]
+    fn test_parse_cloud_provider_show_bare() {
+        // "/cloud provider" without a name shows cloud info
+        assert_eq!(
+            parse_system_command("/cloud provider"),
+            Some(Command::ShowCloud)
+        );
+    }
+
+    #[test]
+    fn test_parse_cloud_provider_empty_name() {
+        // "/cloud provider  " with only whitespace shows cloud info
+        assert_eq!(
+            parse_system_command("/cloud provider  "),
+            Some(Command::ShowCloud)
+        );
+    }
+
+    #[test]
+    fn test_parse_cloud_model_empty_name() {
+        assert_eq!(
+            parse_system_command("/cloud model  "),
+            Some(Command::ShowCloudModel)
+        );
+    }
+
+    #[test]
+    fn test_parse_cloud_key_empty_name() {
+        assert_eq!(
+            parse_system_command("/cloud key  "),
+            Some(Command::ShowCloudKey)
+        );
+    }
+
+    // --- validate_branch_name edge cases ---
+
+    #[test]
+    fn test_validate_branch_name_at_max_length() {
+        let name = "a".repeat(255);
+        assert!(validate_branch_name(&name).is_ok());
+    }
+
+    #[test]
+    fn test_validate_branch_name_just_over_max() {
+        let name = "a".repeat(256);
+        let err = validate_branch_name(&name).unwrap_err();
+        assert!(err.contains("max 255"));
+    }
+
+    #[test]
+    fn test_validate_branch_name_with_special_chars() {
+        assert!(validate_branch_name("save!game").is_err());
+        assert!(validate_branch_name("save@game").is_err());
+        assert!(validate_branch_name("save#game").is_err());
+        assert!(validate_branch_name("save.game").is_err());
+    }
+
+    // --- /speed ludicrous ---
+
+    #[test]
+    fn test_parse_speed_ludicrous() {
+        assert_eq!(
+            parse_system_command("/speed ludicrous"),
+            Some(Command::SetSpeed(GameSpeed::Ludicrous))
+        );
+    }
 }

--- a/crates/parish-core/src/npc/ticks.rs
+++ b/crates/parish-core/src/npc/ticks.rs
@@ -744,4 +744,281 @@ mod tests {
         let recent = mem.recent(1);
         assert!(recent[0].content.len() <= 40);
     }
+
+    // --- truncate_for_memory edge cases ---
+
+    #[test]
+    fn test_truncate_for_memory_empty_string() {
+        assert_eq!(truncate_for_memory("", 10), "");
+    }
+
+    #[test]
+    fn test_truncate_for_memory_exact_boundary() {
+        assert_eq!(truncate_for_memory("12345", 5), "12345");
+    }
+
+    #[test]
+    fn test_truncate_for_memory_one_over() {
+        let result = truncate_for_memory("123456", 5);
+        assert!(result.ends_with("..."));
+        assert!(result.len() <= 5);
+    }
+
+    #[test]
+    fn test_truncate_for_memory_max_len_zero() {
+        let result = truncate_for_memory("hello", 0);
+        assert_eq!(result, "...");
+    }
+
+    #[test]
+    fn test_truncate_for_memory_max_len_three() {
+        // max_len=3 means only room for "..."
+        let result = truncate_for_memory("hello world", 3);
+        assert_eq!(result, "...");
+    }
+
+    #[test]
+    fn test_truncate_for_memory_multibyte_utf8() {
+        // Ensure truncation doesn't split multi-byte characters
+        let irish = "Dia dhuit, a chara. Cén chaoi a bhfuil tú?";
+        let result = truncate_for_memory(irish, 15);
+        assert!(result.ends_with("..."));
+        assert!(result.len() <= 18); // slightly over due to char boundary
+        // Should be valid UTF-8 (no panic)
+        let _ = result.chars().count();
+    }
+
+    #[test]
+    fn test_truncate_for_memory_very_long_string() {
+        let long = "x".repeat(10000);
+        let result = truncate_for_memory(&long, 50);
+        assert!(result.len() <= 50);
+        assert!(result.ends_with("..."));
+    }
+
+    // --- apply_tier2_event edge cases ---
+
+    #[test]
+    fn test_apply_tier2_event_missing_npc_in_map() {
+        let mut npcs: HashMap<NpcId, Npc> = HashMap::new();
+        npcs.insert(NpcId(1), make_test_npc(1, "Padraig", 2));
+        // NpcId(99) is NOT in the map
+
+        let event = Tier2Event {
+            location: LocationId(2),
+            summary: "Something happened".to_string(),
+            participants: vec![NpcId(1), NpcId(99)],
+            mood_changes: vec![MoodChange {
+                npc_id: NpcId(99),
+                new_mood: "happy".to_string(),
+            }],
+            relationship_changes: vec![RelationshipChange {
+                from: NpcId(99),
+                to: NpcId(1),
+                delta: 0.1,
+            }],
+        };
+
+        let game_time = Utc.with_ymd_and_hms(1820, 3, 20, 20, 0, 0).unwrap();
+        // Should not panic — missing NPCs are silently skipped
+        let events = apply_tier2_event(&event, &mut npcs, game_time);
+        // Padraig still gets a memory
+        assert_eq!(npcs.get(&NpcId(1)).unwrap().memory.len(), 1);
+        // Some events generated for the NPC that exists
+        assert!(!events.is_empty());
+    }
+
+    #[test]
+    fn test_apply_tier2_event_empty_participants() {
+        let mut npcs: HashMap<NpcId, Npc> = HashMap::new();
+        npcs.insert(NpcId(1), make_test_npc(1, "Padraig", 2));
+
+        let event = Tier2Event {
+            location: LocationId(2),
+            summary: "Nothing happened".to_string(),
+            participants: Vec::new(),
+            mood_changes: Vec::new(),
+            relationship_changes: Vec::new(),
+        };
+
+        let game_time = Utc.with_ymd_and_hms(1820, 3, 20, 20, 0, 0).unwrap();
+        let events = apply_tier2_event(&event, &mut npcs, game_time);
+        assert!(events.is_empty());
+        // No memories added
+        assert_eq!(npcs.get(&NpcId(1)).unwrap().memory.len(), 0);
+    }
+
+    #[test]
+    fn test_apply_tier2_event_same_mood_no_debug_event() {
+        let mut npcs: HashMap<NpcId, Npc> = HashMap::new();
+        let mut npc = make_test_npc(1, "Padraig", 2);
+        npc.mood = "calm".to_string();
+        npcs.insert(NpcId(1), npc);
+
+        let event = Tier2Event {
+            location: LocationId(2),
+            summary: "Padraig sits quietly".to_string(),
+            participants: vec![NpcId(1)],
+            mood_changes: vec![MoodChange {
+                npc_id: NpcId(1),
+                new_mood: "calm".to_string(), // same as current
+            }],
+            relationship_changes: Vec::new(),
+        };
+
+        let game_time = Utc.with_ymd_and_hms(1820, 3, 20, 20, 0, 0).unwrap();
+        let events = apply_tier2_event(&event, &mut npcs, game_time);
+        // No mood change event since mood didn't actually change
+        assert!(!events.iter().any(|e| e.contains("mood:")));
+        // But memory event should still be there
+        assert!(events.iter().any(|e| e.contains("remembers:")));
+    }
+
+    #[test]
+    fn test_apply_tier2_event_relationship_not_found() {
+        let mut npcs: HashMap<NpcId, Npc> = HashMap::new();
+        // Padraig has no relationship with Tommy
+        npcs.insert(NpcId(1), make_test_npc(1, "Padraig", 2));
+        npcs.insert(NpcId(5), make_test_npc(5, "Tommy", 2));
+
+        let event = Tier2Event {
+            location: LocationId(2),
+            summary: "They chat".to_string(),
+            participants: vec![NpcId(1), NpcId(5)],
+            mood_changes: Vec::new(),
+            relationship_changes: vec![RelationshipChange {
+                from: NpcId(1),
+                to: NpcId(5),
+                delta: 0.1,
+            }],
+        };
+
+        let game_time = Utc.with_ymd_and_hms(1820, 3, 20, 20, 0, 0).unwrap();
+        // Should not panic — missing relationship is silently skipped
+        let _events = apply_tier2_event(&event, &mut npcs, game_time);
+        // Both still get memories
+        assert_eq!(npcs.get(&NpcId(1)).unwrap().memory.len(), 1);
+        assert_eq!(npcs.get(&NpcId(5)).unwrap().memory.len(), 1);
+    }
+
+    // --- run_tier2_for_group solo NPC ---
+
+    #[tokio::test]
+    async fn test_run_tier2_solo_npc_template() {
+        let group = Tier2Group {
+            location: LocationId(2),
+            location_name: "Darcy's Pub".to_string(),
+            npcs: vec![NpcSnapshot {
+                id: NpcId(1),
+                name: "Padraig".to_string(),
+                occupation: "Publican".to_string(),
+                personality: "Warm".to_string(),
+                intelligence_tag: "INT[V3 A3 E4 P4 W5 C4]".to_string(),
+                mood: "content".to_string(),
+                relationship_context: String::new(),
+            }],
+        };
+
+        // Solo NPC should get a template event without needing inference
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        let event = run_tier2_for_group(&client, "test", &group, "Morning", "Clear").await;
+        assert!(event.is_some());
+        let event = event.unwrap();
+        assert!(event.summary.contains("Padraig"));
+        assert!(event.summary.contains("Darcy's Pub"));
+        assert_eq!(event.participants, vec![NpcId(1)]);
+        assert!(event.mood_changes.is_empty());
+        assert!(event.relationship_changes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_run_tier2_empty_group_returns_none() {
+        let group = Tier2Group {
+            location: LocationId(2),
+            location_name: "Darcy's Pub".to_string(),
+            npcs: Vec::new(),
+        };
+
+        let client = OpenAiClient::new("http://localhost:11434", None);
+        let event = run_tier2_for_group(&client, "test", &group, "Morning", "Clear").await;
+        assert!(event.is_none());
+    }
+
+    // --- build_tier2_prompt weather commentary ---
+
+    #[test]
+    fn test_build_tier2_prompt_rain_commentary() {
+        let group = Tier2Group {
+            location: LocationId(2),
+            location_name: "The Crossroads".to_string(),
+            npcs: vec![
+                NpcSnapshot {
+                    id: NpcId(1),
+                    name: "Padraig".to_string(),
+                    occupation: "Publican".to_string(),
+                    personality: "Warm".to_string(),
+                    intelligence_tag: "INT[V3]".to_string(),
+                    mood: "calm".to_string(),
+                    relationship_context: String::new(),
+                },
+                NpcSnapshot {
+                    id: NpcId(2),
+                    name: "Tommy".to_string(),
+                    occupation: "Farmer".to_string(),
+                    personality: "Gruff".to_string(),
+                    intelligence_tag: "INT[V2]".to_string(),
+                    mood: "tired".to_string(),
+                    relationship_context: String::new(),
+                },
+            ],
+        };
+
+        let prompt = build_tier2_prompt(&group, "Afternoon", "Heavy Rain");
+        assert!(prompt.contains("commenting on the weather"));
+
+        let prompt = build_tier2_prompt(&group, "Afternoon", "Clear");
+        assert!(!prompt.contains("commenting on the weather"));
+    }
+
+    // --- apply_tier1_response same mood no change event ---
+
+    #[test]
+    fn test_apply_tier1_response_same_mood_no_change_event() {
+        let mut npc = make_test_npc(1, "Padraig", 1);
+        npc.mood = "calm".to_string();
+        let response = NpcStreamResponse {
+            dialogue: "Hello.".to_string(),
+            metadata: Some(NpcMetadata {
+                action: "speaks".to_string(),
+                mood: "calm".to_string(), // same mood
+                internal_thought: None,
+                language_hints: Vec::new(),
+            }),
+        };
+        let game_time = Utc.with_ymd_and_hms(1820, 3, 20, 10, 0, 0).unwrap();
+        let events = apply_tier1_response(&mut npc, &response, "hello", game_time);
+        // No mood change event
+        assert!(!events.iter().any(|e| e.contains("mood:")));
+        // Memory still recorded
+        assert!(events.iter().any(|e| e.contains("remembers:")));
+    }
+
+    #[test]
+    fn test_apply_tier1_response_empty_mood_no_change() {
+        let mut npc = make_test_npc(1, "Padraig", 1);
+        npc.mood = "calm".to_string();
+        let response = NpcStreamResponse {
+            dialogue: "Hello.".to_string(),
+            metadata: Some(NpcMetadata {
+                action: "speaks".to_string(),
+                mood: String::new(), // empty mood
+                internal_thought: None,
+                language_hints: Vec::new(),
+            }),
+        };
+        let game_time = Utc.with_ymd_and_hms(1820, 3, 20, 10, 0, 0).unwrap();
+        let events = apply_tier1_response(&mut npc, &response, "hello", game_time);
+        assert_eq!(npc.mood, "calm"); // unchanged
+        assert!(!events.iter().any(|e| e.contains("mood:")));
+    }
 }

--- a/crates/parish-core/src/world/time.rs
+++ b/crates/parish-core/src/world/time.rs
@@ -810,4 +810,180 @@ mod tests {
         clock.inference_resume(); // second call is a no-op
         assert!(!clock.is_inference_paused());
     }
+
+    // --- Season boundary tests ---
+
+    #[test]
+    fn test_season_boundary_feb_to_mar() {
+        let date = |m: u32, d: u32| NaiveDate::from_ymd_opt(2026, m, d).unwrap();
+        assert_eq!(Season::from_date(date(2, 28)), Season::Winter);
+        assert_eq!(Season::from_date(date(3, 1)), Season::Spring);
+    }
+
+    #[test]
+    fn test_season_boundary_may_to_jun() {
+        let date = |m: u32, d: u32| NaiveDate::from_ymd_opt(2026, m, d).unwrap();
+        assert_eq!(Season::from_date(date(5, 31)), Season::Spring);
+        assert_eq!(Season::from_date(date(6, 1)), Season::Summer);
+    }
+
+    #[test]
+    fn test_season_boundary_aug_to_sep() {
+        let date = |m: u32, d: u32| NaiveDate::from_ymd_opt(2026, m, d).unwrap();
+        assert_eq!(Season::from_date(date(8, 31)), Season::Summer);
+        assert_eq!(Season::from_date(date(9, 1)), Season::Autumn);
+    }
+
+    #[test]
+    fn test_season_boundary_nov_to_dec() {
+        let date = |m: u32, d: u32| NaiveDate::from_ymd_opt(2026, m, d).unwrap();
+        assert_eq!(Season::from_date(date(11, 30)), Season::Autumn);
+        assert_eq!(Season::from_date(date(12, 1)), Season::Winter);
+    }
+
+    // --- Festival off-by-one tests ---
+
+    #[test]
+    fn test_festival_off_by_one_days() {
+        let date = |m: u32, d: u32| NaiveDate::from_ymd_opt(2026, m, d).unwrap();
+        // Day before and after each festival
+        assert_eq!(Festival::check(date(1, 31)), None);
+        assert_eq!(Festival::check(date(2, 1)), Some(Festival::Imbolc));
+        assert_eq!(Festival::check(date(2, 2)), None);
+
+        assert_eq!(Festival::check(date(4, 30)), None);
+        assert_eq!(Festival::check(date(5, 1)), Some(Festival::Bealtaine));
+        assert_eq!(Festival::check(date(5, 2)), None);
+
+        assert_eq!(Festival::check(date(7, 31)), None);
+        assert_eq!(Festival::check(date(8, 1)), Some(Festival::Lughnasa));
+        assert_eq!(Festival::check(date(8, 2)), None);
+
+        assert_eq!(Festival::check(date(10, 31)), None);
+        assert_eq!(Festival::check(date(11, 1)), Some(Festival::Samhain));
+        assert_eq!(Festival::check(date(11, 2)), None);
+    }
+
+    // --- Large time advances ---
+
+    #[test]
+    fn test_advance_past_midnight() {
+        let mut clock = GameClock::new(game_time(2026, 6, 15, 23));
+        clock.pause(); // freeze for deterministic testing
+        clock.advance(120); // 2 hours past midnight
+        let now = clock.now();
+        assert_eq!(now.hour(), 1);
+        assert_eq!(now.day(), 16); // next day
+    }
+
+    #[test]
+    fn test_advance_full_day() {
+        let mut clock = GameClock::new(game_time(2026, 6, 15, 12));
+        clock.pause();
+        clock.advance(24 * 60); // exactly one day
+        let now = clock.now();
+        assert_eq!(now.day(), 16);
+        assert_eq!(now.hour(), 12);
+    }
+
+    #[test]
+    fn test_advance_multiple_days() {
+        let mut clock = GameClock::new(game_time(2026, 3, 28, 10));
+        clock.pause();
+        clock.advance(5 * 24 * 60); // 5 days
+        let now = clock.now();
+        assert_eq!(now.day(), 2); // April 2
+        assert_eq!(now.month(), 4);
+    }
+
+    #[test]
+    fn test_advance_across_season_boundary() {
+        let mut clock = GameClock::new(game_time(2026, 5, 31, 23));
+        clock.pause();
+        assert_eq!(clock.season(), Season::Spring);
+        clock.advance(120); // 2 hours into June 1
+        assert_eq!(clock.season(), Season::Summer);
+    }
+
+    // --- with_speed ---
+
+    #[test]
+    fn test_with_speed_custom_factor() {
+        let clock = GameClock::with_speed(game_time(2026, 6, 15, 12), 100.0);
+        assert!((clock.speed_factor() - 100.0).abs() < f64::EPSILON);
+        assert_eq!(clock.current_speed(), None); // not a standard preset
+    }
+
+    #[test]
+    fn test_with_speed_matching_preset() {
+        let clock = GameClock::with_speed(game_time(2026, 6, 15, 12), 72.0);
+        assert_eq!(clock.current_speed(), Some(GameSpeed::Fast));
+    }
+
+    // --- Display and formatting ---
+
+    #[test]
+    fn test_season_display_all() {
+        assert_eq!(Season::Spring.to_string(), "Spring");
+        assert_eq!(Season::Summer.to_string(), "Summer");
+        assert_eq!(Season::Autumn.to_string(), "Autumn");
+        assert_eq!(Season::Winter.to_string(), "Winter");
+    }
+
+    #[test]
+    fn test_time_of_day_display_all() {
+        assert_eq!(TimeOfDay::Dawn.to_string(), "Dawn");
+        assert_eq!(TimeOfDay::Morning.to_string(), "Morning");
+        assert_eq!(TimeOfDay::Midday.to_string(), "Midday");
+        assert_eq!(TimeOfDay::Afternoon.to_string(), "Afternoon");
+        assert_eq!(TimeOfDay::Dusk.to_string(), "Dusk");
+        assert_eq!(TimeOfDay::Night.to_string(), "Night");
+        assert_eq!(TimeOfDay::Midnight.to_string(), "Midnight");
+    }
+
+    #[test]
+    fn test_festival_display_all() {
+        assert_eq!(Festival::Imbolc.to_string(), "Imbolc");
+        assert_eq!(Festival::Bealtaine.to_string(), "Bealtaine");
+        assert_eq!(Festival::Lughnasa.to_string(), "Lughnasa");
+        assert_eq!(Festival::Samhain.to_string(), "Samhain");
+    }
+
+    // --- Pause idempotency ---
+
+    #[test]
+    fn test_pause_idempotent() {
+        let mut clock = GameClock::new(game_time(2026, 6, 15, 12));
+        clock.pause();
+        let t1 = clock.now();
+        clock.pause(); // second call is a no-op
+        assert_eq!(clock.now(), t1);
+    }
+
+    #[test]
+    fn test_resume_when_not_paused_is_noop() {
+        let mut clock = GameClock::new(game_time(2026, 6, 15, 12));
+        let t1 = clock.now();
+        clock.resume(); // not paused, should be no-op
+        let t2 = clock.now();
+        let diff = (t2 - t1).num_seconds().abs();
+        assert!(diff < 2);
+    }
+
+    // --- Speed change while set_speed ---
+
+    #[test]
+    fn test_set_speed_to_same_speed() {
+        let mut clock = GameClock::new(game_time(2026, 6, 15, 12));
+        clock.set_speed(GameSpeed::Normal);
+        assert!((clock.speed_factor() - 36.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_set_speed_ludicrous() {
+        let mut clock = GameClock::new(game_time(2026, 6, 15, 12));
+        clock.set_speed(GameSpeed::Ludicrous);
+        assert!((clock.speed_factor() - 864.0).abs() < f64::EPSILON);
+        assert_eq!(clock.current_speed(), Some(GameSpeed::Ludicrous));
+    }
 }

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -474,6 +474,92 @@ mod tests {
     }
 
     #[test]
+    fn test_debug_tiers_empty() {
+        let app = App::new();
+        let lines = debug_tiers(&app);
+        assert!(lines[0].contains("DEBUG TIERS"));
+        assert!(lines[1].contains("Player at:"));
+        // All tiers should show (none)
+        assert!(lines[2..].iter().all(|l| l.contains("(none)")));
+    }
+
+    #[test]
+    fn test_debug_here() {
+        let app = App::new();
+        let lines = debug_here(&app);
+        assert!(lines[0].contains("DEBUG HERE"));
+        // Should show indoor/public info
+        assert!(lines.iter().any(|l| l.contains("Indoor:")));
+        // Should show exits
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("Exits:") || l.contains("NPCs:"))
+        );
+    }
+
+    #[test]
+    fn test_debug_relationships_no_name() {
+        let app = App::new();
+        let lines = debug_relationships(&app, None);
+        assert!(lines[0].contains("Usage:"));
+    }
+
+    #[test]
+    fn test_debug_relationships_not_found() {
+        let app = App::new();
+        let lines = debug_relationships(&app, Some("nobody"));
+        assert!(lines[0].contains("NPC not found"));
+    }
+
+    #[test]
+    fn test_debug_memory_no_name() {
+        let app = App::new();
+        let lines = debug_memory(&app, None);
+        assert!(lines[0].contains("Usage:"));
+    }
+
+    #[test]
+    fn test_debug_schedule_not_found() {
+        let app = App::new();
+        let lines = debug_schedule(&app, Some("nobody"));
+        assert!(lines[0].contains("NPC not found"));
+    }
+
+    #[test]
+    fn test_handle_debug_all_subcommands() {
+        let app = App::new();
+        // Each valid subcommand should return without panicking
+        for sub in &["npcs", "tiers", "clock", "here", "help"] {
+            let lines = handle_debug(Some(sub), &app);
+            assert!(
+                !lines.is_empty(),
+                "Debug subcommand '{}' returned empty",
+                sub
+            );
+        }
+    }
+
+    #[test]
+    fn test_handle_debug_rels_alias() {
+        let app = App::new();
+        let lines = handle_debug(Some("rels"), &app);
+        assert!(lines[0].contains("Usage:"));
+    }
+
+    #[test]
+    fn test_strength_bar_midpoints() {
+        assert_eq!(strength_bar(0.5), "[#######...]");
+        assert_eq!(strength_bar(-0.5), "[##........]");
+    }
+
+    #[test]
+    fn test_tier_counts_empty() {
+        let mgr = NpcManager::new();
+        assert_eq!(tier_counts(&mgr), (0, 0, 0));
+    }
+
+    #[test]
     fn test_location_name_unknown() {
         let graph = crate::world::graph::WorldGraph::new();
         assert_eq!(location_name(LocationId(999), &graph), "Location(999)");

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1712,4 +1712,240 @@ mod tests {
         // Exactly 9 chars — just over the threshold
         assert_eq!(mask_api_key("123456789"), "1234...6789");
     }
+
+    // --- Additional headless command tests ---
+
+    #[tokio::test]
+    async fn test_handle_headless_command_wait() {
+        let mut app = App::new();
+        app.world.clock.pause(); // freeze for determinism
+        let hour_before = app.world.clock.now().hour();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::Wait(60)).await;
+        assert!(!quit);
+        assert!(!rebuild);
+        // Time should have advanced by 60 minutes
+        let hour_after = app.world.clock.now().hour();
+        assert_eq!((hour_after + 24 - hour_before) % 24, 1);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_debug_none() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::Debug(None)).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_debug_with_subcommand() {
+        let mut app = App::new();
+        let (quit, rebuild) =
+            handle_headless_command(&mut app, Command::Debug(Some("clock".to_string()))).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_toggle_sidebar() {
+        // In headless mode, ToggleSidebar just prints a message (not available)
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::ToggleSidebar).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_toggle_improv() {
+        let mut app = App::new();
+        let was_improv = app.improv_enabled;
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::ToggleImprov).await;
+        assert!(!quit);
+        assert!(!rebuild);
+        assert_ne!(app.improv_enabled, was_improv);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_about() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::About).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_map() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::Map).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_npcs_here() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::NpcsHere).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_time() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::Time).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_invalid_speed() {
+        let mut app = App::new();
+        let (quit, rebuild) =
+            handle_headless_command(&mut app, Command::InvalidSpeed("bogus".to_string())).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_invalid_branch_name() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(
+            &mut app,
+            Command::InvalidBranchName("Bad name!".to_string()),
+        )
+        .await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_log() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::Log).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_branches_no_db() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::Branches).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_tick() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::Tick).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_show_cloud() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::ShowCloud).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_show_cloud_model() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::ShowCloudModel).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_show_cloud_key() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::ShowCloudKey).await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_set_cloud_model() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(
+            &mut app,
+            Command::SetCloudModel("claude-sonnet".to_string()),
+        )
+        .await;
+        assert!(!quit);
+        assert!(!rebuild); // SetCloudModel doesn't trigger rebuild
+        assert_eq!(app.cloud_model_name.as_deref(), Some("claude-sonnet"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_set_cloud_key() {
+        let mut app = App::new();
+        let (quit, rebuild) =
+            handle_headless_command(&mut app, Command::SetCloudKey("sk-cloud-123".to_string()))
+                .await;
+        assert!(!quit);
+        assert!(rebuild);
+        assert_eq!(app.cloud_api_key.as_deref(), Some("sk-cloud-123"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_show_category_provider() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(
+            &mut app,
+            Command::ShowCategoryProvider(InferenceCategory::Dialogue),
+        )
+        .await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_show_category_model() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(
+            &mut app,
+            Command::ShowCategoryModel(InferenceCategory::Intent),
+        )
+        .await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[tokio::test]
+    async fn test_handle_headless_command_show_category_key() {
+        let mut app = App::new();
+        let (quit, rebuild) = handle_headless_command(
+            &mut app,
+            Command::ShowCategoryKey(InferenceCategory::Simulation),
+        )
+        .await;
+        assert!(!quit);
+        assert!(!rebuild);
+    }
+
+    #[test]
+    fn test_capitalize_first_normal() {
+        assert_eq!(capitalize_first("hello"), "Hello");
+        assert_eq!(capitalize_first("HELLO"), "HELLO");
+    }
+
+    #[test]
+    fn test_capitalize_first_empty() {
+        assert_eq!(capitalize_first(""), "");
+    }
+
+    #[test]
+    fn test_capitalize_first_single_char() {
+        assert_eq!(capitalize_first("a"), "A");
+    }
+
+    #[test]
+    fn test_default_transport_no_mod() {
+        let app = App::new();
+        let transport = default_transport(&app);
+        assert_eq!(transport.id, "walking");
+        assert!((transport.speed_m_per_s - 1.25).abs() < f64::EPSILON);
+    }
 }


### PR DESCRIPTION
Add ~75 new tests targeting gaps identified in test-coverage-analysis.md:

- input/mod.rs: /debug, /spinner, category commands (/model.dialogue etc.),
  /load edge cases, /cloud edge cases, branch name validation boundaries
- npc/ticks.rs: truncate_for_memory edge cases (empty, boundary, UTF-8, zero),
  apply_tier2_event with missing NPCs, empty participants, same-mood no-op,
  missing relationships, solo NPC tier2 template, weather commentary
- world/time.rs: season boundaries, festival off-by-one days, large time
  advances (midnight, multi-day, cross-season), with_speed, Display impls,
  pause/resume idempotency
- headless.rs: Wait, Debug, ToggleSidebar, ToggleImprov, About, Map, NpcsHere,
  Time, InvalidSpeed, InvalidBranchName, Log, Branches, Tick, cloud commands,
  category show commands, capitalize_first, default_transport
- debug.rs: tiers, here, relationships, memory, schedule subcommands,
  handle_debug routing, strength_bar midpoints, tier_counts, rels alias

https://claude.ai/code/session_01RhqMhxP819wtpCksduEEzU