### PR TITLE
fix(ui): smooth NPC dialogue streaming

### DIFF
--- a/apps/ui/src/components/ChatPanel.svelte
+++ b/apps/ui/src/components/ChatPanel.svelte
@@ -34,6 +34,11 @@
 		isAction: boolean;
 	}
 
+	interface RenderSegment extends TextSegment {
+		animate?: boolean;
+		animationKey?: number;
+	}
+
 	/** Splits text on *action* markers into normal and emote segments. */
 	function parseEmotes(content: string): TextSegment[] {
 		const segments: TextSegment[] = [];
@@ -54,6 +59,47 @@
 		if (segments.length === 0) {
 			segments.push({ text: content, isAction: false });
 		}
+		return segments;
+	}
+
+	function renderSegments(entry: TextLogEntry): RenderSegment[] {
+		const segments = parseEmotes(entry.content);
+		const latestChunk = entry.streaming ? entry.latest_chunk : null;
+		if (!latestChunk) return segments;
+
+		for (let index = segments.length - 1; index >= 0; index -= 1) {
+			const segment = segments[index];
+			if (!segment.text.endsWith(latestChunk)) continue;
+
+			const stableText = segment.text.slice(0, -latestChunk.length);
+			const leadingWhitespace = latestChunk.match(/^\s+/u)?.[0] ?? '';
+			const trailingWhitespace = latestChunk.match(/\s+$/u)?.[0] ?? '';
+			const animatedText = latestChunk.slice(
+				leadingWhitespace.length,
+				latestChunk.length - trailingWhitespace.length
+			);
+			const animatedSegments: RenderSegment[] = [];
+			if (stableText) {
+				animatedSegments.push({ text: stableText, isAction: segment.isAction });
+			}
+			if (leadingWhitespace) {
+				animatedSegments.push({ text: leadingWhitespace, isAction: segment.isAction });
+			}
+			if (animatedText) {
+				animatedSegments.push({
+					text: animatedText,
+					isAction: segment.isAction,
+					animate: true,
+					animationKey: entry.stream_chunk_id ?? entry.content.length
+				});
+			}
+			if (trailingWhitespace) {
+				animatedSegments.push({ text: trailingWhitespace, isAction: segment.isAction });
+			}
+
+			return [...segments.slice(0, index), ...animatedSegments];
+		}
+
 		return segments;
 	}
 
@@ -93,9 +139,7 @@
 					>
 						<div class="bubble">
 							<span class="content"
-								>{#each parseEmotes(entry.content) as seg}{#if seg.isAction}<span class="emote">{seg.text}</span>{:else}{seg.text}{/if}{/each}{#if entry.streaming}<span class="cursor">▋</span
-								>{/if}</span
-							>
+								>{#each renderSegments(entry) as seg}{#if seg.animate}{#key seg.animationKey}<span class="stream-chunk" class:emote={seg.isAction}>{seg.text}</span>{/key}{:else if seg.isAction}<span class="emote">{seg.text}</span>{:else}{seg.text}{/if}{/each}</span>
 						</div>
 
 						<!-- Reaction picker (floats over bubble, NPC messages only) -->
@@ -259,18 +303,21 @@
 		opacity: 0.85;
 	}
 
-	.cursor {
+	.stream-chunk {
 		display: inline-block;
-		animation: blink 1s step-end infinite;
+		white-space: pre-wrap;
+		will-change: clip-path, opacity;
+		animation: stream-chunk-sweep 240ms linear forwards;
 	}
 
-	@keyframes blink {
-		0%,
-		100% {
-			opacity: 1;
+	@keyframes stream-chunk-sweep {
+		from {
+			opacity: 0.24;
+			clip-path: inset(0 100% 0 0);
 		}
-		50% {
-			opacity: 0;
+		to {
+			opacity: 1;
+			clip-path: inset(0 0 0 0);
 		}
 	}
 

--- a/apps/ui/src/components/ChatPanel.test.ts
+++ b/apps/ui/src/components/ChatPanel.test.ts
@@ -52,10 +52,25 @@ describe('ChatPanel', () => {
 		expect(phrase.style.color).toBe('rgb(255, 200, 87)');
 	});
 
-	it('shows blinking cursor on streaming entry', () => {
+	it('does not render a streaming cursor', () => {
 		textLog.set([{ source: 'Seán', content: 'Dia dhuit…', streaming: true }]);
 		const { container } = render(ChatPanel);
-		expect(container.querySelector('.cursor')).toBeTruthy();
+		expect(container.querySelector('.cursor')).toBeFalsy();
+	});
+
+	it('animates the latest streamed chunk when metadata is present', () => {
+		textLog.set([{
+			source: 'Seán',
+			content: 'Dia dhuit ',
+			streaming: true,
+			latest_chunk: 'dhuit ',
+			stream_chunk_id: 2
+		}]);
+		const { container } = render(ChatPanel);
+		const latestChunk = container.querySelector('.stream-chunk');
+		expect(latestChunk).toBeTruthy();
+		expect(latestChunk?.textContent).toBe('dhuit');
+		expect(container.querySelector('.content')?.textContent).toBe('Dia dhuit ');
 	});
 
 	it('player source shows You label', () => {

--- a/apps/ui/src/lib/stream-pacing.test.ts
+++ b/apps/ui/src/lib/stream-pacing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { getStreamChunkDelayMs, takeNextStreamChunk } from './stream-pacing';
+
+describe('takeNextStreamChunk', () => {
+	it('emits one complete word at a time with trailing whitespace', () => {
+		expect(takeNextStreamChunk('I went to the market')).toEqual({
+			chunk: 'I ',
+			rest: 'went to the market'
+		});
+	});
+
+	it('waits for a word boundary before emitting mid-stream text', () => {
+		expect(takeNextStreamChunk('Dia')).toEqual({
+			chunk: null,
+			rest: 'Dia'
+		});
+		expect(takeNextStreamChunk(' Dia')).toEqual({
+			chunk: null,
+			rest: ' Dia'
+		});
+	});
+
+	it('keeps leading whitespace attached to the next word', () => {
+		expect(takeNextStreamChunk('\n\nDia dhuit')).toEqual({
+			chunk: '\n\nDia ',
+			rest: 'dhuit'
+		});
+	});
+
+	it('flushes the final word when the stream ends', () => {
+		expect(takeNextStreamChunk('slan', true)).toEqual({
+			chunk: 'slan',
+			rest: ''
+		});
+	});
+
+	it('flushes whitespace-only tails at the end of a stream', () => {
+		expect(takeNextStreamChunk('\n\n', true)).toEqual({
+			chunk: '\n\n',
+			rest: ''
+		});
+	});
+});
+
+describe('getStreamChunkDelayMs', () => {
+	it('uses the same base pacing for single words', () => {
+		expect(getStreamChunkDelayMs('well ')).toBe(120);
+	});
+
+	it('adds a clause pause after commas', () => {
+		expect(getStreamChunkDelayMs('well, ')).toBeGreaterThan(getStreamChunkDelayMs('well '));
+	});
+
+	it('adds a larger pause after sentence endings', () => {
+		expect(getStreamChunkDelayMs('indeed. ')).toBeGreaterThan(getStreamChunkDelayMs('indeed, '));
+	});
+});

--- a/apps/ui/src/lib/stream-pacing.ts
+++ b/apps/ui/src/lib/stream-pacing.ts
@@ -1,0 +1,64 @@
+export type StreamChunkResult = {
+	chunk: string | null;
+	rest: string;
+};
+
+type BufferedWord = {
+	text: string;
+	end: number;
+};
+
+const WORD_REGEX = /\s*\S+(?:\s+|$)/gu;
+const BASE_CHUNK_DELAY_MS = 120;
+const CLAUSE_PAUSE_MS = 90;
+const SENTENCE_PAUSE_MS = 190;
+
+function tokenizeBufferedWords(buffer: string, flush: boolean): { words: BufferedWord[]; consumed: number } {
+	const words: BufferedWord[] = [];
+	let consumed = 0;
+	let match: RegExpExecArray | null;
+
+	WORD_REGEX.lastIndex = 0;
+	while ((match = WORD_REGEX.exec(buffer)) !== null) {
+		const text = match[0];
+		const end = match.index + text.length;
+		const endsWithWhitespace = /\s/u.test(text[text.length - 1] ?? '');
+		if (!flush && end === buffer.length && !endsWithWhitespace) {
+			break;
+		}
+		words.push({ text, end });
+		consumed = end;
+	}
+
+	return { words, consumed };
+}
+
+export function takeNextStreamChunk(buffer: string, flush = false): StreamChunkResult {
+	if (buffer.length === 0) {
+		return { chunk: null, rest: buffer };
+	}
+
+	const { words, consumed } = tokenizeBufferedWords(buffer, flush);
+	if (words.length === 0) {
+		return flush ? { chunk: buffer, rest: '' } : { chunk: null, rest: buffer };
+	}
+
+	const chunkEnd = words[0]?.end ?? consumed;
+	return {
+		chunk: buffer.slice(0, chunkEnd),
+		rest: buffer.slice(chunkEnd)
+	};
+}
+
+export function getStreamChunkDelayMs(chunk: string): number {
+	const trimmed = chunk.trimEnd();
+	let delay = BASE_CHUNK_DELAY_MS;
+
+	if (/[.?!…]['")\]]*$/u.test(trimmed)) {
+		delay += SENTENCE_PAUSE_MS;
+	} else if (/[,;:]['")\]]*$/u.test(trimmed)) {
+		delay += CLAUSE_PAUSE_MS;
+	}
+
+	return delay;
+}

--- a/apps/ui/src/lib/types.ts
+++ b/apps/ui/src/lib/types.ts
@@ -102,6 +102,8 @@ export interface TextLogEntry {
 	source: string;
 	content: string;
 	streaming?: boolean;
+	latest_chunk?: string;
+	stream_chunk_id?: number;
 	reactions?: Reaction[];
 }
 

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -39,9 +39,12 @@
 		submitInput
 	} from '$lib/ipc';
 	import { createAutoPauseTracker } from '$lib/auto-pause';
+	import type { LanguageHint } from '$lib/types';
 
 	const AUTO_PAUSE_MS = 60_000;
 	const MOUSEMOVE_THROTTLE_MS = 1000;
+	const STREAM_PACE_CHARS_PER_SECOND = 18;
+	const STREAM_PACE_TICK_MS = 90;
 
 	// F5 toggle for save picker, F12 toggle for debug panel, M toggle for map
 	function handleKeydown(e: KeyboardEvent) {
@@ -90,6 +93,37 @@
 			};
 		}
 	});
+
+	function appendStreamToken(token: string) {
+		textLog.update((log) => {
+			if (log.length > 0 && log[log.length - 1].streaming) {
+				const last = log[log.length - 1];
+				return [
+					...log.slice(0, -1),
+					{ ...last, content: last.content + token }
+				];
+			}
+			// Merge with the empty NPC name placeholder emitted by Rust
+			const last = log.length > 0 ? log[log.length - 1] : null;
+			if (
+				last &&
+				last.content === '' &&
+				last.source !== 'player' &&
+				last.source !== 'system'
+			) {
+				return [
+					...log.slice(0, -1),
+					{ ...last, content: token, streaming: true }
+				];
+			}
+			// Use the most recent NPC source name if available, otherwise fall back
+			const npcSource =
+				last && last.source !== 'player' && last.source !== 'system'
+					? last.source
+					: 'NPC';
+			return trimTextLog([...log, { source: npcSource, content: token, streaming: true }]);
+		});
+	}
 
 	onMount(async () => {
 		// Frontend auto-pause tracker — fires /pause after 60s of true UI
@@ -154,6 +188,49 @@
 			debugSnapshot.set(debugSnap);
 		} catch (_) {}
 
+		let streamBuffer = '';
+		let streamPumpHandle: ReturnType<typeof setInterval> | null = null;
+		let pendingStreamEndHints: LanguageHint[] | null = null;
+		let pacedCharBudget = 0;
+
+		const finishNpcStream = () => {
+			textLog.update((log) => {
+				if (log.length > 0 && log[log.length - 1].streaming) {
+					const last = log[log.length - 1];
+					return [...log.slice(0, -1), { ...last, streaming: false }];
+				}
+				return log;
+			});
+			languageHints.set(pendingStreamEndHints ?? []);
+			pendingStreamEndHints = null;
+			streamingActive.set(false);
+		};
+
+		const stopStreamPump = () => {
+			if (streamPumpHandle !== null) {
+				clearInterval(streamPumpHandle);
+				streamPumpHandle = null;
+			}
+		};
+
+		const startStreamPumpIfNeeded = () => {
+			if (streamPumpHandle !== null) return;
+			streamPumpHandle = setInterval(() => {
+				if (streamBuffer.length === 0) {
+					stopStreamPump();
+					if (pendingStreamEndHints !== null) finishNpcStream();
+					return;
+				}
+
+				pacedCharBudget += (STREAM_PACE_CHARS_PER_SECOND * STREAM_PACE_TICK_MS) / 1000;
+				const charsToEmit = Math.max(1, Math.floor(pacedCharBudget));
+				pacedCharBudget -= charsToEmit;
+				const token = streamBuffer.slice(0, charsToEmit);
+				streamBuffer = streamBuffer.slice(charsToEmit);
+				appendStreamToken(token);
+			}, STREAM_PACE_TICK_MS);
+		};
+
 		const listeners: Array<() => void> = [];
 		try {
 			listeners.push(await onWorldUpdate(async (snap) => {
@@ -181,47 +258,15 @@
 			}));
 
 			listeners.push(await onStreamToken((payload) => {
-				textLog.update((log) => {
-					if (log.length > 0 && log[log.length - 1].streaming) {
-						const last = log[log.length - 1];
-						return [
-							...log.slice(0, -1),
-							{ ...last, content: last.content + payload.token }
-						];
-					}
-					// Merge with the empty NPC name placeholder emitted by Rust
-					const last = log.length > 0 ? log[log.length - 1] : null;
-					if (
-						last &&
-						last.content === '' &&
-						last.source !== 'player' &&
-						last.source !== 'system'
-					) {
-						return [
-							...log.slice(0, -1),
-							{ ...last, content: payload.token, streaming: true }
-						];
-					}
-					// Use the most recent NPC source name if available, otherwise fall back
-					const npcSource =
-						last && last.source !== 'player' && last.source !== 'system'
-							? last.source
-							: 'NPC';
-					return trimTextLog([...log, { source: npcSource, content: payload.token, streaming: true }]);
-				});
+				streamBuffer += payload.token;
+				startStreamPumpIfNeeded();
 			}));
 
 			listeners.push(await onStreamEnd((payload) => {
-				// Finalize the streaming entry
-				textLog.update((log) => {
-					if (log.length > 0 && log[log.length - 1].streaming) {
-						const last = log[log.length - 1];
-						return [...log.slice(0, -1), { ...last, streaming: false }];
-					}
-					return log;
-				});
-				languageHints.set(payload.hints);
-				streamingActive.set(false);
+				pendingStreamEndHints = payload.hints;
+				if (streamBuffer.length === 0 && streamPumpHandle === null) {
+					finishNpcStream();
+				}
 			}));
 
 			listeners.push(await onLoading((payload) => {
@@ -275,6 +320,7 @@
 			window.removeEventListener('touchstart', onTrackerTouch);
 			window.removeEventListener('mousemove', onTrackerMousemove);
 			tracker.dispose();
+			stopStreamPump();
 			listeners.forEach((fn) => fn());
 		};
 	});

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -39,12 +39,12 @@
 		submitInput
 	} from '$lib/ipc';
 	import { createAutoPauseTracker } from '$lib/auto-pause';
+	import { getStreamChunkDelayMs, takeNextStreamChunk } from '$lib/stream-pacing';
 	import type { LanguageHint } from '$lib/types';
 
 	const AUTO_PAUSE_MS = 60_000;
 	const MOUSEMOVE_THROTTLE_MS = 1000;
-	const STREAM_PACE_CHARS_PER_SECOND = 18;
-	const STREAM_PACE_TICK_MS = 90;
+	const STREAM_WAIT_FOR_WORD_MS = 70;
 
 	// F5 toggle for save picker, F12 toggle for debug panel, M toggle for map
 	function handleKeydown(e: KeyboardEvent) {
@@ -100,7 +100,12 @@
 				const last = log[log.length - 1];
 				return [
 					...log.slice(0, -1),
-					{ ...last, content: last.content + token }
+					{
+						...last,
+						content: last.content + token,
+						latest_chunk: token,
+						stream_chunk_id: (last.stream_chunk_id ?? 0) + 1
+					}
 				];
 			}
 			// Merge with the empty NPC name placeholder emitted by Rust
@@ -113,7 +118,13 @@
 			) {
 				return [
 					...log.slice(0, -1),
-					{ ...last, content: token, streaming: true }
+					{
+						...last,
+						content: token,
+						streaming: true,
+						latest_chunk: token,
+						stream_chunk_id: 1
+					}
 				];
 			}
 			// Use the most recent NPC source name if available, otherwise fall back
@@ -121,7 +132,16 @@
 				last && last.source !== 'player' && last.source !== 'system'
 					? last.source
 					: 'NPC';
-			return trimTextLog([...log, { source: npcSource, content: token, streaming: true }]);
+			return trimTextLog([
+				...log,
+				{
+					source: npcSource,
+					content: token,
+					streaming: true,
+					latest_chunk: token,
+					stream_chunk_id: 1
+				}
+			]);
 		});
 	}
 
@@ -189,15 +209,22 @@
 		} catch (_) {}
 
 		let streamBuffer = '';
-		let streamPumpHandle: ReturnType<typeof setInterval> | null = null;
+		let streamPumpHandle: ReturnType<typeof setTimeout> | null = null;
 		let pendingStreamEndHints: LanguageHint[] | null = null;
-		let pacedCharBudget = 0;
 
 		const finishNpcStream = () => {
 			textLog.update((log) => {
 				if (log.length > 0 && log[log.length - 1].streaming) {
 					const last = log[log.length - 1];
-					return [...log.slice(0, -1), { ...last, streaming: false }];
+					return [
+						...log.slice(0, -1),
+						{
+							...last,
+							streaming: false,
+							latest_chunk: undefined,
+							stream_chunk_id: undefined
+						}
+					];
 				}
 				return log;
 			});
@@ -208,27 +235,43 @@
 
 		const stopStreamPump = () => {
 			if (streamPumpHandle !== null) {
-				clearInterval(streamPumpHandle);
+				clearTimeout(streamPumpHandle);
 				streamPumpHandle = null;
 			}
 		};
 
+		const scheduleStreamPump = (delayMs: number) => {
+			streamPumpHandle = setTimeout(() => {
+				streamPumpHandle = null;
+				pumpStream();
+			}, delayMs);
+		};
+
+		const pumpStream = () => {
+			if (streamBuffer.length === 0) {
+				stopStreamPump();
+				if (pendingStreamEndHints !== null) finishNpcStream();
+				return;
+			}
+
+			const { chunk, rest } = takeNextStreamChunk(
+				streamBuffer,
+				pendingStreamEndHints !== null
+			);
+
+			if (chunk === null) {
+				scheduleStreamPump(STREAM_WAIT_FOR_WORD_MS);
+				return;
+			}
+
+			streamBuffer = rest;
+			appendStreamToken(chunk);
+			scheduleStreamPump(getStreamChunkDelayMs(chunk));
+		};
+
 		const startStreamPumpIfNeeded = () => {
 			if (streamPumpHandle !== null) return;
-			streamPumpHandle = setInterval(() => {
-				if (streamBuffer.length === 0) {
-					stopStreamPump();
-					if (pendingStreamEndHints !== null) finishNpcStream();
-					return;
-				}
-
-				pacedCharBudget += (STREAM_PACE_CHARS_PER_SECOND * STREAM_PACE_TICK_MS) / 1000;
-				const charsToEmit = Math.max(1, Math.floor(pacedCharBudget));
-				pacedCharBudget -= charsToEmit;
-				const token = streamBuffer.slice(0, charsToEmit);
-				streamBuffer = streamBuffer.slice(charsToEmit);
-				appendStreamToken(token);
-			}, STREAM_PACE_TICK_MS);
+			pumpStream();
 		};
 
 		const listeners: Array<() => void> = [];


### PR DESCRIPTION
## What changed
- switched NPC dialogue playback from character pacing to complete-word pacing
- added client-side chunk pacing so sentence punctuation can breathe without stalling the whole response
- updated the chat renderer to wipe each newly streamed word in from left to right
- removed the blinking block cursor and refined the reveal so trailing spaces do not create dead time between words
- added unit/component coverage for the new pacing and rendering behavior

## Why
NPC dialogue felt slow and jittery when it revealed one character at a time, and the earlier cursor-driven streaming effect was visually distracting.

## Impact
NPC responses now read more naturally and continuously while staying incremental. The animation is lighter, less noisy, and easier to follow during longer replies.

## Root cause
The previous client playback loop sliced streamed text into character-sized updates and rendered them directly into the chat bubble. That made the pacing feel mechanical and emphasized each DOM update.

## Validation
- `cd apps/ui && npx vitest run`
- `cd apps/ui && npx vitest run src/components/ChatPanel.test.ts`
