### PR TITLE
Add travel animation and footprint tracking to maps

### DIFF
--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -145,10 +145,46 @@ pub fn build_map_data(world: &WorldState, speed_m_per_s: f64) -> MapData {
         }
     }
 
+    // Edge traversal counts for footprint rendering
+    let edge_traversals: Vec<(String, String, u32)> = world
+        .edge_traversals
+        .iter()
+        .filter(|((a, b), _)| visible.contains(a) && visible.contains(b))
+        .map(|((a, b), count)| (a.0.to_string(), b.0.to_string(), *count))
+        .collect();
+
     MapData {
         locations,
         edges,
         player_location: player_loc.0.to_string(),
+        edge_traversals,
+    }
+}
+
+/// Builds a [`TravelStartPayload`] from a movement path.
+///
+/// Extracts lat/lon coordinates from the world graph for each waypoint
+/// so the frontend can animate the player's travel along the path.
+pub fn build_travel_start(
+    path: &[crate::world::LocationId],
+    minutes: u16,
+    graph: &crate::world::graph::WorldGraph,
+) -> super::types::TravelStartPayload {
+    let waypoints = path
+        .iter()
+        .filter_map(|id| {
+            graph.get(*id).map(|data| super::types::TravelWaypoint {
+                id: id.0.to_string(),
+                lat: data.lat,
+                lon: data.lon,
+            })
+        })
+        .collect();
+
+    super::types::TravelStartPayload {
+        waypoints,
+        duration_minutes: minutes,
+        destination: path.last().map(|id| id.0.to_string()).unwrap_or_default(),
     }
 }
 
@@ -335,5 +371,57 @@ mod tests {
         assert!(theme.bg.starts_with('#'));
         assert_eq!(theme.bg.len(), 7);
         assert!(theme.fg.starts_with('#'));
+    }
+
+    #[test]
+    fn build_travel_start_basic() {
+        use crate::world::graph::WorldGraph;
+
+        let json = r#"{"locations": [
+            {"id": 1, "name": "A", "description_template": ".", "indoor": false, "public": true, "lat": 53.6, "lon": -8.1, "connections": [{"target": 2, "path_description": "road"}]},
+            {"id": 2, "name": "B", "description_template": ".", "indoor": false, "public": true, "lat": 53.61, "lon": -8.09, "connections": [{"target": 1, "path_description": "back"}]}
+        ]}"#;
+        let graph = WorldGraph::load_from_str(json).unwrap();
+        let path = vec![LocationId(1), LocationId(2)];
+        let payload = build_travel_start(&path, 5, &graph);
+        assert_eq!(payload.waypoints.len(), 2);
+        assert_eq!(payload.waypoints[0].id, "1");
+        assert_eq!(payload.waypoints[1].id, "2");
+        assert_eq!(payload.duration_minutes, 5);
+        assert_eq!(payload.destination, "2");
+        assert!((payload.waypoints[0].lat - 53.6).abs() < 0.001);
+    }
+
+    #[test]
+    fn build_map_data_includes_edge_traversals() {
+        use crate::game_mod::{GameMod, find_default_mod};
+
+        if let Some(mod_dir) = find_default_mod() {
+            let game_mod = GameMod::load(&mod_dir).expect("should load default mod");
+            let mut world = WorldState::from_mod(&game_mod).expect("world from mod");
+            let start = world.player_location;
+            let neighbors = world.graph.neighbors(start);
+            if let Some((neighbor_id, _)) = neighbors.first() {
+                // Traverse the edge twice
+                world.record_path_traversal(&[start, *neighbor_id]);
+                world.record_path_traversal(&[start, *neighbor_id]);
+                world.mark_visited(*neighbor_id);
+
+                let map = build_map_data(&world, 1.25);
+                assert!(
+                    !map.edge_traversals.is_empty(),
+                    "should include edge traversals"
+                );
+                // Find the traversal for start<->neighbor
+                let start_str = start.0.to_string();
+                let neighbor_str = neighbor_id.0.to_string();
+                let found = map.edge_traversals.iter().any(|(a, b, count)| {
+                    ((a == &start_str && b == &neighbor_str)
+                        || (a == &neighbor_str && b == &start_str))
+                        && *count == 2
+                });
+                assert!(found, "should find traversal count of 2");
+            }
+        }
     }
 }

--- a/crates/parish-core/src/ipc/types.rs
+++ b/crates/parish-core/src/ipc/types.rs
@@ -80,6 +80,13 @@ pub struct MapData {
     pub edges: Vec<(String, String)>,
     /// The player's current location id.
     pub player_location: String,
+    /// Edge traversal counts for footprint rendering.
+    ///
+    /// Each entry is `(source_id, target_id, count)` where the edge is
+    /// canonically ordered (smaller id first). Higher counts render as
+    /// thicker/lighter "worn path" lines on the map.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub edge_traversals: Vec<(String, String, u32)>,
 }
 
 // ── NPC info ────────────────────────────────────────────────────────────────
@@ -191,6 +198,30 @@ pub struct LoadingPayload {
     pub active: bool,
 }
 
+/// A waypoint along a travel path, with screen-friendly coordinates.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TravelWaypoint {
+    /// Location ID at this waypoint.
+    pub id: String,
+    /// WGS-84 latitude.
+    pub lat: f64,
+    /// WGS-84 longitude.
+    pub lon: f64,
+}
+
+/// Payload for `travel-start` events, emitted when the player begins moving.
+///
+/// The frontend uses this to animate a moving dot along the path on the map.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TravelStartPayload {
+    /// Ordered waypoints from origin to destination (including both endpoints).
+    pub waypoints: Vec<TravelWaypoint>,
+    /// Total travel duration in game minutes.
+    pub duration_minutes: u16,
+    /// Destination location ID.
+    pub destination: String,
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -251,6 +282,7 @@ mod tests {
             }],
             edges: vec![("1".to_string(), "2".to_string())],
             player_location: "1".to_string(),
+            edge_traversals: vec![],
         };
         let json = serde_json::to_string(&data).unwrap();
         assert!(json.contains("Church"));

--- a/crates/parish-core/src/persistence/snapshot.rs
+++ b/crates/parish-core/src/persistence/snapshot.rs
@@ -147,6 +147,9 @@ pub struct GameSnapshot {
     /// Set of location IDs the player has visited (fog-of-war map).
     #[serde(default)]
     pub visited_locations: HashSet<LocationId>,
+    /// Edge traversal counts for "worn path" footprints on the map.
+    #[serde(default)]
+    pub edge_traversals: HashMap<(LocationId, LocationId), u32>,
     /// Gossip network state.
     #[serde(default)]
     pub gossip_network: GossipNetwork,
@@ -174,6 +177,7 @@ impl GameSnapshot {
             npcs,
             last_tier2_game_time: npc_manager.last_tier2_game_time(),
             visited_locations: world.visited_locations.clone(),
+            edge_traversals: world.edge_traversals.clone(),
             gossip_network: world.gossip_network.clone(),
         }
     }
@@ -225,6 +229,9 @@ impl GameSnapshot {
         // Restore visited locations; ensure current position is always visited
         world.visited_locations = self.visited_locations;
         world.visited_locations.insert(self.player_location);
+
+        // Restore edge traversal counts
+        world.edge_traversals = self.edge_traversals;
 
         // Restore NPCs
         *npc_manager = crate::npc::manager::NpcManager::new();

--- a/crates/parish-core/src/world/mod.rs
+++ b/crates/parish-core/src/world/mod.rs
@@ -82,7 +82,7 @@ impl fmt::Display for Weather {
 }
 
 /// Unique identifier for a location in the world graph.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct LocationId(pub u32);
 
@@ -132,6 +132,11 @@ pub struct WorldState {
     pub event_bus: EventBus,
     /// Set of location IDs the player has visited (for fog-of-war map).
     pub visited_locations: HashSet<LocationId>,
+    /// Edge traversal counts for "worn path" footprints on the map.
+    ///
+    /// Keys are canonically ordered `(min_id, max_id)` pairs. The count
+    /// increments each time the player walks along that edge.
+    pub edge_traversals: HashMap<(LocationId, LocationId), u32>,
     /// Gossip propagation network tracking information spread among NPCs.
     pub gossip_network: GossipNetwork,
 }
@@ -174,6 +179,7 @@ impl WorldState {
             text_log: Vec::new(),
             event_bus: EventBus::new(),
             visited_locations: HashSet::from([crossroads_id]),
+            edge_traversals: HashMap::new(),
             gossip_network: GossipNetwork::new(),
         }
     }
@@ -220,6 +226,7 @@ impl WorldState {
             text_log: Vec::new(),
             event_bus: EventBus::new(),
             visited_locations: HashSet::from([start_location]),
+            edge_traversals: HashMap::new(),
             gossip_network: GossipNetwork::new(),
         })
     }
@@ -277,6 +284,7 @@ impl WorldState {
             text_log: Vec::new(),
             event_bus: EventBus::new(),
             visited_locations: HashSet::from([start_location]),
+            edge_traversals: HashMap::new(),
             gossip_network: GossipNetwork::new(),
         })
     }
@@ -284,6 +292,21 @@ impl WorldState {
     /// Marks a location as visited for the fog-of-war map.
     pub fn mark_visited(&mut self, id: LocationId) {
         self.visited_locations.insert(id);
+    }
+
+    /// Records a traversal along a path of locations, incrementing edge counts.
+    ///
+    /// Edges are stored in canonical order (smaller ID first) so that
+    /// A→B and B→A are the same edge.
+    pub fn record_path_traversal(&mut self, path: &[LocationId]) {
+        for window in path.windows(2) {
+            let (a, b) = if window[0] < window[1] {
+                (window[0], window[1])
+            } else {
+                (window[1], window[0])
+            };
+            *self.edge_traversals.entry((a, b)).or_insert(0) += 1;
+        }
     }
 
     /// Returns a reference to the player's current location.
@@ -423,5 +446,75 @@ mod tests {
             assert_eq!(data.name, "Kilteevan Village");
             assert!(data.description_template.contains("{time}"));
         }
+    }
+
+    #[test]
+    fn test_record_path_traversal() {
+        let mut world = WorldState::new();
+        assert!(world.edge_traversals.is_empty());
+
+        // Single edge
+        world.record_path_traversal(&[LocationId(1), LocationId(2)]);
+        assert_eq!(
+            *world
+                .edge_traversals
+                .get(&(LocationId(1), LocationId(2)))
+                .unwrap(),
+            1
+        );
+
+        // Same edge again increments
+        world.record_path_traversal(&[LocationId(2), LocationId(1)]);
+        assert_eq!(
+            *world
+                .edge_traversals
+                .get(&(LocationId(1), LocationId(2)))
+                .unwrap(),
+            2
+        );
+
+        // Multi-hop path
+        world.record_path_traversal(&[LocationId(3), LocationId(4), LocationId(5)]);
+        assert_eq!(
+            *world
+                .edge_traversals
+                .get(&(LocationId(3), LocationId(4)))
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            *world
+                .edge_traversals
+                .get(&(LocationId(4), LocationId(5)))
+                .unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_record_path_traversal_canonical_order() {
+        let mut world = WorldState::new();
+
+        // Forward: (5, 3) should become (3, 5)
+        world.record_path_traversal(&[LocationId(5), LocationId(3)]);
+        assert!(
+            world
+                .edge_traversals
+                .contains_key(&(LocationId(3), LocationId(5)))
+        );
+        assert!(
+            !world
+                .edge_traversals
+                .contains_key(&(LocationId(5), LocationId(3)))
+        );
+    }
+
+    #[test]
+    fn test_record_path_traversal_empty_and_single() {
+        let mut world = WorldState::new();
+        // Empty path and single-element path should be no-ops
+        world.record_path_traversal(&[]);
+        world.record_path_traversal(&[LocationId(1)]);
+        assert!(world.edge_traversals.is_empty());
     }
 }

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -561,10 +561,18 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
         let mv = movement::resolve_movement(target, &world.graph, world.player_location, transport);
         if let MovementResult::Arrived {
             destination,
+            path,
             minutes,
             ..
         } = &mv
         {
+            // Emit travel-start before changing state so frontend can animate
+            let travel_payload = parish_core::ipc::build_travel_start(path, *minutes, &world.graph);
+            state.event_bus.emit("travel-start", &travel_payload);
+
+            // Record edge traversals for footprints
+            world.record_path_traversal(path);
+
             world.clock.advance(*minutes as i64);
             world.player_location = *destination;
             world.mark_visited(*destination);

--- a/docs/design/map-evolution.md
+++ b/docs/design/map-evolution.md
@@ -121,7 +121,7 @@ The map could be more than navigation:
 | ~~**Quick win**~~ | ~~Label collision avoidance (#3) — fix overlap with force-directed nudge~~ | **Done** |
 | ~~**Phase A**~~ | ~~GTA minimap (#1) + `/map` hotkey for full view (#2c — zoomable graph)~~ | **Done** |
 | ~~**Phase B**~~ | ~~Fog of war / progressive disclosure (#4) + hover tooltips (#5)~~ | **Done** |
-| **Phase C** | Animated travel (#7) + time-of-day atmosphere (#6) | Medium |
+| ~~**Phase C**~~ | ~~Animated travel (#7) + time-of-day atmosphere (#6)~~ | **Done** |
 | **Phase D** | OSM tile background for full map (#9) + TUI ASCII map (#8) | Large |
 | **Phase E** | Narrative annotations (#10) + NPC trails | Large |
 

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -23,8 +23,8 @@ use parish_core::world::palette::compute_palette;
 use parish_core::world::transport::TransportMode;
 
 use crate::events::{
-    EVENT_SAVE_PICKER, EVENT_STREAM_END, EVENT_TEXT_LOG, EVENT_WORLD_UPDATE, NpcReactionPayload,
-    StreamEndPayload, TextLogPayload, spawn_loading_animation,
+    EVENT_SAVE_PICKER, EVENT_STREAM_END, EVENT_TEXT_LOG, EVENT_TRAVEL_START, EVENT_WORLD_UPDATE,
+    NpcReactionPayload, StreamEndPayload, TextLogPayload, spawn_loading_animation,
 };
 use crate::{AppState, MapData, MapLocation, NpcInfo, SaveState, ThemePalette, WorldSnapshot};
 
@@ -210,6 +210,7 @@ pub async fn get_map(state: tauri::State<'_, Arc<AppState>>) -> Result<MapData, 
         player_location: core_map.player_location,
         player_lat,
         player_lon,
+        edge_traversals: core_map.edge_traversals,
     })
 }
 
@@ -858,10 +859,18 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
             movement::resolve_movement(target, &world.graph, world.player_location, &transport);
         if let MovementResult::Arrived {
             destination,
+            path,
             minutes,
             ..
         } = &mv
         {
+            // Emit travel-start before changing state so frontend can animate
+            let travel_payload = parish_core::ipc::build_travel_start(path, *minutes, &world.graph);
+            let _ = app.emit(EVENT_TRAVEL_START, travel_payload);
+
+            // Record edge traversals for footprints
+            world.record_path_traversal(path);
+
             world.clock.advance(*minutes as i64);
             world.player_location = *destination;
             world.mark_visited(*destination);

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -29,6 +29,8 @@ pub const EVENT_SAVE_PICKER: &str = "save-picker";
 pub const EVENT_TOGGLE_MAP: &str = "toggle-full-map";
 /// Event emitted when an NPC reacts to a message with an emoji.
 pub const EVENT_NPC_REACTION: &str = "npc-reaction";
+/// Event emitted when the player begins traveling between locations.
+pub const EVENT_TRAVEL_START: &str = "travel-start";
 
 /// How many milliseconds to batch streaming tokens before emitting.
 pub const BATCH_MS: u64 = 16;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,6 +94,9 @@ pub struct MapData {
     pub player_lat: f64,
     /// Player's WGS-84 longitude (for centering the minimap).
     pub player_lon: f64,
+    /// Edge traversal counts for footprint rendering: `(src_id, dst_id, count)`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub edge_traversals: Vec<(String, String, u32)>,
 }
 
 /// Minimal NPC info for the sidebar.

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1271,13 +1271,14 @@ fn handle_headless_movement(app: &mut App, target: &str) {
     match result {
         MovementResult::Arrived {
             destination,
+            path,
             minutes,
             narration,
-            ..
         } => {
             println!("{}", narration);
             println!();
 
+            app.world.record_path_traversal(&path);
             app.world.clock.advance(minutes as i64);
             app.world.player_location = destination;
             app.world.mark_visited(destination);

--- a/ui/src/components/FullMapOverlay.svelte
+++ b/ui/src/components/FullMapOverlay.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-	import { mapData } from '../stores/game';
+	import { mapData, worldState } from '../stores/game';
+	import { travelState, getTravelPosition } from '../stores/travel';
 	import { submitInput } from '$lib/ipc';
 	import { resolveLabels, distSq, estimateTextWidth, type EdgeLine } from '$lib/map-labels';
-	import { projectWorld } from '$lib/map-projection';
+	import { projectWorld, SCALE, REF_CENTER_LAT, REF_CENTER_LON } from '$lib/map-projection';
 	import { getLocationIcon, ICON_PATHS, type LocationIcon } from '$lib/map-icons';
 	import type { MapLocation } from '$lib/types';
 	import type { ProjectedLocation } from '$lib/map-projection';
 	import type { ResolvedLabel } from '$lib/map-labels';
+	import { onMount } from 'svelte';
 
 	/** All unique icon keys used by current locations, for <defs>. */
 	let usedIcons: LocationIcon[] = $derived(
@@ -92,6 +94,90 @@
 		)
 	);
 
+	// ── Time-of-day atmosphere ───────────────────────────────────────────
+	let nightFactor: number = $derived.by(() => {
+		const h = $worldState?.hour ?? 12;
+		if (h >= 7 && h <= 17) return 0;
+		if (h >= 21 || h <= 4) return 1;
+		if (h >= 18 && h <= 20) return (h - 17) / 3;
+		return (7 - h) / 3;
+	});
+
+	const LIT_PATTERNS = /pub|church|house|village|town|shop|school|letter/i;
+	function isLit(name: string): boolean {
+		return LIT_PATTERNS.test(name);
+	}
+
+	let weatherTint: string = $derived.by(() => {
+		const w = ($worldState?.weather ?? '').toLowerCase();
+		if (w.includes('rain') || w.includes('storm')) return 'weather-rain';
+		if (w.includes('fog')) return 'weather-fog';
+		return '';
+	});
+
+	// ── Travel animation ────────────────────────────────────────────────
+	let animFrame = $state(0);
+
+	function projectToLocal(lat: number, lon: number): { x: number; y: number } {
+		const cosLat = Math.cos(REF_CENTER_LAT * (Math.PI / 180));
+		const wx = (lon - REF_CENTER_LON) * SCALE * cosLat;
+		const wy = (REF_CENTER_LAT - lat) * SCALE;
+		return { x: wx - bounds.minX, y: wy - bounds.minY };
+	}
+
+	let travelDot: { x: number; y: number; progress: number } | null = $derived.by(() => {
+		const ts = $travelState;
+		if (!ts) return null;
+		const pos = getTravelPosition(ts, animFrame);
+		if (!pos) return null;
+		return { ...projectToLocal(pos.lat, pos.lon), progress: pos.progress };
+	});
+
+	let travelEdgeIds: Set<string> | null = $derived.by(() => {
+		const ts = $travelState;
+		if (!ts || ts.waypoints.length < 2) return null;
+		const set = new Set<string>();
+		for (let i = 0; i < ts.waypoints.length - 1; i++) {
+			const a = ts.waypoints[i].id;
+			const b = ts.waypoints[i + 1].id;
+			set.add(a < b ? `${a}-${b}` : `${b}-${a}`);
+		}
+		return set;
+	});
+
+	function isTravelEdge(src: string, dst: string): boolean {
+		if (!travelEdgeIds) return false;
+		const key = src < dst ? `${src}-${dst}` : `${dst}-${src}`;
+		return travelEdgeIds.has(key);
+	}
+
+	onMount(() => {
+		let raf: number;
+		function tick() {
+			animFrame = performance.now();
+			raf = requestAnimationFrame(tick);
+		}
+		const unsub = travelState.subscribe((ts) => {
+			if (ts) { raf = requestAnimationFrame(tick); }
+			else { cancelAnimationFrame(raf); }
+		});
+		return () => { cancelAnimationFrame(raf); unsub(); };
+	});
+
+	// ── Footprints ─────────────────────────────────────────────────────
+	let maxTraversal: number = $derived(
+		Math.max(1, ...($mapData?.edge_traversals ?? []).map(([, , c]) => c))
+	);
+
+	function edgeTraversalCount(src: string, dst: string): number {
+		const traversals = $mapData?.edge_traversals;
+		if (!traversals) return 0;
+		for (const [a, b, count] of traversals) {
+			if ((a === src && b === dst) || (a === dst && b === src)) return count;
+		}
+		return 0;
+	}
+
 	function isPlayer(loc: MapLocation): boolean {
 		return $mapData?.player_location === loc.id;
 	}
@@ -162,6 +248,7 @@
 				xmlns="http://www.w3.org/2000/svg"
 				role="img"
 				aria-label="Full parish map"
+				class={weatherTint}
 				style="transform: translate({panX}px, {panY}px) scale({zoom}); transform-origin: center;"
 			>
 				<defs>
@@ -170,16 +257,45 @@
 							<path d={ICON_PATHS[icon]} />
 						</symbol>
 					{/each}
+					{#if nightFactor > 0}
+						<filter id="fullmap-glow" x="-50%" y="-50%" width="200%" height="200%">
+							<feGaussianBlur in="SourceGraphic" stdDeviation={5 * nightFactor} result="blur" />
+							<feColorMatrix in="blur" type="matrix"
+								values="1 0 0 0 0.3  0 1 0 0 0.25  0 0 1 0 0.1  0 0 0 0.7 0"
+								result="glow" />
+							<feMerge>
+								<feMergeNode in="glow" />
+								<feMergeNode in="SourceGraphic" />
+							</feMerge>
+						</filter>
+					{/if}
 				</defs>
-				<!-- Edges -->
+
+				<!-- Night overlay -->
+				{#if nightFactor > 0}
+					<rect x="0" y="0" width={svgW} height={svgH}
+						fill="black" opacity={nightFactor * 0.45}
+						pointer-events="none" />
+				{/if}
+
+				<!-- Edges (with footprints and travel highlight) -->
 				{#each $mapData?.edges ?? [] as [src, dst]}
 					{@const a = localProjected.find((p) => p.id === src)}
 					{@const b = localProjected.find((p) => p.id === dst)}
 					{@const srcLoc = ($mapData?.locations ?? []).find((l) => l.id === src)}
 					{@const dstLoc = ($mapData?.locations ?? []).find((l) => l.id === dst)}
 					{@const isFrontierEdge = srcLoc?.visited === false || dstLoc?.visited === false}
+					{@const traversals = edgeTraversalCount(src, dst)}
+					{@const footprintWidth = traversals > 0 ? 1.5 + 2 * (traversals / maxTraversal) : 1.5}
+					{@const traveling = isTravelEdge(src, dst)}
 					{#if a && b}
-						<line x1={a.x} y1={a.y} x2={b.x} y2={b.y} class="edge" class:frontier-edge={isFrontierEdge} />
+						<line x1={a.x} y1={a.y} x2={b.x} y2={b.y}
+							class="edge"
+							class:frontier-edge={isFrontierEdge}
+							class:travel-edge={traveling}
+							class:footprint={traversals > 0}
+							stroke-width={footprintWidth}
+						/>
 					{/if}
 				{/each}
 
@@ -206,6 +322,7 @@
 					{@const r = isPlayer(loc) ? PLAYER_R : NODE_R}
 					{@const icon = getLocationIcon(loc.name)}
 					{@const iconSize = r * 2}
+					{@const lit = nightFactor > 0 && isLit(loc.name) && loc.visited !== false}
 					<!-- svelte-ignore a11y_click_events_have_key_events -->
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<g
@@ -213,6 +330,8 @@
 						class:player={isPlayer(loc)}
 						class:adjacent={loc.adjacent}
 						class:frontier={loc.visited === false}
+						class:lit-node={lit}
+						filter={lit ? 'url(#fullmap-glow)' : undefined}
 						onclick={() => handleClick(loc)}
 						onmouseenter={() => (tooltip = { name: loc.name, indoor: loc.indoor, travel_minutes: loc.travel_minutes, visited: loc.visited })}
 						onmouseleave={() => (tooltip = null)}
@@ -239,6 +358,16 @@
 						{/if}
 					</g>
 				{/each}
+
+				<!-- Travel animation dot -->
+				{#if travelDot}
+					<circle
+						cx={travelDot.x}
+						cy={travelDot.y}
+						r={NODE_R * 0.8}
+						class="travel-dot"
+					/>
+				{/if}
 			</svg>
 		</div>
 		{#if tooltip}
@@ -402,6 +531,47 @@
 	.node.frontier.adjacent .node-icon {
 		opacity: 0.6;
 		cursor: pointer;
+	}
+
+	/* ── Footprints (worn paths) ── */
+	.edge.footprint {
+		opacity: 0.85;
+	}
+
+	/* ── Travel animation ── */
+	.edge.travel-edge {
+		stroke: var(--color-accent);
+		opacity: 0.9;
+	}
+
+	.travel-dot {
+		fill: var(--color-accent);
+		stroke: var(--color-fg);
+		stroke-width: 1.5;
+		animation: travel-pulse 0.6s ease-in-out infinite alternate;
+	}
+
+	@keyframes travel-pulse {
+		from { opacity: 0.8; }
+		to { opacity: 1; }
+	}
+
+	/* ── Night atmosphere ── */
+	.node.lit-node .node-icon {
+		fill: var(--color-accent);
+	}
+
+	.node.lit-node .node-label {
+		fill: var(--color-accent);
+	}
+
+	/* ── Weather tinting ── */
+	svg.weather-rain {
+		filter: saturate(0.85) brightness(0.92);
+	}
+
+	svg.weather-fog {
+		filter: saturate(0.6) contrast(0.85) brightness(1.05);
 	}
 
 	.tooltip-unexplored {

--- a/ui/src/components/MapPanel.svelte
+++ b/ui/src/components/MapPanel.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
-	import { mapData } from '../stores/game';
+	import { mapData, worldState } from '../stores/game';
 	import { fullMapOpen } from '../stores/game';
+	import { travelState, getTravelPosition } from '../stores/travel';
 	import { submitInput } from '$lib/ipc';
 	import { resolveLabels, distSq, estimateTextWidth, type EdgeLine } from '$lib/map-labels';
-	import { projectWorld } from '$lib/map-projection';
+	import { projectWorld, SCALE, REF_CENTER_LAT, REF_CENTER_LON } from '$lib/map-projection';
 	import { getLocationIcon, ICON_PATHS, type LocationIcon } from '$lib/map-icons';
 	import type { MapLocation } from '$lib/types';
 	import type { ProjectedLocation } from '$lib/map-projection';
 	import type { ResolvedLabel } from '$lib/map-labels';
 	import { tweened } from 'svelte/motion';
 	import { cubicOut } from 'svelte/easing';
+	import { onMount } from 'svelte';
 
 	/** All unique icon keys used by current locations, for <defs>. */
 	let usedIcons: LocationIcon[] = $derived(
@@ -158,6 +160,107 @@
 		return counts;
 	});
 
+	// ── Time-of-day atmosphere ───────────────────────────────────────────
+	/** 0 = full daylight, 1 = deep night */
+	let nightFactor: number = $derived.by(() => {
+		const h = $worldState?.hour ?? 12;
+		if (h >= 7 && h <= 17) return 0;       // day
+		if (h >= 21 || h <= 4) return 1;        // deep night
+		if (h >= 18 && h <= 20) return (h - 17) / 3; // dusk→night
+		return (7 - h) / 3;                    // dawn→day
+	});
+
+	/** Locations with lights that glow at night. */
+	const LIT_PATTERNS = /pub|church|house|village|town|shop|school|letter/i;
+	function isLit(name: string): boolean {
+		return LIT_PATTERNS.test(name);
+	}
+
+	/** Weather-based tint class. */
+	let weatherTint: string = $derived.by(() => {
+		const w = ($worldState?.weather ?? '').toLowerCase();
+		if (w.includes('rain') || w.includes('storm')) return 'weather-rain';
+		if (w.includes('fog')) return 'weather-fog';
+		return '';
+	});
+
+	// ── Travel animation ────────────────────────────────────────────────
+	let animFrame = $state(0);
+
+	/** Project a lat/lon to viewBox-local coords (same projection as locations). */
+	function projectToLocal(lat: number, lon: number): { x: number; y: number } {
+		const cosLat = Math.cos(REF_CENTER_LAT * (Math.PI / 180));
+		const wx = (lon - REF_CENTER_LON) * SCALE * cosLat;
+		const wy = (REF_CENTER_LAT - lat) * SCALE;
+		return {
+			x: wx - $viewCenter.x - viewBox.x,
+			y: wy - $viewCenter.y - viewBox.y
+		};
+	}
+
+	let travelDot: { x: number; y: number; progress: number } | null = $derived.by(() => {
+		const ts = $travelState;
+		if (!ts) return null;
+		const pos = getTravelPosition(ts, animFrame);
+		if (!pos) return null;
+		return { ...projectToLocal(pos.lat, pos.lon), progress: pos.progress };
+	});
+
+	/** Edges in the travel path, for highlighting. */
+	let travelEdgeIds: Set<string> | null = $derived.by(() => {
+		const ts = $travelState;
+		if (!ts || ts.waypoints.length < 2) return null;
+		const set = new Set<string>();
+		for (let i = 0; i < ts.waypoints.length - 1; i++) {
+			const a = ts.waypoints[i].id;
+			const b = ts.waypoints[i + 1].id;
+			set.add(a < b ? `${a}-${b}` : `${b}-${a}`);
+		}
+		return set;
+	});
+
+	function isTravelEdge(src: string, dst: string): boolean {
+		if (!travelEdgeIds) return false;
+		const key = src < dst ? `${src}-${dst}` : `${dst}-${src}`;
+		return travelEdgeIds.has(key);
+	}
+
+	onMount(() => {
+		let raf: number;
+		function tick() {
+			animFrame = performance.now();
+			raf = requestAnimationFrame(tick);
+		}
+		// Only run the animation loop when traveling
+		const unsub = travelState.subscribe((ts) => {
+			if (ts) {
+				raf = requestAnimationFrame(tick);
+			} else {
+				cancelAnimationFrame(raf);
+			}
+		});
+		return () => {
+			cancelAnimationFrame(raf);
+			unsub();
+		};
+	});
+
+	// ── Footprints ─────────────────────────────────────────────────────
+	/** Max traversal count for normalizing line thickness. */
+	let maxTraversal: number = $derived(
+		Math.max(1, ...($mapData?.edge_traversals ?? []).map(([, , c]) => c))
+	);
+
+	/** Look up traversal count for an edge (canonical order). */
+	function edgeTraversalCount(src: string, dst: string): number {
+		const traversals = $mapData?.edge_traversals;
+		if (!traversals) return 0;
+		for (const [a, b, count] of traversals) {
+			if ((a === src && b === dst) || (a === dst && b === src)) return count;
+		}
+		return 0;
+	}
+
 	interface TooltipInfo {
 		name: string;
 		indoor?: boolean;
@@ -191,13 +294,26 @@
 		</button>
 	</div>
 	{#if $mapData}
-		<svg viewBox="0 0 {viewBox.w} {viewBox.h}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Parish minimap">
+		<svg viewBox="0 0 {viewBox.w} {viewBox.h}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Parish minimap" class={weatherTint}>
 			<defs>
 				{#each usedIcons as icon}
 					<symbol id="minimap-icon-{icon}" viewBox="0 0 256 256">
 						<path d={ICON_PATHS[icon]} />
 					</symbol>
 				{/each}
+				<!-- Night glow filter for lit locations -->
+				{#if nightFactor > 0}
+					<filter id="minimap-glow" x="-50%" y="-50%" width="200%" height="200%">
+						<feGaussianBlur in="SourceGraphic" stdDeviation={4 * s * nightFactor} result="blur" />
+						<feColorMatrix in="blur" type="matrix"
+							values="1 0 0 0 0.3  0 1 0 0 0.25  0 0 1 0 0.1  0 0 0 0.7 0"
+							result="glow" />
+						<feMerge>
+							<feMergeNode in="glow" />
+							<feMergeNode in="SourceGraphic" />
+						</feMerge>
+					</filter>
+				{/if}
 			</defs>
 			<!-- Continuation stubs: short faded lines from nodes with off-map connections -->
 			{#each localProjected as loc}
@@ -218,15 +334,31 @@
 				{/if}
 			{/each}
 
-			<!-- Edges -->
+			<!-- Night overlay — darkens the map at night -->
+			{#if nightFactor > 0}
+				<rect x="0" y="0" width={viewBox.w} height={viewBox.h}
+					fill="black" opacity={nightFactor * 0.45}
+					pointer-events="none" />
+			{/if}
+
+			<!-- Edges (with footprint thickness) -->
 			{#each visibleEdges as [src, dst]}
 				{@const a = localProjected.find((p) => p.id === src)}
 				{@const b = localProjected.find((p) => p.id === dst)}
 				{@const srcLoc = ($mapData?.locations ?? []).find((l) => l.id === src)}
 				{@const dstLoc = ($mapData?.locations ?? []).find((l) => l.id === dst)}
 				{@const isFrontierEdge = srcLoc?.visited === false || dstLoc?.visited === false}
+				{@const traversals = edgeTraversalCount(src, dst)}
+				{@const footprintWidth = traversals > 0 ? 1 + 2 * (traversals / maxTraversal) : 1}
+				{@const traveling = isTravelEdge(src, dst)}
 				{#if a && b}
-					<line x1={a.x} y1={a.y} x2={b.x} y2={b.y} class="edge" class:frontier-edge={isFrontierEdge} stroke-width={1 * s} />
+					<line x1={a.x} y1={a.y} x2={b.x} y2={b.y}
+						class="edge"
+						class:frontier-edge={isFrontierEdge}
+						class:travel-edge={traveling}
+						class:footprint={traversals > 0}
+						stroke-width={footprintWidth * s}
+					/>
 				{/if}
 			{/each}
 
@@ -254,6 +386,7 @@
 				{@const r = isPlayer(loc) ? playerR : nodeR}
 				{@const icon = getLocationIcon(loc.name)}
 				{@const iconSize = r * 2}
+				{@const lit = nightFactor > 0 && isLit(loc.name) && loc.visited !== false}
 				<!-- svelte-ignore a11y_click_events_have_key_events -->
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
 				<g
@@ -261,6 +394,8 @@
 					class:player={isPlayer(loc)}
 					class:adjacent={loc.adjacent}
 					class:frontier={loc.visited === false}
+					class:lit-node={lit}
+					filter={lit ? 'url(#minimap-glow)' : undefined}
 					onclick={() => handleClick(loc)}
 					onmouseenter={() => (tooltip = { name: loc.name, indoor: loc.indoor, travel_minutes: loc.travel_minutes, visited: loc.visited })}
 					onmouseleave={() => (tooltip = null)}
@@ -284,7 +419,16 @@
 				</g>
 			{/each}
 
-			<!-- Off-screen indicators removed: confusing at tight zoom -->
+			<!-- Travel animation dot -->
+			{#if travelDot}
+				<circle
+					cx={travelDot.x}
+					cy={travelDot.y}
+					r={nodeR * 0.8}
+					class="travel-dot"
+					stroke-width={1 * s}
+				/>
+			{/if}
 		</svg>
 		{#if tooltip}
 			<div class="tooltip">
@@ -417,6 +561,46 @@
 	.node.frontier.adjacent .node-icon {
 		opacity: 0.6;
 		cursor: pointer;
+	}
+
+	/* ── Footprints (worn paths) ── */
+	.edge.footprint {
+		opacity: 0.85;
+	}
+
+	/* ── Travel animation ── */
+	.edge.travel-edge {
+		stroke: var(--color-accent);
+		opacity: 0.9;
+	}
+
+	.travel-dot {
+		fill: var(--color-accent);
+		stroke: var(--color-fg);
+		animation: travel-pulse 0.6s ease-in-out infinite alternate;
+	}
+
+	@keyframes travel-pulse {
+		from { opacity: 0.8; }
+		to { opacity: 1; }
+	}
+
+	/* ── Night atmosphere ── */
+	.node.lit-node .node-icon {
+		fill: var(--color-accent);
+	}
+
+	.node.lit-node .node-label {
+		fill: var(--color-accent);
+	}
+
+	/* ── Weather tinting ── */
+	svg.weather-rain {
+		filter: saturate(0.85) brightness(0.92);
+	}
+
+	svg.weather-fog {
+		filter: saturate(0.6) contrast(0.85) brightness(1.05);
 	}
 
 	.tooltip-unexplored {

--- a/ui/src/lib/ipc.ts
+++ b/ui/src/lib/ipc.ts
@@ -18,6 +18,7 @@ import type {
 	NpcReactionPayload,
 	WorldUpdatePayload,
 	LoadingPayload,
+	TravelStartPayload,
 	DebugSnapshot,
 	SaveFileInfo,
 	SaveState
@@ -190,3 +191,6 @@ export const onToggleFullMap = (cb: () => void) =>
 
 export const onNpcReaction = (cb: (payload: NpcReactionPayload) => void) =>
 	onEvent<NpcReactionPayload>('npc-reaction', cb);
+
+export const onTravelStart = (cb: (payload: TravelStartPayload) => void) =>
+	onEvent<TravelStartPayload>('travel-start', cb);

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -34,6 +34,22 @@ export interface MapData {
 	player_location: string;
 	player_lat: number;
 	player_lon: number;
+	/** Edge traversal counts for footprint rendering: [src_id, dst_id, count]. */
+	edge_traversals?: [string, string, number][];
+}
+
+/** A waypoint along a travel path. */
+export interface TravelWaypoint {
+	id: string;
+	lat: number;
+	lon: number;
+}
+
+/** Payload for travel-start events (animated travel on the map). */
+export interface TravelStartPayload {
+	waypoints: TravelWaypoint[];
+	duration_minutes: number;
+	destination: string;
 }
 
 export interface NpcInfo {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -14,6 +14,7 @@
 	import { debugVisible, debugSnapshot } from '../stores/debug';
 	import { savePickerVisible } from '../stores/save';
 	import { palette } from '../stores/theme';
+	import { startTravel } from '../stores/travel';
 	import {
 		getWorldSnapshot,
 		getMap,
@@ -30,7 +31,8 @@
 		onDebugUpdate,
 		onSavePicker,
 		onToggleFullMap,
-		onNpcReaction
+		onNpcReaction,
+		onTravelStart
 	} from '$lib/ipc';
 
 	// F5 toggle for save picker, F12 toggle for debug panel, M toggle for map
@@ -200,6 +202,10 @@
 
 			onToggleFullMap(() => {
 				fullMapOpen.update((v) => !v);
+			}),
+
+			onTravelStart((payload) => {
+				startTravel(payload);
 			})
 		]);
 

--- a/ui/src/stores/travel.ts
+++ b/ui/src/stores/travel.ts
@@ -1,0 +1,84 @@
+import { writable, derived } from 'svelte/store';
+import type { TravelStartPayload, TravelWaypoint } from '$lib/types';
+
+/** Current travel animation state (null when not traveling). */
+export interface TravelState {
+	/** Ordered waypoints from origin to destination. */
+	waypoints: TravelWaypoint[];
+	/** Total travel duration in game minutes. */
+	durationMinutes: number;
+	/** Destination location ID. */
+	destination: string;
+	/** Wall-clock timestamp (ms) when animation started. */
+	startedAt: number;
+	/** Animation duration in real milliseconds. */
+	animationMs: number;
+}
+
+/** How long the travel animation plays in real milliseconds, per game minute. */
+const MS_PER_GAME_MINUTE = 150;
+/** Minimum animation duration. */
+const MIN_ANIMATION_MS = 600;
+/** Maximum animation duration. */
+const MAX_ANIMATION_MS = 3000;
+
+/** The active travel animation, or null if idle. */
+export const travelState = writable<TravelState | null>(null);
+
+/** Whether a travel animation is currently playing. */
+export const isTraveling = derived(travelState, ($t) => $t !== null);
+
+/** Starts a travel animation from a TravelStartPayload. */
+export function startTravel(payload: TravelStartPayload): void {
+	if (payload.waypoints.length < 2) return;
+
+	const raw = payload.duration_minutes * MS_PER_GAME_MINUTE;
+	const animationMs = Math.max(MIN_ANIMATION_MS, Math.min(MAX_ANIMATION_MS, raw));
+
+	travelState.set({
+		waypoints: payload.waypoints,
+		durationMinutes: payload.duration_minutes,
+		destination: payload.destination,
+		startedAt: performance.now(),
+		animationMs
+	});
+
+	// Auto-clear when animation completes
+	setTimeout(() => {
+		travelState.set(null);
+	}, animationMs);
+}
+
+/**
+ * Computes the current interpolated position along the travel path.
+ *
+ * Returns `{ lat, lon, progress, segmentIndex }` where progress is 0–1
+ * and segmentIndex is which edge segment the dot is currently on.
+ * Returns null if not traveling.
+ */
+export function getTravelPosition(
+	state: TravelState,
+	now: number
+): { lat: number; lon: number; progress: number; segmentIndex: number } | null {
+	const elapsed = now - state.startedAt;
+	const progress = Math.min(1, Math.max(0, elapsed / state.animationMs));
+
+	const wps = state.waypoints;
+	const segCount = wps.length - 1;
+	if (segCount < 1) return null;
+
+	// Map progress to segment
+	const segFloat = progress * segCount;
+	const segIndex = Math.min(Math.floor(segFloat), segCount - 1);
+	const segProgress = segFloat - segIndex;
+
+	const from = wps[segIndex];
+	const to = wps[segIndex + 1];
+
+	return {
+		lat: from.lat + (to.lat - from.lat) * segProgress,
+		lon: from.lon + (to.lon - from.lon) * segProgress,
+		progress,
+		segmentIndex: segIndex
+	};
+}


### PR DESCRIPTION
## Summary
This PR adds two major visual enhancements to the game's map system:
1. **Travel animation**: A pulsing dot that animates along the player's path during movement
2. **Footprint tracking**: Worn paths that thicken based on how many times edges have been traversed

Additionally, the maps now respond to time-of-day and weather conditions with atmospheric effects.

## Key Changes

### Travel Animation
- Added `TravelState` store (`ui/src/stores/travel.ts`) to manage active travel animations
- Travel animations interpolate smoothly along waypoints over a configurable duration (150ms per game minute, clamped 600–3000ms)
- Frontend receives `TravelStartPayload` with ordered waypoints (lat/lon coordinates) and duration
- Both minimap and full map render an animated pulsing dot that follows the path
- Animation automatically clears when complete

### Footprint Tracking
- Added `edge_traversals: HashMap<(LocationId, LocationId), u32>` to `WorldState` to count traversals per edge
- New `record_path_traversal()` method increments counts for each edge in a movement path
- Edges are stored in canonical order (smaller ID first) so A→B and B→A are the same edge
- Map data includes traversal counts, which render as thicker/lighter "worn path" lines
- Includes comprehensive unit tests for canonical ordering and multi-hop paths

### Atmospheric Effects
- **Night cycle**: Map darkens at night (0–1 factor based on hour), with lit locations (pubs, churches, houses, etc.) glowing with accent color
- **Weather tinting**: Rain reduces saturation/brightness; fog reduces saturation and contrast
- Night glow filter uses Gaussian blur + color matrix for a soft, atmospheric effect
- Both effects applied consistently to minimap and full map

### Backend Integration
- `LocationId` now derives `PartialOrd` and `Ord` for canonical edge ordering
- `build_travel_start()` helper extracts waypoint coordinates from the world graph
- `build_map_data()` includes edge traversal counts in the response
- Movement handlers emit `travel-start` events before state changes so frontend can animate
- Snapshot persistence includes `edge_traversals` field with serde defaults

### Frontend Integration
- Both `MapPanel.svelte` and `FullMapOverlay.svelte` updated with identical logic
- Travel state subscriptions manage requestAnimationFrame lifecycle (only runs when traveling)
- Edge rendering now includes footprint width calculation and travel-edge highlighting
- Location nodes conditionally apply glow filter and accent color when lit at night
- SVG weather tint class applied to root element

## Implementation Details
- Travel animation uses `performance.now()` for smooth frame-independent timing
- Waypoint interpolation is linear per-segment (not global spline)
- Footprint thickness scales from 1px to 3px based on normalized traversal count
- Night glow filter stdDeviation scales with night factor for gradual intensity
- All edge IDs canonicalized before lookup to ensure consistent matching

https://claude.ai/code/session_01PJo6w6EqLvDsH6NUWwkftB