### PR TITLE
feat: NPC speak-to chips, multi-NPC conversations, and inactivity timers

### DIFF
--- a/crates/parish-core/src/input/mod.rs
+++ b/crates/parish-core/src/input/mod.rs
@@ -659,6 +659,32 @@ pub fn extract_mention(raw: &str) -> Option<MentionExtraction> {
     Some(MentionExtraction { name, remaining })
 }
 
+/// Extracts all `@Name` mentions from input text, returning the names in order
+/// and the remaining dialogue with all mentions stripped.
+///
+/// # Examples
+///
+/// ```
+/// use parish_core::input::extract_all_mentions;
+///
+/// let (names, dialogue) = extract_all_mentions("@Brigid @Seamus good morning");
+/// assert_eq!(names, vec!["Brigid", "Seamus"]);
+/// assert_eq!(dialogue, "good morning");
+///
+/// let (names, dialogue) = extract_all_mentions("no mentions here");
+/// assert!(names.is_empty());
+/// assert_eq!(dialogue, "no mentions here");
+/// ```
+pub fn extract_all_mentions(raw: &str) -> (Vec<String>, String) {
+    let mut names = Vec::new();
+    let mut text = raw.to_string();
+    while let Some(m) = extract_mention(&text) {
+        names.push(m.name);
+        text = m.remaining;
+    }
+    (names, text.trim().to_string())
+}
+
 /// Parses natural language input into a structured `PlayerIntent`.
 ///
 /// First tries local keyword matching for common commands (movement, look).

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -114,6 +114,10 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         .route("/api/new-save-file", get(routes::new_save_file))
         .route("/api/new-game", get(routes::new_game))
         .route("/api/save-state", get(routes::get_save_state))
+        .route(
+            "/api/trigger-ambient-speech",
+            post(routes::trigger_ambient_speech),
+        )
         .route("/api/ws", get(ws::ws_handler))
         .fallback_service(ServeDir::new(&static_dir).append_index_html_on_directories(true))
         .with_state(state);

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -15,7 +15,7 @@ use tokio::sync::mpsc;
 use parish_core::config::InferenceCategory;
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceQueue, new_inference_log, spawn_inference_worker};
-use parish_core::input::{InputResult, classify_input, extract_mention, parse_intent};
+use parish_core::input::{InputResult, classify_input, extract_all_mentions, parse_intent};
 use parish_core::ipc::{
     IDLE_MESSAGES, INFERENCE_FAILURE_MESSAGES, LoadingPayload, MapData, NpcInfo,
     NpcReactionPayload, ReactRequest, StreamEndPayload, StreamTokenPayload, ThemePalette,
@@ -344,13 +344,22 @@ async fn handle_game_input(raw: String, state: &Arc<AppState>) {
         return;
     }
 
-    // Extract @mention for NPC targeting, if present
-    let (target_name, dialogue) = match extract_mention(&raw) {
-        Some(mention) => (Some(mention.name), mention.remaining),
-        None => (None, raw),
+    // Extract all @mentions for NPC targeting, if any
+    let (target_names, dialogue) = extract_all_mentions(&raw);
+    let targets: Vec<Option<String>> = if target_names.is_empty() {
+        vec![None]
+    } else {
+        target_names.into_iter().map(Some).collect()
     };
 
-    handle_npc_conversation(dialogue, target_name, state).await;
+    for target in &targets {
+        handle_single_npc_turn(dialogue.clone(), target.as_deref(), state).await;
+    }
+
+    // After two or more NPCs respond, optionally run NPC-to-NPC follow-up turns
+    if targets.len() >= 2 {
+        run_npc_followup_turns(state).await;
+    }
 }
 
 /// Resolves movement to a named location.
@@ -473,8 +482,8 @@ async fn handle_look(state: &Arc<AppState>) {
     state.event_bus.emit("text-log", &text_log("system", text));
 }
 
-/// Routes input to the NPC at the player's location, or shows idle message.
-async fn handle_npc_conversation(raw: String, target_name: Option<String>, state: &Arc<AppState>) {
+/// Runs a single NPC conversation turn, streaming the response to the frontend.
+async fn handle_single_npc_turn(raw: String, target_name: Option<&str>, state: &Arc<AppState>) {
     let (setup, queue, npc_present) = {
         let world = state.world.lock().await;
         let mut npc_manager = state.npc_manager.lock().await;
@@ -486,7 +495,7 @@ async fn handle_npc_conversation(raw: String, target_name: Option<String>, state
             &world,
             &mut npc_manager,
             &raw,
-            target_name.as_deref(),
+            target_name,
             config.improv_enabled,
         );
         (setup, queue.clone(), npc_present)
@@ -685,6 +694,51 @@ async fn handle_npc_conversation(raw: String, target_name: Option<String>, state
 
     // Cancel loading animation (emits final active: false)
     loading_cancel.cancel();
+}
+
+/// Optionally runs 1–2 additional NPC-to-NPC follow-up turns after a
+/// multi-NPC player exchange. Uses millisecond timing for probability gating.
+async fn run_npc_followup_turns(state: &Arc<AppState>) {
+    fn subsec_millis() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_millis() as u64
+    }
+
+    let thresholds = [70u64, 40u64]; // % chance for 1st and 2nd follow-up
+    for threshold in thresholds {
+        if subsec_millis() % 100 >= threshold {
+            break;
+        }
+
+        // Pick the NPC at the player's location who didn't speak last
+        let (target_name, has_npcs) = {
+            let world = state.world.lock().await;
+            let npc_manager = state.npc_manager.lock().await;
+            let npcs = npc_manager.npcs_at(world.player_location);
+            let last = world
+                .conversation_log
+                .last_speaker_at(world.player_location);
+            let other = npcs.iter().find(|n| Some(n.id) != last);
+            let name = other.map(|n| n.name.clone());
+            (name, !npcs.is_empty())
+        };
+
+        if !has_npcs {
+            break;
+        }
+        let Some(name) = target_name else { break };
+
+        handle_single_npc_turn("".to_string(), Some(name.as_str()), state).await;
+    }
+}
+
+/// `POST /api/trigger-ambient-speech` — triggers unprompted NPC speech at the
+/// player's location. Called by the frontend after a period of player inactivity.
+pub async fn trigger_ambient_speech(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    handle_single_npc_turn("(speaks unprompted)".to_string(), None, &state).await;
+    StatusCode::OK
 }
 
 /// Spawns a background task that emits rich [`LoadingPayload`] events with

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,7 +13,7 @@ use parish_core::config::InferenceCategory;
 use parish_core::debug_snapshot::{self, DebugEvent, DebugSnapshot, InferenceDebug};
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceQueue, spawn_inference_worker};
-use parish_core::input::{InputResult, classify_input, extract_mention, parse_intent};
+use parish_core::input::{InputResult, classify_input, extract_all_mentions, parse_intent};
 use parish_core::ipc::{
     IDLE_MESSAGES, INFERENCE_FAILURE_MESSAGES, capitalize_first, compute_name_hints, text_log,
 };
@@ -436,14 +436,28 @@ async fn handle_game_input(
         return;
     }
 
-    // Extract @mention for NPC targeting, if present
-    let (target_name, dialogue) = match extract_mention(&raw) {
-        Some(mention) => (Some(mention.name), mention.remaining),
-        None => (None, raw),
+    // Extract all @mentions for NPC targeting, if any
+    let (target_names, dialogue) = extract_all_mentions(&raw);
+    let targets: Vec<Option<String>> = if target_names.is_empty() {
+        vec![None]
+    } else {
+        target_names.into_iter().map(Some).collect()
     };
 
-    // Try NPC conversation
-    handle_npc_conversation(dialogue, target_name, state, app).await;
+    for target in &targets {
+        handle_single_npc_turn(
+            dialogue.clone(),
+            target.as_deref(),
+            state.clone(),
+            app.clone(),
+        )
+        .await;
+    }
+
+    // After two or more NPCs respond, optionally run NPC-to-NPC follow-up turns
+    if targets.len() >= 2 {
+        run_npc_followup_turns(Arc::clone(&*state), app.clone()).await;
+    }
 }
 
 /// Resolves movement to a named location using the shared movement pipeline.
@@ -587,11 +601,13 @@ async fn handle_look(state: &Arc<AppState>, app: &tauri::AppHandle) {
 
 /// Routes input to the NPC at the player's location, or shows idle message.
 ///
+/// Runs a single NPC conversation turn, streaming the response to the frontend.
+///
 /// If `target_name` is provided (from an `@mention`), the matching NPC
 /// is selected. Otherwise falls back to the first NPC at the location.
-async fn handle_npc_conversation(
+async fn handle_single_npc_turn(
     raw: String,
-    target_name: Option<String>,
+    target_name: Option<&str>,
     state: tauri::State<'_, Arc<AppState>>,
     app: tauri::AppHandle,
 ) {
@@ -606,7 +622,7 @@ async fn handle_npc_conversation(
             &world,
             &mut npc_manager,
             &raw,
-            target_name.as_deref(),
+            target_name,
             config.improv_enabled,
         );
         (setup, queue.clone(), npc_present)
@@ -829,6 +845,230 @@ async fn handle_npc_conversation(
 
     // Stop the animated loading indicator (emits active: false)
     loading_cancel.cancel();
+}
+
+/// Optionally runs 1–2 additional NPC-to-NPC follow-up turns after a
+/// multi-NPC player exchange. Uses millisecond timing for probability gating.
+async fn run_npc_followup_turns(state: Arc<AppState>, app: tauri::AppHandle) {
+    fn subsec_millis() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_millis() as u64
+    }
+
+    let thresholds = [70u64, 40u64]; // % chance for 1st and 2nd follow-up
+    for threshold in thresholds {
+        if subsec_millis() % 100 >= threshold {
+            break;
+        }
+
+        // Pick the NPC at the player's location who didn't speak last
+        let (target_name, has_npcs) = {
+            let world = state.world.lock().await;
+            let npc_manager = state.npc_manager.lock().await;
+            let npcs = npc_manager.npcs_at(world.player_location);
+            let last = world
+                .conversation_log
+                .last_speaker_at(world.player_location);
+            let other = npcs.iter().find(|n| Some(n.id) != last);
+            let name = other.map(|n| n.name.clone());
+            (name, !npcs.is_empty())
+        };
+
+        if !has_npcs {
+            break;
+        }
+        let Some(name) = target_name else { break };
+
+        // Wrap state in a temporary Tauri-compatible handle via Arc
+        // handle_single_npc_turn needs tauri::State, so we call the inner logic directly
+        handle_single_npc_arc("".to_string(), Some(name.as_str()), &state, app.clone()).await;
+    }
+}
+
+/// Inner NPC turn logic that works with `Arc<AppState>` directly (used by
+/// follow-up turns and ambient speech which don't have a `tauri::State` handle).
+async fn handle_single_npc_arc(
+    raw: String,
+    target_name: Option<&str>,
+    state: &Arc<AppState>,
+    app: tauri::AppHandle,
+) {
+    let (setup, queue, npc_present) = {
+        let world = state.world.lock().await;
+        let mut npc_manager = state.npc_manager.lock().await;
+        let queue = state.inference_queue.lock().await;
+        let config = state.config.lock().await;
+
+        let npc_present = !npc_manager.npcs_at(world.player_location).is_empty();
+        let setup = parish_core::ipc::prepare_npc_conversation(
+            &world,
+            &mut npc_manager,
+            &raw,
+            target_name,
+            config.improv_enabled,
+        );
+        (setup, queue.clone(), npc_present)
+    };
+
+    let (Some(setup), Some(queue)) = (setup, queue) else {
+        if npc_present {
+            let _ = app.emit(
+                EVENT_TEXT_LOG,
+                TextLogPayload {
+                    id: String::new(),
+                    source: "system".to_string(),
+                    content:
+                        "There's someone here, but the LLM is not configured — set a provider with /provider."
+                            .to_string(),
+                },
+            );
+        }
+        return;
+    };
+
+    let npc_id = setup.npc_id;
+    let npc_name = setup.display_name;
+    let system_prompt = setup.system_prompt;
+    let context = setup.context;
+
+    let model = {
+        let config = state.config.lock().await;
+        config.model_name.clone()
+    };
+    let req_id = REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+
+    let loading_cancel = tokio_util::sync::CancellationToken::new();
+    spawn_loading_animation(app.clone(), loading_cancel.clone());
+
+    let (token_tx, token_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+
+    let display_label = capitalize_first(&npc_name);
+    let _ = app.emit(EVENT_TEXT_LOG, text_log(display_label, String::new()));
+
+    {
+        let mut world = state.world.lock().await;
+        world.clock.inference_pause();
+        let transport = state.transport.default_mode();
+        let npc_manager = state.npc_manager.lock().await;
+        let mut snapshot = parish_core::ipc::snapshot_from_world(&world, transport);
+        snapshot.name_hints = compute_name_hints(&world, &npc_manager, &state.pronunciations);
+        let _ = app.emit(EVENT_WORLD_UPDATE, snapshot);
+    }
+
+    match queue
+        .send(
+            req_id,
+            model,
+            context,
+            Some(system_prompt),
+            Some(token_tx),
+            None,
+        )
+        .await
+    {
+        Ok(mut response_rx) => {
+            let app_clone = app.clone();
+            let stream_handle = tokio::spawn(async move {
+                crate::events::stream_npc_response(app_clone, token_rx).await
+            });
+
+            let full_response = loop {
+                match response_rx.try_recv() {
+                    Ok(resp) => {
+                        let _ = stream_handle.await;
+                        break Some(resp);
+                    }
+                    Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
+                        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+                    }
+                    Err(tokio::sync::oneshot::error::TryRecvError::Closed) => break None,
+                }
+            };
+
+            let (hints, parsed_response) = if let Some(resp) = full_response {
+                if resp.error.is_some() {
+                    (vec![], None)
+                } else {
+                    let parsed = parish_core::npc::parse_npc_stream_response(&resp.text);
+                    let hints = parsed
+                        .metadata
+                        .as_ref()
+                        .map(|m| m.language_hints.clone())
+                        .unwrap_or_default();
+                    (hints, Some(parsed))
+                }
+            } else {
+                (vec![], None)
+            };
+
+            if let Some(ref parsed) = parsed_response {
+                let mut world = state.world.lock().await;
+                let mut npc_manager = state.npc_manager.lock().await;
+                let game_time = world.clock.now();
+                let location = world.player_location;
+
+                if let Some(npc_mut) = npc_manager.get_mut(npc_id) {
+                    parish_core::npc::ticks::apply_tier1_response(npc_mut, parsed, &raw, game_time);
+                }
+
+                world
+                    .conversation_log
+                    .add(parish_core::npc::conversation::ConversationExchange {
+                        timestamp: game_time,
+                        speaker_id: npc_id,
+                        speaker_name: npc_name.clone(),
+                        player_input: raw.clone(),
+                        npc_dialogue: parsed.dialogue.clone(),
+                        location,
+                    });
+
+                parish_core::npc::ticks::record_witness_memories(
+                    npc_manager.npcs_mut(),
+                    npc_id,
+                    &npc_name,
+                    &raw,
+                    &parsed.dialogue,
+                    game_time,
+                    location,
+                );
+            }
+
+            let _ = app.emit(EVENT_STREAM_END, StreamEndPayload { hints });
+        }
+        Err(e) => {
+            tracing::error!("Failed to submit inference request: {}", e);
+            let _ = app.emit(
+                EVENT_TEXT_LOG,
+                TextLogPayload {
+                    id: String::new(),
+                    source: "system".to_string(),
+                    content: "The parish storyteller has wandered off. Try again in a moment."
+                        .to_string(),
+                },
+            );
+        }
+    }
+
+    {
+        let mut world = state.world.lock().await;
+        world.clock.inference_resume();
+    }
+    loading_cancel.cancel();
+}
+
+/// Triggers an unprompted NPC utterance at the player's current location.
+///
+/// Called by the frontend after a period of player inactivity to simulate
+/// spontaneous NPC speech.
+#[tauri::command]
+pub async fn trigger_ambient_speech(
+    state: tauri::State<'_, Arc<AppState>>,
+    app: tauri::AppHandle,
+) -> Result<(), String> {
+    handle_single_npc_arc("(speaks unprompted)".to_string(), None, &*state, app).await;
+    Ok(())
 }
 
 // ── Persistence commands ────────────────────────────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -486,6 +486,7 @@ pub fn run() {
             commands::new_game,
             commands::get_save_state,
             commands::react_to_message,
+            commands::trigger_ambient_speech,
         ])
         .setup(move |app| {
             let handle = app.handle().clone();

--- a/ui/src/components/InputField.svelte
+++ b/ui/src/components/InputField.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { streamingActive, npcsHere, mapData } from '../stores/game';
-	import { submitInput } from '$lib/ipc';
+	import { submitInput, triggerAmbientSpeech } from '$lib/ipc';
 	import { filterCommands, type SlashCommand } from '$lib/slash-commands';
 	import { knownNouns, findMatches, type KnownNoun } from '../stores/nouns';
 	import { get } from 'svelte/store';
@@ -50,6 +50,66 @@
 			.filter((loc) => loc.adjacent && loc.id !== $mapData?.player_location)
 			.sort((a, b) => a.name.localeCompare(b.name))
 	);
+
+	// ── NPC chip state ──────────────────────────────────────────────────────
+	let mentionedNpcNames = $state(new Set<string>());
+
+	function syncMentionedNpcs() {
+		if (!editorEl) return;
+		const chips = editorEl.querySelectorAll<HTMLElement>('.mention-chip[data-npc]');
+		mentionedNpcNames = new Set(Array.from(chips).map((c) => c.dataset.npc ?? ''));
+	}
+
+	function insertNpcMention(npcName: string) {
+		if ($streamingActive || !editorEl) return;
+		editorEl.focus();
+
+		const chip = document.createElement('span');
+		chip.className = 'mention-chip';
+		chip.contentEditable = 'false';
+		chip.dataset.npc = npcName;
+		chip.textContent = `@${npcName}`;
+
+		const space = document.createTextNode('\u00a0');
+		editorEl.appendChild(chip);
+		editorEl.appendChild(space);
+
+		const range = document.createRange();
+		const sel = window.getSelection();
+		range.setStartAfter(space);
+		range.collapse(true);
+		sel?.removeAllRanges();
+		sel?.addRange(range);
+
+		syncMentionedNpcs();
+		editorEl.dispatchEvent(new Event('input', { bubbles: true }));
+	}
+
+	// ── Inactivity timers ────────────────────────────────────────────────────
+	let lastActivityAt = $state(Date.now());
+
+	$effect(() => {
+		const spontaneous = setInterval(async () => {
+			if ($streamingActive) return;
+			if (Date.now() - lastActivityAt > 12_000) {
+				lastActivityAt = Date.now();
+				await triggerAmbientSpeech();
+			}
+		}, 2_000);
+
+		const autoPause = setInterval(async () => {
+			if ($streamingActive) return;
+			if (Date.now() - lastActivityAt > 60_000) {
+				lastActivityAt = Date.now();
+				await submitInput('/pause');
+			}
+		}, 10_000);
+
+		return () => {
+			clearInterval(spontaneous);
+			clearInterval(autoPause);
+		};
+	});
 
 	// ── Tab-completion state ────────────────────────────────────────────────
 	interface CompletionState {
@@ -207,6 +267,7 @@
 		if (editorEl) {
 			editorEl.innerHTML = '';
 		}
+		syncMentionedNpcs();
 	}
 
 	/** Sets the editor's plain-text content and places cursor at end. */
@@ -457,6 +518,7 @@
 		}
 		const trimmed = getPlainText().trim();
 		if (!trimmed || $streamingActive) return;
+		lastActivityAt = Date.now();
 		clearEditor();
 		dropdownMode = null;
 
@@ -669,6 +731,8 @@
 		if (dropdownMode !== 'mention') {
 			detectSlash();
 		}
+		syncMentionedNpcs();
+		lastActivityAt = Date.now();
 	}
 
 	// Prevent pasting rich content — only plain text
@@ -736,6 +800,21 @@
 							{/if}
 						</span>
 					{/if}
+				</button>
+			{/each}
+		</div>
+	{/if}
+	{#if $npcsHere.length > 0 && !$streamingActive}
+		<div class="npc-chips">
+			<span class="npc-chips-label">Speak To</span>
+			{#each $npcsHere as npc}
+				<button
+					class="npc-chip"
+					class:active={mentionedNpcNames.has(npc.name)}
+					onclick={() => insertNpcMention(npc.name)}
+					disabled={$streamingActive}
+				>
+					<span class="npc-chip-mood">{npc.mood_emoji}</span>{npc.name}
 				</button>
 			{/each}
 		</div>
@@ -961,5 +1040,64 @@
 		height: 0.75rem;
 		fill: currentColor;
 		vertical-align: middle;
+	}
+
+	/* ── NPC speak-to chips ──────────────────────────────────────────────────── */
+
+	.npc-chips {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.4rem;
+		padding: 0.4rem 0.75rem;
+		background: var(--color-panel-bg);
+		border-top: 1px solid var(--color-border);
+	}
+
+	.npc-chips-label {
+		color: var(--color-muted);
+		font-size: 0.6rem;
+		font-family: var(--font-display);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		opacity: 0.7;
+		flex-shrink: 0;
+	}
+
+	.npc-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		background: transparent;
+		color: var(--color-accent);
+		border: 1px solid color-mix(in srgb, var(--color-accent) 35%, transparent);
+		border-radius: 12px;
+		padding: 0.18rem 0.6rem;
+		font-size: 0.72rem;
+		font-family: var(--font-body);
+		cursor: pointer;
+		transition:
+			background 0.15s,
+			border-color 0.15s;
+	}
+
+	.npc-chip:hover:not(:disabled) {
+		background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+		border-color: var(--color-accent);
+	}
+
+	.npc-chip.active {
+		background: color-mix(in srgb, var(--color-accent) 18%, transparent);
+		border-color: var(--color-accent);
+	}
+
+	.npc-chip:disabled {
+		opacity: 0.4;
+		cursor: not-allowed;
+	}
+
+	.npc-chip-mood {
+		font-size: 0.85em;
+		line-height: 1;
 	}
 </style>

--- a/ui/src/components/InputField.test.ts
+++ b/ui/src/components/InputField.test.ts
@@ -7,7 +7,8 @@ import InputField from './InputField.svelte';
 // Mock ipc submitInput
 const mockSubmitInput = vi.fn(async (_text: string) => {});
 vi.mock('$lib/ipc', () => ({
-	submitInput: (...args: unknown[]) => mockSubmitInput(...args)
+	submitInput: (...args: unknown[]) => mockSubmitInput(...args),
+	triggerAmbientSpeech: vi.fn(async () => {})
 }));
 
 describe('InputField', () => {

--- a/ui/src/components/Sidebar.svelte
+++ b/ui/src/components/Sidebar.svelte
@@ -1,30 +1,8 @@
 <script lang="ts">
-	import { npcsHere, languageHints, nameHints, uiConfig } from '../stores/game';
-	import MoodIcon from './MoodIcon.svelte';
+	import { languageHints, nameHints, uiConfig } from '../stores/game';
 </script>
 
 <aside class="sidebar" data-testid="sidebar">
-	<details open>
-		<summary>NPCs Here</summary>
-		{#if $npcsHere.length > 0}
-			<ul class="npc-list">
-				{#each $npcsHere as npc}
-					<li class="npc-item">
-						<div class="npc-name-row">
-							<span class="npc-mood"><MoodIcon mood={npc.mood} /></span>
-							<span class="npc-name">{npc.name}</span>
-						</div>
-						{#if npc.introduced}
-							<span class="npc-detail">{npc.occupation}</span>
-						{/if}
-					</li>
-				{/each}
-			</ul>
-		{:else}
-			<p class="empty">Nobody nearby.</p>
-		{/if}
-	</details>
-
 	<details open>
 		<summary>{$uiConfig.hints_label}</summary>
 		{#if $nameHints.length > 0 || $languageHints.length > 0}
@@ -96,48 +74,10 @@
 		content: '▾ ';
 	}
 
-	.npc-list,
 	.hint-list {
 		list-style: none;
 		margin: 0;
 		padding: 0.25rem 0;
-	}
-
-	.npc-item {
-		padding: 0.4rem 0.75rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.1rem;
-		border-bottom: 1px solid var(--color-border);
-	}
-
-	.npc-item:last-child {
-		border-bottom: none;
-	}
-
-	.npc-name-row {
-		display: flex;
-		align-items: baseline;
-		gap: 0.35rem;
-	}
-
-	.npc-name {
-		color: var(--color-accent);
-		font-style: italic;
-		font-size: 0.9rem;
-	}
-
-	.npc-detail {
-		color: var(--color-muted);
-		font-size: 0.75rem;
-	}
-
-	.npc-mood {
-		font-size: 1rem;
-		cursor: default;
-		display: inline-flex;
-		align-self: center;
-		transform: translateY(-2px);
 	}
 
 	.hint-item {

--- a/ui/src/lib/ipc.ts
+++ b/ui/src/lib/ipc.ts
@@ -88,6 +88,8 @@ export const getSaveState = () => command<SaveState>('get_save_state');
 export const reactToMessage = (npcName: string, messageSnippet: string, emoji: string) =>
 	command<void>('react_to_message', { npcName, messageSnippet, emoji });
 
+export const triggerAmbientSpeech = () => command<void>('trigger_ambient_speech');
+
 // ── Events ──────────────────────────────────────────────────────────────────
 
 type UnlistenFn = () => void;


### PR DESCRIPTION
## Summary

- **NPC chips row**: Replaces the sidebar NPCs Here list with a "Speak To" row of pill-shaped chip buttons above the input field, styled distinctly from the existing "Go To" travel chips (rounded, accent-colored, with mood emoji, body font)
- **@mention insertion**: Clicking an NPC chip inserts `@Name` as a mention chip in the input; the chip button stays highlighted while that NPC is mentioned
- **Multi-NPC conversations**: Submitting with multiple `@mentions` runs each NPC's response in sequence — later NPCs see earlier responses in their context via the existing `ConversationLog`
- **NPC-to-NPC follow-up turns**: After 2+ player-directed NPC responses, up to 2 additional NPC-to-NPC turns fire automatically (70%/40% probability gates), alternating between the NPCs present
- **Spontaneous speech**: After 12 seconds of player inactivity, `trigger_ambient_speech` fires an unprompted NPC utterance at the player's location
- **Auto-pause**: After 60 seconds of player inactivity, the game pauses automatically

## Backend changes

- `extract_all_mentions(raw) -> (Vec<String>, String)` added to `parish-core/src/input/mod.rs` — extracts all `@Name` tokens iteratively using the existing `extract_mention` logic
- `handle_single_npc_turn` (renamed from `handle_npc_conversation`) in both Tauri and web server handlers
- `run_npc_followup_turns` and `handle_single_npc_arc` helper in Tauri; equivalent in web server
- `trigger_ambient_speech` registered as a Tauri command and `POST /api/trigger-ambient-speech` in the web server

## Test plan

- [ ] Build: `cargo build` and `cd ui && npm run build` pass
- [ ] `cargo test` all pass; `cargo clippy -- -D warnings` clean
- [ ] `cd ui && npx vitest run` — same pass/fail count as baseline (44 pre-existing failures unrelated to this change)
- [ ] Start web server (`cargo run -- --web`), verify NPC chips appear above input field
- [ ] Click a chip — `@Name` chip appears in input, button highlights
- [ ] Click a second chip — both names highlighted, second chip appended
- [ ] Submit — two sequential NPC responses appear, each with the other's exchange in context
- [ ] Wait 12s without input — an NPC speaks spontaneously
- [ ] Wait 60s without input — game pauses
- [ ] Sidebar no longer has an NPCs Here section

🤖 Generated with [Claude Code](https://claude.com/claude-code)