### PR TITLE
feat: fog-of-war map with frontier locations

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"c08b3453-8153-44df-8f3b-95e95e769f4f","pid":41179,"acquiredAt":1775095503037}

--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -54,9 +54,14 @@ pub fn snapshot_from_world(world: &WorldState, transport: &TransportMode) -> Wor
     }
 }
 
-/// Builds the full [`MapData`] with all locations, edges, and player position.
-pub fn build_map_data(world: &WorldState) -> MapData {
+/// Builds the [`MapData`] filtered by fog-of-war (only visited locations).
+///
+/// Only locations the player has visited are included. Edges are filtered
+/// to only include connections between visited locations. Each location
+/// is enriched with tooltip data (indoor flag, travel time).
+pub fn build_map_data(world: &WorldState, speed_m_per_s: f64) -> MapData {
     let player_loc = world.player_location;
+    let visited = &world.visited_locations;
 
     let adjacent_ids: HashSet<LocationId> = world
         .graph
@@ -71,21 +76,38 @@ pub fn build_map_data(world: &WorldState) -> MapData {
         .graph
         .location_ids()
         .into_iter()
+        .filter(|id| visited.contains(id))
         .filter_map(|id| world.graph.get(id).map(|data| (id, data)))
-        .map(|(id, data)| MapLocation {
-            id: id.0.to_string(),
-            name: data.name.clone(),
-            lat: data.lat,
-            lon: data.lon,
-            adjacent: adjacent_ids.contains(&id) || id == player_loc,
-            hops: *hop_map.get(&id).unwrap_or(&u32::MAX),
+        .map(|(id, data)| {
+            let travel_minutes = if id == player_loc {
+                None
+            } else {
+                world
+                    .graph
+                    .shortest_path(player_loc, id)
+                    .map(|path| world.graph.path_travel_time(&path, speed_m_per_s))
+            };
+
+            MapLocation {
+                id: id.0.to_string(),
+                name: data.name.clone(),
+                lat: data.lat,
+                lon: data.lon,
+                adjacent: adjacent_ids.contains(&id) || id == player_loc,
+                hops: *hop_map.get(&id).unwrap_or(&u32::MAX),
+                indoor: Some(data.indoor),
+                travel_minutes,
+            }
         })
         .collect();
 
     let mut edges: Vec<(String, String)> = Vec::new();
     for loc_id in world.graph.location_ids() {
+        if !visited.contains(&loc_id) {
+            continue;
+        }
         for (neighbor_id, _conn) in world.graph.neighbors(loc_id) {
-            if loc_id.0 < neighbor_id.0 {
+            if loc_id.0 < neighbor_id.0 && visited.contains(&neighbor_id) {
                 edges.push((loc_id.0.to_string(), neighbor_id.0.to_string()));
             }
         }
@@ -179,12 +201,65 @@ mod tests {
     #[test]
     fn build_map_data_from_default_world() {
         let world = WorldState::new();
-        let map = build_map_data(&world);
+        let map = build_map_data(&world, 1.25);
         assert!(!map.player_location.is_empty());
         // At least the player's location should exist
         assert!(
             map.locations.iter().any(|l| l.id == map.player_location) || map.locations.is_empty()
         );
+    }
+
+    #[test]
+    fn fog_of_war_only_sends_visited() {
+        use crate::game_mod::{GameMod, find_default_mod};
+        if let Some(mod_dir) = find_default_mod() {
+            let game_mod = GameMod::load(&mod_dir).expect("should load default mod");
+            let world = WorldState::from_mod(&game_mod).expect("world from mod");
+            // Only the start location is visited initially
+            let map = build_map_data(&world, 1.25);
+            assert_eq!(
+                map.locations.len(),
+                1,
+                "only start location should be visible"
+            );
+            assert_eq!(map.locations[0].id, map.player_location);
+            assert!(
+                map.edges.is_empty(),
+                "no edges when only 1 visited location"
+            );
+            // Indoor field should be set
+            assert!(map.locations[0].indoor.is_some());
+            // Travel time to self should be None
+            assert!(map.locations[0].travel_minutes.is_none());
+        }
+    }
+
+    #[test]
+    fn fog_of_war_reveals_after_visit() {
+        use crate::game_mod::{GameMod, find_default_mod};
+        if let Some(mod_dir) = find_default_mod() {
+            let game_mod = GameMod::load(&mod_dir).expect("should load default mod");
+            let mut world = WorldState::from_mod(&game_mod).expect("world from mod");
+            let start = world.player_location;
+            // Visit a neighbor
+            let neighbors = world.graph.neighbors(start);
+            if let Some((neighbor_id, _)) = neighbors.first() {
+                world.mark_visited(*neighbor_id);
+                let map = build_map_data(&world, 1.25);
+                assert_eq!(map.locations.len(), 2);
+                assert!(
+                    !map.edges.is_empty(),
+                    "edge between visited pair should appear"
+                );
+                // The non-player location should have travel_minutes set
+                let other = map
+                    .locations
+                    .iter()
+                    .find(|l| l.id != map.player_location)
+                    .unwrap();
+                assert!(other.travel_minutes.is_some());
+            }
+        }
     }
 
     #[test]

--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -54,11 +54,12 @@ pub fn snapshot_from_world(world: &WorldState, transport: &TransportMode) -> Wor
     }
 }
 
-/// Builds the [`MapData`] filtered by fog-of-war (only visited locations).
+/// Builds the [`MapData`] with fog-of-war: visited locations plus the frontier.
 ///
-/// Only locations the player has visited are included. Edges are filtered
-/// to only include connections between visited locations. Each location
-/// is enriched with tooltip data (indoor flag, travel time).
+/// Visited locations are fully enriched. The "frontier" — unvisited locations
+/// adjacent to any visited location — also appears so the player can see
+/// where they could explore next. Frontier locations are marked with
+/// `visited: false` and have limited tooltip data.
 pub fn build_map_data(world: &WorldState, speed_m_per_s: f64) -> MapData {
     let player_loc = world.player_location;
     let visited = &world.visited_locations;
@@ -72,7 +73,18 @@ pub fn build_map_data(world: &WorldState, speed_m_per_s: f64) -> MapData {
 
     let hop_map = world.graph.hop_distances(player_loc);
 
-    let locations: Vec<MapLocation> = world
+    // Frontier: unvisited locations that neighbor at least one visited location
+    let mut frontier: HashSet<LocationId> = HashSet::new();
+    for &v in visited {
+        for (neighbor_id, _) in world.graph.neighbors(v) {
+            if !visited.contains(&neighbor_id) {
+                frontier.insert(neighbor_id);
+            }
+        }
+    }
+
+    // Build visited locations (fully enriched)
+    let mut locations: Vec<MapLocation> = world
         .graph
         .location_ids()
         .into_iter()
@@ -97,17 +109,37 @@ pub fn build_map_data(world: &WorldState, speed_m_per_s: f64) -> MapData {
                 hops: *hop_map.get(&id).unwrap_or(&u32::MAX),
                 indoor: Some(data.indoor),
                 travel_minutes,
+                visited: true,
             }
         })
         .collect();
 
+    // Append frontier locations (limited info)
+    for id in &frontier {
+        if let Some(data) = world.graph.get(*id) {
+            locations.push(MapLocation {
+                id: id.0.to_string(),
+                name: data.name.clone(),
+                lat: data.lat,
+                lon: data.lon,
+                adjacent: adjacent_ids.contains(id),
+                hops: *hop_map.get(id).unwrap_or(&u32::MAX),
+                indoor: None,
+                travel_minutes: None,
+                visited: false,
+            });
+        }
+    }
+
+    // Edges: between any two locations that are both visible (visited or frontier)
+    let visible: HashSet<LocationId> = visited.union(&frontier).copied().collect();
     let mut edges: Vec<(String, String)> = Vec::new();
     for loc_id in world.graph.location_ids() {
-        if !visited.contains(&loc_id) {
+        if !visible.contains(&loc_id) {
             continue;
         }
         for (neighbor_id, _conn) in world.graph.neighbors(loc_id) {
-            if loc_id.0 < neighbor_id.0 && visited.contains(&neighbor_id) {
+            if loc_id.0 < neighbor_id.0 && visible.contains(&neighbor_id) {
                 edges.push((loc_id.0.to_string(), neighbor_id.0.to_string()));
             }
         }
@@ -210,27 +242,46 @@ mod tests {
     }
 
     #[test]
-    fn fog_of_war_only_sends_visited() {
+    fn fog_of_war_shows_frontier() {
         use crate::game_mod::{GameMod, find_default_mod};
         if let Some(mod_dir) = find_default_mod() {
             let game_mod = GameMod::load(&mod_dir).expect("should load default mod");
             let world = WorldState::from_mod(&game_mod).expect("world from mod");
-            // Only the start location is visited initially
+            let start = world.player_location;
+            let neighbor_count = world.graph.neighbors(start).len();
+
             let map = build_map_data(&world, 1.25);
+
+            // Start location (visited) + its neighbors (frontier)
             assert_eq!(
                 map.locations.len(),
-                1,
-                "only start location should be visible"
+                1 + neighbor_count,
+                "should show start + frontier neighbors"
             );
-            assert_eq!(map.locations[0].id, map.player_location);
-            assert!(
-                map.edges.is_empty(),
-                "no edges when only 1 visited location"
-            );
-            // Indoor field should be set
-            assert!(map.locations[0].indoor.is_some());
-            // Travel time to self should be None
-            assert!(map.locations[0].travel_minutes.is_none());
+
+            // The start location is visited
+            let start_loc = map
+                .locations
+                .iter()
+                .find(|l| l.id == map.player_location)
+                .unwrap();
+            assert!(start_loc.visited);
+            assert!(start_loc.indoor.is_some());
+            assert!(start_loc.travel_minutes.is_none());
+
+            // Frontier locations are not visited and have limited info
+            let frontier: Vec<_> = map.locations.iter().filter(|l| !l.visited).collect();
+            assert_eq!(frontier.len(), neighbor_count);
+            for f in &frontier {
+                assert!(f.indoor.is_none(), "frontier should not reveal indoor flag");
+                assert!(
+                    f.travel_minutes.is_none(),
+                    "frontier should not reveal travel time"
+                );
+            }
+
+            // Edges should connect start to each frontier neighbor
+            assert_eq!(map.edges.len(), neighbor_count);
         }
     }
 
@@ -246,18 +297,25 @@ mod tests {
             if let Some((neighbor_id, _)) = neighbors.first() {
                 world.mark_visited(*neighbor_id);
                 let map = build_map_data(&world, 1.25);
-                assert_eq!(map.locations.len(), 2);
-                assert!(
-                    !map.edges.is_empty(),
-                    "edge between visited pair should appear"
-                );
-                // The non-player location should have travel_minutes set
-                let other = map
-                    .locations
+
+                // Visited locations should have visited=true
+                let visited: Vec<_> = map.locations.iter().filter(|l| l.visited).collect();
+                assert_eq!(visited.len(), 2);
+
+                // The non-player visited location should have travel_minutes
+                let other = visited
                     .iter()
                     .find(|l| l.id != map.player_location)
                     .unwrap();
                 assert!(other.travel_minutes.is_some());
+                assert!(other.indoor.is_some());
+
+                // Frontier locations exist for unvisited neighbors of both visited locs
+                let frontier: Vec<_> = map.locations.iter().filter(|l| !l.visited).collect();
+                assert!(
+                    !frontier.is_empty() || map.locations.len() == 2,
+                    "frontier should appear unless all neighbors are visited"
+                );
             }
         }
     }

--- a/crates/parish-core/src/ipc/types.rs
+++ b/crates/parish-core/src/ipc/types.rs
@@ -62,6 +62,13 @@ pub struct MapLocation {
     /// Estimated walking time from the player's current location, in minutes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub travel_minutes: Option<u16>,
+    /// Whether the player has visited this location (false = fog-of-war frontier).
+    #[serde(default = "default_true")]
+    pub visited: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// The full map graph sent to the frontend.
@@ -214,6 +221,7 @@ mod tests {
                 hops: 0,
                 indoor: Some(true),
                 travel_minutes: Some(5),
+                visited: true,
             }],
             edges: vec![("1".to_string(), "2".to_string())],
             player_location: "1".to_string(),

--- a/crates/parish-core/src/ipc/types.rs
+++ b/crates/parish-core/src/ipc/types.rs
@@ -56,6 +56,12 @@ pub struct MapLocation {
     /// Number of graph hops from the player's current location.
     #[serde(default)]
     pub hops: u32,
+    /// Whether this location is indoors (for tooltip display).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub indoor: Option<bool>,
+    /// Estimated walking time from the player's current location, in minutes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub travel_minutes: Option<u16>,
 }
 
 /// The full map graph sent to the frontend.
@@ -206,6 +212,8 @@ mod tests {
                 lon: -7.0,
                 adjacent: true,
                 hops: 0,
+                indoor: Some(true),
+                travel_minutes: Some(5),
             }],
             edges: vec![("1".to_string(), "2".to_string())],
             player_location: "1".to_string(),

--- a/crates/parish-core/src/persistence/database.rs
+++ b/crates/parish-core/src/persistence/database.rs
@@ -508,6 +508,7 @@ mod tests {
             },
             npcs: Vec::new(),
             last_tier2_game_time: None,
+            visited_locations: std::collections::HashSet::from([crate::world::LocationId(1)]),
         }
     }
 

--- a/crates/parish-core/src/persistence/journal.rs
+++ b/crates/parish-core/src/persistence/journal.rs
@@ -106,6 +106,7 @@ pub fn replay_journal(
         match event {
             WorldEvent::PlayerMoved { to, .. } => {
                 world.player_location = *to;
+                world.visited_locations.insert(*to);
             }
             WorldEvent::NpcMoved { npc_id, to, .. } => {
                 if let Some(npc) = npc_manager.get_mut(*npc_id) {
@@ -221,6 +222,19 @@ mod tests {
         }];
         replay_journal(&mut world, &mut npcs, &events);
         assert_eq!(world.player_location, LocationId(2));
+    }
+
+    #[test]
+    fn test_replay_player_moved_tracks_visited() {
+        let mut world = crate::world::WorldState::new();
+        let mut npcs = crate::npc::manager::NpcManager::new();
+        assert!(!world.visited_locations.contains(&LocationId(2)));
+        let events = vec![WorldEvent::PlayerMoved {
+            from: LocationId(1),
+            to: LocationId(2),
+        }];
+        replay_journal(&mut world, &mut npcs, &events);
+        assert!(world.visited_locations.contains(&LocationId(2)));
     }
 
     #[test]

--- a/crates/parish-core/src/persistence/snapshot.rs
+++ b/crates/parish-core/src/persistence/snapshot.rs
@@ -4,7 +4,7 @@
 //! all dynamic game state. Static data (world graph, location map) is
 //! excluded because it's loaded from data files on startup.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -137,6 +137,9 @@ pub struct GameSnapshot {
     pub npcs: Vec<NpcSnapshot>,
     /// Game time of the last Tier 2 tick.
     pub last_tier2_game_time: Option<DateTime<Utc>>,
+    /// Set of location IDs the player has visited (fog-of-war map).
+    #[serde(default)]
+    pub visited_locations: HashSet<LocationId>,
 }
 
 impl GameSnapshot {
@@ -160,6 +163,7 @@ impl GameSnapshot {
             clock,
             npcs,
             last_tier2_game_time: npc_manager.last_tier2_game_time(),
+            visited_locations: world.visited_locations.clone(),
         }
     }
 
@@ -206,6 +210,10 @@ impl GameSnapshot {
         world.player_location = self.player_location;
         world.weather = self.weather.parse().unwrap_or(crate::world::Weather::Clear);
         world.text_log = self.text_log;
+
+        // Restore visited locations; ensure current position is always visited
+        world.visited_locations = self.visited_locations;
+        world.visited_locations.insert(self.player_location);
 
         // Restore NPCs
         *npc_manager = crate::npc::manager::NpcManager::new();
@@ -343,6 +351,46 @@ mod tests {
         let mut new_npcs = NpcManager::new();
         snapshot.restore(&mut new_world, &mut new_npcs);
         assert!(!new_npcs.needs_tier2_tick(t));
+    }
+
+    #[test]
+    fn test_visited_locations_roundtrip() {
+        let mut world = WorldState::new();
+        world.mark_visited(LocationId(2));
+        world.mark_visited(LocationId(3));
+        let npc_manager = NpcManager::new();
+
+        let snapshot = GameSnapshot::capture(&world, &npc_manager);
+        assert_eq!(snapshot.visited_locations.len(), 3); // 1 (start) + 2
+
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let restored: GameSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.visited_locations.len(), 3);
+        assert!(restored.visited_locations.contains(&LocationId(1)));
+        assert!(restored.visited_locations.contains(&LocationId(2)));
+        assert!(restored.visited_locations.contains(&LocationId(3)));
+    }
+
+    #[test]
+    fn test_old_save_backward_compat_visited() {
+        // Simulate an old save JSON without visited_locations field
+        let json = r#"{
+            "player_location": 5,
+            "weather": "Clear",
+            "text_log": [],
+            "clock": {"game_time": "1820-03-20T08:00:00Z", "speed_factor": 36.0, "paused": false},
+            "npcs": [],
+            "last_tier2_game_time": null
+        }"#;
+        let snapshot: GameSnapshot = serde_json::from_str(json).unwrap();
+        // serde(default) gives empty set
+        assert!(snapshot.visited_locations.is_empty());
+
+        // But restore inserts player location
+        let mut world = WorldState::new();
+        let mut npcs = NpcManager::new();
+        snapshot.restore(&mut world, &mut npcs);
+        assert!(world.visited_locations.contains(&LocationId(5)));
     }
 
     #[test]

--- a/crates/parish-core/src/world/mod.rs
+++ b/crates/parish-core/src/world/mod.rs
@@ -15,7 +15,7 @@ pub mod time;
 pub mod transport;
 pub mod weather;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::path::Path;
 
@@ -129,6 +129,8 @@ pub struct WorldState {
     pub text_log: Vec<String>,
     /// Cross-tier event bus for publishing and subscribing to game events.
     pub event_bus: EventBus,
+    /// Set of location IDs the player has visited (for fog-of-war map).
+    pub visited_locations: HashSet<LocationId>,
 }
 
 impl WorldState {
@@ -168,6 +170,7 @@ impl WorldState {
             weather_engine,
             text_log: Vec::new(),
             event_bus: EventBus::new(),
+            visited_locations: HashSet::from([crossroads_id]),
         }
     }
 
@@ -212,6 +215,7 @@ impl WorldState {
             weather_engine,
             text_log: Vec::new(),
             event_bus: EventBus::new(),
+            visited_locations: HashSet::from([start_location]),
         })
     }
 
@@ -267,7 +271,13 @@ impl WorldState {
             weather_engine,
             text_log: Vec::new(),
             event_bus: EventBus::new(),
+            visited_locations: HashSet::from([start_location]),
         })
+    }
+
+    /// Marks a location as visited for the fog-of-war map.
+    pub fn mark_visited(&mut self, id: LocationId) {
+        self.visited_locations.insert(id);
     }
 
     /// Returns a reference to the player's current location.
@@ -343,6 +353,25 @@ mod tests {
     fn test_default() {
         let world = WorldState::default();
         assert_eq!(world.player_location, LocationId(1));
+    }
+
+    #[test]
+    fn test_visited_initialized_with_start() {
+        let world = WorldState::new();
+        assert!(world.visited_locations.contains(&LocationId(1)));
+        assert_eq!(world.visited_locations.len(), 1);
+    }
+
+    #[test]
+    fn test_mark_visited() {
+        let mut world = WorldState::new();
+        world.mark_visited(LocationId(5));
+        assert!(world.visited_locations.contains(&LocationId(5)));
+        assert!(world.visited_locations.contains(&LocationId(1)));
+        assert_eq!(world.visited_locations.len(), 2);
+        // Idempotent
+        world.mark_visited(LocationId(5));
+        assert_eq!(world.visited_locations.len(), 2);
     }
 
     #[test]

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -41,10 +41,14 @@ pub async fn get_world_snapshot(State(state): State<Arc<AppState>>) -> Json<Worl
     Json(parish_core::ipc::snapshot_from_world(&world, transport))
 }
 
-/// `GET /api/map` — returns the map with all locations and edges.
+/// `GET /api/map` — returns visited locations, edges, and player position.
 pub async fn get_map(State(state): State<Arc<AppState>>) -> Json<MapData> {
     let world = state.world.lock().await;
-    Json(parish_core::ipc::build_map_data(&world))
+    let transport = state.transport.default_mode();
+    Json(parish_core::ipc::build_map_data(
+        &world,
+        transport.speed_m_per_s,
+    ))
 }
 
 /// `GET /api/npcs-here` — returns NPCs at the player's current location.

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -562,6 +562,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
         {
             world.clock.advance(*minutes as i64);
             world.player_location = *destination;
+            world.mark_visited(*destination);
 
             let new_loc = world
                 .graph

--- a/docs/design/map-evolution.md
+++ b/docs/design/map-evolution.md
@@ -120,7 +120,7 @@ The map could be more than navigation:
 |-------|-------|--------|
 | ~~**Quick win**~~ | ~~Label collision avoidance (#3) — fix overlap with force-directed nudge~~ | **Done** |
 | ~~**Phase A**~~ | ~~GTA minimap (#1) + `/map` hotkey for full view (#2c — zoomable graph)~~ | **Done** |
-| **Phase B** | Fog of war / progressive disclosure (#4) + hover tooltips (#5) | Medium |
+| ~~**Phase B**~~ | ~~Fog of war / progressive disclosure (#4) + hover tooltips (#5)~~ | **Done** |
 | **Phase C** | Animated travel (#7) + time-of-day atmosphere (#6) | Medium |
 | **Phase D** | OSM tile background for full map (#9) + TUI ASCII map (#8) | Large |
 | **Phase E** | Narrative annotations (#10) + NPC trails | Large |

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -161,63 +161,16 @@ pub async fn get_world_snapshot(
 
 /// Returns the map data: visited locations with coordinates, edges, and player position.
 ///
-/// Applies fog-of-war filtering: only locations the player has visited are included.
+/// Includes visited locations (fully enriched) and the frontier — unvisited
+/// locations adjacent to any visited location — so the player can see where
+/// to explore next. Frontier locations are marked with `visited: false`.
 #[tauri::command]
 pub async fn get_map(state: tauri::State<'_, Arc<AppState>>) -> Result<MapData, String> {
     let world = state.world.lock().await;
-    let player_loc = world.player_location;
-    let visited = &world.visited_locations;
     let speed = state.transport.default_mode().speed_m_per_s;
+    let core_map = parish_core::ipc::build_map_data(&world, speed);
 
-    let hop_map = world.graph.hop_distances(player_loc);
-
-    let adjacent_ids: std::collections::HashSet<parish_core::world::LocationId> = world
-        .graph
-        .neighbors(player_loc)
-        .into_iter()
-        .map(|(id, _)| id)
-        .collect();
-
-    let locations: Vec<MapLocation> = world
-        .graph
-        .location_ids()
-        .into_iter()
-        .filter(|id| visited.contains(id))
-        .filter_map(|id| world.graph.get(id).map(|data| (id, data)))
-        .map(|(id, data)| {
-            let travel_minutes = if id == player_loc {
-                None
-            } else {
-                world
-                    .graph
-                    .shortest_path(player_loc, id)
-                    .map(|path| world.graph.path_travel_time(&path, speed))
-            };
-            MapLocation {
-                id: id.0.to_string(),
-                name: data.name.clone(),
-                lat: data.lat,
-                lon: data.lon,
-                adjacent: adjacent_ids.contains(&id) || id == player_loc,
-                hops: *hop_map.get(&id).unwrap_or(&u32::MAX),
-                indoor: Some(data.indoor),
-                travel_minutes,
-            }
-        })
-        .collect();
-
-    let mut edges: Vec<(String, String)> = Vec::new();
-    for loc_id in world.graph.location_ids() {
-        if !visited.contains(&loc_id) {
-            continue;
-        }
-        for (neighbor_id, _conn) in world.graph.neighbors(loc_id) {
-            if loc_id.0 < neighbor_id.0 && visited.contains(&neighbor_id) {
-                edges.push((loc_id.0.to_string(), neighbor_id.0.to_string()));
-            }
-        }
-    }
-
+    let player_loc = world.player_location;
     let (player_lat, player_lon) = world
         .graph
         .get(player_loc)
@@ -225,9 +178,23 @@ pub async fn get_map(state: tauri::State<'_, Arc<AppState>>) -> Result<MapData, 
         .unwrap_or((0.0, 0.0));
 
     Ok(MapData {
-        locations,
-        edges,
-        player_location: player_loc.0.to_string(),
+        locations: core_map
+            .locations
+            .into_iter()
+            .map(|l| MapLocation {
+                id: l.id,
+                name: l.name,
+                lat: l.lat,
+                lon: l.lon,
+                adjacent: l.adjacent,
+                hops: l.hops,
+                indoor: l.indoor,
+                travel_minutes: l.travel_minutes,
+                visited: l.visited,
+            })
+            .collect(),
+        edges: core_map.edges,
+        player_location: core_map.player_location,
         player_lat,
         player_lon,
     })

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -159,16 +159,18 @@ pub async fn get_world_snapshot(
     Ok(snapshot)
 }
 
-/// Returns the map data: all locations with coordinates, edges, and player position.
+/// Returns the map data: visited locations with coordinates, edges, and player position.
+///
+/// Applies fog-of-war filtering: only locations the player has visited are included.
 #[tauri::command]
 pub async fn get_map(state: tauri::State<'_, Arc<AppState>>) -> Result<MapData, String> {
     let world = state.world.lock().await;
     let player_loc = world.player_location;
+    let visited = &world.visited_locations;
+    let speed = state.transport.default_mode().speed_m_per_s;
 
-    // Compute hop distances from player for minimap filtering
     let hop_map = world.graph.hop_distances(player_loc);
 
-    // Collect adjacent location IDs
     let adjacent_ids: std::collections::HashSet<parish_core::world::LocationId> = world
         .graph
         .neighbors(player_loc)
@@ -180,29 +182,42 @@ pub async fn get_map(state: tauri::State<'_, Arc<AppState>>) -> Result<MapData, 
         .graph
         .location_ids()
         .into_iter()
+        .filter(|id| visited.contains(id))
         .filter_map(|id| world.graph.get(id).map(|data| (id, data)))
-        .map(|(id, data)| MapLocation {
-            id: id.0.to_string(),
-            name: data.name.clone(),
-            lat: data.lat,
-            lon: data.lon,
-            adjacent: adjacent_ids.contains(&id) || id == player_loc,
-            hops: *hop_map.get(&id).unwrap_or(&u32::MAX),
+        .map(|(id, data)| {
+            let travel_minutes = if id == player_loc {
+                None
+            } else {
+                world
+                    .graph
+                    .shortest_path(player_loc, id)
+                    .map(|path| world.graph.path_travel_time(&path, speed))
+            };
+            MapLocation {
+                id: id.0.to_string(),
+                name: data.name.clone(),
+                lat: data.lat,
+                lon: data.lon,
+                adjacent: adjacent_ids.contains(&id) || id == player_loc,
+                hops: *hop_map.get(&id).unwrap_or(&u32::MAX),
+                indoor: Some(data.indoor),
+                travel_minutes,
+            }
         })
         .collect();
 
-    // Collect edges as (source_id, target_id) string pairs
     let mut edges: Vec<(String, String)> = Vec::new();
     for loc_id in world.graph.location_ids() {
+        if !visited.contains(&loc_id) {
+            continue;
+        }
         for (neighbor_id, _conn) in world.graph.neighbors(loc_id) {
-            // Only add each edge once (lower id first)
-            if loc_id.0 < neighbor_id.0 {
+            if loc_id.0 < neighbor_id.0 && visited.contains(&neighbor_id) {
                 edges.push((loc_id.0.to_string(), neighbor_id.0.to_string()));
             }
         }
     }
 
-    // Get player's coordinates for minimap centering
     let (player_lat, player_lon) = world
         .graph
         .get(player_loc)

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -850,6 +850,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
         {
             world.clock.advance(*minutes as i64);
             world.player_location = *destination;
+            world.mark_visited(*destination);
 
             // Update legacy locations map (clone data first to avoid borrow conflict)
             let new_loc = world

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -71,6 +71,12 @@ pub struct MapLocation {
     pub adjacent: bool,
     /// Number of graph hops from the player's current location.
     pub hops: u32,
+    /// Whether this location is indoors (for tooltip display).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub indoor: Option<bool>,
+    /// Estimated walking time from the player's current location, in minutes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub travel_minutes: Option<u16>,
 }
 
 /// The full map graph sent to the frontend.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -77,6 +77,8 @@ pub struct MapLocation {
     /// Estimated walking time from the player's current location, in minutes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub travel_minutes: Option<u16>,
+    /// Whether the player has visited this location (false = fog-of-war frontier).
+    pub visited: bool,
 }
 
 /// The full map graph sent to the frontend.

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1280,6 +1280,7 @@ fn handle_headless_movement(app: &mut App, target: &str) {
 
             app.world.clock.advance(minutes as i64);
             app.world.player_location = destination;
+            app.world.mark_visited(destination);
 
             if let Some(data) = app.world.graph.get(destination) {
                 app.world

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub use parish_core::error;
 pub use parish_core::inference;
 pub use parish_core::input;
+pub use parish_core::ipc;
 pub use parish_core::loading;
 pub use parish_core::npc;
 pub use parish_core::persistence;

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -985,6 +985,7 @@ impl GameTestHarness {
 
                 self.app.world.clock.advance(minutes as i64);
                 self.app.world.player_location = destination;
+                self.app.world.mark_visited(destination);
 
                 // Update legacy locations map
                 if let Some(data) = self.app.world.graph.get(destination) {

--- a/tests/fixtures/play_frontier.txt
+++ b/tests/fixtures/play_frontier.txt
@@ -1,0 +1,6 @@
+/status
+/map
+go to crossroads
+/map
+go to pub
+/map

--- a/tests/game_harness_integration.rs
+++ b/tests/game_harness_integration.rs
@@ -374,3 +374,85 @@ fn test_long_journey_fairy_fort() {
         other => panic!("Unexpected result: {:?}", other),
     }
 }
+
+#[test]
+fn test_fog_of_war_frontier_at_pub() {
+    use parish::ipc::handlers::build_map_data;
+
+    let mut h = GameTestHarness::new();
+    // Start at Kilteevan Village
+    assert_eq!(h.player_location(), "Kilteevan Village");
+
+    // Move to crossroads then pub
+    h.execute("go to crossroads");
+    h.execute("go to pub");
+    assert_eq!(h.player_location(), "Darcy's Pub");
+
+    let map = build_map_data(&h.app.world, 1.25);
+
+    // The player is at the pub
+    assert_eq!(
+        map.player_location,
+        h.app.world.player_location.0.to_string()
+    );
+
+    // We should have visited locations (Kilteevan, Crossroads, Pub) + frontier
+    let visited: Vec<_> = map.locations.iter().filter(|l| l.visited).collect();
+    let frontier: Vec<_> = map.locations.iter().filter(|l| !l.visited).collect();
+
+    assert_eq!(visited.len(), 3, "should have 3 visited locations");
+    assert!(
+        !frontier.is_empty(),
+        "frontier should include unvisited neighbors of visited locations"
+    );
+
+    // Crossroads should be visited and visible
+    assert!(
+        visited.iter().any(|l| l.name == "The Crossroads"),
+        "crossroads should be in visited set"
+    );
+
+    // The pub's other neighbors (besides crossroads) should be in frontier
+    let pub_id = h.app.world.player_location;
+    let pub_neighbors: Vec<_> = h
+        .app
+        .world
+        .graph
+        .neighbors(pub_id)
+        .iter()
+        .map(|(id, _)| *id)
+        .collect();
+    for neighbor_id in &pub_neighbors {
+        if !h.app.world.visited_locations.contains(neighbor_id) {
+            let name = h
+                .app
+                .world
+                .graph
+                .get(*neighbor_id)
+                .map(|d| d.name.as_str())
+                .unwrap_or("?");
+            assert!(
+                frontier.iter().any(|l| l.id == neighbor_id.0.to_string()),
+                "unvisited neighbor '{}' should appear in frontier",
+                name
+            );
+        }
+    }
+
+    // Edges should connect visited to frontier
+    assert!(
+        map.edges.len() >= visited.len() - 1,
+        "should have edges between visited locations and to frontier"
+    );
+
+    eprintln!("=== Map at Pub ===");
+    eprintln!(
+        "Visited: {:?}",
+        visited.iter().map(|l| &l.name).collect::<Vec<_>>()
+    );
+    eprintln!(
+        "Frontier: {:?}",
+        frontier.iter().map(|l| &l.name).collect::<Vec<_>>()
+    );
+    eprintln!("Edges: {}", map.edges.len());
+}

--- a/ui/src/components/FullMapOverlay.svelte
+++ b/ui/src/components/FullMapOverlay.svelte
@@ -34,6 +34,7 @@
 		name: string;
 		indoor?: boolean;
 		travel_minutes?: number;
+		visited?: boolean;
 	}
 
 	let tooltip: TooltipInfo | null = $state(null);
@@ -174,8 +175,11 @@
 				{#each $mapData?.edges ?? [] as [src, dst]}
 					{@const a = localProjected.find((p) => p.id === src)}
 					{@const b = localProjected.find((p) => p.id === dst)}
+					{@const srcLoc = ($mapData?.locations ?? []).find((l) => l.id === src)}
+					{@const dstLoc = ($mapData?.locations ?? []).find((l) => l.id === dst)}
+					{@const isFrontierEdge = srcLoc?.visited === false || dstLoc?.visited === false}
 					{#if a && b}
-						<line x1={a.x} y1={a.y} x2={b.x} y2={b.y} class="edge" />
+						<line x1={a.x} y1={a.y} x2={b.x} y2={b.y} class="edge" class:frontier-edge={isFrontierEdge} />
 					{/if}
 				{/each}
 
@@ -208,8 +212,9 @@
 						class="node"
 						class:player={isPlayer(loc)}
 						class:adjacent={loc.adjacent}
+						class:frontier={loc.visited === false}
 						onclick={() => handleClick(loc)}
-						onmouseenter={() => (tooltip = { name: loc.name, indoor: loc.indoor, travel_minutes: loc.travel_minutes })}
+						onmouseenter={() => (tooltip = { name: loc.name, indoor: loc.indoor, travel_minutes: loc.travel_minutes, visited: loc.visited })}
 						onmouseleave={() => (tooltip = null)}
 					>
 						{#if isPlayer(loc)}
@@ -239,11 +244,15 @@
 		{#if tooltip}
 			<div class="tooltip">
 				<div class="tooltip-name">{tooltip.name}</div>
-				{#if tooltip.indoor !== undefined}
-					<div class="tooltip-detail">{tooltip.indoor ? 'Indoor' : 'Outdoor'}</div>
-				{/if}
-				{#if tooltip.travel_minutes != null && tooltip.travel_minutes > 0}
-					<div class="tooltip-detail">{tooltip.travel_minutes} min walk</div>
+				{#if tooltip.visited === false}
+					<div class="tooltip-detail tooltip-unexplored">Unexplored</div>
+				{:else}
+					{#if tooltip.indoor !== undefined}
+						<div class="tooltip-detail">{tooltip.indoor ? 'Indoor' : 'Outdoor'}</div>
+					{/if}
+					{#if tooltip.travel_minutes != null && tooltip.travel_minutes > 0}
+						<div class="tooltip-detail">{tooltip.travel_minutes} min walk</div>
+					{/if}
 				{/if}
 			</div>
 		{/if}
@@ -334,6 +343,11 @@
 		stroke-width: 1.5;
 	}
 
+	.edge.frontier-edge {
+		stroke-dasharray: 4 3;
+		opacity: 0.4;
+	}
+
 	.leader {
 		stroke: var(--color-muted);
 		stroke-width: 0.4;
@@ -374,6 +388,24 @@
 	.node.player .node-label {
 		fill: var(--color-fg);
 		font-weight: 600;
+	}
+
+	.node.frontier .node-icon {
+		opacity: 0.4;
+	}
+
+	.node.frontier .node-label {
+		opacity: 0.5;
+		font-style: italic;
+	}
+
+	.node.frontier.adjacent .node-icon {
+		opacity: 0.6;
+		cursor: pointer;
+	}
+
+	.tooltip-unexplored {
+		font-style: italic;
 	}
 
 	.tooltip {

--- a/ui/src/components/FullMapOverlay.svelte
+++ b/ui/src/components/FullMapOverlay.svelte
@@ -30,7 +30,13 @@
 	let panY = $state(0);
 	let dragging = $state(false);
 	let lastPointer = $state({ x: 0, y: 0 });
-	let tooltip: string | null = $state(null);
+	interface TooltipInfo {
+		name: string;
+		indoor?: boolean;
+		travel_minutes?: number;
+	}
+
+	let tooltip: TooltipInfo | null = $state(null);
 
 	let projected: ProjectedLocation[] = $derived(
 		projectWorld($mapData?.locations ?? [])
@@ -203,7 +209,7 @@
 						class:player={isPlayer(loc)}
 						class:adjacent={loc.adjacent}
 						onclick={() => handleClick(loc)}
-						onmouseenter={() => (tooltip = loc.name)}
+						onmouseenter={() => (tooltip = { name: loc.name, indoor: loc.indoor, travel_minutes: loc.travel_minutes })}
 						onmouseleave={() => (tooltip = null)}
 					>
 						{#if isPlayer(loc)}
@@ -231,7 +237,15 @@
 			</svg>
 		</div>
 		{#if tooltip}
-			<div class="tooltip">{tooltip}</div>
+			<div class="tooltip">
+				<div class="tooltip-name">{tooltip.name}</div>
+				{#if tooltip.indoor !== undefined}
+					<div class="tooltip-detail">{tooltip.indoor ? 'Indoor' : 'Outdoor'}</div>
+				{/if}
+				{#if tooltip.travel_minutes != null && tooltip.travel_minutes > 0}
+					<div class="tooltip-detail">{tooltip.travel_minutes} min walk</div>
+				{/if}
+			</div>
 		{/if}
 	</div>
 </div>
@@ -369,9 +383,19 @@
 		background: var(--color-input-bg);
 		border: 1px solid var(--color-border);
 		color: var(--color-fg);
-		padding: 0.25rem 0.6rem;
-		font-size: 0.85rem;
+		padding: 0.3rem 0.6rem;
+		font-size: 0.8rem;
 		border-radius: 4px;
 		pointer-events: none;
+		line-height: 1.3;
+	}
+
+	.tooltip-name {
+		font-weight: 600;
+	}
+
+	.tooltip-detail {
+		color: var(--color-muted);
+		font-size: 0.7rem;
 	}
 </style>

--- a/ui/src/components/MapPanel.svelte
+++ b/ui/src/components/MapPanel.svelte
@@ -158,7 +158,13 @@
 		return counts;
 	});
 
-	let tooltip: string | null = $state(null);
+	interface TooltipInfo {
+		name: string;
+		indoor?: boolean;
+		travel_minutes?: number;
+	}
+
+	let tooltip: TooltipInfo | null = $state(null);
 
 	function isPlayer(loc: MapLocation): boolean {
 		return $mapData?.player_location === loc.id;
@@ -251,7 +257,7 @@
 					class:player={isPlayer(loc)}
 					class:adjacent={loc.adjacent}
 					onclick={() => handleClick(loc)}
-					onmouseenter={() => (tooltip = loc.name)}
+					onmouseenter={() => (tooltip = { name: loc.name, indoor: loc.indoor, travel_minutes: loc.travel_minutes })}
 					onmouseleave={() => (tooltip = null)}
 				>
 					{#if isPlayer(loc)}
@@ -276,7 +282,15 @@
 			<!-- Off-screen indicators removed: confusing at tight zoom -->
 		</svg>
 		{#if tooltip}
-			<div class="tooltip">{tooltip}</div>
+			<div class="tooltip">
+				<div class="tooltip-name">{tooltip.name}</div>
+				{#if tooltip.indoor !== undefined}
+					<div class="tooltip-detail">{tooltip.indoor ? 'Indoor' : 'Outdoor'}</div>
+				{/if}
+				{#if tooltip.travel_minutes != null && tooltip.travel_minutes > 0}
+					<div class="tooltip-detail">{tooltip.travel_minutes} min walk</div>
+				{/if}
+			</div>
 		{/if}
 	{:else}
 		<div class="empty">Loading map&hellip;</div>
@@ -385,10 +399,20 @@
 		background: var(--color-input-bg);
 		border: 1px solid var(--color-border);
 		color: var(--color-fg);
-		padding: 0.2rem 0.5rem;
-		font-size: 0.8rem;
+		padding: 0.25rem 0.5rem;
+		font-size: 0.75rem;
 		border-radius: 3px;
 		pointer-events: none;
+		line-height: 1.3;
+	}
+
+	.tooltip-name {
+		font-weight: 600;
+	}
+
+	.tooltip-detail {
+		color: var(--color-muted);
+		font-size: 0.65rem;
 	}
 
 	.empty {

--- a/ui/src/components/MapPanel.svelte
+++ b/ui/src/components/MapPanel.svelte
@@ -162,6 +162,7 @@
 		name: string;
 		indoor?: boolean;
 		travel_minutes?: number;
+		visited?: boolean;
 	}
 
 	let tooltip: TooltipInfo | null = $state(null);
@@ -221,8 +222,11 @@
 			{#each visibleEdges as [src, dst]}
 				{@const a = localProjected.find((p) => p.id === src)}
 				{@const b = localProjected.find((p) => p.id === dst)}
+				{@const srcLoc = ($mapData?.locations ?? []).find((l) => l.id === src)}
+				{@const dstLoc = ($mapData?.locations ?? []).find((l) => l.id === dst)}
+				{@const isFrontierEdge = srcLoc?.visited === false || dstLoc?.visited === false}
 				{#if a && b}
-					<line x1={a.x} y1={a.y} x2={b.x} y2={b.y} class="edge" stroke-width={1 * s} />
+					<line x1={a.x} y1={a.y} x2={b.x} y2={b.y} class="edge" class:frontier-edge={isFrontierEdge} stroke-width={1 * s} />
 				{/if}
 			{/each}
 
@@ -256,8 +260,9 @@
 					class="node"
 					class:player={isPlayer(loc)}
 					class:adjacent={loc.adjacent}
+					class:frontier={loc.visited === false}
 					onclick={() => handleClick(loc)}
-					onmouseenter={() => (tooltip = { name: loc.name, indoor: loc.indoor, travel_minutes: loc.travel_minutes })}
+					onmouseenter={() => (tooltip = { name: loc.name, indoor: loc.indoor, travel_minutes: loc.travel_minutes, visited: loc.visited })}
 					onmouseleave={() => (tooltip = null)}
 				>
 					{#if isPlayer(loc)}
@@ -284,11 +289,15 @@
 		{#if tooltip}
 			<div class="tooltip">
 				<div class="tooltip-name">{tooltip.name}</div>
-				{#if tooltip.indoor !== undefined}
-					<div class="tooltip-detail">{tooltip.indoor ? 'Indoor' : 'Outdoor'}</div>
-				{/if}
-				{#if tooltip.travel_minutes != null && tooltip.travel_minutes > 0}
-					<div class="tooltip-detail">{tooltip.travel_minutes} min walk</div>
+				{#if tooltip.visited === false}
+					<div class="tooltip-detail tooltip-unexplored">Unexplored</div>
+				{:else}
+					{#if tooltip.indoor !== undefined}
+						<div class="tooltip-detail">{tooltip.indoor ? 'Indoor' : 'Outdoor'}</div>
+					{/if}
+					{#if tooltip.travel_minutes != null && tooltip.travel_minutes > 0}
+						<div class="tooltip-detail">{tooltip.travel_minutes} min walk</div>
+					{/if}
 				{/if}
 			</div>
 		{/if}
@@ -347,6 +356,11 @@
 		stroke: var(--color-border);
 	}
 
+	.edge.frontier-edge {
+		stroke-dasharray: 4 3;
+		opacity: 0.4;
+	}
+
 	.continuation-stub {
 		stroke: var(--color-muted);
 		opacity: 0.4;
@@ -391,6 +405,23 @@
 		fill: var(--color-fg);
 	}
 
+	.node.frontier .node-icon {
+		opacity: 0.4;
+	}
+
+	.node.frontier .node-label {
+		opacity: 0.5;
+		font-style: italic;
+	}
+
+	.node.frontier.adjacent .node-icon {
+		opacity: 0.6;
+		cursor: pointer;
+	}
+
+	.tooltip-unexplored {
+		font-style: italic;
+	}
 
 	.tooltip {
 		position: absolute;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -24,6 +24,8 @@ export interface MapLocation {
 	hops: number;
 	indoor?: boolean;
 	travel_minutes?: number;
+	/** Whether the player has visited this location (false = fog-of-war frontier). */
+	visited?: boolean;
 }
 
 export interface MapData {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -22,6 +22,8 @@ export interface MapLocation {
 	lon: number;
 	adjacent: boolean;
 	hops: number;
+	indoor?: boolean;
+	travel_minutes?: number;
 }
 
 export interface MapData {


### PR DESCRIPTION
## Summary

- Adds fog-of-war to the map: only visited locations are shown, plus the "frontier" — unvisited locations adjacent to any visited location
- Frontier nodes appear as dimmed, semi-transparent icons with italic labels so the player can see where to explore next; tooltips show "Unexplored"
- Edges to frontier locations render dashed and faded
- Fixed mode parity bug: Tauri's `get_map` was duplicating fog-of-war logic instead of delegating to the shared `build_map_data` handler
- Fixed rebase regression: `mark_visited` calls were dropped from the movement lock block in both `routes.rs` and `commands.rs` during conflict resolution

## Test plan

- [ ] Start a new game — only the starting location is visible on the map, with its neighbors as dimmed frontier nodes
- [ ] Move to a neighbor — it becomes fully visible and its unvisited neighbors appear as frontier
- [ ] Hover a frontier node — tooltip shows "Unexplored" with no indoor/travel details
- [ ] Click an adjacent frontier node — navigates there
- [ ] Open full map (M) — same frontier rendering applies
- [ ] All 325 Rust tests pass (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)