### PR TITLE
Move traversal time calculation to runtime in parish-core

### DIFF
--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -433,7 +433,7 @@ fn build_npc_debug_list(
                         .iter()
                         .map(|v| {
                             let is_active =
-                                active_entries.map_or(false, |ae| std::ptr::eq(ae, &v.entries[..]));
+                                active_entries.is_some_and(|ae| std::ptr::eq(ae, &v.entries[..]));
                             let entries = v
                                 .entries
                                 .iter()

--- a/src/bin/geo_tool/connections.rs
+++ b/src/bin/geo_tool/connections.rs
@@ -1,16 +1,14 @@
 //! Connection generation — builds edges between location nodes using road network data.
 //!
-//! Uses the OSM road network to determine which locations are connected
-//! and calculates traversal times from real distances. Ensures the
-//! resulting graph is connected and all edges are bidirectional.
+//! Uses the OSM road network to determine which locations are connected.
+//! Ensures the resulting graph is connected and all edges are bidirectional.
+//! Traversal times are calculated at runtime from coordinates by parish-core.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use tracing::{debug, info, warn};
 
-use super::osm_model::{
-    GeoFeature, LatLon, OverpassResponse, haversine_distance, meters_to_traversal_minutes,
-};
+use super::osm_model::{GeoFeature, LatLon, OverpassResponse, haversine_distance};
 
 /// A generated connection between two features.
 #[derive(Debug, Clone)]
@@ -19,12 +17,6 @@ pub struct GeneratedConnection {
     pub from_idx: usize,
     /// Target feature index.
     pub to_idx: usize,
-    /// Distance in meters.
-    #[allow(dead_code)] // Used in summary output and debugging
-    pub distance_meters: f64,
-    /// Traversal time in game minutes (retained for summary/debug output).
-    #[allow(dead_code)]
-    pub traversal_minutes: u16,
     /// Generated path description.
     pub path_description: String,
     /// Reverse path description (for bidirectional edge).
@@ -80,15 +72,14 @@ pub fn generate_connections(
             // Check if a road connects these features
             let road_dist = find_road_distance(&features[i], &features[j], &road_segments);
 
-            let (distance, desc, rev_desc) = if let Some((dist, segment)) = road_dist {
+            let (desc, rev_desc) = if let Some((_, segment)) = road_dist {
                 let desc = generate_path_description(&segment, &features[i], &features[j]);
                 let rev_desc = generate_path_description(&segment, &features[j], &features[i]);
-                (dist, desc, rev_desc)
+                (desc, rev_desc)
             } else {
-                // Use direct distance with generic description
                 let desc = generate_direct_description(&features[i], &features[j]);
                 let rev_desc = generate_direct_description(&features[j], &features[i]);
-                (direct_dist, desc, rev_desc)
+                (desc, rev_desc)
             };
 
             let pair = (i.min(j), i.max(j));
@@ -96,8 +87,6 @@ pub fn generate_connections(
                 connections.push(GeneratedConnection {
                     from_idx: i,
                     to_idx: j,
-                    distance_meters: distance,
-                    traversal_minutes: meters_to_traversal_minutes(distance),
                     path_description: desc,
                     reverse_path_description: rev_desc,
                 });
@@ -336,8 +325,6 @@ fn ensure_connectivity(features: &[GeoFeature], connections: &mut Vec<GeneratedC
         connections.push(GeneratedConnection {
             from_idx: best_pair.0,
             to_idx: best_pair.1,
-            distance_meters: best_dist,
-            traversal_minutes: meters_to_traversal_minutes(best_dist),
             path_description: generate_direct_description(
                 &features[best_pair.0],
                 &features[best_pair.1],
@@ -384,7 +371,6 @@ mod tests {
         assert_eq!(conns.len(), 1);
         assert_eq!(conns[0].from_idx, 0);
         assert_eq!(conns[0].to_idx, 1);
-        assert!(conns[0].traversal_minutes >= 1);
     }
 
     #[test]
@@ -410,8 +396,6 @@ mod tests {
         let mut connections = vec![GeneratedConnection {
             from_idx: 0,
             to_idx: 1,
-            distance_meters: 100.0,
-            traversal_minutes: 2,
             path_description: "test".to_string(),
             reverse_path_description: "test".to_string(),
         }];
@@ -433,8 +417,6 @@ mod tests {
         let mut connections = vec![GeneratedConnection {
             from_idx: 0,
             to_idx: 1,
-            distance_meters: 11.0,
-            traversal_minutes: 1,
             path_description: "test".to_string(),
             reverse_path_description: "test".to_string(),
         }];

--- a/src/bin/geo_tool/osm_model.rs
+++ b/src/bin/geo_tool/osm_model.rs
@@ -222,17 +222,6 @@ pub fn haversine_distance(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
     EARTH_RADIUS_M * c
 }
 
-/// Convert a real-world distance in meters to game traversal minutes.
-///
-/// Assumes walking speed of ~4.5 km/h (75 m/min) with a small constant
-/// overhead for "getting going" (1 minute minimum).
-pub fn meters_to_traversal_minutes(meters: f64) -> u16 {
-    const WALKING_SPEED_M_PER_MIN: f64 = 75.0;
-    let minutes = meters / WALKING_SPEED_M_PER_MIN;
-    // Minimum 1 minute, maximum 120 minutes (2 hours walk)
-    (minutes.ceil() as u16).clamp(1, 120)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,29 +237,6 @@ mod tests {
     fn test_haversine_same_point() {
         let dist = haversine_distance(53.5, -8.0, 53.5, -8.0);
         assert!(dist.abs() < 0.001);
-    }
-
-    #[test]
-    fn test_meters_to_minutes_short() {
-        // 75m = 1 minute
-        assert_eq!(meters_to_traversal_minutes(75.0), 1);
-    }
-
-    #[test]
-    fn test_meters_to_minutes_medium() {
-        // 300m = 4 minutes
-        assert_eq!(meters_to_traversal_minutes(300.0), 4);
-    }
-
-    #[test]
-    fn test_meters_to_minutes_minimum() {
-        assert_eq!(meters_to_traversal_minutes(1.0), 1);
-    }
-
-    #[test]
-    fn test_meters_to_minutes_maximum() {
-        // Very long distance capped at 120
-        assert_eq!(meters_to_traversal_minutes(100_000.0), 120);
     }
 
     #[test]

--- a/src/bin/geo_tool/pipeline.rs
+++ b/src/bin/geo_tool/pipeline.rs
@@ -281,8 +281,6 @@ mod tests {
         let connections = vec![super::super::connections::GeneratedConnection {
             from_idx: 0,
             to_idx: 1,
-            distance_meters: 111.0,
-            traversal_minutes: 2,
             path_description: "a path to the pub".to_string(),
             reverse_path_description: "a path to the church".to_string(),
         }];


### PR DESCRIPTION
## Summary
This PR removes traversal time calculation from the geo_tool build pipeline and moves it to runtime in parish-core. The `meters_to_traversal_minutes` function and related distance/time fields are removed from the connection generation phase, allowing traversal times to be calculated dynamically based on coordinates at runtime.

## Key Changes
- **Removed `meters_to_traversal_minutes` function** from `osm_model.rs` along with its 4 unit tests
- **Simplified `GeneratedConnection` struct** by removing `distance_meters` and `traversal_minutes` fields
- **Updated connection generation logic** in `connections.rs` to no longer calculate or store traversal times
- **Updated module documentation** to clarify that traversal times are now calculated at runtime by parish-core
- **Removed test fixtures** that referenced the deleted fields in `connections.rs` and `pipeline.rs` tests
- **Minor code quality improvement** in `debug_snapshot.rs` using `is_some_and()` instead of `map_or()`

## Implementation Details
The change decouples distance/time calculations from the build phase, making the system more flexible for runtime adjustments. The `GeneratedConnection` struct now only stores the essential path descriptions and indices, with traversal time computation deferred to the parish-core runtime where it can leverage additional context or dynamic factors.

https://claude.ai/code/session_01JDDQY3c1GEkfKBayWTg2ZW