### PR TITLE
[codex] add multi-npc dialogue and idle pause

### DIFF
--- a/crates/parish-core/src/ipc/config.rs
+++ b/crates/parish-core/src/ipc/config.rs
@@ -30,6 +30,12 @@ pub struct GameConfig {
     pub cloud_base_url: Option<String>,
     /// Whether improv craft mode is enabled for NPC dialogue.
     pub improv_enabled: bool,
+    /// Maximum number of autonomous NPC follow-up turns after the initial reply pass.
+    pub max_follow_up_turns: usize,
+    /// Real-time silence threshold before nearby NPCs may start banter.
+    pub idle_banter_after_secs: u64,
+    /// Real-time inactivity threshold before the game auto-pauses.
+    pub auto_pause_after_secs: u64,
     /// Per-category provider name overrides (None = inherits base).
     /// Index: Dialogue=0, Simulation=1, Intent=2, Reaction=3.
     pub category_provider: [Option<String>; 4],
@@ -104,6 +110,9 @@ impl Default for GameConfig {
             cloud_api_key: None,
             cloud_base_url: None,
             improv_enabled: false,
+            max_follow_up_turns: 2,
+            idle_banter_after_secs: 25,
+            auto_pause_after_secs: 60,
             category_provider: Default::default(),
             category_model: Default::default(),
             category_api_key: Default::default(),
@@ -122,6 +131,9 @@ mod tests {
         assert_eq!(c.provider_name, "ollama");
         assert!(!c.improv_enabled);
         assert!(c.api_key.is_none());
+        assert_eq!(c.max_follow_up_turns, 2);
+        assert_eq!(c.idle_banter_after_secs, 25);
+        assert_eq!(c.auto_pause_after_secs, 60);
     }
 
     #[test]

--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -253,6 +253,173 @@ pub fn text_log(source: impl Into<String>, content: impl Into<String>) -> TextLo
     }
 }
 
+/// One spoken line in a local conversation transcript.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversationLine {
+    /// Speaker label shown to the player.
+    pub speaker: String,
+    /// Spoken text content.
+    pub text: String,
+}
+
+/// Ordered NPC recipients extracted from player input at the current location.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MentionedNpcs {
+    /// Mentioned NPC display names, deduplicated while preserving order.
+    pub names: Vec<String>,
+    /// Remaining player text with the mentions stripped out.
+    pub remaining: String,
+}
+
+fn canonicalize_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn mention_boundary(ch: Option<char>) -> bool {
+    match ch {
+        None => true,
+        Some(c) => c.is_whitespace() || matches!(c, '.' | ',' | '!' | '?' | ':' | ';'),
+    }
+}
+
+/// Extracts all valid `@mentions` that match NPCs at the player's location.
+///
+/// Matching is done against the NPCs currently present using their visible
+/// display names, so multi-word lowercase descriptions like "an older man
+/// behind the bar" remain parseable.
+pub fn extract_npc_mentions(
+    raw: &str,
+    world: &WorldState,
+    npc_manager: &NpcManager,
+) -> MentionedNpcs {
+    let candidates: Vec<String> = npc_manager
+        .npcs_at(world.player_location)
+        .into_iter()
+        .map(|npc| npc_manager.display_name(npc).to_string())
+        .collect();
+
+    if candidates.is_empty() {
+        return MentionedNpcs {
+            names: vec![],
+            remaining: raw.trim().to_string(),
+        };
+    }
+
+    let mut spans: Vec<(usize, usize, String)> = Vec::new();
+    let mut cursor = 0usize;
+    while let Some(rel_at) = raw[cursor..].find('@') {
+        let at = cursor + rel_at;
+        let before_ok = at == 0
+            || match raw[..at].chars().next_back() {
+                None => true,
+                Some(ch) => ch.is_whitespace(),
+            };
+        if !before_ok {
+            cursor = at + 1;
+            continue;
+        }
+
+        let rest = &raw[at + 1..];
+        let mut matched: Option<(usize, String)> = None;
+        for name in &candidates {
+            if rest.len() < name.len() {
+                continue;
+            }
+            let candidate = &rest[..name.len()];
+            if candidate.eq_ignore_ascii_case(name)
+                && mention_boundary(rest[name.len()..].chars().next())
+            {
+                match &matched {
+                    Some((len, _)) if *len >= name.len() => {}
+                    _ => matched = Some((name.len(), name.clone())),
+                }
+            }
+        }
+
+        if let Some((name_len, name)) = matched {
+            spans.push((at, at + 1 + name_len, name));
+            cursor = at + 1 + name_len;
+        } else {
+            cursor = at + 1;
+        }
+    }
+
+    if spans.is_empty() {
+        return MentionedNpcs {
+            names: vec![],
+            remaining: raw.trim().to_string(),
+        };
+    }
+
+    let mut names = Vec::new();
+    let mut dedupe = HashSet::new();
+    let mut remaining = String::new();
+    let mut last = 0usize;
+    for (start, end, name) in spans {
+        if dedupe.insert(name.to_lowercase()) {
+            names.push(name);
+        }
+        remaining.push_str(&raw[last..start]);
+        remaining.push(' ');
+        last = end;
+    }
+    remaining.push_str(&raw[last..]);
+
+    MentionedNpcs {
+        names,
+        remaining: canonicalize_whitespace(&remaining),
+    }
+}
+
+/// Resolves ordered conversation targets from extracted display names.
+///
+/// Falls back to the first NPC at the current location when no names are
+/// supplied. Unknown names are ignored.
+pub fn resolve_npc_targets(
+    world: &WorldState,
+    npc_manager: &NpcManager,
+    target_names: &[String],
+) -> Vec<NpcId> {
+    let mut targets = Vec::new();
+    let mut seen = HashSet::new();
+    for name in target_names {
+        if let Some(npc) = npc_manager.find_by_name(name, world.player_location)
+            && seen.insert(npc.id)
+        {
+            targets.push(npc.id);
+        }
+    }
+
+    if targets.is_empty()
+        && let Some(npc) = npc_manager
+            .npcs_at(world.player_location)
+            .into_iter()
+            .next()
+    {
+        targets.push(npc.id);
+    }
+
+    targets
+}
+
+fn append_transcript_context(context: &mut String, transcript: &[ConversationLine]) {
+    let lines: Vec<&ConversationLine> = transcript
+        .iter()
+        .filter(|line| !line.text.trim().is_empty())
+        .collect();
+    if lines.is_empty() {
+        return;
+    }
+
+    context.push_str("\n\nRecent conversation here:\n");
+    for line in lines {
+        context.push_str(&format!("- {}: {}\n", line.speaker, line.text.trim()));
+    }
+    context.push_str(
+        "\nRespond to the live exchange above. You may answer the player or another nearby NPC by name when it feels natural.\n",
+    );
+}
+
 /// Irish-themed canned messages shown when NPC inference fails.
 ///
 /// Indexed by `request_id % len` so different attempts get different messages.
@@ -301,13 +468,48 @@ pub struct NpcConversationSetup {
     pub context: String,
 }
 
-/// Prepares an NPC conversation: finds the NPC, builds prompts, and marks them
-/// as introduced. All backends call this before submitting to the inference queue.
+/// Prepares a specific NPC's turn in an ongoing conversation.
 ///
-/// If `target_name` is provided (from an `@mention`), the matching NPC is
-/// selected; otherwise falls back to the first NPC at the player's location.
-///
-/// Returns `None` if no NPC is present at the player's location.
+/// The supplied `player_input` describes the current trigger for this turn,
+/// while `transcript` carries the recent local exchange for continuity.
+pub fn prepare_npc_conversation_turn(
+    world: &WorldState,
+    npc_manager: &mut NpcManager,
+    player_input: &str,
+    speaker_id: NpcId,
+    transcript: &[ConversationLine],
+    improv_enabled: bool,
+) -> Option<NpcConversationSetup> {
+    let npc = npc_manager.get(speaker_id)?.clone();
+    let display_name = npc_manager.display_name(&npc).to_string();
+    let other_npcs: Vec<&Npc> = npc_manager
+        .npcs_at(world.player_location)
+        .into_iter()
+        .filter(|other| other.id != npc.id)
+        .collect();
+
+    let system_prompt = ticks::build_enhanced_system_prompt(&npc, improv_enabled);
+    let mut context = ticks::build_enhanced_context(&npc, world, player_input, &other_npcs);
+    append_transcript_context(&mut context, transcript);
+
+    // Check for anachronisms in player input and inject alert into context
+    let anachronisms = anachronism::check_input(player_input);
+    if let Some(alert) = anachronism::format_context_alert(&anachronisms) {
+        context.push_str(&alert);
+    }
+
+    // Mark NPC as introduced on first conversation
+    npc_manager.mark_introduced(speaker_id);
+
+    Some(NpcConversationSetup {
+        display_name,
+        npc_id: speaker_id,
+        system_prompt,
+        context,
+    })
+}
+
+/// Backward-compatible single-target helper retained for older callers.
 pub fn prepare_npc_conversation(
     world: &WorldState,
     npc_manager: &mut NpcManager,
@@ -315,44 +517,13 @@ pub fn prepare_npc_conversation(
     target_name: Option<&str>,
     improv_enabled: bool,
 ) -> Option<NpcConversationSetup> {
-    let npcs_here = npc_manager.npcs_at(world.player_location);
-    if npcs_here.is_empty() {
-        return None;
-    }
-
-    // If an @mention was provided, try to find that NPC; otherwise first NPC
-    let npc: Option<Npc> = if let Some(name) = target_name {
-        npc_manager
-            .find_by_name(name, world.player_location)
-            .cloned()
-            .or_else(|| npcs_here.first().cloned().cloned())
-    } else {
-        npcs_here.first().cloned().cloned()
-    };
-
-    let npc = npc?;
-    let display_name = npc_manager.display_name(&npc).to_string();
-    let npc_id = npc.id;
-
-    let other_npcs: Vec<&Npc> = npcs_here.into_iter().filter(|n| n.id != npc.id).collect();
-    let system_prompt = ticks::build_enhanced_system_prompt(&npc, improv_enabled);
-    let mut context = ticks::build_enhanced_context(&npc, world, raw, &other_npcs);
-
-    // Check for anachronisms in player input and inject alert into context
-    let anachronisms = anachronism::check_input(raw);
-    if let Some(alert) = anachronism::format_context_alert(&anachronisms) {
-        context.push_str(&alert);
-    }
-
-    // Mark NPC as introduced on first conversation
-    npc_manager.mark_introduced(npc_id);
-
-    Some(NpcConversationSetup {
-        display_name,
-        npc_id,
-        system_prompt,
-        context,
-    })
+    let target_names = target_name
+        .map(|name| vec![name.to_string()])
+        .unwrap_or_default();
+    let speaker_id = resolve_npc_targets(world, npc_manager, &target_names)
+        .into_iter()
+        .next()?;
+    prepare_npc_conversation_turn(world, npc_manager, raw, speaker_id, &[], improv_enabled)
 }
 
 // ── Pronunciation hints ────────────────────────────────────────────────────
@@ -524,6 +695,76 @@ mod tests {
         let npc_mgr = NpcManager::new();
         let npcs = build_npcs_here(&world, &npc_mgr);
         assert!(npcs.is_empty());
+    }
+
+    #[test]
+    fn extract_npc_mentions_matches_visible_display_names() {
+        let world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+        let mut npc = Npc::new_test_npc();
+        npc.location = world.player_location;
+        npc_mgr.add_npc(npc);
+        npc_mgr.mark_introduced(NpcId(1));
+
+        let extracted = extract_npc_mentions(
+            "@Padraig O'Brien @padraig o'brien tell me the news",
+            &world,
+            &npc_mgr,
+        );
+
+        assert_eq!(extracted.names, vec!["Padraig O'Brien".to_string()]);
+        assert_eq!(extracted.remaining, "tell me the news");
+    }
+
+    #[test]
+    fn extract_npc_mentions_handles_unintroduced_descriptions() {
+        let world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+        let mut npc = Npc::new_test_npc();
+        npc.location = world.player_location;
+        npc.brief_description = "an older man behind the bar".to_string();
+        npc_mgr.add_npc(npc);
+
+        let extracted = extract_npc_mentions(
+            "@an older man behind the bar what have you heard?",
+            &world,
+            &npc_mgr,
+        );
+
+        assert_eq!(
+            extracted.names,
+            vec!["an older man behind the bar".to_string()]
+        );
+        assert_eq!(extracted.remaining, "what have you heard?");
+    }
+
+    #[test]
+    fn resolve_npc_targets_preserves_order() {
+        let world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+
+        let mut npc1 = Npc::new_test_npc();
+        npc1.id = NpcId(1);
+        npc1.name = "Padraig Darcy".to_string();
+        npc1.location = world.player_location;
+
+        let mut npc2 = Npc::new_test_npc();
+        npc2.id = NpcId(2);
+        npc2.name = "Siobhan Murphy".to_string();
+        npc2.location = world.player_location;
+
+        npc_mgr.add_npc(npc1);
+        npc_mgr.add_npc(npc2);
+        npc_mgr.mark_introduced(NpcId(1));
+        npc_mgr.mark_introduced(NpcId(2));
+
+        let targets = resolve_npc_targets(
+            &world,
+            &npc_mgr,
+            &["Siobhan Murphy".to_string(), "Padraig Darcy".to_string()],
+        );
+
+        assert_eq!(targets, vec![NpcId(2), NpcId(1)]);
     }
 
     #[test]

--- a/crates/parish-core/src/ipc/types.rs
+++ b/crates/parish-core/src/ipc/types.rs
@@ -285,6 +285,7 @@ mod tests {
             paused: false,
             game_epoch_ms: 1234567890.0,
             speed_factor: 36.0,
+            name_hints: vec![],
             day_of_week: "Monday".to_string(),
         };
         let json = serde_json::to_string(&snap).unwrap();
@@ -324,6 +325,7 @@ mod tests {
             occupation: "Farmer".to_string(),
             mood: "content".to_string(),
             introduced: true,
+            mood_emoji: "😌".to_string(),
         };
         let json = serde_json::to_string(&info).unwrap();
         let deser: NpcInfo = serde_json::from_str(&json).unwrap();
@@ -346,7 +348,12 @@ mod tests {
         let json = serde_json::to_string(&log).unwrap();
         assert!(json.contains("system"));
 
-        let loading = LoadingPayload { active: true };
+        let loading = LoadingPayload {
+            active: true,
+            spinner: None,
+            phrase: None,
+            color: None,
+        };
         let json = serde_json::to_string(&loading).unwrap();
         assert!(json.contains("true"));
     }

--- a/crates/parish-core/src/npc/reactions.rs
+++ b/crates/parish-core/src/npc/reactions.rs
@@ -916,6 +916,8 @@ mod tests {
             state: NpcState::Present,
             deflated_summary: None,
             reaction_log: ReactionLog::default(),
+            last_activity: None,
+            is_ill: false,
         }
     }
 

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -219,6 +219,15 @@ fn spawn_background_ticks(state: Arc<AppState>) {
         }
     });
 
+    // Inactivity tick: drive idle banter and auto-pause.
+    let state_idle = Arc::clone(&state);
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            routes::tick_inactivity(&state_idle).await;
+        }
+    });
+
     // Autosave tick: save snapshot every 60 seconds (if a save file is active)
     let state_autosave = Arc::clone(&state);
     tokio::spawn(async move {
@@ -283,6 +292,9 @@ fn build_client_and_config() -> (Option<OpenAiClient>, GameConfig) {
         cloud_api_key: None,
         cloud_base_url: None,
         improv_enabled: false,
+        max_follow_up_turns: 2,
+        idle_banter_after_secs: 25,
+        auto_pause_after_secs: 60,
         category_provider: [None, None, None, None],
         category_model: [None, None, None, None],
         category_api_key: [None, None, None, None],

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -15,15 +15,17 @@ use tokio::sync::mpsc;
 use parish_core::config::InferenceCategory;
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceQueue, new_inference_log, spawn_inference_worker};
-use parish_core::input::{InputResult, classify_input, extract_mention, parse_intent};
+use parish_core::input::{InputResult, classify_input, parse_intent};
 use parish_core::ipc::{
-    IDLE_MESSAGES, INFERENCE_FAILURE_MESSAGES, LoadingPayload, MapData, NpcInfo,
+    ConversationLine, IDLE_MESSAGES, INFERENCE_FAILURE_MESSAGES, LoadingPayload, MapData, NpcInfo,
     NpcReactionPayload, ReactRequest, StreamEndPayload, StreamTokenPayload, ThemePalette,
     WorldSnapshot, capitalize_first, text_log,
 };
+use parish_core::npc::NpcId;
 use parish_core::npc::manager::NpcManager;
 use parish_core::npc::parse_npc_stream_response;
 use parish_core::npc::reactions;
+use parish_core::npc::ticks::apply_tier1_response;
 use parish_core::world::{LocationId, WorldState};
 
 use parish_core::debug_snapshot::{self, DebugSnapshot, InferenceDebug};
@@ -122,6 +124,8 @@ pub async fn submit_input(
         return StatusCode::BAD_REQUEST;
     }
 
+    touch_player_activity(&state).await;
+
     match classify_input(&text) {
         InputResult::SystemCommand(cmd) => {
             handle_system_command(cmd, &state).await;
@@ -163,6 +167,33 @@ async fn rebuild_inference(state: &Arc<AppState>) {
     let queue = InferenceQueue::new(tx);
     let mut iq = state.inference_queue.lock().await;
     *iq = Some(queue);
+}
+
+async fn touch_player_activity(state: &Arc<AppState>) {
+    let mut conversation = state.conversation.lock().await;
+    let now = std::time::Instant::now();
+    conversation.last_player_activity = now;
+    conversation.last_spoken_at = now;
+}
+
+async fn emit_world_update(state: &Arc<AppState>) {
+    let world = state.world.lock().await;
+    let npc_manager = state.npc_manager.lock().await;
+    let transport = state.transport.default_mode();
+    let mut ws = parish_core::ipc::snapshot_from_world(&world, transport);
+    ws.name_hints =
+        parish_core::ipc::compute_name_hints(&world, &npc_manager, &state.pronunciations);
+    state.event_bus.emit("world-update", &ws);
+}
+
+fn build_turn_order(targets: &[NpcId], max_follow_up_turns: usize) -> Vec<(NpcId, bool)> {
+    let mut turns: Vec<(NpcId, bool)> = targets.iter().copied().map(|id| (id, false)).collect();
+    if targets.len() >= 2 {
+        for idx in 0..max_follow_up_turns {
+            turns.push((targets[idx % targets.len()], true));
+        }
+    }
+    turns
 }
 
 /// Handles `/command` system inputs using the shared command handler.
@@ -344,13 +375,14 @@ async fn handle_game_input(raw: String, state: &Arc<AppState>) {
         return;
     }
 
-    // Extract @mention for NPC targeting, if present
-    let (target_name, dialogue) = match extract_mention(&raw) {
-        Some(mention) => (Some(mention.name), mention.remaining),
-        None => (None, raw),
+    // Resolve ordered NPC recipients from visible local names.
+    let mentions = {
+        let world = state.world.lock().await;
+        let npc_manager = state.npc_manager.lock().await;
+        parish_core::ipc::extract_npc_mentions(&raw, &world, &npc_manager)
     };
 
-    handle_npc_conversation(dialogue, target_name, state).await;
+    handle_npc_conversation(mentions.remaining, mentions.names, state).await;
 }
 
 /// Resolves movement to a named location.
@@ -449,6 +481,15 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
 
     // Emit updated world snapshot after a successful move
     if effects.world_changed {
+        let current_location = {
+            let world = state.world.lock().await;
+            world.player_location
+        };
+        let mut conversation = state.conversation.lock().await;
+        conversation.sync_location(current_location);
+        conversation.last_spoken_at = std::time::Instant::now();
+        drop(conversation);
+
         let world = state.world.lock().await;
         let npc_manager = state.npc_manager.lock().await;
         let mut ws = parish_core::ipc::snapshot_from_world(&world, &transport);
@@ -473,145 +514,55 @@ async fn handle_look(state: &Arc<AppState>) {
     state.event_bus.emit("text-log", &text_log("system", text));
 }
 
-/// Routes input to the NPC at the player's location, or shows idle message.
-async fn handle_npc_conversation(raw: String, target_name: Option<String>, state: &Arc<AppState>) {
-    let (setup, queue, npc_present) = {
+struct TurnOutcome {
+    line: Option<ConversationLine>,
+}
+
+async fn run_npc_turn(
+    state: &Arc<AppState>,
+    queue: &InferenceQueue,
+    model: &str,
+    speaker_id: NpcId,
+    prompt_input: &str,
+    transcript: &[ConversationLine],
+) -> Option<TurnOutcome> {
+    let setup = {
         let world = state.world.lock().await;
         let mut npc_manager = state.npc_manager.lock().await;
-        let queue = state.inference_queue.lock().await;
         let config = state.config.lock().await;
-
-        let npc_present = !npc_manager.npcs_at(world.player_location).is_empty();
-        let setup = parish_core::ipc::prepare_npc_conversation(
+        parish_core::ipc::prepare_npc_conversation_turn(
             &world,
             &mut npc_manager,
-            &raw,
-            target_name.as_deref(),
+            prompt_input,
+            speaker_id,
+            transcript,
             config.improv_enabled,
-        );
-        (setup, queue.clone(), npc_present)
-    };
+        )
+    }?;
 
-    let (Some(setup), Some(queue)) = (setup, queue) else {
-        let content = if npc_present {
-            "There's someone here, but the LLM is not configured — set a provider with /provider."
-                .to_string()
-        } else {
-            let idx = REQUEST_ID.fetch_add(1, Ordering::SeqCst) as usize % IDLE_MESSAGES.len();
-            IDLE_MESSAGES[idx].to_string()
-        };
-        state
-            .event_bus
-            .emit("text-log", &text_log("system", content));
-        return;
-    };
-
-    let npc_name = setup.display_name;
-    let system_prompt = setup.system_prompt;
-    let context = setup.context;
-
-    let model = {
-        let config = state.config.lock().await;
-        config.model_name.clone()
-    };
-    let req_id = REQUEST_ID.fetch_add(1, Ordering::SeqCst);
-
-    // Spawn animated loading indicator (fun Irish phrases)
     let loading_cancel = tokio_util::sync::CancellationToken::new();
     spawn_loading_animation(Arc::clone(state), loading_cancel.clone());
 
     let (token_tx, token_rx) = mpsc::unbounded_channel::<String>();
-
-    let display_label = capitalize_first(&npc_name);
+    let display_label = capitalize_first(&setup.display_name);
     state
         .event_bus
-        .emit("text-log", &text_log(display_label, String::new()));
+        .emit("text-log", &text_log(display_label.clone(), String::new()));
 
-    // Pause the game clock while waiting for the inference response
-    // and immediately notify the frontend so it stops interpolating.
-    {
-        let mut world = state.world.lock().await;
-        world.clock.inference_pause();
-        let npc_manager = state.npc_manager.lock().await;
-        let transport = state.transport.default_mode();
-        let mut ws = parish_core::ipc::snapshot_from_world(&world, transport);
-        ws.name_hints =
-            parish_core::ipc::compute_name_hints(&world, &npc_manager, &state.pronunciations);
-        state.event_bus.emit("world-update", &ws);
-    }
-
-    match queue
+    let req_id = REQUEST_ID.fetch_add(1, Ordering::SeqCst);
+    let send_result = queue
         .send(
             req_id,
-            model,
-            context,
-            Some(system_prompt),
+            model.to_string(),
+            setup.context,
+            Some(setup.system_prompt),
             Some(token_tx),
             None,
         )
-        .await
-    {
-        Ok(mut response_rx) => {
-            let stream_handle = tokio::spawn({
-                let state_clone = Arc::clone(state);
-                let cancel = loading_cancel.clone();
-                async move {
-                    parish_core::ipc::stream_npc_tokens(token_rx, |batch| {
-                        // Cancel loading animation on first token
-                        cancel.cancel();
-                        state_clone.event_bus.emit(
-                            "stream-token",
-                            &StreamTokenPayload {
-                                token: batch.to_string(),
-                            },
-                        );
-                    })
-                    .await
-                }
-            });
+        .await;
 
-            let full_response = loop {
-                match response_rx.try_recv() {
-                    Ok(resp) => {
-                        let _ = stream_handle.await;
-                        break Some(resp);
-                    }
-                    Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
-                        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-                    }
-                    Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
-                        break None;
-                    }
-                }
-            };
-
-            let hints = if let Some(resp) = full_response {
-                if resp.error.is_some() {
-                    tracing::warn!("Inference error: {:?}", resp.error);
-
-                    // Show a canned Irish-themed failure message
-                    let idx = resp.id as usize % INFERENCE_FAILURE_MESSAGES.len();
-                    state.event_bus.emit(
-                        "text-log",
-                        &text_log("system", INFERENCE_FAILURE_MESSAGES[idx]),
-                    );
-
-                    vec![]
-                } else {
-                    let parsed = parse_npc_stream_response(&resp.text);
-                    parsed
-                        .metadata
-                        .map(|m| m.language_hints)
-                        .unwrap_or_default()
-                }
-            } else {
-                vec![]
-            };
-
-            state
-                .event_bus
-                .emit("stream-end", &StreamEndPayload { hints });
-        }
+    let response_rx = match send_result {
+        Ok(rx) => rx,
         Err(e) => {
             tracing::error!("Failed to submit inference request: {}", e);
             state.event_bus.emit(
@@ -621,23 +572,328 @@ async fn handle_npc_conversation(raw: String, target_name: Option<String>, state
                     "The parish storyteller has wandered off. Try again.",
                 ),
             );
+            loading_cancel.cancel();
+            return None;
+        }
+    };
+
+    let stream_handle = tokio::spawn({
+        let state_clone = Arc::clone(state);
+        let cancel = loading_cancel.clone();
+        async move {
+            parish_core::ipc::stream_npc_tokens(token_rx, |batch| {
+                cancel.cancel();
+                state_clone.event_bus.emit(
+                    "stream-token",
+                    &StreamTokenPayload {
+                        token: batch.to_string(),
+                    },
+                );
+            })
+            .await
+        }
+    });
+
+    let response = response_rx.await.ok();
+    let _ = stream_handle.await;
+    loading_cancel.cancel();
+
+    let Some(response) = response else {
+        state.event_bus.emit(
+            "text-log",
+            &text_log("system", "The storyteller has wandered off mid-tale."),
+        );
+        state
+            .event_bus
+            .emit("stream-end", &StreamEndPayload { hints: vec![] });
+        return None;
+    };
+
+    if response.error.is_some() {
+        tracing::warn!("Inference error: {:?}", response.error);
+        let idx = response.id as usize % INFERENCE_FAILURE_MESSAGES.len();
+        state.event_bus.emit(
+            "text-log",
+            &text_log("system", INFERENCE_FAILURE_MESSAGES[idx]),
+        );
+        state
+            .event_bus
+            .emit("stream-end", &StreamEndPayload { hints: vec![] });
+        return None;
+    }
+
+    let parsed = parse_npc_stream_response(&response.text);
+    let hints = parsed
+        .metadata
+        .as_ref()
+        .map(|meta| meta.language_hints.clone())
+        .unwrap_or_default();
+
+    {
+        let world = state.world.lock().await;
+        let game_time = world.clock.now();
+        let mut npc_manager = state.npc_manager.lock().await;
+        if let Some(npc) = npc_manager.get_mut(speaker_id) {
+            let _ = apply_tier1_response(npc, &parsed, prompt_input, game_time);
         }
     }
 
-    // Resume the game clock and notify frontend of updated time.
+    state
+        .event_bus
+        .emit("stream-end", &StreamEndPayload { hints });
+
+    let line = if parsed.dialogue.trim().is_empty() {
+        None
+    } else {
+        Some(ConversationLine {
+            speaker: display_label,
+            text: parsed.dialogue,
+        })
+    };
+
+    Some(TurnOutcome { line })
+}
+
+async fn set_conversation_running(state: &Arc<AppState>, running: bool) {
+    let mut conversation = state.conversation.lock().await;
+    conversation.conversation_in_progress = running;
+}
+
+/// Routes input to one or more NPCs at the player's location, or shows idle message.
+async fn handle_npc_conversation(raw: String, target_names: Vec<String>, state: &Arc<AppState>) {
+    let trimmed = raw.trim().to_string();
+    let (npc_present, player_location, queue, model, max_follow_up_turns, targets) = {
+        let world = state.world.lock().await;
+        let npc_manager = state.npc_manager.lock().await;
+        let queue = state.inference_queue.lock().await;
+        let config = state.config.lock().await;
+        let npc_present = !npc_manager.npcs_at(world.player_location).is_empty();
+        let targets = parish_core::ipc::resolve_npc_targets(&world, &npc_manager, &target_names);
+        (
+            npc_present,
+            world.player_location,
+            queue.clone(),
+            config.model_name.clone(),
+            config.max_follow_up_turns,
+            targets,
+        )
+    };
+
+    if !npc_present {
+        let idx = REQUEST_ID.fetch_add(1, Ordering::SeqCst) as usize % IDLE_MESSAGES.len();
+        state
+            .event_bus
+            .emit("text-log", &text_log("system", IDLE_MESSAGES[idx]));
+        return;
+    }
+
+    if trimmed.is_empty() {
+        state.event_bus.emit(
+            "text-log",
+            &text_log(
+                "system",
+                "There are ears enough for ye here, but say something first.",
+            ),
+        );
+        return;
+    }
+
+    let Some(queue) = queue else {
+        state.event_bus.emit(
+            "text-log",
+            &text_log(
+                "system",
+                "There's someone here, but the LLM is not configured — set a provider with /provider.",
+            ),
+        );
+        return;
+    };
+
+    if targets.is_empty() {
+        state.event_bus.emit(
+            "text-log",
+            &text_log("system", "No one here answers to that name just now."),
+        );
+        return;
+    }
+
+    let mut transcript = {
+        let mut conversation = state.conversation.lock().await;
+        conversation.sync_location(player_location);
+        conversation.push_line(ConversationLine {
+            speaker: "You".to_string(),
+            text: trimmed.clone(),
+        });
+        conversation.transcript.iter().cloned().collect::<Vec<_>>()
+    };
+
+    set_conversation_running(state, true).await;
+    {
+        let mut world = state.world.lock().await;
+        world.clock.inference_pause();
+    }
+    emit_world_update(state).await;
+
+    for (speaker_id, follow_up) in build_turn_order(&targets, max_follow_up_turns) {
+        let prompt = if follow_up {
+            "listens while the nearby conversation continues"
+        } else {
+            trimmed.as_str()
+        };
+
+        let Some(outcome) =
+            run_npc_turn(state, &queue, &model, speaker_id, prompt, &transcript).await
+        else {
+            break;
+        };
+
+        if let Some(line) = outcome.line {
+            transcript.push(line.clone());
+            let mut conversation = state.conversation.lock().await;
+            conversation.push_line(line);
+            conversation.last_spoken_at = std::time::Instant::now();
+        }
+    }
+
     {
         let mut world = state.world.lock().await;
         world.clock.inference_resume();
+    }
+    set_conversation_running(state, false).await;
+    emit_world_update(state).await;
+}
+
+async fn run_idle_banter(state: &Arc<AppState>) {
+    let (queue, model, player_location, max_follow_up_turns, speakers) = {
+        let world = state.world.lock().await;
         let npc_manager = state.npc_manager.lock().await;
-        let transport = state.transport.default_mode();
-        let mut ws = parish_core::ipc::snapshot_from_world(&world, transport);
-        ws.name_hints =
-            parish_core::ipc::compute_name_hints(&world, &npc_manager, &state.pronunciations);
-        state.event_bus.emit("world-update", &ws);
+        let queue = state.inference_queue.lock().await;
+        let config = state.config.lock().await;
+
+        let mut speakers = npc_manager.npcs_at_ids(world.player_location);
+        speakers.sort_by_key(|id| id.0);
+        speakers.truncate(2);
+
+        (
+            queue.clone(),
+            config.model_name.clone(),
+            world.player_location,
+            config.max_follow_up_turns.min(2),
+            speakers,
+        )
+    };
+
+    let Some(queue) = queue else {
+        return;
+    };
+    if speakers.is_empty() {
+        return;
     }
 
-    // Cancel loading animation (emits final active: false)
-    loading_cancel.cancel();
+    let mut transcript = {
+        let mut conversation = state.conversation.lock().await;
+        conversation.sync_location(player_location);
+        conversation.transcript.iter().cloned().collect::<Vec<_>>()
+    };
+
+    set_conversation_running(state, true).await;
+    {
+        let mut world = state.world.lock().await;
+        world.clock.inference_pause();
+    }
+    emit_world_update(state).await;
+
+    for (speaker_id, follow_up) in build_turn_order(&speakers, max_follow_up_turns) {
+        let prompt = if follow_up {
+            "answers the nearby remark and keeps the local chatter going"
+        } else {
+            "breaks the silence with a natural nearby remark"
+        };
+        let Some(outcome) =
+            run_npc_turn(state, &queue, &model, speaker_id, prompt, &transcript).await
+        else {
+            break;
+        };
+
+        if let Some(line) = outcome.line {
+            transcript.push(line.clone());
+            let mut conversation = state.conversation.lock().await;
+            conversation.push_line(line);
+            conversation.last_spoken_at = std::time::Instant::now();
+        }
+    }
+
+    {
+        let mut world = state.world.lock().await;
+        world.clock.inference_resume();
+    }
+    set_conversation_running(state, false).await;
+    emit_world_update(state).await;
+}
+
+pub(crate) async fn tick_inactivity(state: &Arc<AppState>) {
+    let (last_player_activity, last_spoken_at, running, idle_after, auto_pause_after) = {
+        let conversation = state.conversation.lock().await;
+        let config = state.config.lock().await;
+        (
+            conversation.last_player_activity,
+            conversation.last_spoken_at,
+            conversation.conversation_in_progress,
+            config.idle_banter_after_secs,
+            config.auto_pause_after_secs,
+        )
+    };
+
+    if running {
+        return;
+    }
+
+    let world_state = {
+        let world = state.world.lock().await;
+        (
+            world.clock.is_paused(),
+            world.clock.is_inference_paused(),
+            world.player_location,
+        )
+    };
+
+    if world_state.0 || world_state.1 {
+        return;
+    }
+
+    {
+        let mut conversation = state.conversation.lock().await;
+        conversation.sync_location(world_state.2);
+    }
+
+    let now = std::time::Instant::now();
+    let player_idle = now.duration_since(last_player_activity).as_secs();
+    let speech_idle = now.duration_since(last_spoken_at).as_secs();
+
+    if player_idle >= auto_pause_after {
+        {
+            let mut world = state.world.lock().await;
+            if world.clock.is_paused() || world.clock.is_inference_paused() {
+                return;
+            }
+            world.clock.pause();
+        }
+        state.event_bus.emit(
+            "text-log",
+            &text_log(
+                "system",
+                "The parish falls quiet after a full minute of silence. Time is now paused.",
+            ),
+        );
+        emit_world_update(state).await;
+        let mut conversation = state.conversation.lock().await;
+        conversation.last_spoken_at = now;
+        return;
+    }
+
+    if player_idle >= idle_after && speech_idle >= idle_after {
+        run_idle_banter(state).await;
+    }
 }
 
 /// Spawns a background task that emits rich [`LoadingPayload`] events with
@@ -1193,6 +1449,13 @@ pub async fn get_save_state(State(state): State<Arc<AppState>>) -> Json<SaveStat
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex as StdMutex};
+    use std::time::{Duration, Instant};
+
+    use parish_core::inference::{InferenceQueue, InferenceRequest, InferenceResponse};
+    use parish_core::ipc::TextLogPayload;
+    use parish_core::npc::Npc;
     use parish_core::npc::manager::NpcManager;
     use parish_core::world::transport::TransportConfig;
     use parish_core::world::{LocationId, WorldState};
@@ -1232,17 +1495,86 @@ mod tests {
                 cloud_api_key: None,
                 cloud_base_url: None,
                 improv_enabled: false,
-                category_provider: [None, None, None],
-                category_model: [None, None, None],
-                category_api_key: [None, None, None],
-                category_base_url: [None, None, None],
+                max_follow_up_turns: 2,
+                idle_banter_after_secs: 25,
+                auto_pause_after_secs: 60,
+                category_provider: [None, None, None, None],
+                category_model: [None, None, None, None],
+                category_api_key: [None, None, None, None],
+                category_base_url: [None, None, None, None],
             },
             None,
             transport,
             ui_config,
             saves_dir,
             data_dir,
+            None,
         )
+    }
+
+    async fn add_introduced_npc(state: &Arc<AppState>, id: u32, name: &str, occupation: &str) {
+        let player_location = {
+            let world = state.world.lock().await;
+            world.player_location
+        };
+
+        let mut npc = Npc::new_test_npc();
+        npc.id = NpcId(id);
+        npc.name = name.to_string();
+        npc.occupation = occupation.to_string();
+        npc.brief_description = format!("a {}", occupation.to_lowercase());
+        npc.location = player_location;
+
+        let mut npc_manager = state.npc_manager.lock().await;
+        npc_manager.add_npc(npc);
+        npc_manager.mark_introduced(NpcId(id));
+    }
+
+    async fn install_scripted_inference_queue(
+        state: &Arc<AppState>,
+        responses: Vec<&str>,
+    ) -> (Arc<StdMutex<Vec<String>>>, tokio::task::JoinHandle<()>) {
+        let (tx, mut rx) = mpsc::channel::<InferenceRequest>(8);
+        let prompts = Arc::new(StdMutex::new(Vec::new()));
+        let prompt_log = Arc::clone(&prompts);
+        let mut scripted: VecDeque<String> = responses.into_iter().map(str::to_string).collect();
+
+        let handle = tokio::spawn(async move {
+            while let Some(request) = rx.recv().await {
+                prompt_log.lock().unwrap().push(request.prompt.clone());
+
+                let text = scripted.pop_front().unwrap_or_else(|| {
+                    "Aye.\n---\n{\"action\":\"speaks\",\"mood\":\"content\"}".to_string()
+                });
+
+                let _ = request.response_tx.send(InferenceResponse {
+                    id: request.id,
+                    text,
+                    error: None,
+                });
+            }
+        });
+
+        *state.inference_queue.lock().await = Some(InferenceQueue::new(tx));
+        (prompts, handle)
+    }
+
+    fn drain_text_logs(
+        rx: &mut tokio::sync::broadcast::Receiver<crate::state::ServerEvent>,
+    ) -> Vec<TextLogPayload> {
+        let mut logs = Vec::new();
+        loop {
+            match rx.try_recv() {
+                Ok(event) if event.event == "text-log" => {
+                    logs.push(serde_json::from_value(event.payload).unwrap());
+                }
+                Ok(_) => {}
+                Err(tokio::sync::broadcast::error::TryRecvError::Empty) => break,
+                Err(tokio::sync::broadcast::error::TryRecvError::Closed) => break,
+                Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => continue,
+            }
+        }
+        logs
     }
 
     /// Verifies that handle_movement resolves and applies movement atomically
@@ -1347,5 +1679,162 @@ mod tests {
         let req: CreateBranchRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.name, "alternate");
         assert_eq!(req.parent_branch_id, 1);
+    }
+
+    #[tokio::test]
+    async fn handle_npc_conversation_preserves_order_and_follow_up_context() {
+        let state = test_app_state();
+        add_introduced_npc(&state, 1, "Siobhan Murphy", "Teacher").await;
+        add_introduced_npc(&state, 2, "Padraig Darcy", "Farmer").await;
+
+        {
+            let mut config = state.config.lock().await;
+            config.model_name = "test-model".to_string();
+            config.max_follow_up_turns = 1;
+        }
+
+        let (prompts, worker) = install_scripted_inference_queue(
+            &state,
+            vec![
+                "I heard the fair will be lively.\n---\n{\"action\":\"speaks\",\"mood\":\"curious\"}",
+                "If it is, Siobhan, I'll bring the cart.\n---\n{\"action\":\"speaks\",\"mood\":\"content\"}",
+                "Then we'd best leave early, Padraig.\n---\n{\"action\":\"speaks\",\"mood\":\"content\"}",
+            ],
+        )
+        .await;
+
+        handle_npc_conversation(
+            "What news is there?".to_string(),
+            vec!["Siobhan Murphy".to_string(), "Padraig Darcy".to_string()],
+            &state,
+        )
+        .await;
+
+        let transcript = {
+            let conversation = state.conversation.lock().await;
+            conversation.transcript.iter().cloned().collect::<Vec<_>>()
+        };
+        assert_eq!(
+            transcript,
+            vec![
+                ConversationLine {
+                    speaker: "You".to_string(),
+                    text: "What news is there?".to_string(),
+                },
+                ConversationLine {
+                    speaker: "Siobhan Murphy".to_string(),
+                    text: "I heard the fair will be lively.".to_string(),
+                },
+                ConversationLine {
+                    speaker: "Padraig Darcy".to_string(),
+                    text: "If it is, Siobhan, I'll bring the cart.".to_string(),
+                },
+                ConversationLine {
+                    speaker: "Siobhan Murphy".to_string(),
+                    text: "Then we'd best leave early, Padraig.".to_string(),
+                },
+            ]
+        );
+
+        let prompts = prompts.lock().unwrap().clone();
+        assert_eq!(prompts.len(), 3);
+        assert!(prompts[0].contains("Recent conversation here:"));
+        assert!(prompts[0].contains("- You: What news is there?"));
+        assert!(prompts[1].contains("- Siobhan Murphy: I heard the fair will be lively."));
+        assert!(prompts[2].contains("- Padraig Darcy: If it is, Siobhan, I'll bring the cart."));
+
+        worker.abort();
+    }
+
+    #[tokio::test]
+    async fn tick_inactivity_runs_idle_banter_before_auto_pause() {
+        let state = test_app_state();
+        add_introduced_npc(&state, 1, "Siobhan Murphy", "Teacher").await;
+        add_introduced_npc(&state, 2, "Padraig Darcy", "Farmer").await;
+
+        {
+            let mut config = state.config.lock().await;
+            config.model_name = "test-model".to_string();
+            config.max_follow_up_turns = 0;
+            config.idle_banter_after_secs = 1;
+            config.auto_pause_after_secs = 60;
+        }
+
+        let (prompts, worker) = install_scripted_inference_queue(
+            &state,
+            vec![
+                "Quiet morning for it.\n---\n{\"action\":\"speaks\",\"mood\":\"content\"}",
+                "Too quiet. Even the crows have given up.\n---\n{\"action\":\"speaks\",\"mood\":\"content\"}",
+            ],
+        )
+        .await;
+
+        let player_location = {
+            let world = state.world.lock().await;
+            world.player_location
+        };
+        {
+            let mut conversation = state.conversation.lock().await;
+            conversation.sync_location(player_location);
+            let inactive_since = Instant::now() - Duration::from_secs(2);
+            conversation.last_player_activity = inactive_since;
+            conversation.last_spoken_at = inactive_since;
+        }
+
+        tick_inactivity(&state).await;
+
+        let transcript = {
+            let conversation = state.conversation.lock().await;
+            conversation.transcript.iter().cloned().collect::<Vec<_>>()
+        };
+        assert_eq!(
+            transcript,
+            vec![
+                ConversationLine {
+                    speaker: "Siobhan Murphy".to_string(),
+                    text: "Quiet morning for it.".to_string(),
+                },
+                ConversationLine {
+                    speaker: "Padraig Darcy".to_string(),
+                    text: "Too quiet. Even the crows have given up.".to_string(),
+                },
+            ]
+        );
+        assert!(!state.world.lock().await.clock.is_paused());
+
+        let prompts = prompts.lock().unwrap().clone();
+        assert_eq!(prompts.len(), 2);
+        assert!(prompts[1].contains("Recent conversation here:"));
+        assert!(prompts[1].contains("- Siobhan Murphy: Quiet morning for it."));
+
+        worker.abort();
+    }
+
+    #[tokio::test]
+    async fn tick_inactivity_auto_pauses_after_full_minute_of_silence() {
+        let state = test_app_state();
+        let mut rx = state.event_bus.subscribe();
+        let player_location = {
+            let world = state.world.lock().await;
+            world.player_location
+        };
+
+        {
+            let mut conversation = state.conversation.lock().await;
+            conversation.sync_location(player_location);
+            let inactive_since = Instant::now() - Duration::from_secs(61);
+            conversation.last_player_activity = inactive_since;
+            conversation.last_spoken_at = inactive_since;
+        }
+
+        tick_inactivity(&state).await;
+
+        assert!(state.world.lock().await.clock.is_paused());
+
+        let logs = drain_text_logs(&mut rx);
+        assert!(logs.iter().any(|log| {
+            log.content
+                .contains("The parish falls quiet after a full minute of silence")
+        }));
     }
 }

--- a/crates/parish-server/src/state.rs
+++ b/crates/parish-server/src/state.rs
@@ -2,15 +2,17 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 
 use tokio::sync::{Mutex, broadcast};
 
 use parish_core::game_mod::PronunciationEntry;
 use parish_core::inference::InferenceQueue;
 use parish_core::inference::openai_client::OpenAiClient;
+use parish_core::ipc::ConversationLine;
 use parish_core::npc::manager::NpcManager;
-use parish_core::world::WorldState;
 use parish_core::world::transport::TransportConfig;
+use parish_core::world::{LocationId, WorldState};
 
 /// UI configuration snapshot returned by the `/api/ui-config` endpoint.
 #[derive(serde::Serialize, Clone)]
@@ -34,6 +36,50 @@ pub struct SaveState {
     pub branch_name: Option<String>,
 }
 
+/// Runtime conversation/session state used for multi-NPC continuity and idle timers.
+pub struct ConversationRuntimeState {
+    /// Player location associated with the current transcript.
+    pub location: Option<LocationId>,
+    /// Recent dialogue at the current location.
+    pub transcript: std::collections::VecDeque<ConversationLine>,
+    /// Last wall-clock moment when the player submitted input.
+    pub last_player_activity: Instant,
+    /// Last wall-clock moment when anyone said something in the local conversation.
+    pub last_spoken_at: Instant,
+    /// Whether a player- or idle-triggered NPC exchange is currently running.
+    pub conversation_in_progress: bool,
+}
+
+impl ConversationRuntimeState {
+    pub fn new() -> Self {
+        let now = Instant::now();
+        Self {
+            location: None,
+            transcript: std::collections::VecDeque::with_capacity(16),
+            last_player_activity: now,
+            last_spoken_at: now,
+            conversation_in_progress: false,
+        }
+    }
+
+    pub fn sync_location(&mut self, location: LocationId) {
+        if self.location != Some(location) {
+            self.location = Some(location);
+            self.transcript.clear();
+        }
+    }
+
+    pub fn push_line(&mut self, line: ConversationLine) {
+        if line.text.trim().is_empty() {
+            return;
+        }
+        if self.transcript.len() >= 12 {
+            self.transcript.pop_front();
+        }
+        self.transcript.push_back(line);
+    }
+}
+
 /// Shared mutable game state for the web server.
 ///
 /// Mirrors the Tauri `AppState` but uses an [`EventBus`] for push events
@@ -51,6 +97,8 @@ pub struct AppState {
     pub cloud_client: Mutex<Option<OpenAiClient>>,
     /// Mutable runtime configuration.
     pub config: Mutex<GameConfig>,
+    /// Local conversation transcript and inactivity tracking.
+    pub conversation: Mutex<ConversationRuntimeState>,
     /// Broadcast channel for pushing events to WebSocket clients.
     pub event_bus: EventBus,
     /// Transport mode configuration from the loaded game mod.
@@ -159,6 +207,7 @@ pub fn build_app_state(
         client: Mutex::new(client),
         cloud_client: Mutex::new(cloud_client),
         config: Mutex::new(config),
+        conversation: Mutex::new(ConversationRuntimeState::new()),
         event_bus: EventBus::new(256),
         transport,
         ui_config,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,12 +13,15 @@ use parish_core::config::InferenceCategory;
 use parish_core::debug_snapshot::{self, DebugEvent, DebugSnapshot, InferenceDebug};
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceQueue, spawn_inference_worker};
-use parish_core::input::{InputResult, classify_input, extract_mention, parse_intent};
+use parish_core::input::{InputResult, classify_input, parse_intent};
 use parish_core::ipc::{
-    IDLE_MESSAGES, INFERENCE_FAILURE_MESSAGES, capitalize_first, compute_name_hints, text_log,
+    ConversationLine, IDLE_MESSAGES, INFERENCE_FAILURE_MESSAGES, capitalize_first,
+    compute_name_hints, text_log,
 };
+use parish_core::npc::NpcId;
 use parish_core::npc::parse_npc_stream_response;
 use parish_core::npc::reactions;
+use parish_core::npc::ticks::apply_tier1_response;
 use parish_core::world::transport::TransportMode;
 
 use crate::events::{
@@ -213,6 +216,8 @@ pub async fn submit_input(
         return Err("Input too long (max 2000 characters).".to_string());
     }
 
+    touch_player_activity(&state).await;
+
     match classify_input(&text) {
         InputResult::SystemCommand(cmd) => {
             handle_system_command(cmd, &state, &app).await;
@@ -253,6 +258,32 @@ async fn rebuild_inference(state: &Arc<AppState>) {
     let queue = InferenceQueue::new(tx);
     let mut iq = state.inference_queue.lock().await;
     *iq = Some(queue);
+}
+
+async fn touch_player_activity(state: &Arc<AppState>) {
+    let mut conversation = state.conversation.lock().await;
+    let now = std::time::Instant::now();
+    conversation.last_player_activity = now;
+    conversation.last_spoken_at = now;
+}
+
+async fn emit_world_update(state: &Arc<AppState>, app: &tauri::AppHandle) {
+    let world = state.world.lock().await;
+    let transport = state.transport.default_mode();
+    let npc_manager = state.npc_manager.lock().await;
+    let mut snapshot = snapshot_from_world(&world, transport);
+    snapshot.name_hints = compute_name_hints(&world, &npc_manager, &state.pronunciations);
+    let _ = app.emit(EVENT_WORLD_UPDATE, snapshot);
+}
+
+fn build_turn_order(targets: &[NpcId], max_follow_up_turns: usize) -> Vec<(NpcId, bool)> {
+    let mut turns: Vec<(NpcId, bool)> = targets.iter().copied().map(|id| (id, false)).collect();
+    if targets.len() >= 2 {
+        for idx in 0..max_follow_up_turns {
+            turns.push((targets[idx % targets.len()], true));
+        }
+    }
+    turns
 }
 
 /// Handles `/command` inputs using the shared command handler.
@@ -436,14 +467,13 @@ async fn handle_game_input(
         return;
     }
 
-    // Extract @mention for NPC targeting, if present
-    let (target_name, dialogue) = match extract_mention(&raw) {
-        Some(mention) => (Some(mention.name), mention.remaining),
-        None => (None, raw),
+    let mentions = {
+        let world = state.world.lock().await;
+        let npc_manager = state.npc_manager.lock().await;
+        parish_core::ipc::extract_npc_mentions(&raw, &world, &npc_manager)
     };
 
-    // Try NPC conversation
-    handle_npc_conversation(dialogue, target_name, state, app).await;
+    handle_npc_conversation(mentions.remaining, mentions.names, state, app).await;
 }
 
 /// Resolves movement to a named location using the shared movement pipeline.
@@ -555,6 +585,15 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
 
     // Emit updated world snapshot after a successful move
     if effects.world_changed {
+        let current_location = {
+            let world = state.world.lock().await;
+            world.player_location
+        };
+        let mut conversation = state.conversation.lock().await;
+        conversation.sync_location(current_location);
+        conversation.last_spoken_at = std::time::Instant::now();
+        drop(conversation);
+
         let world = state.world.lock().await;
         let npc_manager = state.npc_manager.lock().await;
         let mut snapshot = snapshot_from_world(&world, &transport);
@@ -589,169 +628,59 @@ async fn handle_look(state: &Arc<AppState>, app: &tauri::AppHandle) {
 ///
 /// If `target_name` is provided (from an `@mention`), the matching NPC
 /// is selected. Otherwise falls back to the first NPC at the location.
-async fn handle_npc_conversation(
-    raw: String,
-    target_name: Option<String>,
-    state: tauri::State<'_, Arc<AppState>>,
-    app: tauri::AppHandle,
-) {
-    let (setup, queue, npc_present) = {
+struct TurnOutcome {
+    line: Option<ConversationLine>,
+}
+
+async fn run_npc_turn(
+    state: &Arc<AppState>,
+    app: &tauri::AppHandle,
+    queue: &InferenceQueue,
+    model: &str,
+    speaker_id: NpcId,
+    prompt_input: &str,
+    transcript: &[ConversationLine],
+) -> Option<TurnOutcome> {
+    let setup = {
         let world = state.world.lock().await;
         let mut npc_manager = state.npc_manager.lock().await;
-        let queue = state.inference_queue.lock().await;
         let config = state.config.lock().await;
-
-        let npc_present = !npc_manager.npcs_at(world.player_location).is_empty();
-        let setup = parish_core::ipc::prepare_npc_conversation(
+        parish_core::ipc::prepare_npc_conversation_turn(
             &world,
             &mut npc_manager,
-            &raw,
-            target_name.as_deref(),
+            prompt_input,
+            speaker_id,
+            transcript,
             config.improv_enabled,
-        );
-        (setup, queue.clone(), npc_present)
-    };
+        )
+    }?;
 
-    let (Some(setup), Some(queue)) = (setup, queue) else {
-        let content = if npc_present {
-            "There's someone here, but the LLM is not configured — set a provider with /provider."
-                .to_string()
-        } else {
-            let idx = REQUEST_ID.fetch_add(1, Ordering::Relaxed) as usize % IDLE_MESSAGES.len();
-            IDLE_MESSAGES[idx].to_string()
-        };
-        let _ = app.emit(
-            EVENT_TEXT_LOG,
-            TextLogPayload {
-                id: String::new(),
-                source: "system".to_string(),
-                content,
-            },
-        );
-        return;
-    };
-
-    let npc_name = setup.display_name;
-    let system_prompt = setup.system_prompt;
-    let context = setup.context;
-
-    let model = {
-        let config = state.config.lock().await;
-        config.model_name.clone()
-    };
-    let req_id = REQUEST_ID.fetch_add(1, Ordering::Relaxed);
-
-    // Spawn the animated loading indicator (fun Irish phrases)
     let loading_cancel = tokio_util::sync::CancellationToken::new();
     spawn_loading_animation(app.clone(), loading_cancel.clone());
 
     let (token_tx, token_rx) = mpsc::unbounded_channel::<String>();
+    let display_label = capitalize_first(&setup.display_name);
+    let _ = app.emit(
+        EVENT_TEXT_LOG,
+        text_log(display_label.clone(), String::new()),
+    );
 
-    // Emit NPC name prefix as the start of the streaming entry
-    let display_label = capitalize_first(&npc_name);
-    let _ = app.emit(EVENT_TEXT_LOG, text_log(display_label, String::new()));
-
-    // Pause the game clock while waiting for the inference response
-    // and immediately notify the frontend so it stops interpolating.
-    {
-        let mut world = state.world.lock().await;
-        world.clock.inference_pause();
-        let transport = state.transport.default_mode();
-        let npc_manager = state.npc_manager.lock().await;
-        let mut snapshot = snapshot_from_world(&world, transport);
-        snapshot.name_hints = compute_name_hints(&world, &npc_manager, &state.pronunciations);
-        let _ = app.emit(EVENT_WORLD_UPDATE, snapshot);
-    }
-
-    match queue
+    let req_id = REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+    let send_result = queue
         .send(
             req_id,
-            model,
-            context,
-            Some(system_prompt),
+            model.to_string(),
+            setup.context,
+            Some(setup.system_prompt),
             Some(token_tx),
             None,
         )
-        .await
-    {
-        Ok(mut response_rx) => {
-            let app_clone = app.clone();
+        .await;
 
-            // Stream tokens to the frontend
-            let stream_handle = tokio::spawn(async move {
-                crate::events::stream_npc_response(app_clone, token_rx).await
-            });
-
-            // Wait for the complete response
-            let full_response = match response_rx.try_recv() {
-                Ok(resp) => {
-                    let _ = stream_handle.await;
-                    Some(resp)
-                }
-                Err(_) => {
-                    // Poll until done
-                    loop {
-                        match response_rx.try_recv() {
-                            Ok(resp) => {
-                                let _ = stream_handle.await;
-                                break Some(resp);
-                            }
-                            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
-                                tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-                            }
-                            Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
-                                break None;
-                            }
-                        }
-                    }
-                }
-            };
-
-            // Parse Irish word hints from the complete response
-            let hints = if let Some(resp) = full_response {
-                if let Some(ref err) = resp.error {
-                    tracing::warn!("Inference error: {:?}", err);
-
-                    // Log actual error to the debug events panel
-                    let mut events = state.debug_events.lock().await;
-                    if events.len() >= crate::DEBUG_EVENT_CAPACITY {
-                        events.pop_front();
-                    }
-                    events.push_back(DebugEvent {
-                        timestamp: String::new(),
-                        category: "inference".to_string(),
-                        message: format!("Dialogue error: {err}"),
-                    });
-
-                    // Show a funny canned message to the player
-                    let idx = resp.id as usize % INFERENCE_FAILURE_MESSAGES.len();
-                    let _ = app.emit(
-                        EVENT_TEXT_LOG,
-                        TextLogPayload {
-                            id: String::new(),
-                            source: "system".to_string(),
-                            content: INFERENCE_FAILURE_MESSAGES[idx].to_string(),
-                        },
-                    );
-
-                    vec![]
-                } else {
-                    let parsed = parse_npc_stream_response(&resp.text);
-                    parsed
-                        .metadata
-                        .map(|m| m.language_hints)
-                        .unwrap_or_default()
-                }
-            } else {
-                vec![]
-            };
-
-            let _ = app.emit(EVENT_STREAM_END, StreamEndPayload { hints });
-        }
+    let response_rx = match send_result {
+        Ok(rx) => rx,
         Err(e) => {
             tracing::error!("Failed to submit inference request: {}", e);
-
-            // Log to debug events
             let mut events = state.debug_events.lock().await;
             if events.len() >= crate::DEBUG_EVENT_CAPACITY {
                 events.pop_front();
@@ -761,7 +690,6 @@ async fn handle_npc_conversation(
                 category: "inference".to_string(),
                 message: format!("Queue submit failed: {e}"),
             });
-
             let _ = app.emit(
                 EVENT_TEXT_LOG,
                 TextLogPayload {
@@ -771,17 +699,354 @@ async fn handle_npc_conversation(
                         .to_string(),
                 },
             );
+            loading_cancel.cancel();
+            return None;
+        }
+    };
+
+    let stream_handle = tokio::spawn({
+        let app_clone = app.clone();
+        async move { crate::events::stream_npc_response(app_clone, token_rx).await }
+    });
+
+    let response = response_rx.await.ok();
+    let _ = stream_handle.await;
+    loading_cancel.cancel();
+
+    let Some(response) = response else {
+        let _ = app.emit(
+            EVENT_TEXT_LOG,
+            TextLogPayload {
+                id: String::new(),
+                source: "system".to_string(),
+                content: "The storyteller has wandered off mid-tale.".to_string(),
+            },
+        );
+        let _ = app.emit(EVENT_STREAM_END, StreamEndPayload { hints: vec![] });
+        return None;
+    };
+
+    if let Some(ref err) = response.error {
+        tracing::warn!("Inference error: {:?}", err);
+        let mut events = state.debug_events.lock().await;
+        if events.len() >= crate::DEBUG_EVENT_CAPACITY {
+            events.pop_front();
+        }
+        events.push_back(DebugEvent {
+            timestamp: String::new(),
+            category: "inference".to_string(),
+            message: format!("Dialogue error: {err}"),
+        });
+        let idx = response.id as usize % INFERENCE_FAILURE_MESSAGES.len();
+        let _ = app.emit(
+            EVENT_TEXT_LOG,
+            TextLogPayload {
+                id: String::new(),
+                source: "system".to_string(),
+                content: INFERENCE_FAILURE_MESSAGES[idx].to_string(),
+            },
+        );
+        let _ = app.emit(EVENT_STREAM_END, StreamEndPayload { hints: vec![] });
+        return None;
+    }
+
+    let parsed = parse_npc_stream_response(&response.text);
+    let hints = parsed
+        .metadata
+        .as_ref()
+        .map(|meta| meta.language_hints.clone())
+        .unwrap_or_default();
+
+    {
+        let world = state.world.lock().await;
+        let game_time = world.clock.now();
+        let mut npc_manager = state.npc_manager.lock().await;
+        if let Some(npc) = npc_manager.get_mut(speaker_id) {
+            let _ = apply_tier1_response(npc, &parsed, prompt_input, game_time);
         }
     }
 
-    // Resume the game clock now that inference is complete
+    let _ = app.emit(EVENT_STREAM_END, StreamEndPayload { hints });
+
+    let line = if parsed.dialogue.trim().is_empty() {
+        None
+    } else {
+        Some(ConversationLine {
+            speaker: display_label,
+            text: parsed.dialogue,
+        })
+    };
+
+    Some(TurnOutcome { line })
+}
+
+async fn set_conversation_running(state: &Arc<AppState>, running: bool) {
+    let mut conversation = state.conversation.lock().await;
+    conversation.conversation_in_progress = running;
+}
+
+async fn handle_npc_conversation(
+    raw: String,
+    target_names: Vec<String>,
+    state: tauri::State<'_, Arc<AppState>>,
+    app: tauri::AppHandle,
+) {
+    let trimmed = raw.trim().to_string();
+    let (npc_present, player_location, queue, model, max_follow_up_turns, targets) = {
+        let world = state.world.lock().await;
+        let npc_manager = state.npc_manager.lock().await;
+        let queue = state.inference_queue.lock().await;
+        let config = state.config.lock().await;
+        let npc_present = !npc_manager.npcs_at(world.player_location).is_empty();
+        let targets = parish_core::ipc::resolve_npc_targets(&world, &npc_manager, &target_names);
+        (
+            npc_present,
+            world.player_location,
+            queue.clone(),
+            config.model_name.clone(),
+            config.max_follow_up_turns,
+            targets,
+        )
+    };
+
+    if !npc_present {
+        let idx = REQUEST_ID.fetch_add(1, Ordering::Relaxed) as usize % IDLE_MESSAGES.len();
+        let _ = app.emit(
+            EVENT_TEXT_LOG,
+            TextLogPayload {
+                id: String::new(),
+                source: "system".to_string(),
+                content: IDLE_MESSAGES[idx].to_string(),
+            },
+        );
+        return;
+    }
+
+    if trimmed.is_empty() {
+        let _ = app.emit(
+            EVENT_TEXT_LOG,
+            TextLogPayload {
+                id: String::new(),
+                source: "system".to_string(),
+                content: "There are ears enough for ye here, but say something first.".to_string(),
+            },
+        );
+        return;
+    }
+
+    let Some(queue) = queue else {
+        let _ = app.emit(
+            EVENT_TEXT_LOG,
+            TextLogPayload {
+                id: String::new(),
+                source: "system".to_string(),
+                content:
+                    "There's someone here, but the LLM is not configured — set a provider with /provider."
+                        .to_string(),
+            },
+        );
+        return;
+    };
+
+    if targets.is_empty() {
+        let _ = app.emit(
+            EVENT_TEXT_LOG,
+            TextLogPayload {
+                id: String::new(),
+                source: "system".to_string(),
+                content: "No one here answers to that name just now.".to_string(),
+            },
+        );
+        return;
+    }
+
+    let mut transcript = {
+        let mut conversation = state.conversation.lock().await;
+        conversation.sync_location(player_location);
+        conversation.push_line(ConversationLine {
+            speaker: "You".to_string(),
+            text: trimmed.clone(),
+        });
+        conversation.transcript.iter().cloned().collect::<Vec<_>>()
+    };
+
+    set_conversation_running(&state, true).await;
+    {
+        let mut world = state.world.lock().await;
+        world.clock.inference_pause();
+    }
+    emit_world_update(&state, &app).await;
+
+    for (speaker_id, follow_up) in build_turn_order(&targets, max_follow_up_turns) {
+        let prompt = if follow_up {
+            "listens while the nearby conversation continues"
+        } else {
+            trimmed.as_str()
+        };
+        let Some(outcome) = run_npc_turn(
+            &state,
+            &app,
+            &queue,
+            &model,
+            speaker_id,
+            prompt,
+            &transcript,
+        )
+        .await
+        else {
+            break;
+        };
+
+        if let Some(line) = outcome.line {
+            transcript.push(line.clone());
+            let mut conversation = state.conversation.lock().await;
+            conversation.push_line(line);
+            conversation.last_spoken_at = std::time::Instant::now();
+        }
+    }
+
     {
         let mut world = state.world.lock().await;
         world.clock.inference_resume();
     }
+    set_conversation_running(&state, false).await;
+    emit_world_update(&state, &app).await;
+}
 
-    // Stop the animated loading indicator (emits active: false)
-    loading_cancel.cancel();
+async fn run_idle_banter(state: &Arc<AppState>, app: &tauri::AppHandle) {
+    let (queue, model, player_location, max_follow_up_turns, speakers) = {
+        let world = state.world.lock().await;
+        let npc_manager = state.npc_manager.lock().await;
+        let queue = state.inference_queue.lock().await;
+        let config = state.config.lock().await;
+
+        let mut speakers = npc_manager.npcs_at_ids(world.player_location);
+        speakers.sort_by_key(|id| id.0);
+        speakers.truncate(2);
+
+        (
+            queue.clone(),
+            config.model_name.clone(),
+            world.player_location,
+            config.max_follow_up_turns.min(2),
+            speakers,
+        )
+    };
+
+    let Some(queue) = queue else {
+        return;
+    };
+    if speakers.is_empty() {
+        return;
+    }
+
+    let mut transcript = {
+        let mut conversation = state.conversation.lock().await;
+        conversation.sync_location(player_location);
+        conversation.transcript.iter().cloned().collect::<Vec<_>>()
+    };
+
+    set_conversation_running(state, true).await;
+    {
+        let mut world = state.world.lock().await;
+        world.clock.inference_pause();
+    }
+    emit_world_update(state, app).await;
+
+    for (speaker_id, follow_up) in build_turn_order(&speakers, max_follow_up_turns) {
+        let prompt = if follow_up {
+            "answers the nearby remark and keeps the local chatter going"
+        } else {
+            "breaks the silence with a natural nearby remark"
+        };
+        let Some(outcome) =
+            run_npc_turn(state, app, &queue, &model, speaker_id, prompt, &transcript).await
+        else {
+            break;
+        };
+
+        if let Some(line) = outcome.line {
+            transcript.push(line.clone());
+            let mut conversation = state.conversation.lock().await;
+            conversation.push_line(line);
+            conversation.last_spoken_at = std::time::Instant::now();
+        }
+    }
+
+    {
+        let mut world = state.world.lock().await;
+        world.clock.inference_resume();
+    }
+    set_conversation_running(state, false).await;
+    emit_world_update(state, app).await;
+}
+
+pub(crate) async fn tick_inactivity(state: &Arc<AppState>, app: &tauri::AppHandle) {
+    let (last_player_activity, last_spoken_at, running, idle_after, auto_pause_after) = {
+        let conversation = state.conversation.lock().await;
+        let config = state.config.lock().await;
+        (
+            conversation.last_player_activity,
+            conversation.last_spoken_at,
+            conversation.conversation_in_progress,
+            config.idle_banter_after_secs,
+            config.auto_pause_after_secs,
+        )
+    };
+
+    if running {
+        return;
+    }
+
+    let world_state = {
+        let world = state.world.lock().await;
+        (
+            world.clock.is_paused(),
+            world.clock.is_inference_paused(),
+            world.player_location,
+        )
+    };
+
+    if world_state.0 || world_state.1 {
+        return;
+    }
+
+    {
+        let mut conversation = state.conversation.lock().await;
+        conversation.sync_location(world_state.2);
+    }
+
+    let now = std::time::Instant::now();
+    let player_idle = now.duration_since(last_player_activity).as_secs();
+    let speech_idle = now.duration_since(last_spoken_at).as_secs();
+
+    if player_idle >= auto_pause_after {
+        {
+            let mut world = state.world.lock().await;
+            if world.clock.is_paused() || world.clock.is_inference_paused() {
+                return;
+            }
+            world.clock.pause();
+        }
+        let _ = app.emit(
+            EVENT_TEXT_LOG,
+            TextLogPayload {
+                id: String::new(),
+                source: "system".to_string(),
+                content:
+                    "The parish falls quiet after a full minute of silence. Time is now paused."
+                        .to_string(),
+            },
+        );
+        emit_world_update(state, app).await;
+        let mut conversation = state.conversation.lock().await;
+        conversation.last_spoken_at = now;
+        return;
+    }
+
+    if player_idle >= idle_after && speech_idle >= idle_after {
+        run_idle_banter(state, app).await;
+    }
 }
 
 // ── Persistence commands ────────────────────────────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ pub mod events;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use tauri::Emitter;
 use tokio::sync::Mutex;
@@ -20,6 +21,7 @@ use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{
     InferenceLog, InferenceQueue, new_inference_log, spawn_inference_worker,
 };
+use parish_core::ipc::ConversationLine;
 use parish_core::npc::manager::NpcManager;
 use parish_core::npc::reactions::ReactionTemplates;
 use parish_core::world::palette::compute_palette;
@@ -137,6 +139,50 @@ pub struct UiConfigSnapshot {
     pub splash_text: String,
 }
 
+/// Runtime conversation/session state used for continuity and inactivity timers.
+pub struct ConversationRuntimeState {
+    /// Player location associated with the current transcript.
+    pub location: Option<LocationId>,
+    /// Recent dialogue at the current location.
+    pub transcript: std::collections::VecDeque<ConversationLine>,
+    /// Last wall-clock moment when the player submitted input.
+    pub last_player_activity: Instant,
+    /// Last wall-clock moment when anyone spoke at this location.
+    pub last_spoken_at: Instant,
+    /// Whether an NPC conversation sequence is currently active.
+    pub conversation_in_progress: bool,
+}
+
+impl ConversationRuntimeState {
+    pub fn new() -> Self {
+        let now = Instant::now();
+        Self {
+            location: None,
+            transcript: std::collections::VecDeque::with_capacity(16),
+            last_player_activity: now,
+            last_spoken_at: now,
+            conversation_in_progress: false,
+        }
+    }
+
+    pub fn sync_location(&mut self, location: LocationId) {
+        if self.location != Some(location) {
+            self.location = Some(location);
+            self.transcript.clear();
+        }
+    }
+
+    pub fn push_line(&mut self, line: ConversationLine) {
+        if line.text.trim().is_empty() {
+            return;
+        }
+        if self.transcript.len() >= 12 {
+            self.transcript.pop_front();
+        }
+        self.transcript.push_back(line);
+    }
+}
+
 /// Shared mutable game state managed by Tauri.
 ///
 /// Wrapped in `Arc` so background tasks can hold references without
@@ -154,6 +200,8 @@ pub struct AppState {
     pub cloud_client: Mutex<Option<OpenAiClient>>,
     /// Mutable runtime configuration (provider, model, cloud, improv).
     pub config: Mutex<GameConfig>,
+    /// Local conversation transcript and inactivity tracking.
+    pub conversation: Mutex<ConversationRuntimeState>,
     /// Rolling debug event log for the debug panel.
     pub debug_events: Mutex<std::collections::VecDeque<DebugEvent>>,
     /// Shared inference call log for the debug panel.
@@ -440,6 +488,7 @@ pub fn run() {
         inference_queue: Mutex::new(None),
         client: Mutex::new(client.clone()),
         cloud_client: Mutex::new(cloud_env.client),
+        conversation: Mutex::new(ConversationRuntimeState::new()),
         debug_events: Mutex::new(std::collections::VecDeque::with_capacity(
             DEBUG_EVENT_CAPACITY,
         )),
@@ -461,6 +510,9 @@ pub fn run() {
             cloud_api_key: cloud_env.api_key,
             cloud_base_url: cloud_env.base_url,
             improv_enabled: false,
+            max_follow_up_turns: 2,
+            idle_banter_after_secs: 25,
+            auto_pause_after_secs: 60,
             category_provider: [None, None, None, None],
             category_model: [None, None, None, None],
             category_api_key: [None, None, None, None],
@@ -809,6 +861,16 @@ pub fn run() {
                         );
                         let palette = ThemePalette::from(raw);
                         let _ = handle_theme.emit(events::EVENT_THEME_UPDATE, palette);
+                    }
+                });
+
+                // Inactivity tick: drive idle banter and auto-pause.
+                let state_idle = Arc::clone(&state_setup);
+                let handle_idle = handle.clone();
+                tokio::spawn(async move {
+                    loop {
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        crate::commands::tick_inactivity(&state_idle, &handle_idle).await;
                     }
                 });
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -362,6 +362,9 @@ impl App {
             cloud_api_key: self.cloud_api_key.clone(),
             cloud_base_url: self.cloud_base_url.clone(),
             improv_enabled: self.improv_enabled,
+            max_follow_up_turns: 2,
+            idle_banter_after_secs: 25,
+            auto_pause_after_secs: 60,
             ..GameConfig::default()
         };
 

--- a/ui/src/components/InputField.svelte
+++ b/ui/src/components/InputField.svelte
@@ -4,6 +4,7 @@
 	import { filterCommands, type SlashCommand } from '$lib/slash-commands';
 	import { knownNouns, findMatches, type KnownNoun } from '../stores/nouns';
 	import { get } from 'svelte/store';
+	import MoodIcon from './MoodIcon.svelte';
 
 	let editorEl: HTMLDivElement;
 
@@ -50,6 +51,16 @@
 			.filter((loc) => loc.adjacent && loc.id !== $mapData?.player_location)
 			.sort((a, b) => a.name.localeCompare(b.name))
 	);
+
+	let selectedNpcNames = $state<string[]>([]);
+
+	$effect(() => {
+		const visible = new Set($npcsHere.map((npc) => npc.name));
+		const pruned = selectedNpcNames.filter((name) => visible.has(name));
+		if (pruned.length !== selectedNpcNames.length || pruned.some((name, i) => name !== selectedNpcNames[i])) {
+			selectedNpcNames = pruned;
+		}
+	});
 
 	// ── Tab-completion state ────────────────────────────────────────────────
 	interface CompletionState {
@@ -438,8 +449,25 @@
 
 	async function quickTravel(locationName: string) {
 		if ($streamingActive) return;
+		selectedNpcNames = [];
 		clearEditor();
 		await submitInput(`go to ${locationName}`);
+	}
+
+	function toggleNpcSelection(npcName: string) {
+		if ($streamingActive) return;
+		if (selectedNpcNames.includes(npcName)) {
+			selectedNpcNames = selectedNpcNames.filter((name) => name !== npcName);
+		} else {
+			selectedNpcNames = [...selectedNpcNames, npcName];
+		}
+		editorEl?.focus();
+	}
+
+	function buildSubmittedText(trimmed: string): string {
+		if (selectedNpcNames.length === 0) return trimmed;
+		const mentions = selectedNpcNames.map((name) => `@${name}`).join(' ');
+		return `${mentions} ${trimmed}`.trim();
 	}
 
 	// ── Submit ──────────────────────────────────────────────────────────────
@@ -467,7 +495,9 @@
 		}
 		historyIndex = -1;
 
-		await submitInput(trimmed);
+		const submitted = buildSubmittedText(trimmed);
+		selectedNpcNames = [];
+		await submitInput(submitted);
 	}
 
 	// ── Keyboard handling ───────────────────────────────────────────────────
@@ -716,6 +746,27 @@
 			{/each}
 		</ul>
 	{/if}
+	{#if $npcsHere.length > 0 && !$streamingActive}
+		<div class="npc-chips" data-testid="npc-chips">
+			<span class="npc-label">Speak To</span>
+			{#each $npcsHere as npc}
+				<button
+					class="npc-chip"
+					class:selected={selectedNpcNames.includes(npc.name)}
+					aria-pressed={selectedNpcNames.includes(npc.name)}
+					onclick={() => toggleNpcSelection(npc.name)}
+				>
+					<span class="npc-chip-mood"><MoodIcon mood={npc.mood} /></span>
+					<span class="npc-chip-copy">
+						<span class="npc-chip-name">{npc.name}</span>
+						{#if npc.introduced}
+							<span class="npc-chip-detail">{npc.occupation}</span>
+						{/if}
+					</span>
+				</button>
+			{/each}
+		</div>
+	{/if}
 	{#if adjacentLocations.length > 0 && !$streamingActive}
 		<div class="travel-chips">
 			<span class="travel-label">Go To</span>
@@ -899,6 +950,78 @@
 	}
 
 	/* ── Quick-travel chips ────────────────────────────────────────────────── */
+
+	.npc-chips {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.45rem;
+		padding: 0.45rem 0.75rem;
+		background:
+			linear-gradient(180deg, color-mix(in srgb, var(--color-panel-bg) 88%, var(--color-accent) 12%), var(--color-panel-bg));
+		border-top: 1px solid var(--color-border);
+	}
+
+	.npc-label {
+		color: var(--color-muted);
+		font-size: 0.6rem;
+		font-family: var(--font-display);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		opacity: 0.8;
+		flex-shrink: 0;
+	}
+
+	.npc-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		min-width: 0;
+		padding: 0.35rem 0.55rem;
+		border: 1px solid color-mix(in srgb, var(--color-accent) 30%, var(--color-border));
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--color-panel-bg) 80%, var(--color-bg));
+		color: var(--color-fg);
+		cursor: pointer;
+		text-align: left;
+		transition: background 0.15s, border-color 0.15s, transform 0.15s, color 0.15s;
+	}
+
+	.npc-chip:hover {
+		border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-border));
+		transform: translateY(-1px);
+	}
+
+	.npc-chip.selected {
+		background: color-mix(in srgb, var(--color-accent) 18%, var(--color-panel-bg));
+		border-color: var(--color-accent);
+		color: var(--color-accent);
+	}
+
+	.npc-chip-mood {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 1rem;
+		flex-shrink: 0;
+	}
+
+	.npc-chip-copy {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+	}
+
+	.npc-chip-name {
+		font-size: 0.78rem;
+		line-height: 1.1;
+	}
+
+	.npc-chip-detail {
+		font-size: 0.62rem;
+		color: var(--color-muted);
+		line-height: 1.1;
+	}
 
 	.travel-chips {
 		display: flex;

--- a/ui/src/components/InputField.test.ts
+++ b/ui/src/components/InputField.test.ts
@@ -10,13 +10,29 @@ vi.mock('$lib/ipc', () => ({
 	submitInput: (...args: unknown[]) => mockSubmitInput(...args)
 }));
 
+const localStore: Record<string, string> = {};
+if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') {
+	Object.defineProperty(globalThis, 'localStorage', {
+		configurable: true,
+		value: {
+			getItem: (key: string) => localStore[key] ?? null,
+			setItem: (key: string, value: string) => {
+				localStore[key] = value;
+			},
+			clear: () => {
+				for (const key of Object.keys(localStore)) delete localStore[key];
+			}
+		}
+	});
+}
+
 describe('InputField', () => {
 	beforeEach(() => {
 		streamingActive.set(false);
 		npcsHere.set([]);
 		mapData.set(null);
 		mockSubmitInput.mockClear();
-		localStorage.clear();
+		localStorage.clear?.();
 	});
 
 	it('renders an editable input area', () => {
@@ -376,6 +392,71 @@ describe('InputField', () => {
 	});
 
 	// ── Location quick-travel chips ─────────────────────────────────────
+
+	describe('npc selection buttons', () => {
+		const testNpcs = [
+			{ name: 'Padraig Darcy', occupation: 'Publican', mood: 'content', introduced: true, mood_emoji: '😌' },
+			{ name: 'an older man behind the bar', occupation: 'Publican', mood: 'wary', introduced: false, mood_emoji: '😐' },
+			{ name: 'Siobhan Murphy', occupation: 'Farmer', mood: 'determined', introduced: true, mood_emoji: '😤' }
+		];
+
+		function typeIntoEditor(editor: HTMLElement, text: string) {
+			editor.textContent = text;
+			const range = document.createRange();
+			const sel = window.getSelection();
+			if (editor.firstChild) {
+				range.setStart(editor.firstChild, text.length);
+			} else {
+				range.setStart(editor, 0);
+			}
+			range.collapse(true);
+			sel?.removeAllRanges();
+			sel?.addRange(range);
+		}
+
+		beforeEach(() => {
+			npcsHere.set(testNpcs);
+		});
+
+		it('renders npc buttons and hides occupation for unintroduced npcs', () => {
+			const { container, getByText } = render(InputField);
+			expect(container.querySelectorAll('.npc-chip').length).toBe(3);
+			expect(getByText('Padraig Darcy')).toBeTruthy();
+			expect(getByText('Publican')).toBeTruthy();
+			expect((container.querySelectorAll('.npc-chip')[1] as HTMLElement).textContent).not.toContain('Publican');
+		});
+
+		it('toggles persistent npc selection', async () => {
+			const { container } = render(InputField);
+			const chip = container.querySelector('.npc-chip') as HTMLButtonElement;
+			await fireEvent.click(chip);
+			expect(chip.getAttribute('aria-pressed')).toBe('true');
+			await fireEvent.click(chip);
+			expect(chip.getAttribute('aria-pressed')).toBe('false');
+		});
+
+		it('submits selected npcs in selection order and clears selection', async () => {
+			const { container, getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+			const chips = container.querySelectorAll('.npc-chip');
+			await fireEvent.click(chips[2] as HTMLButtonElement);
+			await fireEvent.click(chips[0] as HTMLButtonElement);
+
+			typeIntoEditor(editor, 'Any news?');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			expect(mockSubmitInput).toHaveBeenCalledWith('@Siobhan Murphy @Padraig Darcy Any news?');
+			expect((chips[2] as HTMLButtonElement).getAttribute('aria-pressed')).toBe('false');
+			expect((chips[0] as HTMLButtonElement).getAttribute('aria-pressed')).toBe('false');
+		});
+
+		it('hides npc buttons during streaming', () => {
+			streamingActive.set(true);
+			const { container } = render(InputField);
+			expect(container.querySelector('.npc-chips')).toBeFalsy();
+		});
+	});
 
 	describe('quick-travel chips', () => {
 		const testMapData = {

--- a/ui/src/components/Sidebar.svelte
+++ b/ui/src/components/Sidebar.svelte
@@ -1,30 +1,8 @@
 <script lang="ts">
-	import { npcsHere, languageHints, nameHints, uiConfig } from '../stores/game';
-	import MoodIcon from './MoodIcon.svelte';
+	import { languageHints, nameHints, uiConfig } from '../stores/game';
 </script>
 
 <aside class="sidebar" data-testid="sidebar">
-	<details open>
-		<summary>NPCs Here</summary>
-		{#if $npcsHere.length > 0}
-			<ul class="npc-list">
-				{#each $npcsHere as npc}
-					<li class="npc-item">
-						<div class="npc-name-row">
-							<span class="npc-mood"><MoodIcon mood={npc.mood} /></span>
-							<span class="npc-name">{npc.name}</span>
-						</div>
-						{#if npc.introduced}
-							<span class="npc-detail">{npc.occupation}</span>
-						{/if}
-					</li>
-				{/each}
-			</ul>
-		{:else}
-			<p class="empty">Nobody nearby.</p>
-		{/if}
-	</details>
-
 	<details open>
 		<summary>{$uiConfig.hints_label}</summary>
 		{#if $nameHints.length > 0 || $languageHints.length > 0}
@@ -96,48 +74,10 @@
 		content: '▾ ';
 	}
 
-	.npc-list,
 	.hint-list {
 		list-style: none;
 		margin: 0;
 		padding: 0.25rem 0;
-	}
-
-	.npc-item {
-		padding: 0.4rem 0.75rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.1rem;
-		border-bottom: 1px solid var(--color-border);
-	}
-
-	.npc-item:last-child {
-		border-bottom: none;
-	}
-
-	.npc-name-row {
-		display: flex;
-		align-items: baseline;
-		gap: 0.35rem;
-	}
-
-	.npc-name {
-		color: var(--color-accent);
-		font-style: italic;
-		font-size: 0.9rem;
-	}
-
-	.npc-detail {
-		color: var(--color-muted);
-		font-size: 0.75rem;
-	}
-
-	.npc-mood {
-		font-size: 1rem;
-		cursor: default;
-		display: inline-flex;
-		align-self: center;
-		transform: translateY(-2px);
 	}
 
 	.hint-item {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -245,7 +245,7 @@
 			class="mobile-btn"
 			class:active={mobilePanel === 'sidebar'}
 			onclick={() => mobilePanel = mobilePanel === 'sidebar' ? 'none' : 'sidebar'}
-		>NPCs &amp; Hints</button>
+		>Hints</button>
 	</div>
 
 	<div class="main-area">


### PR DESCRIPTION
## What changed
This adds the new multi-NPC conversation flow across the Svelte UI and both runtime backends.

Players can now select multiple nearby NPCs from a dedicated button row in the composer, keep those selections active until submit, and send a single message to several NPCs in order. The backend now preserves local transcript continuity so later NPCs overhear earlier replies, supports bounded NPC-to-NPC follow-up turns, allows idle banter after silence, and automatically pauses the game after 60 seconds of player inactivity.

## Why
The old NPC list was passive and only supported single-recipient interactions. The new behavior requires persistent multi-select targeting, sequential conversation orchestration, and timer-based inactivity handling so NPC exchanges can feel more like a shared scene instead of isolated one-off replies.

## User impact
Players can direct one message to multiple NPCs, watch them respond in sequence, and hear short back-and-forth exchanges before control returns. Nearby NPCs can also break silence on their own, and the game now safely auto-pauses after a minute of inactivity.

## Validation
- `cargo fmt --all`
- `cargo test --workspace --no-run`
- `cargo test -p parish-server --lib`
- `cargo test -p parish-core --lib extract_npc_mentions`
- `npx vitest run src/components/InputField.test.ts`
