### PR TITLE
fix: populate cloud GameConfig fields in parish-server

### DIFF
--- a/crates/parish-core/src/inference/openai_client.rs
+++ b/crates/parish-core/src/inference/openai_client.rs
@@ -133,10 +133,20 @@ impl OpenAiClient {
             .build()
             .expect("failed to build streaming reqwest client");
 
+        // Normalize the base URL: strip a trailing slash, and also strip a
+        // trailing `/v1` (with or without slash) because the endpoint paths
+        // below unconditionally append `/v1/chat/completions`. Users who set
+        // `PARISH_BASE_URL=https://api.groq.com/openai/v1` would otherwise get
+        // `https://api.groq.com/openai/v1/v1/chat/completions` (404).
+        let normalized = {
+            let trimmed = base_url.trim_end_matches('/');
+            trimmed.strip_suffix("/v1").unwrap_or(trimmed).to_string()
+        };
+
         Self {
             client,
             streaming_client,
-            base_url: base_url.trim_end_matches('/').to_string(),
+            base_url: normalized,
             api_key: api_key.map(|s| s.to_string()),
         }
     }

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -49,8 +49,13 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     npc_manager.assign_tiers(&world, &[]);
 
     // Build client from env
-    let (client, config) = build_client_and_config();
-    let cloud_client = build_cloud_client();
+    let (client, mut config) = build_client_and_config();
+    let cloud_env = build_cloud_client_from_env();
+    let cloud_client = cloud_env.client;
+    config.cloud_provider_name = cloud_env.provider_name;
+    config.cloud_model_name = cloud_env.model_name;
+    config.cloud_api_key = cloud_env.api_key;
+    config.cloud_base_url = cloud_env.base_url;
 
     let transport = TransportConfig::default();
 
@@ -292,17 +297,50 @@ fn build_client_and_config() -> (Option<OpenAiClient>, GameConfig) {
     (client, config)
 }
 
-/// Builds the cloud LLM client from environment variables.
-fn build_cloud_client() -> Option<OpenAiClient> {
-    let base_url = std::env::var("PARISH_CLOUD_BASE_URL")
-        .unwrap_or_else(|_| "https://openrouter.ai/api".to_string());
+/// Cloud LLM environment configuration loaded from `PARISH_CLOUD_*` vars.
+struct CloudEnvConfig {
+    client: Option<OpenAiClient>,
+    provider_name: Option<String>,
+    model_name: Option<String>,
+    api_key: Option<String>,
+    base_url: Option<String>,
+}
+
+/// Builds the cloud LLM client and associated config from environment variables.
+///
+/// Without populating `cloud_provider_name`/`cloud_model_name` on the
+/// `GameConfig`, `resolve_category_client` would never route Dialogue
+/// inference to the cloud client — so even with `PARISH_CLOUD_API_KEY` set,
+/// no requests would actually be sent (e.g. on Railway with Groq configured).
+fn build_cloud_client_from_env() -> CloudEnvConfig {
+    let provider = std::env::var("PARISH_CLOUD_PROVIDER")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let base_url = std::env::var("PARISH_CLOUD_BASE_URL").unwrap_or_else(|_| {
+        provider
+            .as_deref()
+            .and_then(|p| parish_core::config::Provider::from_str_loose(p).ok())
+            .map(|p| p.default_base_url().to_string())
+            .unwrap_or_else(|| "https://openrouter.ai/api".to_string())
+    });
     let api_key = std::env::var("PARISH_CLOUD_API_KEY")
         .ok()
         .filter(|s| !s.is_empty());
+    let model = std::env::var("PARISH_CLOUD_MODEL")
+        .ok()
+        .filter(|s| !s.is_empty());
 
-    api_key
+    let client = api_key
         .as_deref()
-        .map(|key| OpenAiClient::new(&base_url, Some(key)))
+        .map(|key| OpenAiClient::new(&base_url, Some(key)));
+
+    CloudEnvConfig {
+        client,
+        provider_name: provider.or_else(|| api_key.as_ref().map(|_| "openrouter".to_string())),
+        model_name: model,
+        api_key,
+        base_url: Some(base_url),
+    }
 }
 
 #[cfg(test)]

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -65,10 +65,17 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         .as_ref()
         .and_then(|gm| gm.manifest.meta.title.clone())
         .unwrap_or_else(|| "Parish".to_string());
+    // Railway injects RAILWAY_GIT_COMMIT_SHA at runtime; also accept a
+    // generic PARISH_COMMIT_SHA override. Short-hash for display.
+    let commit_sha = std::env::var("RAILWAY_GIT_COMMIT_SHA")
+        .or_else(|_| std::env::var("PARISH_COMMIT_SHA"))
+        .unwrap_or_else(|_| "unknown".to_string());
+    let short_sha: String = commit_sha.chars().take(7).collect();
     let splash_text = format!(
-        "{}\nCopyright \u{00A9} 2026 David Mooney. All rights reserved.\nweb-server - {}",
+        "{}\nCopyright \u{00A9} 2026 David Mooney. All rights reserved.\nweb-server - {} - build {}",
         game_title,
         chrono::Local::now().format("%Y-%m-%d %H:%M"),
+        short_sha,
     );
     let ui_config = UiConfigSnapshot {
         hints_label: "Language Hints".to_string(),

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -18,7 +18,7 @@ use tower_http::services::ServeDir;
 
 use parish_core::game_mod::{GameMod, find_default_mod};
 use parish_core::inference::openai_client::OpenAiClient;
-use parish_core::inference::{InferenceQueue, new_inference_log, spawn_inference_worker};
+use parish_core::inference::{InferenceQueue, spawn_inference_worker};
 use parish_core::npc::manager::NpcManager;
 use parish_core::world::transport::TransportConfig;
 use parish_core::world::{LocationId, WorldState};
@@ -93,7 +93,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     // Initialize inference queue
     if let Some(ref client) = client {
         let (tx, rx) = tokio::sync::mpsc::channel(32);
-        let _worker = spawn_inference_worker(client.clone(), rx, new_inference_log());
+        let _worker = spawn_inference_worker(client.clone(), rx, state.inference_log.clone());
         let queue = InferenceQueue::new(tx);
         let mut iq = state.inference_queue.lock().await;
         *iq = Some(queue);

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc;
 
 use parish_core::config::InferenceCategory;
 use parish_core::inference::openai_client::OpenAiClient;
-use parish_core::inference::{InferenceQueue, new_inference_log, spawn_inference_worker};
+use parish_core::inference::{InferenceQueue, spawn_inference_worker};
 use parish_core::input::{InputResult, classify_input, extract_mention, parse_intent};
 use parish_core::ipc::{
     IDLE_MESSAGES, INFERENCE_FAILURE_MESSAGES, LoadingPayload, MapData, NpcInfo,
@@ -82,6 +82,8 @@ pub async fn get_debug_snapshot(State(state): State<Arc<AppState>>) -> Json<Debu
     let npc_manager = state.npc_manager.lock().await;
     let config = state.config.lock().await;
     let events = std::collections::VecDeque::new();
+    let call_log: Vec<parish_core::debug_snapshot::InferenceLogEntry> =
+        state.inference_log.lock().await.iter().cloned().collect();
     let inference = InferenceDebug {
         provider_name: config.provider_name.clone(),
         model_name: config.model_name.clone(),
@@ -90,7 +92,7 @@ pub async fn get_debug_snapshot(State(state): State<Arc<AppState>>) -> Json<Debu
         cloud_model: config.cloud_model_name.clone(),
         has_queue: state.inference_queue.lock().await.is_some(),
         improv_enabled: config.improv_enabled,
-        call_log: Vec::new(),
+        call_log,
     };
     Json(debug_snapshot::build_debug_snapshot(
         &world,
@@ -159,7 +161,7 @@ async fn rebuild_inference(state: &Arc<AppState>) {
     }
 
     let (tx, rx) = tokio::sync::mpsc::channel(32);
-    let _worker = spawn_inference_worker(new_client, rx, new_inference_log());
+    let _worker = spawn_inference_worker(new_client, rx, state.inference_log.clone());
     let queue = InferenceQueue::new(tx);
     let mut iq = state.inference_queue.lock().await;
     *iq = Some(queue);
@@ -524,9 +526,9 @@ async fn handle_npc_conversation(raw: String, target_name: Option<String>, state
     let (token_tx, token_rx) = mpsc::unbounded_channel::<String>();
 
     let display_label = capitalize_first(&npc_name);
-    state
-        .event_bus
-        .emit("text-log", &text_log(display_label, String::new()));
+    // Note: the empty NPC name placeholder is intentionally NOT emitted here.
+    // It is emitted lazily on the first streamed token (see below) so that a
+    // failed inference call leaves no orphaned empty talk bubble in the chat.
 
     // Pause the game clock while waiting for the inference response
     // and immediately notify the frontend so it stops interpolating.
@@ -556,10 +558,21 @@ async fn handle_npc_conversation(raw: String, target_name: Option<String>, state
             let stream_handle = tokio::spawn({
                 let state_clone = Arc::clone(state);
                 let cancel = loading_cancel.clone();
+                let label = display_label.clone();
                 async move {
+                    let mut first_token = true;
                     parish_core::ipc::stream_npc_tokens(token_rx, |batch| {
                         // Cancel loading animation on first token
                         cancel.cancel();
+                        if first_token {
+                            // Emit the empty NPC name bubble lazily, so a
+                            // failed inference call never produces an
+                            // orphaned empty talk bubble.
+                            state_clone
+                                .event_bus
+                                .emit("text-log", &text_log(label.clone(), String::new()));
+                            first_token = false;
+                        }
                         state_clone.event_bus.emit(
                             "stream-token",
                             &StreamTokenPayload {

--- a/crates/parish-server/src/state.rs
+++ b/crates/parish-server/src/state.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, broadcast};
 
 use parish_core::game_mod::PronunciationEntry;
-use parish_core::inference::InferenceQueue;
 use parish_core::inference::openai_client::OpenAiClient;
+use parish_core::inference::{InferenceLog, InferenceQueue};
 use parish_core::npc::manager::NpcManager;
 use parish_core::world::WorldState;
 use parish_core::world::transport::TransportConfig;
@@ -45,6 +45,8 @@ pub struct AppState {
     pub npc_manager: Mutex<NpcManager>,
     /// Inference request queue (None if no provider configured).
     pub inference_queue: Mutex<Option<InferenceQueue>>,
+    /// Shared ring buffer of recent inference calls (for the debug panel).
+    pub inference_log: InferenceLog,
     /// Local LLM client (None if no provider is configured).
     pub client: Mutex<Option<OpenAiClient>>,
     /// Cloud LLM client for dialogue (None if not configured).
@@ -156,6 +158,7 @@ pub fn build_app_state(
         world: Mutex::new(world),
         npc_manager: Mutex::new(npc_manager),
         inference_queue: Mutex::new(None),
+        inference_log: parish_core::inference::new_inference_log(),
         client: Mutex::new(client),
         cloud_client: Mutex::new(cloud_client),
         config: Mutex::new(config),

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -61,6 +61,28 @@
 		}
 	}
 
+	// Poll the debug snapshot while the debug panel is visible.
+	//
+	// The Tauri backend pushes `debug-update` events whenever state changes,
+	// but the web server has no equivalent push channel for the snapshot —
+	// so without polling, the panel only sees whatever was current at the
+	// moment it was opened (e.g. an empty inference call_log). 1s polling
+	// is cheap (the snapshot is just JSON over HTTP) and only runs while
+	// the panel is actually visible.
+	let debugPollHandle: ReturnType<typeof setInterval> | null = null;
+	$: {
+		if ($debugVisible && debugPollHandle === null) {
+			debugPollHandle = setInterval(() => {
+				getDebugSnapshot()
+					.then((s) => debugSnapshot.set(s))
+					.catch(() => {});
+			}, 1000);
+		} else if (!$debugVisible && debugPollHandle !== null) {
+			clearInterval(debugPollHandle);
+			debugPollHandle = null;
+		}
+	}
+
 	onMount(async () => {
 		// Initial data fetch (theme first to avoid color flash)
 		try {

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -70,18 +70,21 @@
 	// is cheap (the snapshot is just JSON over HTTP) and only runs while
 	// the panel is actually visible.
 	let debugPollHandle: ReturnType<typeof setInterval> | null = null;
-	$: {
-		if ($debugVisible && debugPollHandle === null) {
+	$effect(() => {
+		if ($debugVisible) {
 			debugPollHandle = setInterval(() => {
 				getDebugSnapshot()
 					.then((s) => debugSnapshot.set(s))
 					.catch(() => {});
 			}, 1000);
-		} else if (!$debugVisible && debugPollHandle !== null) {
-			clearInterval(debugPollHandle);
-			debugPollHandle = null;
+			return () => {
+				if (debugPollHandle !== null) {
+					clearInterval(debugPollHandle);
+					debugPollHandle = null;
+				}
+			};
 		}
-	}
+	});
 
 	onMount(async () => {
 		// Initial data fetch (theme first to avoid color flash)


### PR DESCRIPTION
The web server built a cloud OpenAiClient from PARISH_CLOUD_API_KEY but
left cloud_provider_name/cloud_model_name unset on GameConfig. Without
those, resolve_category_client never routed Dialogue inference to the
cloud client, so on Railway with Groq configured the debug panel showed
the API but no requests were ever sent.

Mirror the Tauri backend: read PARISH_CLOUD_PROVIDER and
PARISH_CLOUD_MODEL, derive base URL from the provider, and apply all
fields to GameConfig before constructing AppState.