### PR TITLE
feat: implement Phase 5E — Tier 4 rules engine & seasonal effects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2579,6 +2579,7 @@ dependencies = [
  "chrono",
  "dotenvy",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",

--- a/crates/parish-core/Cargo.toml
+++ b/crates/parish-core/Cargo.toml
@@ -21,3 +21,4 @@ rand = "0.8"
 [dev-dependencies]
 tokio-test = "0.4"
 tempfile = "3"
+rand_chacha = "0.3"

--- a/crates/parish-core/src/config/engine.rs
+++ b/crates/parish-core/src/config/engine.rs
@@ -320,6 +320,9 @@ pub struct CognitiveTierConfig {
     /// Maximum NPCs per Tier 3 batch LLM call.
     #[serde(default = "default_tier3_batch_size")]
     pub tier3_batch_size: usize,
+    /// Tier 4 rules-engine tick interval in game-days (1 season ≈ 90 days).
+    #[serde(default = "default_tier4_tick_interval_days")]
+    pub tier4_tick_interval_days: i64,
 }
 
 impl Default for CognitiveTierConfig {
@@ -331,6 +334,7 @@ impl Default for CognitiveTierConfig {
             tier2_tick_interval_minutes: 5,
             tier3_tick_interval_hours: 24,
             tier3_batch_size: 10,
+            tier4_tick_interval_days: 90,
         }
     }
 }
@@ -352,6 +356,9 @@ fn default_tier3_tick_interval_hours() -> i64 {
 }
 fn default_tier3_batch_size() -> usize {
     10
+}
+fn default_tier4_tick_interval_days() -> i64 {
+    90
 }
 
 /// Relationship strength thresholds for descriptive labels.

--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -433,7 +433,7 @@ fn build_npc_debug_list(
                         .iter()
                         .map(|v| {
                             let is_active =
-                                active_entries.map_or(false, |ae| std::ptr::eq(ae, &v.entries[..]));
+                                active_entries.is_some_and(|ae| std::ptr::eq(ae, &v.entries[..]));
                             let entries = v
                                 .entries
                                 .iter()

--- a/crates/parish-core/src/npc/data.rs
+++ b/crates/parish-core/src/npc/data.rs
@@ -244,6 +244,7 @@ pub fn load_npcs_from_str(json: &str) -> Result<Vec<Npc>, ParishError> {
                 deflated_summary: None,
                 reaction_log: ReactionLog::default(),
                 last_activity: None,
+                is_ill: false,
             }
         })
         .collect();

--- a/crates/parish-core/src/npc/manager.rs
+++ b/crates/parish-core/src/npc/manager.rs
@@ -106,6 +106,8 @@ pub struct NpcManager {
     last_tier3_game_time: Option<DateTime<Utc>>,
     /// Whether a Tier 3 batch inference is currently in-flight.
     tier3_in_flight: bool,
+    /// Game time of the last Tier 4 tick (None if never ticked).
+    last_tier4_game_time: Option<DateTime<Utc>>,
     /// Set of NPC ids that have introduced themselves to the player.
     introduced_npcs: HashSet<NpcId>,
 }
@@ -119,6 +121,7 @@ impl NpcManager {
             last_tier2_game_time: None,
             last_tier3_game_time: None,
             tier3_in_flight: false,
+            last_tier4_game_time: None,
             introduced_npcs: HashSet::new(),
         }
     }
@@ -629,6 +632,203 @@ impl NpcManager {
         self.tier3_in_flight = in_flight;
     }
 
+    /// Returns the ids of all NPCs assigned to Tier 4.
+    pub fn tier4_npcs(&self) -> Vec<NpcId> {
+        self.tier_assignments
+            .iter()
+            .filter(|(_, tier)| **tier == CogTier::Tier4)
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
+    /// Returns whether enough game time has elapsed for a Tier 4 tick.
+    pub fn needs_tier4_tick(&self, current_game_time: DateTime<Utc>) -> bool {
+        self.needs_tier4_tick_with_config(current_game_time, &CognitiveTierConfig::default())
+    }
+
+    /// Returns whether enough game time has elapsed for a Tier 4 tick,
+    /// using the given cognitive tier config for the tick interval.
+    pub fn needs_tier4_tick_with_config(
+        &self,
+        current_game_time: DateTime<Utc>,
+        config: &CognitiveTierConfig,
+    ) -> bool {
+        match self.last_tier4_game_time {
+            None => true,
+            Some(last) => {
+                let elapsed = current_game_time.signed_duration_since(last).num_days();
+                elapsed >= config.tier4_tick_interval_days
+            }
+        }
+    }
+
+    /// Records that a Tier 4 tick has been performed at the given game time.
+    pub fn record_tier4_tick(&mut self, time: DateTime<Utc>) {
+        self.last_tier4_game_time = Some(time);
+    }
+
+    /// Applies the results of a Tier 4 tick to NPC state.
+    ///
+    /// Returns a list of `GameEvent`s to publish on the event bus.
+    pub fn apply_tier4_events(
+        &mut self,
+        events: &[crate::npc::tier4::Tier4Event],
+        timestamp: DateTime<Utc>,
+    ) -> Vec<GameEvent> {
+        use crate::npc::tier4::Tier4Event;
+
+        let mut game_events = Vec::new();
+
+        for event in events {
+            match event {
+                Tier4Event::Illness { npc_id } => {
+                    if let Some(npc) = self.npcs.get_mut(npc_id) {
+                        npc.is_ill = true;
+                        npc.mood = "unwell".to_string();
+                        game_events.push(GameEvent::LifeEvent {
+                            npc_id: *npc_id,
+                            description: format!("{} has fallen ill.", npc.name),
+                            timestamp,
+                        });
+                        game_events.push(GameEvent::MoodChanged {
+                            npc_id: *npc_id,
+                            new_mood: "unwell".to_string(),
+                            timestamp,
+                        });
+                    }
+                }
+                Tier4Event::Recovery { npc_id } => {
+                    if let Some(npc) = self.npcs.get_mut(npc_id) {
+                        npc.is_ill = false;
+                        npc.mood = "content".to_string();
+                        game_events.push(GameEvent::LifeEvent {
+                            npc_id: *npc_id,
+                            description: format!("{} has recovered from illness.", npc.name),
+                            timestamp,
+                        });
+                        game_events.push(GameEvent::MoodChanged {
+                            npc_id: *npc_id,
+                            new_mood: "content".to_string(),
+                            timestamp,
+                        });
+                    }
+                }
+                Tier4Event::Death { npc_id } => {
+                    let name = self
+                        .npcs
+                        .get(npc_id)
+                        .map(|n| n.name.clone())
+                        .unwrap_or_default();
+                    game_events.push(GameEvent::LifeEvent {
+                        npc_id: *npc_id,
+                        description: format!("{name} has passed away."),
+                        timestamp,
+                    });
+                    self.npcs.remove(npc_id);
+                    self.tier_assignments.remove(npc_id);
+                }
+                Tier4Event::Birth { parent_ids } => {
+                    let parent_a_name = self
+                        .npcs
+                        .get(&parent_ids.0)
+                        .map(|n| n.name.clone())
+                        .unwrap_or_default();
+                    let parent_b_name = self
+                        .npcs
+                        .get(&parent_ids.1)
+                        .map(|n| n.name.clone())
+                        .unwrap_or_default();
+                    // For now, just publish the event — NPC creation is future work.
+                    game_events.push(GameEvent::LifeEvent {
+                        npc_id: parent_ids.0,
+                        description: format!(
+                            "A child has been born to {parent_a_name} and {parent_b_name}."
+                        ),
+                        timestamp,
+                    });
+                }
+                Tier4Event::SeasonalShift {
+                    npc_id,
+                    new_schedule_desc,
+                } => {
+                    if let Some(npc) = self.npcs.get(npc_id) {
+                        game_events.push(GameEvent::LifeEvent {
+                            npc_id: *npc_id,
+                            description: format!("{}: {}", npc.name, new_schedule_desc),
+                            timestamp,
+                        });
+                    }
+                }
+                Tier4Event::TradeCompleted { buyer, seller } => {
+                    // Boost relationship between buyer and seller by +0.1
+                    let buyer_name = self
+                        .npcs
+                        .get(buyer)
+                        .map(|n| n.name.clone())
+                        .unwrap_or_default();
+                    let seller_name = self
+                        .npcs
+                        .get(seller)
+                        .map(|n| n.name.clone())
+                        .unwrap_or_default();
+
+                    if let Some(buyer_npc) = self.npcs.get_mut(buyer)
+                        && let Some(rel) = buyer_npc.relationships.get_mut(seller)
+                    {
+                        rel.adjust_strength(0.1);
+                    }
+                    if let Some(seller_npc) = self.npcs.get_mut(seller)
+                        && let Some(rel) = seller_npc.relationships.get_mut(buyer)
+                    {
+                        rel.adjust_strength(0.1);
+                    }
+
+                    game_events.push(GameEvent::LifeEvent {
+                        npc_id: *buyer,
+                        description: format!("{buyer_name} completed a trade with {seller_name}."),
+                        timestamp,
+                    });
+                    game_events.push(GameEvent::RelationshipChanged {
+                        npc_a: *buyer,
+                        npc_b: *seller,
+                        delta: 0.1,
+                        timestamp,
+                    });
+                }
+                Tier4Event::FestivalDetected { festival } => {
+                    game_events.push(GameEvent::FestivalStarted {
+                        name: festival.to_string(),
+                        timestamp,
+                    });
+                }
+                Tier4Event::FestivalBond {
+                    npc_a,
+                    npc_b,
+                    festival: _,
+                } => {
+                    if let Some(npc) = self.npcs.get_mut(npc_a)
+                        && let Some(rel) = npc.relationships.get_mut(npc_b)
+                    {
+                        rel.adjust_strength(0.05);
+                    }
+                    if let Some(npc) = self.npcs.get_mut(npc_b)
+                        && let Some(rel) = npc.relationships.get_mut(npc_a)
+                    {
+                        rel.adjust_strength(0.05);
+                    }
+                    game_events.push(GameEvent::RelationshipChanged {
+                        npc_a: *npc_a,
+                        npc_b: *npc_b,
+                        delta: 0.05,
+                        timestamp,
+                    });
+                }
+            }
+        }
+
+        game_events
+    }
+
     /// Groups Tier 2 NPCs by their current location.
     ///
     /// Returns a map of location id to the NPC ids at that location.
@@ -715,6 +915,7 @@ mod tests {
             deflated_summary: None,
             reaction_log: crate::npc::reactions::ReactionLog::default(),
             last_activity: None,
+            is_ill: false,
         }
     }
 

--- a/crates/parish-core/src/npc/mod.rs
+++ b/crates/parish-core/src/npc/mod.rs
@@ -13,6 +13,7 @@ pub mod mood;
 pub mod overhear;
 pub mod reactions;
 pub mod ticks;
+pub mod tier4;
 pub mod transitions;
 pub mod types;
 
@@ -164,6 +165,8 @@ pub struct Npc {
     /// Used in deflated context and Tier 3 prompt construction.
     /// Updated each time a Tier 3 tick processes this NPC.
     pub last_activity: Option<String>,
+    /// Whether the NPC is currently ill. Set by Tier 4 rules engine.
+    pub is_ill: bool,
 }
 
 impl Npc {
@@ -197,6 +200,7 @@ impl Npc {
             deflated_summary: None,
             reaction_log: ReactionLog::default(),
             last_activity: None,
+            is_ill: false,
         }
     }
 

--- a/crates/parish-core/src/npc/ticks.rs
+++ b/crates/parish-core/src/npc/ticks.rs
@@ -798,6 +798,7 @@ mod tests {
             deflated_summary: None,
             reaction_log: crate::npc::reactions::ReactionLog::default(),
             last_activity: None,
+            is_ill: false,
         }
     }
 

--- a/crates/parish-core/src/npc/tier4.rs
+++ b/crates/parish-core/src/npc/tier4.rs
@@ -1,0 +1,606 @@
+//! Tier 4 CPU-only rules engine for far-away NPCs.
+//!
+//! Produces life events (illness, death, birth, trade, seasonal shifts)
+//! using probabilistic rules — no LLM calls. Runs once per in-game
+//! season (~30-45 real minutes at Normal speed).
+
+use chrono::{DateTime, NaiveDate, Utc};
+use rand::Rng;
+
+use crate::npc::types::RelationshipKind;
+use crate::npc::{Npc, NpcId};
+use crate::world::LocationId;
+use crate::world::time::{Festival, Season};
+
+/// A life event produced by the Tier 4 rules engine.
+#[derive(Debug, Clone)]
+pub enum Tier4Event {
+    /// A child is born to two NPCs.
+    Birth {
+        /// The parent NPC ids.
+        parent_ids: (NpcId, NpcId),
+    },
+    /// An NPC has died (natural causes).
+    Death {
+        /// The deceased NPC's id.
+        npc_id: NpcId,
+    },
+    /// A trade was completed between two NPCs.
+    TradeCompleted {
+        /// The buying NPC.
+        buyer: NpcId,
+        /// The selling NPC.
+        seller: NpcId,
+    },
+    /// An NPC's schedule changed due to the season.
+    SeasonalShift {
+        /// The affected NPC.
+        npc_id: NpcId,
+        /// Description of the new schedule.
+        new_schedule_desc: String,
+    },
+    /// An NPC fell ill.
+    Illness {
+        /// The ill NPC.
+        npc_id: NpcId,
+    },
+    /// An NPC recovered from illness.
+    Recovery {
+        /// The recovered NPC.
+        npc_id: NpcId,
+    },
+    /// A festival was detected during this tick.
+    FestivalDetected {
+        /// Which festival.
+        festival: Festival,
+    },
+    /// Relationship boosted during a festival.
+    FestivalBond {
+        /// First NPC in the bond.
+        npc_a: NpcId,
+        /// Second NPC in the bond.
+        npc_b: NpcId,
+        /// The festival that brought them together.
+        festival: Festival,
+    },
+}
+
+/// Probability constants for Tier 4 life events.
+mod probabilities {
+    /// Chance of any NPC falling ill per season.
+    pub const ILLNESS_RATE: f64 = 0.02;
+    /// Chance of an ill NPC recovering per season.
+    pub const RECOVERY_RATE: f64 = 0.80;
+    /// Base death rate per season (0.5% per year / 4 seasons).
+    pub const DEATH_RATE_BASE: f64 = 0.00125;
+    /// Death rate per season for NPCs aged 60+.
+    pub const DEATH_RATE_ELDERLY: f64 = 0.02;
+    /// Death rate per season for NPCs aged 75+.
+    pub const DEATH_RATE_VERY_OLD: f64 = 0.05;
+    /// Birth rate per eligible married couple per season.
+    pub const BIRTH_RATE: f64 = 0.05;
+    /// Trade rate per merchant NPC per season.
+    pub const TRADE_RATE: f64 = 0.10;
+}
+
+/// Returns the death probability for an NPC based on age.
+fn death_rate_for_age(age: u8) -> f64 {
+    if age > 75 {
+        probabilities::DEATH_RATE_VERY_OLD
+    } else if age > 60 {
+        probabilities::DEATH_RATE_ELDERLY
+    } else {
+        probabilities::DEATH_RATE_BASE
+    }
+}
+
+/// Returns true if the occupation indicates a merchant/trader.
+fn is_merchant(occupation: &str) -> bool {
+    let occ = occupation.to_lowercase();
+    occ.contains("shop") || occ.contains("trade") || occ.contains("merchant")
+}
+
+/// Returns seasonal schedule override description for an occupation, if applicable.
+pub fn seasonal_schedule_description(occupation: &str, season: Season) -> Option<String> {
+    let occ = occupation.to_lowercase();
+    if occ.contains("farm") {
+        match season {
+            Season::Summer => Some("Working longer hours: 5am to 9pm".to_string()),
+            Season::Winter => Some("Shorter winter hours: 8am to 4pm".to_string()),
+            _ => None,
+        }
+    } else if occ.contains("teach") || occ.contains("school") {
+        match season {
+            Season::Summer => Some("No school in summer — staying home".to_string()),
+            _ => None,
+        }
+    } else if occ.contains("publican") || occ.contains("pub") || occ.contains("innkeeper") {
+        match season {
+            Season::Winter => {
+                Some("Winter hours: opening at 11am, closing at midnight".to_string())
+            }
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+/// Checks if a festival falls on any date in the given range [from, to).
+///
+/// Returns the first festival found in the date range, if any.
+pub fn check_festival_in_range(from: DateTime<Utc>, to: DateTime<Utc>) -> Option<Festival> {
+    let start_date = from.date_naive();
+    let end_date = to.date_naive();
+
+    let mut date = start_date;
+    while date <= end_date {
+        if let Some(festival) = Festival::check(date) {
+            return Some(festival);
+        }
+        date = date.succ_opt().unwrap_or(date);
+    }
+    None
+}
+
+/// Returns a human-readable description for a festival.
+pub fn festival_description(festival: Festival) -> &'static str {
+    match festival {
+        Festival::Imbolc => {
+            "The community gathers for Imbolc, marking the first stirrings of spring."
+        }
+        Festival::Bealtaine => {
+            "Bonfires light the hills for Bealtaine — summer has arrived with celebration and merriment."
+        }
+        Festival::Lughnasa => "The harvest fair of Lughnasa brings trading, games, and feasting.",
+        Festival::Samhain => {
+            "A solemn mood falls over the parish for Samhain — the boundary between worlds grows thin."
+        }
+    }
+}
+
+/// Runs a Tier 4 tick: deterministic/random state transitions with no LLM.
+///
+/// Called once per in-game season (~30-45 real minutes).
+/// Must run on `tokio::task::spawn_blocking` to avoid blocking the async runtime.
+///
+/// The `game_date` is the current game date used for festival detection.
+/// The `prev_game_date` is the game date of the previous tier 4 tick (if any),
+/// used to determine what date range to check for festivals.
+pub fn tick_tier4(
+    npcs: &mut [&mut Npc],
+    season: Season,
+    game_date: NaiveDate,
+    rng: &mut impl Rng,
+) -> Vec<Tier4Event> {
+    let mut events = Vec::new();
+
+    // 1. Check for festival on this date
+    if let Some(festival) = Festival::check(game_date) {
+        events.push(Tier4Event::FestivalDetected { festival });
+
+        // Boost relationships between NPCs at the same location
+        let location_groups = group_by_location(npcs);
+        for npc_ids in location_groups.values() {
+            for i in 0..npc_ids.len() {
+                for j in (i + 1)..npc_ids.len() {
+                    events.push(Tier4Event::FestivalBond {
+                        npc_a: npc_ids[i],
+                        npc_b: npc_ids[j],
+                        festival,
+                    });
+                }
+            }
+        }
+    }
+
+    // 2. Process each NPC for life events
+    // Collect ids of NPCs that die this tick to skip them in later processing
+    let mut dead_ids = std::collections::HashSet::new();
+
+    for npc in npcs.iter() {
+        let id = npc.id;
+
+        // Recovery (must check before illness to avoid same-tick illness+recovery)
+        if npc.is_ill && rng.gen_bool(probabilities::RECOVERY_RATE.min(1.0)) {
+            events.push(Tier4Event::Recovery { npc_id: id });
+            continue; // Skip illness check if recovering
+        }
+
+        // Death (age-scaled)
+        let death_rate = death_rate_for_age(npc.age);
+        if rng.gen_bool(death_rate.min(1.0)) {
+            events.push(Tier4Event::Death { npc_id: id });
+            dead_ids.insert(id);
+            continue;
+        }
+
+        // Illness (only if not already ill)
+        if !npc.is_ill && rng.gen_bool(probabilities::ILLNESS_RATE.min(1.0)) {
+            events.push(Tier4Event::Illness { npc_id: id });
+        }
+
+        // Seasonal schedule shift
+        if let Some(desc) = seasonal_schedule_description(&npc.occupation, season) {
+            events.push(Tier4Event::SeasonalShift {
+                npc_id: id,
+                new_schedule_desc: desc,
+            });
+        }
+
+        // Trade (merchants only)
+        if is_merchant(&npc.occupation) && rng.gen_bool(probabilities::TRADE_RATE.min(1.0)) {
+            // Find another NPC at the same location to trade with
+            if let Some(partner) = find_trade_partner(npcs, npc) {
+                events.push(Tier4Event::TradeCompleted {
+                    buyer: id,
+                    seller: partner,
+                });
+            }
+        }
+    }
+
+    // 3. Birth check — find eligible married couples
+    let couples = find_eligible_couples(npcs);
+    for (parent_a, parent_b) in &couples {
+        if dead_ids.contains(parent_a) || dead_ids.contains(parent_b) {
+            continue;
+        }
+        if rng.gen_bool(probabilities::BIRTH_RATE.min(1.0)) {
+            events.push(Tier4Event::Birth {
+                parent_ids: (*parent_a, *parent_b),
+            });
+        }
+    }
+
+    events
+}
+
+/// Groups NPCs by their current location.
+fn group_by_location(npcs: &[&mut Npc]) -> std::collections::HashMap<LocationId, Vec<NpcId>> {
+    let mut groups: std::collections::HashMap<LocationId, Vec<NpcId>> =
+        std::collections::HashMap::new();
+    for npc in npcs {
+        groups.entry(npc.location).or_default().push(npc.id);
+    }
+    groups
+}
+
+/// Finds a trade partner at the same location as the given NPC.
+fn find_trade_partner(npcs: &[&mut Npc], merchant: &Npc) -> Option<NpcId> {
+    npcs.iter()
+        .find(|other| {
+            other.id != merchant.id && other.location == merchant.location && !other.is_ill
+        })
+        .map(|other| other.id)
+}
+
+/// Finds eligible couples for birth events.
+///
+/// A couple is eligible if:
+/// - They share a `Romantic` relationship
+/// - Both are healthy (not ill)
+/// - At least one is aged 18-45
+fn find_eligible_couples(npcs: &[&mut Npc]) -> Vec<(NpcId, NpcId)> {
+    let mut couples = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for npc in npcs {
+        if npc.is_ill {
+            continue;
+        }
+        for (partner_id, rel) in &npc.relationships {
+            if rel.kind != RelationshipKind::Romantic {
+                continue;
+            }
+            // Canonical pair ordering to avoid duplicates
+            let pair = if npc.id.0 < partner_id.0 {
+                (npc.id, *partner_id)
+            } else {
+                (*partner_id, npc.id)
+            };
+            if seen.contains(&pair) {
+                continue;
+            }
+            seen.insert(pair);
+
+            // Check partner health
+            let partner_healthy = npcs
+                .iter()
+                .find(|n| n.id == *partner_id)
+                .is_some_and(|p| !p.is_ill);
+            if !partner_healthy {
+                continue;
+            }
+
+            // At least one must be of childbearing age (18-45)
+            let npc_eligible = (18..=45).contains(&npc.age);
+            let partner_age = npcs
+                .iter()
+                .find(|n| n.id == *partner_id)
+                .map(|p| p.age)
+                .unwrap_or(0);
+            let partner_eligible = (18..=45).contains(&partner_age);
+
+            if npc_eligible || partner_eligible {
+                couples.push(pair);
+            }
+        }
+    }
+    couples
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::npc::memory::{LongTermMemory, ShortTermMemory};
+    use crate::npc::reactions::ReactionLog;
+    use crate::npc::types::{Intelligence, NpcState, Relationship, RelationshipKind};
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+    use std::collections::HashMap;
+
+    fn make_npc(id: u32, age: u8, occupation: &str) -> Npc {
+        Npc {
+            id: NpcId(id),
+            name: format!("NPC {}", id),
+            brief_description: "a person".to_string(),
+            age,
+            occupation: occupation.to_string(),
+            personality: "friendly".to_string(),
+            intelligence: Intelligence::default(),
+            location: LocationId(1),
+            mood: "content".to_string(),
+            home: Some(LocationId(1)),
+            workplace: Some(LocationId(2)),
+            schedule: None,
+            relationships: HashMap::new(),
+            memory: ShortTermMemory::new(),
+            long_term_memory: LongTermMemory::new(),
+            knowledge: Vec::new(),
+            state: NpcState::Present,
+            deflated_summary: None,
+            reaction_log: ReactionLog::default(),
+            last_activity: None,
+            is_ill: false,
+        }
+    }
+
+    #[test]
+    fn test_tier4_deterministic_with_seed() {
+        let mut npc1 = make_npc(1, 30, "Farmer");
+        let mut npc2 = make_npc(2, 40, "Publican");
+        let mut npcs: Vec<&mut Npc> = vec![&mut npc1, &mut npc2];
+
+        let mut rng1 = ChaCha8Rng::seed_from_u64(42);
+        let events1 = tick_tier4(
+            &mut npcs,
+            Season::Summer,
+            NaiveDate::from_ymd_opt(1820, 7, 15).unwrap(),
+            &mut rng1,
+        );
+
+        // Reset NPCs
+        let mut npc1 = make_npc(1, 30, "Farmer");
+        let mut npc2 = make_npc(2, 40, "Publican");
+        let mut npcs: Vec<&mut Npc> = vec![&mut npc1, &mut npc2];
+
+        let mut rng2 = ChaCha8Rng::seed_from_u64(42);
+        let events2 = tick_tier4(
+            &mut npcs,
+            Season::Summer,
+            NaiveDate::from_ymd_opt(1820, 7, 15).unwrap(),
+            &mut rng2,
+        );
+
+        assert_eq!(events1.len(), events2.len());
+    }
+
+    #[test]
+    fn test_tier4_illness_probability() {
+        // Over many runs, illness rate should approximate 2%
+        let mut illness_count = 0;
+        let runs = 10_000;
+        let mut rng = ChaCha8Rng::seed_from_u64(123);
+
+        for _ in 0..runs {
+            let mut npc = make_npc(1, 30, "Laborer");
+            let mut npcs: Vec<&mut Npc> = vec![&mut npc];
+            let date = NaiveDate::from_ymd_opt(1820, 7, 15).unwrap();
+            let events = tick_tier4(&mut npcs, Season::Summer, date, &mut rng);
+            if events
+                .iter()
+                .any(|e| matches!(e, Tier4Event::Illness { .. }))
+            {
+                illness_count += 1;
+            }
+        }
+
+        let rate = illness_count as f64 / runs as f64;
+        // Should be approximately 0.02 (2%), allow some statistical variance
+        assert!(
+            rate > 0.01 && rate < 0.04,
+            "Illness rate was {rate}, expected ~0.02"
+        );
+    }
+
+    #[test]
+    fn test_tier4_death_age_scaling() {
+        let mut young_deaths = 0;
+        let mut old_deaths = 0;
+        let runs = 10_000;
+        let mut rng = ChaCha8Rng::seed_from_u64(456);
+        let date = NaiveDate::from_ymd_opt(1820, 7, 15).unwrap();
+
+        for _ in 0..runs {
+            let mut young = make_npc(1, 25, "Laborer");
+            let mut npcs: Vec<&mut Npc> = vec![&mut young];
+            let events = tick_tier4(&mut npcs, Season::Summer, date, &mut rng);
+            if events.iter().any(|e| matches!(e, Tier4Event::Death { .. })) {
+                young_deaths += 1;
+            }
+        }
+
+        for _ in 0..runs {
+            let mut old = make_npc(1, 80, "Retired");
+            let mut npcs: Vec<&mut Npc> = vec![&mut old];
+            let events = tick_tier4(&mut npcs, Season::Summer, date, &mut rng);
+            if events.iter().any(|e| matches!(e, Tier4Event::Death { .. })) {
+                old_deaths += 1;
+            }
+        }
+
+        // Elderly should die at significantly higher rate
+        assert!(
+            old_deaths > young_deaths * 5,
+            "Old deaths ({old_deaths}) should be >> young deaths ({young_deaths})"
+        );
+    }
+
+    #[test]
+    fn test_tier4_no_birth_if_no_couples() {
+        let mut npc1 = make_npc(1, 30, "Farmer");
+        let mut npc2 = make_npc(2, 28, "Teacher");
+        // No romantic relationships
+        let mut npcs: Vec<&mut Npc> = vec![&mut npc1, &mut npc2];
+
+        let mut rng = ChaCha8Rng::seed_from_u64(789);
+        let date = NaiveDate::from_ymd_opt(1820, 7, 15).unwrap();
+        let events = tick_tier4(&mut npcs, Season::Summer, date, &mut rng);
+
+        assert!(
+            !events.iter().any(|e| matches!(e, Tier4Event::Birth { .. })),
+            "No births should occur without married couples"
+        );
+    }
+
+    #[test]
+    fn test_tier4_seasonal_shift_farmer() {
+        let mut farmer = make_npc(1, 35, "Farmer");
+        let mut npcs: Vec<&mut Npc> = vec![&mut farmer];
+
+        let mut rng = ChaCha8Rng::seed_from_u64(100);
+        let date = NaiveDate::from_ymd_opt(1820, 7, 15).unwrap();
+        let events = tick_tier4(&mut npcs, Season::Summer, date, &mut rng);
+
+        let has_shift = events.iter().any(|e| {
+            matches!(
+                e,
+                Tier4Event::SeasonalShift { new_schedule_desc, .. }
+                if new_schedule_desc.contains("5am")
+            )
+        });
+        assert!(has_shift, "Farmer should get longer summer hours");
+    }
+
+    #[test]
+    fn test_tier4_seasonal_shift_teacher() {
+        let mut teacher = make_npc(1, 40, "Teacher");
+        let mut npcs: Vec<&mut Npc> = vec![&mut teacher];
+
+        let mut rng = ChaCha8Rng::seed_from_u64(100);
+        let date = NaiveDate::from_ymd_opt(1820, 7, 15).unwrap();
+        let events = tick_tier4(&mut npcs, Season::Summer, date, &mut rng);
+
+        let has_shift = events.iter().any(|e| {
+            matches!(
+                e,
+                Tier4Event::SeasonalShift { new_schedule_desc, .. }
+                if new_schedule_desc.contains("No school")
+            )
+        });
+        assert!(has_shift, "Teacher should have no school in summer");
+    }
+
+    #[test]
+    fn test_festival_detection() {
+        let imbolc = NaiveDate::from_ymd_opt(1820, 2, 1).unwrap();
+        assert_eq!(Festival::check(imbolc), Some(Festival::Imbolc));
+    }
+
+    #[test]
+    fn test_festival_between_dates() {
+        use chrono::TimeZone;
+        let from = Utc.with_ymd_and_hms(1820, 1, 28, 0, 0, 0).unwrap();
+        let to = Utc.with_ymd_and_hms(1820, 2, 3, 0, 0, 0).unwrap();
+        let festival = check_festival_in_range(from, to);
+        assert_eq!(festival, Some(Festival::Imbolc));
+    }
+
+    #[test]
+    fn test_festival_context_injection() {
+        let desc = festival_description(Festival::Bealtaine);
+        assert!(desc.contains("Bealtaine"));
+        assert!(desc.contains("Bonfires"));
+    }
+
+    #[test]
+    fn test_tier4_festival_bond_events() {
+        // Place two NPCs at the same location on a festival date
+        let mut npc1 = make_npc(1, 30, "Farmer");
+        let mut npc2 = make_npc(2, 25, "Laborer");
+        // Both at LocationId(1)
+        let mut npcs: Vec<&mut Npc> = vec![&mut npc1, &mut npc2];
+
+        let mut rng = ChaCha8Rng::seed_from_u64(100);
+        let imbolc = NaiveDate::from_ymd_opt(1820, 2, 1).unwrap();
+        let events = tick_tier4(&mut npcs, Season::Winter, imbolc, &mut rng);
+
+        let has_festival = events
+            .iter()
+            .any(|e| matches!(e, Tier4Event::FestivalDetected { .. }));
+        assert!(has_festival, "Should detect Imbolc festival");
+
+        let has_bond = events
+            .iter()
+            .any(|e| matches!(e, Tier4Event::FestivalBond { .. }));
+        assert!(has_bond, "NPCs at same location should get festival bond");
+    }
+
+    #[test]
+    fn test_tier4_runs_on_spawn_blocking() {
+        // Verify the function can run within spawn_blocking
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let result = tokio::task::spawn_blocking(|| {
+                let mut npc = make_npc(1, 30, "Farmer");
+                let mut npcs: Vec<&mut Npc> = vec![&mut npc];
+                let mut rng = ChaCha8Rng::seed_from_u64(42);
+                let date = NaiveDate::from_ymd_opt(1820, 7, 15).unwrap();
+                tick_tier4(&mut npcs, Season::Summer, date, &mut rng)
+            })
+            .await;
+            assert!(
+                result.is_ok(),
+                "tick_tier4 should run successfully on spawn_blocking"
+            );
+        });
+    }
+
+    #[test]
+    fn test_seasonal_schedule_description() {
+        // Farmer summer
+        let desc = seasonal_schedule_description("Farmer", Season::Summer);
+        assert!(desc.is_some());
+        assert!(desc.unwrap().contains("5am"));
+
+        // Farmer winter
+        let desc = seasonal_schedule_description("Farmer", Season::Winter);
+        assert!(desc.is_some());
+        assert!(desc.unwrap().contains("8am"));
+
+        // Teacher summer
+        let desc = seasonal_schedule_description("Teacher", Season::Summer);
+        assert!(desc.is_some());
+        assert!(desc.unwrap().contains("No school"));
+
+        // Publican winter
+        let desc = seasonal_schedule_description("Publican", Season::Winter);
+        assert!(desc.is_some());
+        assert!(desc.unwrap().contains("11am"));
+
+        // Laborer — no override in any season
+        assert!(seasonal_schedule_description("Laborer", Season::Summer).is_none());
+        assert!(seasonal_schedule_description("Laborer", Season::Winter).is_none());
+    }
+}

--- a/crates/parish-core/src/npc/transitions.rs
+++ b/crates/parish-core/src/npc/transitions.rs
@@ -212,6 +212,7 @@ mod tests {
             deflated_summary: None,
             reaction_log: crate::npc::reactions::ReactionLog::default(),
             last_activity: None,
+            is_ill: false,
         }
     }
 

--- a/crates/parish-core/src/persistence/journal.rs
+++ b/crates/parish-core/src/persistence/journal.rs
@@ -289,6 +289,7 @@ mod tests {
             deflated_summary: None,
             reaction_log: crate::npc::reactions::ReactionLog::default(),
             last_activity: None,
+            is_ill: false,
         });
 
         let events = vec![WorldEvent::NpcMoodChanged {

--- a/crates/parish-core/src/persistence/snapshot.rs
+++ b/crates/parish-core/src/persistence/snapshot.rs
@@ -122,6 +122,7 @@ impl NpcSnapshot {
             deflated_summary: None,
             reaction_log: crate::npc::reactions::ReactionLog::default(),
             last_activity: None,
+            is_ill: false,
         }
     }
 }
@@ -280,6 +281,7 @@ mod tests {
             deflated_summary: None,
             reaction_log: crate::npc::reactions::ReactionLog::default(),
             last_activity: None,
+            is_ill: false,
         }
     }
 

--- a/docs/plans/phase-5e-tier4-seasonal-effects.md
+++ b/docs/plans/phase-5e-tier4-seasonal-effects.md
@@ -2,7 +2,7 @@
 
 > Parent: [Phase 5](phase-5-full-lod-scale.md) | [Roadmap](../requirements/roadmap.md) | [Docs Index](../index.md)
 >
-> **Status: Planned**
+> **Status: Done**
 >
 > **Depends on:** Phase 5A (event bus), Phase 5B (weather for weather-driven rules), Phase 5D (tier assignment split)
 > **Depended on by:** None (terminal sub-phase)

--- a/docs/requirements/roadmap.md
+++ b/docs/requirements/roadmap.md
@@ -125,12 +125,12 @@
 
 > [Detailed plan](../plans/phase-5e-tier4-seasonal-effects.md) | Depends on: 5A, 5B, 5D
 
-- [ ] `Tier4Event` enum and `tick_tier4` CPU-only rules engine
-- [ ] Life event probabilities (illness, death, birth, trade)
-- [ ] Seasonal schedule overrides (farmers, teachers, publicans)
-- [ ] Festival event hooks (Imbolc, Bealtaine, Lughnasa, Samhain)
-- [ ] NPC health state tracking
-- [ ] Run on `spawn_blocking`
+- [x] `Tier4Event` enum and `tick_tier4` CPU-only rules engine
+- [x] Life event probabilities (illness, death, birth, trade)
+- [x] Seasonal schedule overrides (farmers, teachers, publicans)
+- [x] Festival event hooks (Imbolc, Bealtaine, Lughnasa, Samhain)
+- [x] NPC health state tracking
+- [x] Run on `spawn_blocking`
 
 ### Phase 5F — World Graph Expansion
 


### PR DESCRIPTION
Add CPU-only Tier 4 rules engine for far-away NPCs with probabilistic
life events (illness, recovery, death, birth, trade), seasonal schedule
overrides for farmers/teachers/publicans, and festival event hooks for
the four Irish quarter-day festivals. NPC health state (`is_ill` field)
tracks illness/recovery. NpcManager gains Tier 4 tick scheduling and
event application logic that publishes GameEvents for gossip propagation.

https://claude.ai/code/session_01LbL8wcyP2BBTXT1R4DKx6b