### PR TITLE
Deduplicate backend bootstrap across headless, testing, Tauri, and web server

### DIFF
--- a/crates/parish-core/src/backend_init.rs
+++ b/crates/parish-core/src/backend_init.rs
@@ -1,0 +1,77 @@
+//! Shared backend bootstrapping helpers.
+//!
+//! Centralizes world/NPC/mod loading for all runtime backends
+//! (headless CLI, test harness, Tauri, and web server).
+
+use std::path::Path;
+
+use crate::game_mod::{GameMod, find_default_mod};
+use crate::npc::{Npc, manager::NpcManager};
+use crate::world::{LocationId, WorldState};
+
+/// Fallback behavior to use if NPC data cannot be loaded from disk.
+#[derive(Debug, Clone, Copy)]
+pub enum NpcFallback {
+    /// Return an empty [`NpcManager`].
+    Empty,
+    /// Seed manager with one deterministic test NPC.
+    TestNpc,
+}
+
+/// Result of backend bootstrap: optional mod plus initialized world + NPCs.
+pub struct BackendBootstrap {
+    pub game_mod: Option<GameMod>,
+    pub world: WorldState,
+    pub npc_manager: NpcManager,
+}
+
+/// Loads the default game mod if available, then initializes world + NPCs.
+///
+/// If mod loading fails, falls back to legacy `data/` JSON files.
+/// If those fail too, falls back to default empty world and NPC fallback policy.
+pub fn bootstrap_default_mod_or_data(
+    data_dir: &Path,
+    start_location: LocationId,
+    npc_fallback: NpcFallback,
+) -> BackendBootstrap {
+    let game_mod = find_default_mod().and_then(|dir| GameMod::load(&dir).ok());
+    let (world, npc_manager) =
+        load_world_and_npcs(game_mod.as_ref(), data_dir, start_location, npc_fallback);
+
+    BackendBootstrap {
+        game_mod,
+        world,
+        npc_manager,
+    }
+}
+
+/// Loads world + NPCs from either a game mod or legacy `data/` files.
+pub fn load_world_and_npcs(
+    game_mod: Option<&GameMod>,
+    data_dir: &Path,
+    start_location: LocationId,
+    npc_fallback: NpcFallback,
+) -> (WorldState, NpcManager) {
+    let world = game_mod
+        .and_then(|gm| WorldState::from_mod(gm).ok())
+        .or_else(|| {
+            WorldState::from_parish_file(&data_dir.join("parish.json"), start_location).ok()
+        })
+        .unwrap_or_else(WorldState::new);
+
+    let npcs_path = game_mod
+        .map(|gm| gm.npcs_path())
+        .unwrap_or_else(|| data_dir.join("npcs.json"));
+
+    let mut npc_manager = NpcManager::load_from_file(&npcs_path).unwrap_or_else(|_| {
+        let mut manager = NpcManager::new();
+        if matches!(npc_fallback, NpcFallback::TestNpc) {
+            manager.add_npc(Npc::new_test_npc());
+        }
+        manager
+    });
+
+    npc_manager.assign_tiers(&world, &[]);
+
+    (world, npc_manager)
+}

--- a/crates/parish-core/src/lib.rs
+++ b/crates/parish-core/src/lib.rs
@@ -5,6 +5,7 @@
 //! Consumed by the CLI binary (headless), the Tauri desktop frontend,
 //! and the axum web server.
 
+pub mod backend_init;
 pub mod config;
 pub mod debug_snapshot;
 pub mod dice;

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -17,12 +17,11 @@ use axum::Router;
 use axum::routing::{get, post};
 use tower_http::services::ServeDir;
 
+use parish_core::backend_init::{NpcFallback, bootstrap_default_mod_or_data};
 use parish_core::game_mod::{GameMod, find_default_mod};
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceQueue, new_inference_log, spawn_inference_worker};
-use parish_core::npc::manager::NpcManager;
 use parish_core::world::transport::TransportConfig;
-use parish_core::world::{LocationId, WorldState};
 
 use state::{AppState, GameConfig, UiConfigSnapshot, build_app_state};
 
@@ -34,20 +33,13 @@ use state::{AppState, GameConfig, UiConfigSnapshot, build_app_state};
 pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
-    // Load world
-    let world = WorldState::from_parish_file(&data_dir.join("parish.json"), LocationId(15))
-        .unwrap_or_else(|e| {
-            tracing::warn!("Failed to load parish.json: {}. Using default world.", e);
-            WorldState::new()
-        });
-
-    // Load NPCs
-    let mut npc_manager =
-        NpcManager::load_from_file(&data_dir.join("npcs.json")).unwrap_or_else(|e| {
-            tracing::warn!("Failed to load npcs.json: {}. No NPCs.", e);
-            NpcManager::new()
-        });
-    npc_manager.assign_tiers(&world, &[]);
+    let bootstrap = bootstrap_default_mod_or_data(
+        &data_dir,
+        parish_core::world::LocationId(15),
+        NpcFallback::Empty,
+    );
+    let world = bootstrap.world;
+    let npc_manager = bootstrap.npc_manager;
 
     // Build client from env
     let (client, config) = build_client_and_config();
@@ -56,7 +48,9 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     let transport = TransportConfig::default();
 
     // Load game mod (if available) for splash text and reaction templates
-    let game_mod = find_default_mod().and_then(|dir| GameMod::load(&dir).ok());
+    let game_mod = bootstrap
+        .game_mod
+        .or_else(|| find_default_mod().and_then(|dir| GameMod::load(&dir).ok()));
     let game_title = game_mod
         .as_ref()
         .and_then(|gm| gm.manifest.meta.title.clone())

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -12,6 +12,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use tokio::sync::mpsc;
 
+use parish_core::backend_init::{NpcFallback, load_world_and_npcs};
 use parish_core::config::Provider;
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceQueue, new_inference_log, spawn_inference_worker};
@@ -1126,21 +1127,13 @@ pub async fn new_save_file(
 pub async fn new_game(
     State(state): State<Arc<AppState>>,
 ) -> Result<StatusCode, (StatusCode, String)> {
-    use parish_core::npc::manager::NpcManager;
-    use parish_core::world::{LocationId, WorldState};
-
     let data_dir = state.data_dir.clone();
-
-    let fresh_world = WorldState::from_parish_file(&data_dir.join("parish.json"), LocationId(15))
-        .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to load world: {}", e),
-        )
-    })?;
-
-    let fresh_npcs = NpcManager::load_from_file(&data_dir.join("npcs.json"))
-        .unwrap_or_else(|_| NpcManager::new());
+    let (fresh_world, fresh_npcs) = load_world_and_npcs(
+        None,
+        &data_dir,
+        parish_core::world::LocationId(15),
+        NpcFallback::Empty,
+    );
 
     let snapshot = {
         let mut world = state.world.lock().await;

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tauri::Emitter;
 use tokio::sync::mpsc;
 
+use parish_core::backend_init::{NpcFallback, load_world_and_npcs};
 use parish_core::config::Provider;
 use parish_core::debug_snapshot::{self, DebugEvent, DebugSnapshot, InferenceDebug};
 use parish_core::inference::openai_client::OpenAiClient;
@@ -1483,18 +1484,13 @@ pub async fn new_game(
 ) -> Result<(), String> {
     let data_dir = crate::find_data_dir();
 
-    // Reload fresh world and NPCs from data files
-    let fresh_world = parish_core::world::WorldState::from_parish_file(
-        &data_dir.join("parish.json"),
+    // Reload fresh world and NPCs from shared backend bootstrap helpers
+    let (fresh_world, fresh_npcs) = load_world_and_npcs(
+        None,
+        &data_dir,
         parish_core::world::LocationId(15),
-    )
-    .map_err(|e| format!("Failed to load parish.json: {}", e))?;
-
-    let mut fresh_npcs =
-        parish_core::npc::manager::NpcManager::load_from_file(&data_dir.join("npcs.json"))
-            .unwrap_or_else(|_| parish_core::npc::manager::NpcManager::new());
-
-    fresh_npcs.assign_tiers(&fresh_world, &[]);
+        NpcFallback::Empty,
+    );
 
     // Replace live state
     let mut world = state.world.lock().await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use tauri::Emitter;
 use tokio::sync::Mutex;
 
+use parish_core::backend_init::{NpcFallback, bootstrap_default_mod_or_data};
 use parish_core::config::Provider;
 use parish_core::debug_snapshot::{DebugEvent, InferenceDebug};
 use parish_core::game_mod::PronunciationEntry;
@@ -428,52 +429,10 @@ pub fn run() {
             })
     };
 
-    // Try to load game mod (auto-detect from workspace root)
-    let game_mod = parish_core::game_mod::find_default_mod().and_then(|dir| {
-        match parish_core::game_mod::GameMod::load(&dir) {
-            Ok(gm) => {
-                tracing::info!(
-                    "Loaded game mod: {} ({})",
-                    gm.manifest.meta.name,
-                    dir.display()
-                );
-                Some(gm)
-            }
-            Err(e) => {
-                tracing::warn!("Failed to load mod from {}: {}", dir.display(), e);
-                None
-            }
-        }
-    });
-
-    // Load world — prefer mod data, fall back to legacy data/ directory
-    let world = if let Some(ref gm) = game_mod {
-        WorldState::from_mod(gm).unwrap_or_else(|e| {
-            tracing::warn!("Failed to load world from mod: {}. Using default.", e);
-            WorldState::new()
-        })
-    } else {
-        WorldState::from_parish_file(&data_dir.join("parish.json"), LocationId(15)).unwrap_or_else(
-            |e| {
-                tracing::warn!("Failed to load parish.json: {}. Using default world.", e);
-                WorldState::new()
-            },
-        )
-    };
-
-    // Load NPCs — prefer mod data, fall back to legacy data/ directory
-    let npcs_path = if let Some(ref gm) = game_mod {
-        gm.npcs_path()
-    } else {
-        data_dir.join("npcs.json")
-    };
-    let mut npc_manager = NpcManager::load_from_file(&npcs_path).unwrap_or_else(|e| {
-        tracing::warn!("Failed to load npcs.json: {}. No NPCs.", e);
-        NpcManager::new()
-    });
-
-    // Initial tier assignment
-    npc_manager.assign_tiers(&world, &[]);
+    let bootstrap = bootstrap_default_mod_or_data(&data_dir, LocationId(15), NpcFallback::Empty);
+    let game_mod = bootstrap.game_mod;
+    let world = bootstrap.world;
+    let npc_manager = bootstrap.npc_manager;
 
     // Read provider config from env vars (optional)
     let (client, model_name, provider_name, base_url, api_key) = build_client_from_env();

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -20,6 +20,7 @@ use crate::world::description::{format_exits, render_description};
 use crate::world::movement::{self, MovementResult};
 use anyhow::Result;
 use chrono::Timelike;
+use parish_core::backend_init::{NpcFallback, load_world_and_npcs};
 use parish_core::world::transport::TransportMode;
 use std::collections::HashMap;
 use std::io::{BufRead, Write};
@@ -64,25 +65,17 @@ pub async fn run_headless(
     let _worker = inference::spawn_inference_worker(dial_client.clone(), rx, inference_log.clone());
     let queue = InferenceQueue::new(tx);
 
-    // Initialize app state — prefer mod data, fall back to legacy parish.json
+    // Initialize app state from shared backend bootstrap helpers
     let mut app = App::new();
-    if let Some(ref gm) = game_mod {
-        match crate::world::WorldState::from_mod(gm) {
-            Ok(world) => app.world = world,
-            Err(e) => eprintln!("Warning: Failed to load world from mod: {}", e),
-        }
-    } else {
-        let parish_path = Path::new("data/parish.json");
-        if parish_path.exists() {
-            match crate::world::WorldState::from_parish_file(
-                parish_path,
-                crate::world::LocationId(15),
-            ) {
-                Ok(world) => app.world = world,
-                Err(e) => eprintln!("Warning: Failed to load parish data: {}", e),
-            }
-        }
-    }
+    let data_dir = Path::new("data");
+    let (world, npc_manager) = load_world_and_npcs(
+        game_mod.as_ref(),
+        data_dir,
+        crate::world::LocationId(15),
+        NpcFallback::Empty,
+    );
+    app.world = world;
+    app.npc_manager = npc_manager;
     app.game_mod = game_mod;
     app.inference_queue = Some(queue);
     app.client = Some(clients.base.clone());
@@ -138,22 +131,6 @@ pub async fn run_headless(
         app.cloud_api_key = cc.api_key.clone();
         app.cloud_base_url = Some(cc.base_url.clone());
     }
-
-    // Load NPCs — prefer mod data, fall back to legacy data/ directory
-    let npcs_path = if let Some(ref gm) = app.game_mod {
-        gm.npcs_path()
-    } else {
-        std::path::PathBuf::from("data/npcs.json")
-    };
-    if npcs_path.exists() {
-        match NpcManager::load_from_file(&npcs_path) {
-            Ok(mgr) => app.npc_manager = mgr,
-            Err(e) => eprintln!("Warning: Failed to load NPC data: {}", e),
-        }
-    }
-
-    // Initial tier assignment
-    app.npc_manager.assign_tiers(&app.world, &[]);
 
     // Initialize persistence — Papers Please-style save picker
     let saves_dir = crate::persistence::picker::ensure_saves_dir();
@@ -922,43 +899,14 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             println!("It is now {:02}:{:02} {}.", now.hour(), now.minute(), tod);
         }
         Command::NewGame => {
-            // Re-initialize world from mod or data files
-            if let Some(ref gm) = app.game_mod {
-                match crate::world::WorldState::from_mod(gm) {
-                    Ok(world) => app.world = world,
-                    Err(e) => {
-                        eprintln!("Failed to reset world: {}", e);
-                        return (false, false);
-                    }
-                }
-            } else {
-                let parish_path = Path::new("data/parish.json");
-                if parish_path.exists() {
-                    match crate::world::WorldState::from_parish_file(
-                        parish_path,
-                        crate::world::LocationId(15),
-                    ) {
-                        Ok(world) => app.world = world,
-                        Err(e) => {
-                            eprintln!("Failed to reset world: {}", e);
-                            return (false, false);
-                        }
-                    }
-                }
-            }
-            // Re-initialize NPCs
-            let npcs_path = if let Some(ref gm) = app.game_mod {
-                gm.npcs_path()
-            } else {
-                std::path::PathBuf::from("data/npcs.json")
-            };
-            if npcs_path.exists() {
-                match NpcManager::load_from_file(&npcs_path) {
-                    Ok(mgr) => app.npc_manager = mgr,
-                    Err(e) => eprintln!("Warning: Failed to reload NPCs: {}", e),
-                }
-            }
-            app.npc_manager.assign_tiers(&app.world, &[]);
+            let (world, npc_manager) = load_world_and_npcs(
+                app.game_mod.as_ref(),
+                Path::new("data"),
+                crate::world::LocationId(15),
+                NpcFallback::Empty,
+            );
+            app.world = world;
+            app.npc_manager = npc_manager;
 
             // Reset persistence
             if let Some(ref db) = app.db

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -18,11 +18,10 @@
 
 use crate::app::App;
 use crate::input::{self, Command, InputResult, IntentKind};
-use crate::npc::Npc;
-use crate::npc::manager::NpcManager;
 use crate::world::LocationId;
 use crate::world::description::{format_exits, render_description};
 use crate::world::time::{Season, TimeOfDay};
+use parish_core::backend_init::{NpcFallback, bootstrap_default_mod_or_data};
 use parish_core::world::transport::TransportMode;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -122,45 +121,11 @@ impl GameTestHarness {
     /// falls back to `data/parish.json`. Adds NPCs from the mod or data directory.
     pub fn new() -> Self {
         let mut app = App::new();
-
-        // Try to load game mod
-        let game_mod = parish_core::game_mod::find_default_mod()
-            .and_then(|dir| parish_core::game_mod::GameMod::load(&dir).ok());
-
-        // Load world — prefer mod, fall back to legacy data/parish.json
-        if let Some(ref gm) = game_mod {
-            match crate::world::WorldState::from_mod(gm) {
-                Ok(world) => app.world = world,
-                Err(e) => eprintln!("Warning: Failed to load world from mod: {}", e),
-            }
-        } else {
-            let parish_path = Path::new("data/parish.json");
-            if parish_path.exists() {
-                match crate::world::WorldState::from_parish_file(parish_path, LocationId(15)) {
-                    Ok(world) => app.world = world,
-                    Err(e) => eprintln!("Warning: Failed to load parish data: {}", e),
-                }
-            }
-        }
-
-        // Load NPCs — prefer mod, fall back to legacy data/npcs.json, then test NPC
-        let npcs_path = if let Some(ref gm) = game_mod {
-            gm.npcs_path()
-        } else {
-            std::path::PathBuf::from("data/npcs.json")
-        };
-        if npcs_path.exists() {
-            match NpcManager::load_from_file(&npcs_path) {
-                Ok(mgr) => app.npc_manager = mgr,
-                Err(_) => app.npc_manager.add_npc(Npc::new_test_npc()),
-            }
-        } else {
-            app.npc_manager.add_npc(Npc::new_test_npc());
-        }
-        app.game_mod = game_mod;
-
-        // Initial tier assignment
-        app.npc_manager.assign_tiers(&app.world, &[]);
+        let bootstrap =
+            bootstrap_default_mod_or_data(Path::new("data"), LocationId(15), NpcFallback::TestNpc);
+        app.world = bootstrap.world;
+        app.npc_manager = bootstrap.npc_manager;
+        app.game_mod = bootstrap.game_mod;
 
         // Initialize in-memory persistence for test harness
         let db_sync = crate::persistence::Database::open_memory().ok();
@@ -886,36 +851,14 @@ impl GameTestHarness {
                 ActionResult::SystemCommand { response: msg }
             }
             Command::NewGame => {
-                // Re-initialize from GameTestHarness::new() logic
-                let game_mod = parish_core::game_mod::find_default_mod()
-                    .and_then(|dir| parish_core::game_mod::GameMod::load(&dir).ok());
-
-                if let Some(ref gm) = game_mod
-                    && let Ok(world) = crate::world::WorldState::from_mod(gm)
-                {
-                    self.app.world = world;
-                } else {
-                    let parish_path = Path::new("data/parish.json");
-                    if parish_path.exists()
-                        && let Ok(world) =
-                            crate::world::WorldState::from_parish_file(parish_path, LocationId(15))
-                    {
-                        self.app.world = world;
-                    }
-                }
-
-                let npcs_path = if let Some(ref gm) = game_mod {
-                    gm.npcs_path()
-                } else {
-                    std::path::PathBuf::from("data/npcs.json")
-                };
-                if npcs_path.exists()
-                    && let Ok(mgr) = NpcManager::load_from_file(&npcs_path)
-                {
-                    self.app.npc_manager = mgr;
-                }
-                self.app.game_mod = game_mod;
-                self.app.npc_manager.assign_tiers(&self.app.world, &[]);
+                let bootstrap = bootstrap_default_mod_or_data(
+                    Path::new("data"),
+                    LocationId(15),
+                    NpcFallback::TestNpc,
+                );
+                self.app.world = bootstrap.world;
+                self.app.npc_manager = bootstrap.npc_manager;
+                self.app.game_mod = bootstrap.game_mod;
 
                 let msg = "New game started.".to_string();
                 self.app.world.log(msg.clone());


### PR DESCRIPTION
### Motivation
- Reduce duplication between runtime backends by centralizing game-mod / world / NPC loading and initial tier assignment so all backends behave consistently.

### Description
- Added a shared bootstrap module `crates/parish-core/src/backend_init.rs` that provides `NpcFallback`, `BackendBootstrap`, `bootstrap_default_mod_or_data(...)`, and `load_world_and_npcs(...)` to encapsulate mod/data loading and NPC fallback behavior.
- Exported the new module from `crates/parish-core/src/lib.rs` so other crates can call the helpers via `parish_core::backend_init`.
- Replaced duplicated startup and `new_game` reload logic in the four backends to use the shared helpers in the following files: `src/headless.rs`, `src/testing.rs`, `src-tauri/src/lib.rs`, `src-tauri/src/commands.rs`, `crates/parish-server/src/lib.rs`, and `crates/parish-server/src/routes.rs`.
- Preserved test-harness behavior by using `NpcFallback::TestNpc` where tests require a deterministic test NPC, and used `NpcFallback::Empty` for runtime backends.

### Testing
- Ran `cargo fmt` successfully to format the codebase.
- Ran targeted checks `cargo check -p parish-core -p parish-server -p parish` which completed successfully for the affected crates.
- Attempted `cargo check --workspace` but it fails in this environment due to missing system `glib-2.0` needed by `glib-sys` (Tauri Linux native dependency), so a full workspace check could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d25ba5ea348325b7259b40831d5b25)