### PR TITLE
Fix overnight schedule wraparound and improve code quality

### DIFF
--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -425,7 +425,7 @@ fn build_npc_debug_list(
                         .iter()
                         .map(|v| {
                             let is_active =
-                                active_entries.map_or(false, |ae| std::ptr::eq(ae, &v.entries[..]));
+                                active_entries.is_some_and(|ae| std::ptr::eq(ae, &v.entries[..]));
                             let entries = v
                                 .entries
                                 .iter()
@@ -796,7 +796,7 @@ mod tests {
         mgr.add_npc(npc);
 
         let graph = WorldGraph::new();
-        let npcs = build_npc_debug_list(&mgr, &graph);
+        let npcs = build_npc_debug_list(&mgr, &graph, 12, Season::Summer, DayType::Weekday);
         assert_eq!(npcs.len(), 1);
         // Relationships should be sorted by strength descending
         assert_eq!(npcs[0].relationships.len(), 2);

--- a/crates/parish-core/src/npc/manager.rs
+++ b/crates/parish-core/src/npc/manager.rs
@@ -1209,7 +1209,7 @@ mod tests {
         clock.pause();
 
         // With LightRain, farmer should still go to work (tolerate light rain)
-        let events = mgr.tick_schedules(&clock, &graph, crate::world::Weather::LightRain);
+        let _events = mgr.tick_schedules(&clock, &graph, crate::world::Weather::LightRain);
 
         let npc = mgr.get(NpcId(1)).unwrap();
         // Farmer should be in transit to the farm

--- a/crates/parish-core/src/npc/types.rs
+++ b/crates/parish-core/src/npc/types.rs
@@ -351,11 +351,19 @@ pub struct DailySchedule {
 impl DailySchedule {
     /// Returns the schedule entry active at the given hour.
     ///
+    /// Handles overnight wraparound: an entry with `start_hour > end_hour`
+    /// (e.g. 22–06) is active when `hour >= start_hour OR hour <= end_hour`.
+    ///
     /// Returns `None` if no entry covers the hour (schedule gap).
     pub fn entry_at(&self, hour: u8) -> Option<&ScheduleEntry> {
-        self.entries
-            .iter()
-            .find(|e| hour >= e.start_hour && hour <= e.end_hour)
+        self.entries.iter().find(|e| {
+            if e.start_hour <= e.end_hour {
+                hour >= e.start_hour && hour <= e.end_hour
+            } else {
+                // Overnight: e.g. 22–06
+                hour >= e.start_hour || hour <= e.end_hour
+            }
+        })
     }
 
     /// Returns the desired location at the given hour.
@@ -438,11 +446,19 @@ impl SeasonalSchedule {
     }
 
     /// Returns the schedule entry active at the given hour for the given context.
+    ///
+    /// Handles overnight wraparound: an entry with `start_hour > end_hour`
+    /// (e.g. 22–06) is active when `hour >= start_hour OR hour <= end_hour`.
     pub fn entry_at(&self, hour: u8, season: Season, day_type: DayType) -> Option<&ScheduleEntry> {
         let entries = self.resolve(season, day_type)?;
-        entries
-            .iter()
-            .find(|e| hour >= e.start_hour && hour <= e.end_hour)
+        entries.iter().find(|e| {
+            if e.start_hour <= e.end_hour {
+                hour >= e.start_hour && hour <= e.end_hour
+            } else {
+                // Overnight: e.g. 22–06
+                hour >= e.start_hour || hour <= e.end_hour
+            }
+        })
     }
 
     /// Returns the desired location at the given hour for the given context.
@@ -614,9 +630,46 @@ mod tests {
         let entry = schedule.entry_at(15).unwrap();
         assert_eq!(entry.activity, "tending bar");
 
-        // Gap — no entry covers hour 5 unless the sleeping entry wraps
-        // Note: for overnight entries (23-5), our simple check won't match hour 3.
-        // This is expected; the data.rs loader should handle wrap-around.
+        // Overnight entry (23-5): hours 23 and 3 should both match.
+        let entry = schedule.entry_at(23).unwrap();
+        assert_eq!(entry.activity, "sleeping");
+
+        let entry = schedule.entry_at(3).unwrap();
+        assert_eq!(entry.activity, "sleeping");
+
+        // Hour 6 is the start of "opening the pub", not covered by the overnight entry.
+        let entry = schedule.entry_at(6).unwrap();
+        assert_eq!(entry.activity, "opening the pub");
+
+        // Hour 5 is covered by the overnight sleeping entry (end_hour=5).
+        let entry = schedule.entry_at(5).unwrap();
+        assert_eq!(entry.activity, "sleeping");
+    }
+
+    #[test]
+    fn test_schedule_entry_at_overnight_only() {
+        // A schedule with a single overnight entry (22–06).
+        let schedule = DailySchedule {
+            entries: vec![ScheduleEntry {
+                start_hour: 22,
+                end_hour: 6,
+                location: LocationId(1),
+                activity: "sleeping".to_string(),
+                cuaird: false,
+            }],
+        };
+
+        // Hours in the evening portion (after midnight rollover)
+        assert!(schedule.entry_at(22).is_some());
+        assert!(schedule.entry_at(23).is_some());
+        // Hours in the early-morning portion (before end_hour)
+        assert!(schedule.entry_at(0).is_some());
+        assert!(schedule.entry_at(3).is_some());
+        assert!(schedule.entry_at(6).is_some());
+        // Hour 7 is outside the range
+        assert!(schedule.entry_at(7).is_none());
+        assert!(schedule.entry_at(12).is_none());
+        assert!(schedule.entry_at(21).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This PR fixes a bug in schedule entry matching where overnight entries (those with `start_hour > end_hour`, e.g., 22–06) were not correctly identified as active during early morning hours. It also includes minor code quality improvements.

## Key Changes

- **Fixed overnight schedule wraparound logic** in `DailySchedule::entry_at()` and `SeasonalSchedule::entry_at()`:
  - Changed from simple range check (`hour >= start_hour && hour <= end_hour`) to conditional logic that handles wraparound
  - Overnight entries now correctly match when `hour >= start_hour OR hour <= end_hour`
  - Added documentation explaining the overnight wraparound behavior

- **Enhanced test coverage**:
  - Updated existing test to verify overnight entry matching at both evening (23) and early morning (3) hours
  - Added new `test_schedule_entry_at_overnight_only()` test with comprehensive coverage of a single overnight entry (22–06)
  - Tests now verify both matching and non-matching hours

- **Code quality improvements**:
  - Replaced `map_or(false, |ae| ...)` with more idiomatic `is_some_and(|ae| ...)` in `debug_snapshot.rs`
  - Fixed function signature in test to include required parameters (`hour`, `season`, `day_type`)
  - Added underscore prefix to unused variable in `manager.rs` test

## Implementation Details
The fix properly handles the 24-hour wraparound case where a schedule entry spans midnight. For example, a "sleeping" entry from 22:00 to 06:00 now correctly matches hours 22, 23, 0, 1, 2, 3, 4, 5, and 6, while excluding hours 7–21.

https://claude.ai/code/session_018Q4eTvmC5ig2KuiY7mmzCy