### PR TITLE
feat: add Go To label, travel time, and mode icon to location chips

### DIFF
--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -407,6 +407,7 @@ pub fn render_look_text(
     npc_manager: &NpcManager,
     speed_m_per_s: f64,
     transport_label: &str,
+    include_exits: bool,
 ) -> String {
     use crate::world::description::{format_exits, render_description};
 
@@ -424,14 +425,17 @@ pub fn render_look_text(
         world.current_location().description.clone()
     };
 
-    let exits = format_exits(
-        world.player_location,
-        &world.graph,
-        speed_m_per_s,
-        transport_label,
-    );
-
-    format!("{}\n{}", desc, exits)
+    if include_exits {
+        let exits = format_exits(
+            world.player_location,
+            &world.graph,
+            speed_m_per_s,
+            transport_label,
+        );
+        format!("{}\n{}", desc, exits)
+    } else {
+        desc
+    }
 }
 
 // ── Tests ────────���──────────────────────────────────────────────────────────
@@ -550,7 +554,7 @@ mod tests {
     fn render_look_text_basic() {
         let world = WorldState::new();
         let npc = NpcManager::new();
-        let text = render_look_text(&world, &npc, 1.25, "on foot");
+        let text = render_look_text(&world, &npc, 1.25, "on foot", true);
         assert!(!text.is_empty());
     }
 }

--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -14,7 +14,7 @@ use crate::npc::manager::NpcManager;
 use crate::npc::mood::mood_emoji;
 use crate::npc::ticks;
 use crate::npc::{LanguageHint, Npc, NpcId};
-use crate::world::description::{format_exits, render_description};
+use crate::world::description::render_description;
 use crate::world::palette::compute_palette;
 use crate::world::transport::TransportMode;
 use crate::world::{LocationId, WorldState};
@@ -22,7 +22,7 @@ use crate::world::{LocationId, WorldState};
 use super::types::{MapData, MapLocation, NpcInfo, TextLogPayload, ThemePalette, WorldSnapshot};
 
 /// Builds a [`WorldSnapshot`] from the current world state.
-pub fn snapshot_from_world(world: &WorldState, transport: &TransportMode) -> WorldSnapshot {
+pub fn snapshot_from_world(world: &WorldState, _transport: &TransportMode) -> WorldSnapshot {
     let now = world.clock.now();
     let hour = now.hour() as u8;
     let minute = now.minute() as u8;
@@ -33,14 +33,7 @@ pub fn snapshot_from_world(world: &WorldState, transport: &TransportMode) -> Wor
 
     let loc = world.current_location();
     let description = if let Some(data) = world.current_location_data() {
-        let desc = render_description(data, tod, &weather_str, &[]);
-        let exits = format_exits(
-            world.player_location,
-            &world.graph,
-            transport.speed_m_per_s,
-            &transport.label,
-        );
-        format!("{}\n\n{}", desc, exits)
+        render_description(data, tod, &weather_str, &[])
     } else {
         loc.description.clone()
     };
@@ -79,7 +72,8 @@ pub fn snapshot_from_world(world: &WorldState, transport: &TransportMode) -> Wor
 /// adjacent to any visited location — also appears so the player can see
 /// where they could explore next. Frontier locations are marked with
 /// `visited: false` and have limited tooltip data.
-pub fn build_map_data(world: &WorldState, speed_m_per_s: f64) -> MapData {
+pub fn build_map_data(world: &WorldState, transport: &TransportMode) -> MapData {
+    let speed_m_per_s = transport.speed_m_per_s;
     let player_loc = world.player_location;
     let visited = &world.visited_locations;
 
@@ -177,6 +171,8 @@ pub fn build_map_data(world: &WorldState, speed_m_per_s: f64) -> MapData {
         edges,
         player_location: player_loc.0.to_string(),
         edge_traversals,
+        transport_label: transport.label.clone(),
+        transport_id: transport.id.clone(),
     }
 }
 
@@ -435,7 +431,7 @@ mod tests {
     #[test]
     fn build_map_data_from_default_world() {
         let world = WorldState::new();
-        let map = build_map_data(&world, 1.25);
+        let map = build_map_data(&world, &TransportMode::walking());
         assert!(!map.player_location.is_empty());
         // At least the player's location should exist
         assert!(
@@ -452,7 +448,7 @@ mod tests {
             let start = world.player_location;
             let neighbor_count = world.graph.neighbors(start).len();
 
-            let map = build_map_data(&world, 1.25);
+            let map = build_map_data(&world, &TransportMode::walking());
 
             // Start location (visited) + its neighbors (frontier)
             assert_eq!(
@@ -498,7 +494,7 @@ mod tests {
             let neighbors = world.graph.neighbors(start);
             if let Some((neighbor_id, _)) = neighbors.first() {
                 world.mark_visited(*neighbor_id);
-                let map = build_map_data(&world, 1.25);
+                let map = build_map_data(&world, &TransportMode::walking());
 
                 // Visited locations should have visited=true
                 let visited: Vec<_> = map.locations.iter().filter(|l| l.visited).collect();
@@ -573,7 +569,7 @@ mod tests {
                 world.record_path_traversal(&[start, *neighbor_id]);
                 world.mark_visited(*neighbor_id);
 
-                let map = build_map_data(&world, 1.25);
+                let map = build_map_data(&world, &TransportMode::walking());
                 assert!(
                     !map.edge_traversals.is_empty(),
                     "should include edge traversals"

--- a/crates/parish-core/src/ipc/types.rs
+++ b/crates/parish-core/src/ipc/types.rs
@@ -94,6 +94,10 @@ pub struct MapData {
     /// thicker/lighter "worn path" lines on the map.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub edge_traversals: Vec<(String, String, u32)>,
+    /// Human-readable transport mode label (e.g. `"on foot"`).
+    pub transport_label: String,
+    /// Machine identifier for the active transport mode (e.g. `"walking"`).
+    pub transport_id: String,
 }
 
 // ── NPC info ────────────────────────────────────────────────────────────────
@@ -306,6 +310,8 @@ mod tests {
             edges: vec![("1".to_string(), "2".to_string())],
             player_location: "1".to_string(),
             edge_traversals: vec![],
+            transport_label: "on foot".to_string(),
+            transport_id: "walking".to_string(),
         };
         let json = serde_json::to_string(&data).unwrap();
         assert!(json.contains("Church"));

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -53,10 +53,7 @@ pub async fn get_world_snapshot(State(state): State<Arc<AppState>>) -> Json<Worl
 pub async fn get_map(State(state): State<Arc<AppState>>) -> Json<MapData> {
     let world = state.world.lock().await;
     let transport = state.transport.default_mode();
-    Json(parish_core::ipc::build_map_data(
-        &world,
-        transport.speed_m_per_s,
-    ))
+    Json(parish_core::ipc::build_map_data(&world, transport))
 }
 
 /// `GET /api/npcs-here` — returns NPCs at the player's current location.
@@ -471,6 +468,7 @@ async fn handle_look(state: &Arc<AppState>) {
         &npc_manager,
         transport.speed_m_per_s,
         &transport.label,
+        false,
     );
     state.event_bus.emit("text-log", &text_log("system", text));
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -99,8 +99,8 @@ pub async fn get_world_snapshot(
 #[tauri::command]
 pub async fn get_map(state: tauri::State<'_, Arc<AppState>>) -> Result<MapData, String> {
     let world = state.world.lock().await;
-    let speed = state.transport.default_mode().speed_m_per_s;
-    let core_map = parish_core::ipc::build_map_data(&world, speed);
+    let transport = state.transport.default_mode();
+    let core_map = parish_core::ipc::build_map_data(&world, transport);
 
     let player_loc = world.player_location;
     let (player_lat, player_lon) = world
@@ -130,6 +130,8 @@ pub async fn get_map(state: tauri::State<'_, Arc<AppState>>) -> Result<MapData, 
         player_lat,
         player_lon,
         edge_traversals: core_map.edge_traversals,
+        transport_label: core_map.transport_label,
+        transport_id: core_map.transport_id,
     })
 }
 
@@ -571,6 +573,7 @@ async fn handle_look(state: &Arc<AppState>, app: &tauri::AppHandle) {
         &npc_manager,
         transport.speed_m_per_s,
         &transport.label,
+        false,
     );
     let _ = app.emit(
         EVENT_TEXT_LOG,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,6 +100,10 @@ pub struct MapData {
     /// Edge traversal counts for footprint rendering: `(src_id, dst_id, count)`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub edge_traversals: Vec<(String, String, u32)>,
+    /// Human-readable transport mode label (e.g. `"on foot"`).
+    pub transport_label: String,
+    /// Machine identifier for the active transport mode (e.g. `"walking"`).
+    pub transport_id: String,
 }
 
 // NpcInfo and ThemePalette are defined in parish-core and re-exported here.

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -965,6 +965,7 @@ fn print_location_description(app: &App) {
         &app.npc_manager,
         transport.speed_m_per_s,
         &transport.label,
+        true,
     );
     println!("{}", text);
 }

--- a/tests/game_harness_integration.rs
+++ b/tests/game_harness_integration.rs
@@ -388,7 +388,10 @@ fn test_fog_of_war_frontier_at_pub() {
     h.execute("go to pub");
     assert_eq!(h.player_location(), "Darcy's Pub");
 
-    let map = build_map_data(&h.app.world, 1.25);
+    let map = build_map_data(
+        &h.app.world,
+        &parish_core::world::transport::TransportMode::walking(),
+    );
 
     // The player is at the pub
     assert_eq!(

--- a/ui/src/components/InputField.svelte
+++ b/ui/src/components/InputField.svelte
@@ -421,6 +421,19 @@
 		sel?.addRange(range);
 	}
 
+	// ── Transport icons ──────────────────────────────────────────────────────
+
+	const TRANSPORT_ICON_PATHS: Record<string, string> = {
+		walking:
+			'M152,80a32,32,0,1,0-32-32A32,32,0,0,0,152,80Zm0-48a16,16,0,1,1-16,16A16,16,0,0,1,152,32Zm64,112a8,8,0,0,1-8,8c-35.31,0-52.95-17.81-67.12-32.12-2.74-2.77-5.36-5.4-8-7.84l-13.43,30.88,37.2,26.57A8,8,0,0,1,160,176v56a8,8,0,0,1-16,0V180.12l-31.07-22.2L79.34,235.19A8,8,0,0,1,72,240a7.84,7.84,0,0,1-3.19-.67,8,8,0,0,1-4.15-10.52l54.08-124.37c-9.31-1.65-20.92,1.2-34.7,8.58a163.88,163.88,0,0,0-30.57,21.77,8,8,0,0,1-10.95-11.66c2.5-2.35,61.69-57.23,98.72-25.08,3.83,3.32,7.48,7,11,10.57C166.19,122.7,179.36,136,208,136A8,8,0,0,1,216,144Z',
+		jaunting_car:
+			'M232,136a8,8,0,0,0-8-8H195.7L133.86,59.06A16,16,0,0,0,121,52H40A16,16,0,0,0,24,68V172a8,8,0,0,0,8,8H49a36,36,0,0,0,70,0h58a36,36,0,0,0,70,0h7a8,8,0,0,0,8-8V152A16.09,16.09,0,0,0,232,136ZM121,68l55.93,72H121ZM84,196a20,20,0,1,1-20-20A20,20,0,0,1,84,196Zm128,0a20,20,0,1,1-20-20A20,20,0,0,1,212,196Z'
+	};
+
+	function transportIconPath(id: string | undefined): string | undefined {
+		return id ? TRANSPORT_ICON_PATHS[id] : undefined;
+	}
+
 	// ── Quick-travel ────────────────────────────────────────────────────────
 
 	async function quickTravel(locationName: string) {
@@ -705,6 +718,7 @@
 	{/if}
 	{#if adjacentLocations.length > 0 && !$streamingActive}
 		<div class="travel-chips">
+			<span class="travel-label">Go To</span>
 			{#each adjacentLocations as loc}
 				<button
 					class="travel-chip"
@@ -712,6 +726,16 @@
 					disabled={$streamingActive}
 				>
 					{loc.name}
+					{#if loc.travel_minutes !== undefined}
+						<span class="chip-meta">
+							{loc.travel_minutes}m
+							{#if transportIconPath($mapData?.transport_id)}
+								<svg viewBox="0 0 256 256" class="transport-icon" aria-hidden="true">
+									<path d={transportIconPath($mapData?.transport_id)} />
+								</svg>
+							{/if}
+						</span>
+					{/if}
 				</button>
 			{/each}
 		</div>
@@ -879,18 +903,32 @@
 	.travel-chips {
 		display: flex;
 		flex-wrap: wrap;
+		align-items: center;
 		gap: 0.4rem;
 		padding: 0.4rem 0.75rem;
 		background: var(--color-panel-bg);
 		border-top: 1px solid var(--color-border);
 	}
 
+	.travel-label {
+		color: var(--color-muted);
+		font-size: 0.6rem;
+		font-family: var(--font-display);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		opacity: 0.7;
+		flex-shrink: 0;
+	}
+
 	.travel-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
 		background: transparent;
 		color: var(--color-muted);
 		border: 1px solid var(--color-border);
 		border-radius: 2px;
-		padding: 0.2rem 0.65rem;
+		padding: 0.2rem 0.55rem;
 		font-size: 0.64rem;
 		font-family: var(--font-display);
 		letter-spacing: 0.06em;
@@ -908,5 +946,20 @@
 	.travel-chip:disabled {
 		opacity: 0.4;
 		cursor: not-allowed;
+	}
+
+	.chip-meta {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.2rem;
+		opacity: 0.7;
+		font-size: 0.58rem;
+	}
+
+	.transport-icon {
+		width: 0.75rem;
+		height: 0.75rem;
+		fill: currentColor;
+		vertical-align: middle;
 	}
 </style>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -37,6 +37,10 @@ export interface MapData {
 	player_lon: number;
 	/** Edge traversal counts for footprint rendering: [src_id, dst_id, count]. */
 	edge_traversals?: [string, string, number][];
+	/** Human-readable transport mode label (e.g. "on foot"). */
+	transport_label?: string;
+	/** Machine identifier for the active transport mode (e.g. "walking"). */
+	transport_id?: string;
 }
 
 /** A waypoint along a travel path. */


### PR DESCRIPTION
## Summary

- Suppresses redundant "You can go to:" text from chat in GUI modes (Tauri and web) — the travel chip buttons already surface this information. Headless mode retains the exits text since text is its only interface.
- Adds a **"Go To"** label before the travel chip row in `InputField.svelte`
- Each chip now shows **travel time** (e.g. `3m`) and a **PersonSimpleWalk icon** (Phosphor Regular, inline SVG) indicating the active transport mode
- `MapData` carries new `transport_label` and `transport_id` fields so the frontend can render mode-appropriate icons
- `render_look_text` gains an `include_exits: bool` param — GUI backends pass `false`, headless passes `true`
- `build_map_data` now takes `&TransportMode` instead of `f64` so transport metadata flows through to the frontend

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test --lib --bins --tests` — all 324 tests pass
- [x] Headless mode: `echo "look" | cargo run` still shows "You can go to:" in CLI output
- [x] Tauri dev (`just run`): travel chips show "Go To" label, time + icon; no exits in chat text on arrival or `look`

🤖 Generated with [Claude Code](https://claude.com/claude-code)