### PR TITLE
fix: suppress slash command echoes from dialogue bubbles

### DIFF
--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -133,16 +133,15 @@ pub async fn submit_input(
         return StatusCode::BAD_REQUEST;
     }
 
-    // Emit the player's own text as a log entry
-    let player_msg = text_log("player", format!("> {}", text));
-    let player_msg_id = player_msg.id.clone();
-    state.event_bus.emit("text-log", &player_msg);
-
     match classify_input(&text) {
         InputResult::SystemCommand(cmd) => {
             handle_system_command(cmd, &state).await;
         }
         InputResult::GameInput(raw) => {
+            // Emit the player's own text as a dialogue bubble only for actual dialogue
+            let player_msg = text_log("player", format!("> {}", raw));
+            let player_msg_id = player_msg.id.clone();
+            state.event_bus.emit("text-log", &player_msg);
             let raw_for_reactions = raw.clone();
             handle_game_input(raw, &state).await;
             // Generate rule-based NPC reactions to the player's message

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -325,16 +325,15 @@ pub async fn submit_input(
         return Err("Input too long (max 2000 characters).".to_string());
     }
 
-    // Emit the player's own text as a log entry
-    let player_msg = text_log("player", format!("> {}", text));
-    let player_msg_id = player_msg.id.clone();
-    let _ = app.emit(EVENT_TEXT_LOG, player_msg);
-
     match classify_input(&text) {
         InputResult::SystemCommand(cmd) => {
             handle_system_command(cmd, &state, &app).await;
         }
         InputResult::GameInput(raw) => {
+            // Emit the player's own text as a dialogue bubble only for actual dialogue
+            let player_msg = text_log("player", format!("> {}", raw));
+            let player_msg_id = player_msg.id.clone();
+            let _ = app.emit(EVENT_TEXT_LOG, player_msg);
             let raw_for_reactions = raw.clone();
             handle_game_input(raw, state.clone(), app.clone()).await;
             // Generate rule-based NPC reactions to the player's message


### PR DESCRIPTION
Player input is now only emitted as a dialogue bubble when it is actual
game dialogue (GameInput). Slash commands are handled silently — their
responses appear as system prose, not paired with a player bubble.

https://claude.ai/code/session_019pUEhwkCywCJHQMmMe9G6S