### PR TITLE
Implement Tier 3 batch inference for distant NPCs

### DIFF
--- a/crates/parish-core/src/config/engine.rs
+++ b/crates/parish-core/src/config/engine.rs
@@ -308,9 +308,18 @@ pub struct CognitiveTierConfig {
     /// Maximum distance for Tier 2 (nearby).
     #[serde(default = "default_tier2_max_distance")]
     pub tier2_max_distance: u32,
+    /// Maximum distance for Tier 3 (distant but still LLM-simulated).
+    #[serde(default = "default_tier3_max_distance")]
+    pub tier3_max_distance: u32,
     /// Tier 2 simulation tick interval in game-minutes.
     #[serde(default = "default_tier2_tick_interval_minutes")]
     pub tier2_tick_interval_minutes: i64,
+    /// Tier 3 simulation tick interval in game-hours (1 game-day = 24).
+    #[serde(default = "default_tier3_tick_interval_hours")]
+    pub tier3_tick_interval_hours: i64,
+    /// Maximum NPCs per Tier 3 batch LLM call.
+    #[serde(default = "default_tier3_batch_size")]
+    pub tier3_batch_size: usize,
 }
 
 impl Default for CognitiveTierConfig {
@@ -318,7 +327,10 @@ impl Default for CognitiveTierConfig {
         Self {
             tier1_max_distance: 0,
             tier2_max_distance: 2,
+            tier3_max_distance: 5,
             tier2_tick_interval_minutes: 5,
+            tier3_tick_interval_hours: 24,
+            tier3_batch_size: 10,
         }
     }
 }
@@ -331,6 +343,15 @@ fn default_tier2_max_distance() -> u32 {
 }
 fn default_tier2_tick_interval_minutes() -> i64 {
     5
+}
+fn default_tier3_max_distance() -> u32 {
+    5
+}
+fn default_tier3_tick_interval_hours() -> i64 {
+    24
+}
+fn default_tier3_batch_size() -> usize {
+    10
 }
 
 /// Relationship strength thresholds for descriptive labels.

--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -126,6 +126,8 @@ pub struct NpcDebug {
     pub knowledge: Vec<String>,
     /// Intelligence profile dimensions (each 1–5).
     pub intelligence: IntelligenceDebug,
+    /// Last Tier 3 batch activity summary, if this NPC has received one.
+    pub last_activity: Option<String>,
 }
 
 /// Compact intelligence profile for debug display.
@@ -212,6 +214,12 @@ pub struct TierSummary {
     pub tier1_names: Vec<String>,
     /// Names of Tier 2 NPCs (nearby).
     pub tier2_names: Vec<String>,
+    /// Names of Tier 3 NPCs (distant, batch-simulated).
+    pub tier3_names: Vec<String>,
+    /// Whether a Tier 3 batch inference is currently in flight.
+    pub tier3_in_flight: bool,
+    /// Formatted game time of last Tier 3 batch tick, or null if never run.
+    pub last_tier3_tick: Option<String>,
 }
 
 /// A timestamped debug event for the event log.
@@ -511,6 +519,7 @@ fn build_npc_debug_list(
                     wisdom: npc.intelligence.wisdom,
                     creative: npc.intelligence.creative,
                 },
+                last_activity: npc.last_activity.clone(),
             }
         })
         .collect();
@@ -524,26 +533,32 @@ fn build_npc_debug_list(
 fn build_tier_summary(npc_manager: &NpcManager) -> TierSummary {
     let mut t1 = Vec::new();
     let mut t2 = Vec::new();
-    let mut t3: usize = 0;
+    let mut t3: Vec<String> = Vec::new();
     let mut t4: usize = 0;
 
     for npc in npc_manager.all_npcs() {
         match npc_manager.tier_of(npc.id) {
             Some(CogTier::Tier1) => t1.push(npc.name.clone()),
             Some(CogTier::Tier2) => t2.push(npc.name.clone()),
-            Some(CogTier::Tier3) => t3 += 1,
+            Some(CogTier::Tier3) | None => t3.push(npc.name.clone()),
             Some(CogTier::Tier4) => t4 += 1,
-            None => t3 += 1, // unassigned counts as Tier3
         }
     }
+
+    let last_tier3_tick = npc_manager
+        .last_tier3_game_time()
+        .map(|t| t.format("%H:%M %Y-%m-%d").to_string());
 
     TierSummary {
         tier1_count: t1.len(),
         tier2_count: t2.len(),
-        tier3_count: t3,
+        tier3_count: t3.len(),
         tier4_count: t4,
         tier1_names: t1,
         tier2_names: t2,
+        tier3_names: t3,
+        tier3_in_flight: npc_manager.tier3_in_flight(),
+        last_tier3_tick,
     }
 }
 

--- a/crates/parish-core/src/npc/data.rs
+++ b/crates/parish-core/src/npc/data.rs
@@ -243,6 +243,7 @@ pub fn load_npcs_from_str(json: &str) -> Result<Vec<Npc>, ParishError> {
                 state: NpcState::default(),
                 deflated_summary: None,
                 reaction_log: ReactionLog::default(),
+                last_activity: None,
             }
         })
         .collect();

--- a/crates/parish-core/src/npc/manager.rs
+++ b/crates/parish-core/src/npc/manager.rs
@@ -102,6 +102,10 @@ pub struct NpcManager {
     tier_assignments: HashMap<NpcId, CogTier>,
     /// Game time of the last Tier 2 tick (None if never ticked).
     last_tier2_game_time: Option<DateTime<Utc>>,
+    /// Game time of the last Tier 3 tick (None if never ticked).
+    last_tier3_game_time: Option<DateTime<Utc>>,
+    /// Whether a Tier 3 batch inference is currently in-flight.
+    tier3_in_flight: bool,
     /// Set of NPC ids that have introduced themselves to the player.
     introduced_npcs: HashSet<NpcId>,
 }
@@ -113,6 +117,8 @@ impl NpcManager {
             npcs: HashMap::new(),
             tier_assignments: HashMap::new(),
             last_tier2_game_time: None,
+            last_tier3_game_time: None,
+            tier3_in_flight: false,
             introduced_npcs: HashSet::new(),
         }
     }
@@ -269,14 +275,15 @@ impl NpcManager {
             let new_tier = match distance {
                 Some(d) if d <= config.tier1_max_distance => CogTier::Tier1,
                 Some(d) if d <= config.tier2_max_distance => CogTier::Tier2,
-                _ => CogTier::Tier3,
+                Some(d) if d <= config.tier3_max_distance => CogTier::Tier3,
+                _ => CogTier::Tier4,
             };
 
             let old_tier = self
                 .tier_assignments
                 .get(&npc.id)
                 .copied()
-                .unwrap_or(CogTier::Tier3);
+                .unwrap_or(CogTier::Tier4);
 
             if new_tier != old_tier {
                 changes.push((npc.id, old_tier, new_tier));
@@ -570,6 +577,58 @@ impl NpcManager {
         self.last_tier2_game_time = Some(time);
     }
 
+    /// Returns the ids of all NPCs assigned to Tier 3.
+    pub fn tier3_npcs(&self) -> Vec<NpcId> {
+        self.tier_assignments
+            .iter()
+            .filter(|(_, tier)| **tier == CogTier::Tier3)
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
+    /// Returns whether enough game time has elapsed for a Tier 3 tick.
+    ///
+    /// Tier 3 ticks every 1 in-game day (24 game-hours).
+    pub fn needs_tier3_tick(&self, current_game_time: DateTime<Utc>) -> bool {
+        self.needs_tier3_tick_with_config(current_game_time, &CognitiveTierConfig::default())
+    }
+
+    /// Returns whether enough game time has elapsed for a Tier 3 tick,
+    /// using the given cognitive tier config for the tick interval.
+    pub fn needs_tier3_tick_with_config(
+        &self,
+        current_game_time: DateTime<Utc>,
+        config: &CognitiveTierConfig,
+    ) -> bool {
+        match self.last_tier3_game_time {
+            None => true,
+            Some(last) => {
+                let elapsed = current_game_time.signed_duration_since(last);
+                elapsed.num_hours() >= config.tier3_tick_interval_hours
+            }
+        }
+    }
+
+    /// Returns the game time of the last Tier 3 tick, if any.
+    pub fn last_tier3_game_time(&self) -> Option<DateTime<Utc>> {
+        self.last_tier3_game_time
+    }
+
+    /// Records that a Tier 3 tick has been performed at the given game time.
+    pub fn record_tier3_tick(&mut self, time: DateTime<Utc>) {
+        self.last_tier3_game_time = Some(time);
+    }
+
+    /// Returns whether a Tier 3 tick is currently in-flight.
+    pub fn tier3_in_flight(&self) -> bool {
+        self.tier3_in_flight
+    }
+
+    /// Sets whether a Tier 3 tick is currently in-flight.
+    pub fn set_tier3_in_flight(&mut self, in_flight: bool) {
+        self.tier3_in_flight = in_flight;
+    }
+
     /// Groups Tier 2 NPCs by their current location.
     ///
     /// Returns a map of location id to the NPC ids at that location.
@@ -655,6 +714,7 @@ mod tests {
             state: NpcState::Present,
             deflated_summary: None,
             reaction_log: crate::npc::reactions::ReactionLog::default(),
+            last_activity: None,
         }
     }
 
@@ -804,8 +864,10 @@ mod tests {
         // Fairy fort distance depends on graph topology
         let fairy_tier = mgr.tier_of(NpcId(3)).unwrap();
         assert!(
-            fairy_tier == CogTier::Tier2 || fairy_tier == CogTier::Tier3,
-            "fairy fort should be Tier2 or Tier3 based on distance"
+            fairy_tier == CogTier::Tier2
+                || fairy_tier == CogTier::Tier3
+                || fairy_tier == CogTier::Tier4,
+            "fairy fort should be Tier2, Tier3, or Tier4 based on distance"
         );
     }
 
@@ -1123,9 +1185,8 @@ mod tests {
         mgr.record_tier2_tick(t0);
 
         let config = CognitiveTierConfig {
-            tier1_max_distance: 0,
-            tier2_max_distance: 2,
             tier2_tick_interval_minutes: 10,
+            ..CognitiveTierConfig::default()
         };
 
         // 5 minutes later: not enough (interval is 10)
@@ -1143,9 +1204,8 @@ mod tests {
         let now = Utc.with_ymd_and_hms(1820, 3, 20, 12, 0, 0).unwrap();
 
         let config = CognitiveTierConfig {
-            tier1_max_distance: 0,
-            tier2_max_distance: 2,
             tier2_tick_interval_minutes: 10,
+            ..CognitiveTierConfig::default()
         };
 
         // First time should always need a tick regardless of config
@@ -1218,5 +1278,137 @@ mod tests {
             "Farmer should tolerate light rain and head to outdoor work, got {:?}",
             npc.state
         );
+    }
+
+    // --- Tier 3 / Tier 4 assignment tests ---
+
+    /// Builds a linear chain graph: 0 - 1 - 2 - ... - n for testing.
+    fn make_chain_graph(n: u32) -> WorldGraph {
+        let locations: Vec<serde_json::Value> = (0..=n)
+            .map(|i| {
+                let mut conns = Vec::new();
+                if i > 0 {
+                    conns.push(serde_json::json!({
+                        "target": i - 1,
+                        "path_description": "a path"
+                    }));
+                }
+                if i < n {
+                    conns.push(serde_json::json!({
+                        "target": i + 1,
+                        "path_description": "a path"
+                    }));
+                }
+                serde_json::json!({
+                    "id": i,
+                    "name": format!("Loc {}", i),
+                    "description_template": "Test",
+                    "indoor": false,
+                    "public": true,
+                    "connections": conns
+                })
+            })
+            .collect();
+        let json = serde_json::json!({"locations": locations}).to_string();
+        WorldGraph::load_from_str(&json).unwrap()
+    }
+
+    #[test]
+    fn test_tier_assignment_3_vs_4() {
+        let graph = make_chain_graph(6);
+
+        let mut mgr = NpcManager::new();
+        // Place NPCs at various distances from player (at location 0)
+        for i in 0..=6 {
+            mgr.add_npc(make_test_npc(i + 10, i));
+        }
+
+        let mut world = WorldState::new();
+        world.player_location = LocationId(0);
+        world.graph = graph;
+
+        mgr.assign_tiers(&world, &[]);
+
+        // Distance 0 → Tier 1
+        assert_eq!(mgr.tier_of(NpcId(10)), Some(CogTier::Tier1));
+        // Distance 1 → Tier 2
+        assert_eq!(mgr.tier_of(NpcId(11)), Some(CogTier::Tier2));
+        // Distance 2 → Tier 2
+        assert_eq!(mgr.tier_of(NpcId(12)), Some(CogTier::Tier2));
+        // Distance 3 → Tier 3
+        assert_eq!(mgr.tier_of(NpcId(13)), Some(CogTier::Tier3));
+        // Distance 4 → Tier 3
+        assert_eq!(mgr.tier_of(NpcId(14)), Some(CogTier::Tier3));
+        // Distance 5 → Tier 3
+        assert_eq!(mgr.tier_of(NpcId(15)), Some(CogTier::Tier3));
+        // Distance 6 → Tier 4
+        assert_eq!(mgr.tier_of(NpcId(16)), Some(CogTier::Tier4));
+    }
+
+    #[test]
+    fn test_tier3_npcs() {
+        let graph = make_chain_graph(5);
+
+        let mut mgr = NpcManager::new();
+        // NPC at distance 3 = Tier 3, NPC at distance 4 = Tier 3
+        mgr.add_npc(make_test_npc(1, 3));
+        mgr.add_npc(make_test_npc(2, 4));
+        // NPC at distance 1 = Tier 2
+        mgr.add_npc(make_test_npc(3, 1));
+
+        let mut world = WorldState::new();
+        world.player_location = LocationId(0);
+        world.graph = graph;
+
+        mgr.assign_tiers(&world, &[]);
+
+        let tier3 = mgr.tier3_npcs();
+        assert_eq!(tier3.len(), 2);
+        assert!(tier3.contains(&NpcId(1)));
+        assert!(tier3.contains(&NpcId(2)));
+    }
+
+    #[test]
+    fn test_tier3_tick_interval() {
+        let config = CognitiveTierConfig::default();
+        let mgr = NpcManager::new();
+
+        // Never ticked → needs tick
+        let now = Utc.with_ymd_and_hms(1820, 3, 20, 12, 0, 0).unwrap();
+        assert!(mgr.needs_tier3_tick_with_config(now, &config));
+    }
+
+    #[test]
+    fn test_tier3_tick_not_yet_due() {
+        let config = CognitiveTierConfig::default();
+        let mut mgr = NpcManager::new();
+        let t0 = Utc.with_ymd_and_hms(1820, 3, 20, 0, 0, 0).unwrap();
+        mgr.record_tier3_tick(t0);
+
+        // 12 hours later → not yet (need 24)
+        let t1 = Utc.with_ymd_and_hms(1820, 3, 20, 12, 0, 0).unwrap();
+        assert!(!mgr.needs_tier3_tick_with_config(t1, &config));
+    }
+
+    #[test]
+    fn test_tier3_tick_due() {
+        let config = CognitiveTierConfig::default();
+        let mut mgr = NpcManager::new();
+        let t0 = Utc.with_ymd_and_hms(1820, 3, 20, 0, 0, 0).unwrap();
+        mgr.record_tier3_tick(t0);
+
+        // 24 hours later → due
+        let t1 = Utc.with_ymd_and_hms(1820, 3, 21, 0, 0, 0).unwrap();
+        assert!(mgr.needs_tier3_tick_with_config(t1, &config));
+    }
+
+    #[test]
+    fn test_tier3_in_flight_tracking() {
+        let mut mgr = NpcManager::new();
+        assert!(!mgr.tier3_in_flight());
+        mgr.set_tier3_in_flight(true);
+        assert!(mgr.tier3_in_flight());
+        mgr.set_tier3_in_flight(false);
+        assert!(!mgr.tier3_in_flight());
     }
 }

--- a/crates/parish-core/src/npc/mod.rs
+++ b/crates/parish-core/src/npc/mod.rs
@@ -159,6 +159,11 @@ pub struct Npc {
     pub deflated_summary: Option<NpcSummary>,
     /// Log of recent player reactions (emoji) toward this NPC.
     pub reaction_log: ReactionLog,
+    /// Last activity summary from Tier 3 batch simulation.
+    ///
+    /// Used in deflated context and Tier 3 prompt construction.
+    /// Updated each time a Tier 3 tick processes this NPC.
+    pub last_activity: Option<String>,
 }
 
 impl Npc {
@@ -191,6 +196,7 @@ impl Npc {
             state: NpcState::default(),
             deflated_summary: None,
             reaction_log: ReactionLog::default(),
+            last_activity: None,
         }
     }
 

--- a/crates/parish-core/src/npc/ticks.rs
+++ b/crates/parish-core/src/npc/ticks.rs
@@ -1,16 +1,19 @@
-//! Tier 1 and Tier 2 tick functions for NPC simulation.
+//! Tier 1, Tier 2, and Tier 3 tick functions for NPC simulation.
 //!
 //! Tier 1 ticks run per player interaction (full LLM inference).
 //! Tier 2 ticks run every 5 game-minutes for nearby NPCs (lighter inference).
+//! Tier 3 ticks run every 1 game-day for distant NPCs (batch inference).
 
 use chrono::Utc;
 
 use crate::config::{NpcConfig, RelationshipLabelConfig};
+use crate::error::ParishError;
 use crate::inference::openai_client::OpenAiClient;
 use crate::npc::gossip::GossipNetwork;
 use crate::npc::memory::{MemoryEntry, try_promote};
-use crate::npc::types::{Tier2Event, Tier2Response};
+use crate::npc::types::{Tier2Event, Tier2Response, Tier3Response, Tier3Update};
 use crate::npc::{Npc, NpcId, NpcStreamResponse, build_tier1_context, build_tier1_system_prompt};
+use crate::world::graph::WorldGraph;
 use crate::world::{LocationId, WorldState};
 
 /// A lightweight snapshot of an NPC's state for Tier 2 inference.
@@ -488,6 +491,269 @@ pub fn propagate_gossip_at_location(
     all_transmitted
 }
 
+// ---------------------------------------------------------------------------
+// Tier 3 — batch inference for distant NPCs
+// ---------------------------------------------------------------------------
+
+/// Default batch size for Tier 3 inference (NPCs per LLM call).
+pub const TIER3_BATCH_SIZE: usize = 10;
+
+/// A lightweight snapshot of an NPC's state for Tier 3 batch inference.
+#[derive(Debug, Clone)]
+pub struct Tier3Snapshot {
+    /// NPC id.
+    pub id: NpcId,
+    /// NPC name.
+    pub name: String,
+    /// Occupation.
+    pub occupation: String,
+    /// Age.
+    pub age: u8,
+    /// Current location id.
+    pub location: LocationId,
+    /// Location name.
+    pub location_name: String,
+    /// Current mood.
+    pub mood: String,
+    /// Deflated summary or last activity.
+    pub context: String,
+    /// Relationship summaries for prompt injection.
+    pub relationship_context: String,
+}
+
+/// Builds a Tier 3 batch prompt for a set of NPC snapshots.
+pub fn build_tier3_prompt(
+    snapshots: &[Tier3Snapshot],
+    time_desc: &str,
+    weather: &str,
+    season: &str,
+    hours: u32,
+) -> String {
+    let npc_summaries: Vec<String> = snapshots
+        .iter()
+        .map(|snap| {
+            let context_line = if snap.context.is_empty() {
+                String::new()
+            } else {
+                format!("\nRecent: {}", snap.context)
+            };
+            let rel_line = if snap.relationship_context.is_empty() {
+                String::new()
+            } else {
+                format!("\nRelationships: {}", snap.relationship_context)
+            };
+            format!(
+                "NPC {id} \"{name}\" ({occupation}, age {age}): At {location}. Mood: {mood}.{context}{rels}",
+                id = snap.id.0,
+                name = snap.name,
+                occupation = snap.occupation,
+                age = snap.age,
+                location = snap.location_name,
+                mood = snap.mood,
+                context = context_line,
+                rels = rel_line,
+            )
+        })
+        .collect();
+
+    format!(
+        "You are simulating background NPC activity in a rural Irish parish in 1820.\n\
+        Given the following NPCs and their current states, simulate {hours} hours of activity.\n\
+        The weather is {weather}. The season is {season}. The time is {time}.\n\n\
+        Return a JSON object with an \"updates\" array. Each update has:\n\
+        - npc_id (integer)\n\
+        - mood (string, one word)\n\
+        - activity_summary (string, 1 sentence)\n\
+        - new_location (integer or null)\n\
+        - relationship_changes (array of {{\"from\": <id>, \"to\": <id>, \"delta\": <-0.1 to 0.1>}})\n\n\
+        NPCs:\n{npcs}",
+        hours = hours,
+        weather = weather,
+        season = season,
+        time = time_desc,
+        npcs = npc_summaries.join("\n\n"),
+    )
+}
+
+/// Creates a Tier 3 snapshot from an NPC, resolving location names from the graph.
+pub fn tier3_snapshot_from_npc(npc: &Npc, graph: &WorldGraph) -> Tier3Snapshot {
+    let location_name = graph
+        .get(npc.location)
+        .map(|d| d.name.clone())
+        .unwrap_or_else(|| format!("Location {}", npc.location.0));
+
+    let context = if let Some(ref activity) = npc.last_activity {
+        activity.clone()
+    } else if let Some(ref summary) = npc.deflated_summary {
+        summary.recent_activity.first().cloned().unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    let relationship_context: Vec<String> = npc
+        .relationships
+        .iter()
+        .take(3)
+        .map(|(target_id, rel)| format!("NPC {} ({:.1})", target_id.0, rel.strength))
+        .collect();
+
+    Tier3Snapshot {
+        id: npc.id,
+        name: npc.name.clone(),
+        occupation: npc.occupation.clone(),
+        age: npc.age,
+        location: npc.location,
+        location_name,
+        mood: npc.mood.clone(),
+        context,
+        relationship_context: relationship_context.join(", "),
+    }
+}
+
+/// Context for a Tier 3 batch simulation call.
+pub struct Tier3Context<'a> {
+    /// NPC snapshots to simulate.
+    pub snapshots: &'a [Tier3Snapshot],
+    /// LLM client for inference.
+    pub client: &'a OpenAiClient,
+    /// Model name to use.
+    pub model: &'a str,
+    /// Time description (e.g. "Morning").
+    pub time_desc: &'a str,
+    /// Weather description (e.g. "Overcast").
+    pub weather: &'a str,
+    /// Season (e.g. "Spring").
+    pub season: &'a str,
+    /// Number of game hours to simulate.
+    pub hours: u32,
+    /// Maximum NPCs per batch LLM call.
+    pub batch_size: usize,
+}
+
+/// Runs a Tier 3 batch simulation for distant NPCs.
+///
+/// Builds a single prompt summarizing all provided NPC snapshots and their states,
+/// sends it to the simulation LLM client, and parses the JSON response.
+/// If there are more NPCs than `batch_size`, they are split into multiple
+/// sequential LLM calls.
+pub async fn tick_tier3(ctx: &Tier3Context<'_>) -> Result<Vec<Tier3Update>, ParishError> {
+    let batch_size = if ctx.batch_size == 0 {
+        TIER3_BATCH_SIZE
+    } else {
+        ctx.batch_size
+    };
+
+    let mut all_updates = Vec::new();
+
+    for batch in ctx.snapshots.chunks(batch_size) {
+        let prompt = build_tier3_prompt(batch, ctx.time_desc, ctx.weather, ctx.season, ctx.hours);
+
+        match ctx
+            .client
+            .generate_json::<Tier3Response>(ctx.model, &prompt, None, None)
+            .await
+        {
+            Ok(resp) => {
+                all_updates.extend(resp.updates);
+            }
+            Err(e) => {
+                tracing::warn!("Tier 3 batch inference failed: {}", e);
+                // Continue with other batches rather than failing entirely
+            }
+        }
+    }
+
+    Ok(all_updates)
+}
+
+/// Applies Tier 3 updates to NPCs.
+///
+/// For each update: sets mood, stores activity_summary as `last_activity`,
+/// updates location (if valid in graph), and adjusts relationships.
+///
+/// Returns debug event strings describing what happened.
+pub fn apply_tier3_updates(
+    updates: &[Tier3Update],
+    npcs: &mut std::collections::HashMap<NpcId, Npc>,
+    graph: &WorldGraph,
+    game_time: chrono::DateTime<Utc>,
+) -> Vec<String> {
+    let mut debug_events = Vec::new();
+
+    for update in updates {
+        let Some(npc) = npcs.get_mut(&update.npc_id) else {
+            tracing::warn!(
+                npc_id = update.npc_id.0,
+                "Tier 3 update for unknown NPC, skipping"
+            );
+            continue;
+        };
+
+        // Update mood
+        if !update.mood.is_empty() && update.mood != npc.mood {
+            debug_events.push(format!(
+                "{} mood: {} -> {} (tier3)",
+                npc.name, npc.mood, update.mood
+            ));
+            npc.mood = update.mood.clone();
+        }
+
+        // Store activity summary
+        if !update.activity_summary.is_empty() {
+            debug_events.push(format!(
+                "{} activity: {} (tier3)",
+                npc.name, update.activity_summary
+            ));
+            npc.last_activity = Some(update.activity_summary.clone());
+
+            // Also record as memory
+            let mem_entry = MemoryEntry {
+                timestamp: game_time,
+                content: update.activity_summary.clone(),
+                participants: vec![update.npc_id],
+                location: npc.location,
+            };
+            if let Some(evicted) = npc.memory.add(mem_entry) {
+                let npc_name = npc.name.clone();
+                try_promote(&mut npc.long_term_memory, &evicted, &[npc_name], "");
+            }
+        }
+
+        // Update location if valid
+        if let Some(new_loc) = update.new_location {
+            if graph.get(new_loc).is_some() {
+                debug_events.push(format!(
+                    "{} moved: {:?} -> {:?} (tier3)",
+                    npc.name, npc.location, new_loc
+                ));
+                npc.location = new_loc;
+            } else {
+                tracing::warn!(
+                    npc_id = update.npc_id.0,
+                    location = new_loc.0,
+                    "Tier 3 update has invalid location, ignoring"
+                );
+            }
+        }
+
+        // Apply relationship changes
+        for rc in &update.relationship_changes {
+            if rc.from == update.npc_id
+                && let Some(npc) = npcs.get_mut(&rc.from)
+                && let Some(rel) = npc.relationships.get_mut(&rc.to)
+            {
+                rel.adjust_strength(rc.delta);
+                debug_events.push(format!(
+                    "NPC {} -> NPC {}: relationship {:.2} (tier3)",
+                    rc.from.0, rc.to.0, rc.delta
+                ));
+            }
+        }
+    }
+
+    debug_events
+}
+
 /// Truncates a string to a maximum length, adding "..." if truncated.
 fn truncate_for_memory(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
@@ -531,6 +797,7 @@ mod tests {
             state: NpcState::default(),
             deflated_summary: None,
             reaction_log: crate::npc::reactions::ReactionLog::default(),
+            last_activity: None,
         }
     }
 
@@ -1124,5 +1391,275 @@ mod tests {
         let events = apply_tier1_response(&mut npc, &response, "hello", game_time);
         assert_eq!(npc.mood, "calm"); // unchanged
         assert!(!events.iter().any(|e| e.contains("mood:")));
+    }
+
+    // --- Tier 3 tests ---
+
+    #[test]
+    fn test_tier3_response_parsing() {
+        let json = r#"{
+            "updates": [
+                {
+                    "npc_id": 1,
+                    "mood": "content",
+                    "activity_summary": "Tended the fields all morning.",
+                    "new_location": null,
+                    "relationship_changes": [{"from": 1, "to": 2, "delta": 0.05}]
+                },
+                {
+                    "npc_id": 2,
+                    "mood": "tired",
+                    "activity_summary": "Mended a fence near the road.",
+                    "new_location": 3,
+                    "relationship_changes": []
+                }
+            ]
+        }"#;
+        let resp: Tier3Response = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.updates.len(), 2);
+        assert_eq!(resp.updates[0].npc_id, NpcId(1));
+        assert_eq!(resp.updates[0].mood, "content");
+        assert_eq!(
+            resp.updates[0].activity_summary,
+            "Tended the fields all morning."
+        );
+        assert!(resp.updates[0].new_location.is_none());
+        assert_eq!(resp.updates[0].relationship_changes.len(), 1);
+        assert_eq!(resp.updates[1].npc_id, NpcId(2));
+        assert_eq!(resp.updates[1].new_location, Some(LocationId(3)));
+    }
+
+    #[test]
+    fn test_tier3_response_partial() {
+        // Missing optional fields should default gracefully
+        let json = r#"{"updates": [{"npc_id": 5}]}"#;
+        let resp: Tier3Response = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.updates.len(), 1);
+        assert_eq!(resp.updates[0].npc_id, NpcId(5));
+        assert_eq!(resp.updates[0].mood, "");
+        assert_eq!(resp.updates[0].activity_summary, "");
+        assert!(resp.updates[0].new_location.is_none());
+        assert!(resp.updates[0].relationship_changes.is_empty());
+    }
+
+    #[test]
+    fn test_tier3_response_empty_updates() {
+        let json = r#"{}"#;
+        let resp: Tier3Response = serde_json::from_str(json).unwrap();
+        assert!(resp.updates.is_empty());
+    }
+
+    #[test]
+    fn test_tier3_prompt_construction() {
+        let snapshots = vec![
+            Tier3Snapshot {
+                id: NpcId(1),
+                name: "Padraig".to_string(),
+                occupation: "Publican".to_string(),
+                age: 58,
+                location: LocationId(2),
+                location_name: "Darcy's Pub".to_string(),
+                mood: "content".to_string(),
+                context: "Served drinks all evening.".to_string(),
+                relationship_context: "NPC 2 (0.5)".to_string(),
+            },
+            Tier3Snapshot {
+                id: NpcId(3),
+                name: "Bridget".to_string(),
+                occupation: "Farmer".to_string(),
+                age: 35,
+                location: LocationId(5),
+                location_name: "O'Brien's Farm".to_string(),
+                mood: "worried".to_string(),
+                context: String::new(),
+                relationship_context: String::new(),
+            },
+        ];
+
+        let prompt = build_tier3_prompt(&snapshots, "Morning", "Overcast", "Spring", 24);
+        assert!(prompt.contains("simulate 24 hours"));
+        assert!(prompt.contains("Overcast"));
+        assert!(prompt.contains("Spring"));
+        assert!(prompt.contains("Morning"));
+        assert!(prompt.contains("NPC 1 \"Padraig\""));
+        assert!(prompt.contains("Publican, age 58"));
+        assert!(prompt.contains("Darcy's Pub"));
+        assert!(prompt.contains("Served drinks all evening."));
+        assert!(prompt.contains("NPC 3 \"Bridget\""));
+        assert!(prompt.contains("Farmer, age 35"));
+        // NPC with no context should not have "Recent:" line
+        assert!(prompt.contains("Mood: worried."));
+        // JSON format instructions
+        assert!(prompt.contains("npc_id"));
+        assert!(prompt.contains("activity_summary"));
+    }
+
+    #[test]
+    fn test_tier3_batching() {
+        // Verify that 25 snapshots would be split into 3 batches of 10, 10, 5
+        let snapshots: Vec<Tier3Snapshot> = (1..=25)
+            .map(|i| Tier3Snapshot {
+                id: NpcId(i),
+                name: format!("NPC {}", i),
+                occupation: "Test".to_string(),
+                age: 30,
+                location: LocationId(1),
+                location_name: "Test".to_string(),
+                mood: "calm".to_string(),
+                context: String::new(),
+                relationship_context: String::new(),
+            })
+            .collect();
+
+        let chunks: Vec<&[Tier3Snapshot]> = snapshots.chunks(TIER3_BATCH_SIZE).collect();
+        assert_eq!(chunks.len(), 3);
+        assert_eq!(chunks[0].len(), 10);
+        assert_eq!(chunks[1].len(), 10);
+        assert_eq!(chunks[2].len(), 5);
+    }
+
+    #[test]
+    fn test_tier3_update_application() {
+        use crate::npc::types::{Relationship, RelationshipKind};
+        use crate::world::graph::WorldGraph;
+
+        let mut npcs: HashMap<NpcId, Npc> = HashMap::new();
+        let mut npc1 = make_test_npc(1, "Padraig", 2);
+        npc1.relationships
+            .insert(NpcId(5), Relationship::new(RelationshipKind::Friend, 0.5));
+        npcs.insert(NpcId(1), npc1);
+        npcs.insert(NpcId(5), make_test_npc(5, "Tommy", 2));
+
+        let graph = WorldGraph::new();
+
+        let updates = vec![Tier3Update {
+            npc_id: NpcId(1),
+            mood: "jovial".to_string(),
+            activity_summary: "Spent the day cleaning the pub.".to_string(),
+            new_location: None,
+            relationship_changes: vec![RelationshipChange {
+                from: NpcId(1),
+                to: NpcId(5),
+                delta: 0.1,
+            }],
+        }];
+
+        let game_time = Utc.with_ymd_and_hms(1820, 3, 20, 20, 0, 0).unwrap();
+        let events = apply_tier3_updates(&updates, &mut npcs, &graph, game_time);
+
+        // Mood updated
+        assert_eq!(npcs.get(&NpcId(1)).unwrap().mood, "jovial");
+
+        // Activity stored
+        assert_eq!(
+            npcs.get(&NpcId(1)).unwrap().last_activity.as_deref(),
+            Some("Spent the day cleaning the pub.")
+        );
+
+        // Memory recorded
+        assert!(npcs.get(&NpcId(1)).unwrap().memory.len() > 0);
+
+        // Relationship adjusted
+        let rel = npcs
+            .get(&NpcId(1))
+            .unwrap()
+            .relationships
+            .get(&NpcId(5))
+            .unwrap();
+        assert!((rel.strength - 0.6).abs() < f64::EPSILON);
+
+        // Debug events generated
+        assert!(!events.is_empty());
+        assert!(events.iter().any(|e| e.contains("mood")));
+        assert!(events.iter().any(|e| e.contains("activity")));
+    }
+
+    #[test]
+    fn test_tier3_invalid_location_ignored() {
+        use crate::world::graph::WorldGraph;
+
+        let mut npcs: HashMap<NpcId, Npc> = HashMap::new();
+        npcs.insert(NpcId(1), make_test_npc(1, "Padraig", 2));
+
+        let graph = WorldGraph::new(); // empty graph — no valid locations
+
+        let updates = vec![Tier3Update {
+            npc_id: NpcId(1),
+            mood: "calm".to_string(),
+            activity_summary: "Walked to market.".to_string(),
+            new_location: Some(LocationId(999)), // nonexistent
+            relationship_changes: Vec::new(),
+        }];
+
+        let game_time = Utc.with_ymd_and_hms(1820, 3, 20, 20, 0, 0).unwrap();
+        apply_tier3_updates(&updates, &mut npcs, &graph, game_time);
+
+        // Location should NOT have changed
+        assert_eq!(npcs.get(&NpcId(1)).unwrap().location, LocationId(2));
+    }
+
+    #[test]
+    fn test_tier3_unknown_npc_skipped() {
+        use crate::world::graph::WorldGraph;
+
+        let mut npcs: HashMap<NpcId, Npc> = HashMap::new();
+        npcs.insert(NpcId(1), make_test_npc(1, "Padraig", 2));
+
+        let graph = WorldGraph::new();
+
+        let updates = vec![Tier3Update {
+            npc_id: NpcId(99), // does not exist
+            mood: "happy".to_string(),
+            activity_summary: "Ghost NPC.".to_string(),
+            new_location: None,
+            relationship_changes: Vec::new(),
+        }];
+
+        let game_time = Utc.with_ymd_and_hms(1820, 3, 20, 20, 0, 0).unwrap();
+        let events = apply_tier3_updates(&updates, &mut npcs, &graph, game_time);
+
+        // Should produce no events (NPC not found)
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn test_tier3_snapshot_from_npc_with_last_activity() {
+        let mut npc = make_test_npc(1, "Padraig", 2);
+        npc.last_activity = Some("Tended bar all evening.".to_string());
+
+        let graph = WorldGraph::new();
+        let snap = tier3_snapshot_from_npc(&npc, &graph);
+
+        assert_eq!(snap.id, NpcId(1));
+        assert_eq!(snap.name, "Padraig");
+        assert_eq!(snap.context, "Tended bar all evening.");
+    }
+
+    #[test]
+    fn test_tier3_snapshot_from_npc_with_deflated_summary() {
+        use crate::npc::transitions::NpcSummary;
+
+        let mut npc = make_test_npc(1, "Padraig", 2);
+        npc.deflated_summary = Some(NpcSummary {
+            npc_id: NpcId(1),
+            location: LocationId(2),
+            mood: "calm".to_string(),
+            recent_activity: vec!["Chatted with Tommy.".to_string()],
+            key_relationship_changes: Vec::new(),
+        });
+
+        let graph = WorldGraph::new();
+        let snap = tier3_snapshot_from_npc(&npc, &graph);
+
+        assert_eq!(snap.context, "Chatted with Tommy.");
+    }
+
+    #[test]
+    fn test_tier3_snapshot_from_npc_no_context() {
+        let npc = make_test_npc(1, "Padraig", 2);
+        let graph = WorldGraph::new();
+        let snap = tier3_snapshot_from_npc(&npc, &graph);
+
+        assert_eq!(snap.context, "");
     }
 }

--- a/crates/parish-core/src/npc/transitions.rs
+++ b/crates/parish-core/src/npc/transitions.rs
@@ -211,6 +211,7 @@ mod tests {
             state: NpcState::Present,
             deflated_summary: None,
             reaction_log: crate::npc::reactions::ReactionLog::default(),
+            last_activity: None,
         }
     }
 

--- a/crates/parish-core/src/npc/types.rs
+++ b/crates/parish-core/src/npc/types.rs
@@ -541,6 +541,52 @@ pub struct Tier2Response {
     pub relationship_changes: Vec<RelationshipChange>,
 }
 
+/// The result of a Tier 3 batch simulation for a single NPC.
+///
+/// Produced by the batch LLM call that simulates many distant NPCs at once.
+/// Each update describes what one NPC did during the simulated period.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tier3Update {
+    /// Which NPC this update is for.
+    pub npc_id: NpcId,
+    /// New location (if NPC moved during the simulated period).
+    #[serde(default)]
+    pub new_location: Option<LocationId>,
+    /// Updated mood string.
+    #[serde(default)]
+    pub mood: String,
+    /// Summary of what the NPC did during the simulated period.
+    #[serde(default)]
+    pub activity_summary: String,
+    /// Relationship changes: (from, to, strength_delta).
+    #[serde(default)]
+    pub relationship_changes: Vec<RelationshipChange>,
+}
+
+/// The full response from a Tier 3 batch LLM call.
+///
+/// Contains an array of updates, one per NPC in the batch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Tier3Response {
+    /// Per-NPC updates from the batch simulation.
+    #[serde(default)]
+    pub updates: Vec<Tier3Update>,
+}
+
+/// Priority levels for inference requests.
+///
+/// Lower values = higher priority. Used to ensure player-facing dialogue
+/// is never delayed by background batch simulation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum InferencePriority {
+    /// Tier 1: player-facing dialogue (highest priority).
+    Interactive = 0,
+    /// Tier 2: nearby NPC background simulation.
+    Background = 1,
+    /// Tier 3: distant NPC batch simulation (lowest LLM priority).
+    Batch = 2,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -994,5 +1040,60 @@ mod tests {
             .unwrap();
         assert!(resolved.cuaird);
         assert_eq!(resolved.activity, "cuaird visiting");
+    }
+
+    // --- Tier 3 type tests ---
+
+    #[test]
+    fn test_tier3_update_deserialize_full() {
+        use super::{Tier3Response, Tier3Update};
+
+        let json = r#"{
+            "updates": [{
+                "npc_id": 1,
+                "mood": "content",
+                "activity_summary": "Worked in the field.",
+                "new_location": 5,
+                "relationship_changes": [{"from": 1, "to": 2, "delta": 0.1}]
+            }]
+        }"#;
+        let resp: Tier3Response = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.updates.len(), 1);
+        let u = &resp.updates[0];
+        assert_eq!(u.npc_id, NpcId(1));
+        assert_eq!(u.mood, "content");
+        assert_eq!(u.activity_summary, "Worked in the field.");
+        assert_eq!(u.new_location, Some(LocationId(5)));
+        assert_eq!(u.relationship_changes.len(), 1);
+    }
+
+    #[test]
+    fn test_tier3_update_deserialize_minimal() {
+        use super::Tier3Update;
+
+        let json = r#"{"npc_id": 3}"#;
+        let u: Tier3Update = serde_json::from_str(json).unwrap();
+        assert_eq!(u.npc_id, NpcId(3));
+        assert_eq!(u.mood, "");
+        assert_eq!(u.activity_summary, "");
+        assert!(u.new_location.is_none());
+        assert!(u.relationship_changes.is_empty());
+    }
+
+    #[test]
+    fn test_tier3_response_empty() {
+        use super::Tier3Response;
+
+        let json = r#"{}"#;
+        let resp: Tier3Response = serde_json::from_str(json).unwrap();
+        assert!(resp.updates.is_empty());
+    }
+
+    #[test]
+    fn test_inference_priority_ordering() {
+        use super::InferencePriority;
+
+        assert!(InferencePriority::Interactive < InferencePriority::Background);
+        assert!(InferencePriority::Background < InferencePriority::Batch);
     }
 }

--- a/crates/parish-core/src/persistence/journal.rs
+++ b/crates/parish-core/src/persistence/journal.rs
@@ -288,6 +288,7 @@ mod tests {
             state: NpcState::Present,
             deflated_summary: None,
             reaction_log: crate::npc::reactions::ReactionLog::default(),
+            last_activity: None,
         });
 
         let events = vec![WorldEvent::NpcMoodChanged {

--- a/crates/parish-core/src/persistence/snapshot.rs
+++ b/crates/parish-core/src/persistence/snapshot.rs
@@ -121,6 +121,7 @@ impl NpcSnapshot {
             state: self.state,
             deflated_summary: None,
             reaction_log: crate::npc::reactions::ReactionLog::default(),
+            last_activity: None,
         }
     }
 }
@@ -271,6 +272,7 @@ mod tests {
             state: NpcState::Present,
             deflated_summary: None,
             reaction_log: crate::npc::reactions::ReactionLog::default(),
+            last_activity: None,
         }
     }
 

--- a/ui/src/components/DebugPanel.svelte
+++ b/ui/src/components/DebugPanel.svelte
@@ -84,8 +84,23 @@
 					<h4>Tiers</h4>
 					<div class="field">T1: {snap.tier_summary.tier1_count} | T2: {snap.tier_summary.tier2_count} | T3: {snap.tier_summary.tier3_count} | T4: {snap.tier_summary.tier4_count}</div>
 					{#if snap.tier_summary.tier1_names.length > 0}
-						<div class="field muted">T1 NPCs: {snap.tier_summary.tier1_names.join(', ')}</div>
+						<div class="field muted">T1: {snap.tier_summary.tier1_names.join(', ')}</div>
 					{/if}
+					{#if snap.tier_summary.tier3_names.length > 0}
+						<div class="field muted">T3: {snap.tier_summary.tier3_names.join(', ')}</div>
+					{/if}
+					<div class="field">T3 batch:
+						{#if snap.tier_summary.tier3_in_flight}
+							<span class="accent">IN FLIGHT</span>
+						{:else}
+							idle
+						{/if}
+						{#if snap.tier_summary.last_tier3_tick}
+							| last: {snap.tier_summary.last_tier3_tick}
+						{:else}
+							| (never run)
+						{/if}
+					</div>
 				</div>
 
 			{:else if tab === 1}
@@ -113,6 +128,13 @@
 							<div class="field">Mood: {selectedNpc.mood}</div>
 							<div class="field">Tier: {selectedNpc.tier} | {selectedNpc.state}</div>
 						</div>
+
+						{#if selectedNpc.last_activity}
+							<div class="section">
+								<h5>Last Batch Activity</h5>
+								<div class="field muted">{selectedNpc.last_activity}</div>
+							</div>
+						{/if}
 
 						<div class="section">
 							<h5>Intelligence</h5>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -169,6 +169,7 @@ export interface NpcDebug {
 	memories: MemoryDebug[];
 	knowledge: string[];
 	intelligence: IntelligenceDebug;
+	last_activity: string | null;
 }
 
 export interface ScheduleVariantDebug {
@@ -215,6 +216,9 @@ export interface TierSummary {
 	tier4_count: number;
 	tier1_names: string[];
 	tier2_names: string[];
+	tier3_names: string[];
+	tier3_in_flight: boolean;
+	last_tier3_tick: string | null;
 }
 
 export interface DebugEvent {


### PR DESCRIPTION
## Summary

This PR introduces Tier 3 cognitive tier support for NPC simulation, enabling efficient batch LLM inference for distant NPCs. Tier 3 NPCs are simulated once per in-game day (24 hours) in batches of up to 10 NPCs per LLM call, reducing computational overhead while maintaining world consistency.

## Key Changes

- **New Tier 3 simulation tier**: Added between Tier 2 (nearby NPCs, 5-minute ticks) and Tier 4 (off-world NPCs, no simulation)
  - Tier 3 covers NPCs at distance 3-5 from the player
  - Tier 4 now represents NPCs beyond the simulation range

- **Batch inference infrastructure** (`npc/ticks.rs`):
  - `Tier3Snapshot`: lightweight NPC state for batch prompts
  - `build_tier3_prompt()`: constructs a single prompt for multiple NPCs
  - `tick_tier3()`: executes batch LLM calls with automatic chunking
  - `apply_tier3_updates()`: applies mood, activity, location, and relationship changes from batch responses
  - `tier3_snapshot_from_npc()`: extracts relevant NPC state for batch simulation

- **Manager support** (`npc/manager.rs`):
  - `tier3_npcs()`: retrieves all Tier 3 NPCs
  - `needs_tier3_tick()`: checks if 24 game-hours have elapsed
  - `tier3_in_flight`: tracks whether a batch inference is currently running
  - Tier assignment logic updated to distinguish Tier 3 from Tier 4

- **Type definitions** (`npc/types.rs`):
  - `Tier3Update`: per-NPC result from batch simulation (mood, activity, location, relationships)
  - `Tier3Response`: batch response containing array of updates
  - `InferencePriority`: enum for prioritizing inference requests (Interactive > Background > Batch)

- **Configuration** (`config/engine.rs`):
  - `tier3_max_distance`: configurable distance threshold (default: 5)
  - `tier3_tick_interval_hours`: batch tick frequency (default: 24 hours)
  - `tier3_batch_size`: NPCs per LLM call (default: 10)

- **NPC state** (`npc/mod.rs`):
  - `last_activity`: field to store activity summaries from Tier 3 simulation

## Implementation Details

- Batch prompts include NPC occupation, age, mood, location, recent activity, and key relationships
- Invalid location updates are silently ignored; unknown NPCs are skipped with warnings
- Activity summaries are stored as both `last_activity` and memory entries
- Relationship changes are applied only if both NPCs exist
- Graceful error handling: batch failures log warnings but don't block other batches
- Comprehensive test coverage including snapshot creation, prompt building, batching logic, and update application

https://claude.ai/code/session_01NVfW3eLVxs3GZKQdH85c6B