### PR TITLE
feat: redesign UI with Antiquary's Journal aesthetic

### DIFF
--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -9,6 +9,9 @@
 	--color-input-bg: #f5ebd2;
 	--color-border: #d2be96;
 	--color-muted: #78643c;
+	/* Typography */
+	--font-body: 'IM Fell English', Georgia, serif;
+	--font-display: 'Cinzel', 'Trajan Pro', Georgia, serif;
 }
 
 *,
@@ -25,9 +28,29 @@ body {
 	overflow: hidden;
 	background: var(--color-bg);
 	color: var(--color-fg);
-	font-family: 'IM Fell English', Georgia, serif;
+	font-family: var(--font-body);
 	font-size: 16px;
 	line-height: 1.5;
+}
+
+/* Subtle paper grain overlay */
+body::after {
+	content: '';
+	position: fixed;
+	inset: 0;
+	pointer-events: none;
+	z-index: 500;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='200' height='200' filter='url(%23n)' opacity='0.045'/%3E%3C/svg%3E");
+}
+
+/* Vignette — focuses the eye on centre content */
+body::before {
+	content: '';
+	position: fixed;
+	inset: 0;
+	pointer-events: none;
+	z-index: 499;
+	background: radial-gradient(ellipse at 50% 40%, transparent 35%, rgba(0, 0, 0, 0.28) 100%);
 }
 
 #svelte {
@@ -46,16 +69,16 @@ body {
 }
 
 ::-webkit-scrollbar {
-	width: 6px;
+	width: 4px;
 }
 
 ::-webkit-scrollbar-track {
-	background: var(--color-bg);
+	background: transparent;
 }
 
 ::-webkit-scrollbar-thumb {
 	background: var(--color-border);
-	border-radius: 3px;
+	border-radius: 2px;
 }
 
 ::-webkit-scrollbar-thumb:hover {

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -6,7 +6,7 @@
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
 		<link
-			href="https://fonts.googleapis.com/css2?family=IM+Fell+English:ital@0;1&display=swap"
+			href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=IM+Fell+English:ital@0;1&display=swap"
 			rel="stylesheet"
 		/>
 		%sveltekit.head%

--- a/ui/src/components/ChatPanel.svelte
+++ b/ui/src/components/ChatPanel.svelte
@@ -164,13 +164,25 @@
 		background: var(--color-bg);
 	}
 
-	/* System messages: full-width, no bubble */
+	/* System messages: narrative prose */
 	.entry.system {
-		line-height: 1.6;
+		line-height: 1.75;
 		font-size: 1.05rem;
 		color: var(--color-fg);
 		white-space: pre-wrap;
-		padding: 0.25rem 0;
+		padding: 0.65rem 0;
+	}
+
+	/* Title card: splash message with <strong> title */
+	.entry.system :global(strong) {
+		font-family: var(--font-display);
+		font-size: 1.25rem;
+		letter-spacing: 0.06em;
+		display: block;
+		color: var(--color-accent);
+		font-weight: 600;
+		margin-bottom: 0.4rem;
+		text-align: center;
 	}
 
 	/* Bubble row: flex container controlling left/right alignment */
@@ -194,44 +206,52 @@
 		max-width: 75%;
 	}
 
-	/* Name label above the bubble */
+	/* Name labels — Cinzel small caps */
 	.label {
-		font-size: 0.8rem;
+		font-family: var(--font-display);
+		font-size: 0.66rem;
 		font-weight: 600;
+		letter-spacing: 0.1em;
 		margin-bottom: 0.2rem;
-		padding: 0 0.5rem;
 	}
 
 	.npc .label {
 		color: var(--color-accent);
 		text-align: left;
+		padding-left: 0.75rem;
 	}
 
 	.player .label {
 		color: var(--color-muted);
 		text-align: right;
+		padding-right: 0.5rem;
 	}
 
-	/* Message bubble */
-	.bubble {
-		padding: 0.6rem 0.9rem;
-		border-radius: 1rem;
+	/* NPC message: dialogue leaf — left accent border, no rounded top-left */
+	.npc .bubble {
+		background: var(--color-panel-bg);
+		color: var(--color-fg);
+		border-radius: 0 0.85rem 0.85rem 0.15rem;
+		border-left: 3px solid var(--color-accent);
+		font-style: italic;
+		padding: 0.6rem 0.9rem 0.6rem 0.85rem;
 		font-size: 1.1rem;
-		line-height: 1.5;
+		line-height: 1.6;
 		white-space: pre-wrap;
 		word-wrap: break-word;
 	}
 
-	.npc .bubble {
-		background: var(--color-border);
-		color: var(--color-fg);
-		border-top-left-radius: 0.25rem;
-	}
-
+	/* Player message: italic, no rounded top-right */
 	.player .bubble {
 		background: var(--color-accent);
 		color: var(--color-bg);
-		border-top-right-radius: 0.25rem;
+		border-radius: 0.85rem 0 0.15rem 0.85rem;
+		font-style: italic;
+		padding: 0.6rem 0.9rem;
+		font-size: 1.05rem;
+		line-height: 1.5;
+		white-space: pre-wrap;
+		word-wrap: break-word;
 	}
 
 	.emote {
@@ -319,14 +339,16 @@
 	.loading-row {
 		display: flex;
 		align-items: center;
-		gap: 0.5rem;
-		padding: 0.25rem 0;
-		font-size: 1.1rem;
-		animation: fade-in 0.3s ease-in;
+		gap: 0.65rem;
+		padding: 0.5rem 0;
+		font-size: 1.05rem;
+		animation: fade-in 0.4s ease-in;
 	}
 
 	.loading-phrase {
 		font-style: italic;
+		font-family: var(--font-body);
+		letter-spacing: 0.01em;
 		transition: color 0.5s ease;
 	}
 

--- a/ui/src/components/InputField.svelte
+++ b/ui/src/components/InputField.svelte
@@ -760,17 +760,19 @@
 	.input-field {
 		background: var(--color-input-bg);
 		border: 1px solid var(--color-border);
+		border-radius: 2px;
 		color: var(--color-fg);
 		padding: 0.5rem 0.75rem;
 		font-size: 0.95rem;
-		font-family: inherit;
-		border-radius: 4px;
+		font-family: var(--font-body);
+		font-style: italic;
 		outline: none;
 		max-height: 6em;
 		overflow-y: auto;
 		white-space: pre-wrap;
 		word-wrap: break-word;
 		overflow-wrap: break-word;
+		transition: border-color 0.2s;
 	}
 
 	.input-field:focus {
@@ -807,11 +809,13 @@
 		background: var(--color-accent);
 		color: var(--color-bg);
 		border: none;
-		padding: 0.5rem 1rem;
-		font-size: 0.85rem;
-		font-family: inherit;
+		padding: 0.5rem 1.1rem;
+		font-size: 0.65rem;
+		font-family: var(--font-display);
 		font-weight: 600;
-		border-radius: 4px;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		border-radius: 2px;
 		cursor: pointer;
 		transition: opacity 0.15s;
 	}
@@ -882,20 +886,23 @@
 	}
 
 	.travel-chip {
-		background: var(--color-border);
-		color: var(--color-fg);
-		border: none;
-		border-radius: 12px;
-		padding: 0.25rem 0.6rem;
-		font-size: 0.8rem;
-		font-family: inherit;
+		background: transparent;
+		color: var(--color-muted);
+		border: 1px solid var(--color-border);
+		border-radius: 2px;
+		padding: 0.2rem 0.65rem;
+		font-size: 0.64rem;
+		font-family: var(--font-display);
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
 		cursor: pointer;
-		transition: background 0.15s, color 0.15s;
+		transition: background 0.15s, color 0.15s, border-color 0.15s;
 	}
 
 	.travel-chip:hover:not(:disabled) {
 		background: var(--color-accent);
 		color: var(--color-bg);
+		border-color: var(--color-accent);
 	}
 
 	.travel-chip:disabled {

--- a/ui/src/components/MapPanel.svelte
+++ b/ui/src/components/MapPanel.svelte
@@ -468,10 +468,11 @@
 	}
 
 	.map-title {
-		font-size: 0.75rem;
+		font-family: var(--font-display);
+		font-size: 0.62rem;
 		color: var(--color-muted);
 		text-transform: uppercase;
-		letter-spacing: 0.08em;
+		letter-spacing: 0.13em;
 	}
 
 	.expand-btn {

--- a/ui/src/components/Sidebar.svelte
+++ b/ui/src/components/Sidebar.svelte
@@ -71,10 +71,11 @@
 	}
 
 	summary {
-		padding: 0.5rem 0.75rem;
-		font-size: 0.75rem;
+		padding: 0.55rem 0.75rem;
+		font-family: var(--font-display);
+		font-size: 0.62rem;
 		text-transform: uppercase;
-		letter-spacing: 0.08em;
+		letter-spacing: 0.13em;
 		color: var(--color-muted);
 		cursor: pointer;
 		user-select: none;
@@ -86,12 +87,13 @@
 	}
 
 	summary::before {
-		content: '▶ ';
-		font-size: 0.6rem;
+		content: '▸ ';
+		font-size: 0.55rem;
+		opacity: 0.7;
 	}
 
 	details[open] summary::before {
-		content: '▼ ';
+		content: '▾ ';
 	}
 
 	.npc-list,
@@ -121,8 +123,8 @@
 
 	.npc-name {
 		color: var(--color-accent);
-		font-weight: 600;
-		font-size: 0.85rem;
+		font-style: italic;
+		font-size: 0.9rem;
 	}
 
 	.npc-detail {

--- a/ui/src/components/StatusBar.svelte
+++ b/ui/src/components/StatusBar.svelte
@@ -60,25 +60,25 @@
 <div class="status-bar" data-testid="status-bar">
 	{#if $worldState}
 		<span class="location">{$worldState.location_name}</span>
-		<span class="sep">|</span>
+		<span class="sep">·</span>
 		<span class="time-label">{displayTimeLabel}</span>
-		<span class="sep">|</span>
+		<span class="sep">·</span>
 		<span class="day-of-week">{$worldState.day_of_week}</span>
-		<span class="sep">|</span>
+		<span class="sep">·</span>
 		<span class="weather">{$worldState.weather}</span>
-		<span class="sep">|</span>
+		<span class="sep">·</span>
 		<span class="season">{$worldState.season}</span>
 		{#if $worldState.festival}
-			<span class="sep">|</span>
-			<span class="festival">🎉 {$worldState.festival}</span>
+			<span class="sep">·</span>
+			<span class="festival">✦ {$worldState.festival}</span>
 		{/if}
 		{#if $worldState.paused}
-			<span class="sep">|</span>
+			<span class="sep">·</span>
 			<span class="paused">⏸ Paused</span>
 		{/if}
 		<span class="spacer"></span>
-		<button class="save-toggle" class:save-active={$savePickerVisible} onclick={() => savePickerVisible.update(v => !v)} title="Save/Load picker (F5)">LEDGER</button>
-		<button class="debug-toggle" class:debug-active={$debugVisible} onclick={() => debugVisible.update(v => !v)} title="Toggle debug panel (F12)">DBG</button>
+		<button class="save-toggle" class:save-active={$savePickerVisible} onclick={() => savePickerVisible.update(v => !v)} title="Save/Load picker (F5)">Ledger</button>
+		<button class="debug-toggle" class:debug-active={$debugVisible} onclick={() => debugVisible.update(v => !v)} title="Toggle debug panel (F12)">Dbg</button>
 		<span class="clock">{#each displayHour.toString().padStart(2, '0').split('') as d}<span class="digit">{d}</span>{/each}<span class="colon">:</span>{#each displayMinute.toString().padStart(2, '0').split('') as d}<span class="digit">{d}</span>{/each}</span>
 	{:else}
 		<span class="muted">Loading…</span>
@@ -89,12 +89,14 @@
 	.status-bar {
 		background: var(--color-panel-bg);
 		border-bottom: 1px solid var(--color-border);
-		padding: 0.4rem 1rem;
-		font-size: 1rem;
+		padding: 0.32rem 1rem;
+		font-family: var(--font-display);
+		font-size: 0.7rem;
+		letter-spacing: 0.07em;
 		display: flex;
 		align-items: center;
-		gap: 0.5rem;
-		color: var(--color-fg);
+		gap: 0.55rem;
+		color: var(--color-muted);
 		white-space: nowrap;
 		overflow: hidden;
 	}
@@ -106,11 +108,17 @@
 	.clock {
 		display: inline-flex;
 		align-items: baseline;
+		background: var(--color-input-bg);
+		border: 1px solid var(--color-border);
+		padding: 0.1rem 0.5rem;
+		letter-spacing: 0.1em;
+		font-size: 0.78rem;
+		color: var(--color-fg);
 	}
 
 	.digit {
 		display: inline-block;
-		width: 0.5em;
+		width: 0.55em;
 		text-align: center;
 	}
 
@@ -122,11 +130,25 @@
 
 	.sep {
 		color: var(--color-border);
+		font-size: 0.7rem;
+		letter-spacing: 0;
+		opacity: 0.8;
 	}
 
 	.location {
+		font-family: var(--font-body);
+		font-style: italic;
+		font-size: 1.05rem;
+		font-weight: normal;
 		color: var(--color-accent);
-		font-weight: 600;
+		letter-spacing: 0.02em;
+	}
+
+	.time-label,
+	.weather,
+	.season,
+	.day-of-week {
+		color: var(--color-muted);
 	}
 
 	.festival {
@@ -148,11 +170,11 @@
 		border: 1px solid var(--color-border);
 		color: var(--color-muted);
 		font-size: 0.6rem;
-		padding: 0.1rem 0.35rem;
+		padding: 0.1rem 0.45rem;
 		cursor: pointer;
-		font-family: monospace;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
+		font-family: var(--font-display);
+		letter-spacing: 0.1em;
+		transition: color 0.2s, border-color 0.2s;
 	}
 
 	.save-toggle:hover {
@@ -170,11 +192,11 @@
 		border: 1px solid var(--color-border);
 		color: var(--color-muted);
 		font-size: 0.6rem;
-		padding: 0.1rem 0.35rem;
+		padding: 0.1rem 0.45rem;
 		cursor: pointer;
-		font-family: monospace;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
+		font-family: var(--font-display);
+		letter-spacing: 0.1em;
+		transition: color 0.2s, border-color 0.2s;
 	}
 
 	.debug-toggle:hover {


### PR DESCRIPTION
## Summary

- **Cinzel** (classical Roman caps) for all UI chrome — status bar metadata, sidebar headers, travel chips, send button, NPC/player message labels
- **IM Fell English italic** for all narrative content — NPC dialogue, player input, system prose
- **NPC dialogue bubbles** restyled as "dialogue leaves": 3px left accent border, no top-left radius, italic text — feels like dialogue in a 19th-century novel
- **Player bubbles** italic with square top-right corner and Cinzel "You" label
- **Splash title card** ("Parish: Kilteevan 1820") centred in large Cinzel gold
- **Travel chips** as rectangular Cinzel uppercase stamps instead of rounded pills
- **Status bar** separators changed from `|` to `·`, location name in italic serif, clock in a bordered box
- **Background texture**: subtle SVG paper grain overlay + radial vignette at edges for atmospheric depth
- **CSS variables** `--font-display` and `--font-body` added for consistent typography across all components

## Test plan

- [ ] Load the UI at morning, midday, dusk, and night and verify the dynamic palette still looks good with the new typography
- [ ] Travel between locations — confirm travel chips render correctly, player bubbles styled properly
- [ ] Speak to an NPC — verify left-bordered dialogue leaf with Cinzel speaker label
- [ ] Run `cd ui && npx vitest run` — confirm no frontend test regressions
- [ ] Run `cd ui && npx playwright test` — confirm E2E screenshots pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)