### PR TITLE
feat: add Railway deployment for phone testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,6 +2598,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "base64 0.22.1",
  "chrono",
  "dotenvy",
  "parish-core",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# ── Stage 1: build Svelte frontend ───────────────────────────────────────────
+FROM node:22-slim AS frontend
+WORKDIR /build
+COPY ui/package*.json ./
+RUN npm ci
+COPY ui/ ./
+RUN npm run build
+
+# ── Stage 2: build Rust binary ────────────────────────────────────────────────
+FROM rust:1.86-slim-bookworm AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY src/ src/
+COPY crates/ crates/
+COPY src-tauri/ src-tauri/
+# Build only the parish binary (excludes the Tauri desktop binary)
+RUN cargo build --release --bin parish
+
+# ── Stage 3: minimal runtime image ────────────────────────────────────────────
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /build/target/release/parish ./
+COPY --from=frontend /build/dist ./ui/dist/
+COPY data/ ./data/
+COPY mods/ ./mods/
+
+ENV RUST_LOG=info
+EXPOSE 3001
+# Railway injects $PORT; fall back to 3001 for local docker testing
+CMD sh -c "./parish --web ${PORT:-3001}"

--- a/crates/parish-server/Cargo.toml
+++ b/crates/parish-server/Cargo.toml
@@ -16,3 +16,4 @@ anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "0.15"
 rand = "0.8"
+base64 = "0.22"

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -14,6 +14,10 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::Router;
+use axum::extract::Request;
+use axum::http::{StatusCode, header};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use tower_http::services::ServeDir;
 
@@ -115,6 +119,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         .route("/api/save-state", get(routes::get_save_state))
         .route("/api/ws", get(ws::ws_handler))
         .fallback_service(ServeDir::new(&static_dir).append_index_html_on_directories(true))
+        .layer(middleware::from_fn(basic_auth_middleware))
         .with_state(state);
 
     let addr = format!("0.0.0.0:{}", port);
@@ -240,6 +245,68 @@ fn build_cloud_client() -> Option<OpenAiClient> {
         .map(|key| OpenAiClient::new(&base_url, Some(key)))
 }
 
+/// Cache the `AUTH_PASSWORD` env var so we only read it once.
+static AUTH_PASSWORD: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+
+fn get_auth_password() -> Option<&'static str> {
+    AUTH_PASSWORD
+        .get_or_init(|| {
+            std::env::var("AUTH_PASSWORD")
+                .ok()
+                .filter(|s| !s.is_empty())
+        })
+        .as_deref()
+}
+
+/// Axum middleware that enforces HTTP Basic Auth when `AUTH_PASSWORD` is set.
+///
+/// If `AUTH_PASSWORD` is not set (local dev), all requests pass through. When
+/// set, any request without a valid `Authorization: Basic ...` header receives
+/// a 401 with a `WWW-Authenticate` challenge, prompting the browser to show a
+/// login dialog.
+///
+/// The username may be anything; only the password is checked.
+async fn basic_auth_middleware(req: Request, next: Next) -> Response {
+    let Some(expected) = get_auth_password() else {
+        return next.run(req).await;
+    };
+
+    let authorized = req
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Basic "))
+        .map(|b64| verify_basic_auth_password(b64, expected))
+        .unwrap_or(false);
+
+    if authorized {
+        next.run(req).await
+    } else {
+        (
+            StatusCode::UNAUTHORIZED,
+            [(header::WWW_AUTHENTICATE, r#"Basic realm="Parish""#)],
+        )
+            .into_response()
+    }
+}
+
+/// Decodes a Base64 Basic Auth credential string and checks the password.
+///
+/// The credential format is `username:password`; only the password is compared.
+fn verify_basic_auth_password(b64: &str, expected_password: &str) -> bool {
+    use base64::Engine;
+    let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(b64.trim()) else {
+        return false;
+    };
+    let Ok(creds) = std::str::from_utf8(&decoded) else {
+        return false;
+    };
+    creds
+        .splitn(2, ':')
+        .nth(1)
+        .map_or(false, |p| p == expected_password)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -249,5 +316,27 @@ mod tests {
         // In test env, PARISH_PROVIDER is usually not set → defaults to "ollama"
         let (_client, config) = build_client_and_config();
         assert_eq!(config.provider_name, "ollama");
+    }
+
+    #[test]
+    fn verify_basic_auth_password_correct() {
+        // Base64("user:secret") = "dXNlcjpzZWNyZXQ="
+        assert!(verify_basic_auth_password("dXNlcjpzZWNyZXQ=", "secret"));
+    }
+
+    #[test]
+    fn verify_basic_auth_password_wrong() {
+        assert!(!verify_basic_auth_password("dXNlcjpzZWNyZXQ=", "wrong"));
+    }
+
+    #[test]
+    fn verify_basic_auth_password_invalid_base64() {
+        assert!(!verify_basic_auth_password("!!!notbase64!!!", "secret"));
+    }
+
+    #[test]
+    fn verify_basic_auth_password_no_colon() {
+        // Base64("nocolon") = "bm9jb2xvbg=="
+        assert!(!verify_basic_auth_password("bm9jb2xvbg==", "secret"));
     }
 }

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+# /api/ui-config is a lightweight endpoint — good for health checks
+healthcheckPath = "/api/ui-config"
+healthcheckTimeout = 300
+restartPolicyType = "on_failure"


### PR DESCRIPTION
- Add HTTP Basic Auth middleware to parish-server (activated via
  AUTH_PASSWORD env var; no-op when unset so local dev is unchanged)
- Add multi-stage Dockerfile (Node 22 frontend + Rust 1.86 builder +
  debian:bookworm-slim runtime)
- Add railway.toml pointing to the Dockerfile with health check

Set AUTH_PASSWORD in Railway's dashboard to protect the deployed URL.
Railway auto-deploys on every push to the branch.

https://claude.ai/code/session_01VYL7QCQ75mr9hAWnmAFdsk