### PR TITLE
[codex] fix: make the UI theme static and configurable

### DIFF
--- a/apps/ui/e2e/app.spec.ts
+++ b/apps/ui/e2e/app.spec.ts
@@ -4,6 +4,7 @@
 
 import { test, expect, installTauriMock, emitEvent, applyTheme } from './fixtures';
 import { SNAPSHOTS, PALETTES, NPCS, MAP_DATA } from './mock-data';
+import { DEFAULT_THEME_PALETTE } from '../src/lib/theme';
 
 test.describe('App layout', () => {
 	test.beforeEach(async ({ page }) => {
@@ -67,11 +68,11 @@ test.describe('Theme application', () => {
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
 
-		// The default palette from theme.ts is applied before any event
+		// The configured fixed palette is applied on load.
 		const bgColor = await page.evaluate(() =>
 			getComputedStyle(document.documentElement).getPropertyValue('--color-bg').trim()
 		);
-		expect(bgColor).toBe('#1a1a2e');
+		expect(bgColor).toBe(DEFAULT_THEME_PALETTE.bg);
 	});
 
 	test('theme updates when theme-update event is emitted', async ({ page }) => {

--- a/apps/ui/e2e/fixtures.ts
+++ b/apps/ui/e2e/fixtures.ts
@@ -27,7 +27,7 @@ export async function installTauriMock(
 	timeOfDay: string = 'morning'
 ): Promise<void> {
 	const snapshot = SNAPSHOTS[timeOfDay];
-	const palette = PALETTES[timeOfDay];
+	const palette = PALETTES.default;
 	const mapData = MAP_DATA;
 	const npcs = NPCS;
 
@@ -50,7 +50,7 @@ export async function installTauriMock(
 				get_theme: palette,
 				get_ui_config: {
 					hints_label: 'Focail',
-					default_accent: '#c4a35a',
+					default_accent: palette.accent,
 					splash_text: 'Parish: Kilteevan 1820\nCopyright \u00A9 2026 David Mooney. All rights reserved.\ntest-branch - 2026-03-29 00:00'
 				}
 			};

--- a/apps/ui/e2e/mock-data.ts
+++ b/apps/ui/e2e/mock-data.ts
@@ -10,10 +10,12 @@ import type {
 	TextLogEntry,
 	UiConfig
 } from '../src/lib/types';
+import { DEFAULT_THEME_PALETTE } from '../src/lib/theme';
 
-// ── Theme palettes for each time of day ─────────────────────────────────────
+// ── Theme palettes used in tests ────────────────────────────────────────────
 
 export const PALETTES: Record<string, ThemePalette> = {
+	default: DEFAULT_THEME_PALETTE,
 	morning: {
 		bg: '#1e2a3a',
 		fg: '#f0e6d2',
@@ -136,7 +138,8 @@ export const IRISH_HINTS: LanguageHint[] = [
 
 export const UI_CONFIG: UiConfig = {
 	hints_label: 'Focail (Irish Words)',
-	default_accent: '#c4a35a'
+	default_accent: DEFAULT_THEME_PALETTE.accent,
+	splash_text: ''
 };
 
 // ── Text log entries ────────────────────────────────────────────────────────

--- a/apps/ui/src/app.css
+++ b/apps/ui/src/app.css
@@ -1,14 +1,14 @@
 /* Parish — Global CSS Theme */
 
 :root {
-	/* Default palette: morning (game starts at 8 AM). Overridden at runtime by Rust theme-update events. */
-	--color-bg: #fff5dc;
-	--color-fg: #32230f;
-	--color-accent: #b48232;
-	--color-panel-bg: #faf0d7;
-	--color-input-bg: #f5ebd2;
-	--color-border: #d2be96;
-	--color-muted: #78643c;
+	/* Default palette mirrors the fixed theme configured in the active mod. */
+	--color-bg: #fafad8;
+	--color-fg: #31240f;
+	--color-accent: #b08531;
+	--color-panel-bg: #f5f5d3;
+	--color-input-bg: #f0f0ce;
+	--color-border: #cec293;
+	--color-muted: #76663b;
 	/* Typography */
 	--font-body: 'IM Fell English', Georgia, serif;
 	--font-display: 'Cinzel', 'Trajan Pro', Georgia, serif;

--- a/apps/ui/src/components/FullMapOverlay.svelte
+++ b/apps/ui/src/components/FullMapOverlay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { mapData, worldState } from '../stores/game';
+	import { mapData } from '../stores/game';
 	import { travelState, getTravelPosition } from '../stores/travel';
 	import { submitInput } from '$lib/ipc';
 	import { resolveLabels, distSq, estimateTextWidth, type EdgeLine } from '$lib/map-labels';
@@ -94,26 +94,10 @@
 		)
 	);
 
-	// ── Time-of-day atmosphere ───────────────────────────────────────────
-	let nightFactor: number = $derived.by(() => {
-		const h = $worldState?.hour ?? 12;
-		if (h >= 7 && h <= 17) return 0;
-		if (h >= 21 || h <= 4) return 1;
-		if (h >= 18 && h <= 20) return (h - 17) / 3;
-		return (7 - h) / 3;
-	});
-
 	const LIT_PATTERNS = /pub|church|house|village|town|shop|school|letter/i;
 	function isLit(name: string): boolean {
 		return LIT_PATTERNS.test(name);
 	}
-
-	let weatherTint: string = $derived.by(() => {
-		const w = ($worldState?.weather ?? '').toLowerCase();
-		if (w.includes('rain') || w.includes('storm')) return 'weather-rain';
-		if (w.includes('fog')) return 'weather-fog';
-		return '';
-	});
 
 	// ── Travel animation ────────────────────────────────────────────────
 	let animFrame = $state(0);
@@ -248,7 +232,6 @@
 				xmlns="http://www.w3.org/2000/svg"
 				role="img"
 				aria-label="Full parish map"
-				class={weatherTint}
 				style="transform: translate({panX}px, {panY}px) scale({zoom}); transform-origin: center;"
 			>
 				<defs>
@@ -257,26 +240,20 @@
 							<path d={ICON_PATHS[icon]} />
 						</symbol>
 					{/each}
-					{#if nightFactor > 0}
-						<filter id="fullmap-glow" x="-50%" y="-50%" width="200%" height="200%">
-							<feGaussianBlur in="SourceGraphic" stdDeviation={5 * nightFactor} result="blur" />
-							<feColorMatrix in="blur" type="matrix"
-								values="1 0 0 0 0.3  0 1 0 0 0.25  0 0 1 0 0.1  0 0 0 0.7 0"
-								result="glow" />
-							<feMerge>
-								<feMergeNode in="glow" />
-								<feMergeNode in="SourceGraphic" />
-							</feMerge>
-						</filter>
-					{/if}
+					<filter id="fullmap-glow" x="-50%" y="-50%" width="200%" height="200%">
+						<feGaussianBlur in="SourceGraphic" stdDeviation="5" result="blur" />
+						<feColorMatrix
+							in="blur"
+							type="matrix"
+							values="1 0 0 0 0.3  0 1 0 0 0.25  0 0 1 0 0.1  0 0 0 0.7 0"
+							result="glow"
+						/>
+						<feMerge>
+							<feMergeNode in="glow" />
+							<feMergeNode in="SourceGraphic" />
+						</feMerge>
+					</filter>
 				</defs>
-
-				<!-- Night overlay -->
-				{#if nightFactor > 0}
-					<rect x="0" y="0" width={svgW} height={svgH}
-						fill="black" opacity={nightFactor * 0.45}
-						pointer-events="none" />
-				{/if}
 
 				<!-- Edges (with footprints and travel highlight) -->
 				{#each $mapData?.edges ?? [] as [src, dst]}
@@ -322,7 +299,7 @@
 					{@const r = isPlayer(loc) ? PLAYER_R : NODE_R}
 					{@const icon = getLocationIcon(loc.name)}
 					{@const iconSize = r * 2}
-					{@const lit = nightFactor > 0 && isLit(loc.name) && loc.visited !== false}
+					{@const lit = isLit(loc.name) && loc.visited !== false}
 					<!-- svelte-ignore a11y_click_events_have_key_events -->
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<g
@@ -556,22 +533,12 @@
 		to { opacity: 1; }
 	}
 
-	/* ── Night atmosphere ── */
 	.node.lit-node .node-icon {
 		fill: var(--color-accent);
 	}
 
 	.node.lit-node .node-label {
 		fill: var(--color-accent);
-	}
-
-	/* ── Weather tinting ── */
-	svg.weather-rain {
-		filter: saturate(0.85) brightness(0.92);
-	}
-
-	svg.weather-fog {
-		filter: saturate(0.6) contrast(0.85) brightness(1.05);
 	}
 
 	.tooltip-unexplored {

--- a/apps/ui/src/components/MapPanel.svelte
+++ b/apps/ui/src/components/MapPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { mapData, worldState } from '../stores/game';
+	import { mapData } from '../stores/game';
 	import { fullMapOpen } from '../stores/game';
 	import { travelState, getTravelPosition } from '../stores/travel';
 	import { submitInput } from '$lib/ipc';
@@ -119,6 +119,11 @@
 		}))
 	);
 
+	// Edges between 1-hop locations
+	let visibleEdges: [string, string][] = $derived.by(() => {
+		const nearbyIds = new Set(nearbyProjected.map((l) => l.id));
+		return ($mapData?.edges ?? []).filter(([a, b]) => nearbyIds.has(a) && nearbyIds.has(b));
+	});
 
 	let edgeLines: EdgeLine[] = $derived(
 		visibleEdges.map(([src, dst]) => {
@@ -143,12 +148,6 @@
 		)
 	);
 
-	// Edges between 1-hop locations
-	let visibleEdges: [string, string][] = $derived.by(() => {
-		const nearbyIds = new Set(nearbyProjected.map((l) => l.id));
-		return ($mapData?.edges ?? []).filter(([a, b]) => nearbyIds.has(a) && nearbyIds.has(b));
-	});
-
 	// Count of off-map connections per visible node (for "road continues" stubs)
 	let offMapCounts: Map<string, number> = $derived.by(() => {
 		const nearbyIds = new Set(nearbyProjected.map((l) => l.id));
@@ -160,29 +159,10 @@
 		return counts;
 	});
 
-	// ── Time-of-day atmosphere ───────────────────────────────────────────
-	/** 0 = full daylight, 1 = deep night */
-	let nightFactor: number = $derived.by(() => {
-		const h = $worldState?.hour ?? 12;
-		if (h >= 7 && h <= 17) return 0;       // day
-		if (h >= 21 || h <= 4) return 1;        // deep night
-		if (h >= 18 && h <= 20) return (h - 17) / 3; // dusk→night
-		return (7 - h) / 3;                    // dawn→day
-	});
-
-	/** Locations with lights that glow at night. */
 	const LIT_PATTERNS = /pub|church|house|village|town|shop|school|letter/i;
 	function isLit(name: string): boolean {
 		return LIT_PATTERNS.test(name);
 	}
-
-	/** Weather-based tint class. */
-	let weatherTint: string = $derived.by(() => {
-		const w = ($worldState?.weather ?? '').toLowerCase();
-		if (w.includes('rain') || w.includes('storm')) return 'weather-rain';
-		if (w.includes('fog')) return 'weather-fog';
-		return '';
-	});
 
 	// ── Travel animation ────────────────────────────────────────────────
 	let animFrame = $state(0);
@@ -294,26 +274,26 @@
 		</button>
 	</div>
 	{#if $mapData}
-		<svg viewBox="0 0 {viewBox.w} {viewBox.h}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Parish minimap" class={weatherTint}>
+		<svg viewBox="0 0 {viewBox.w} {viewBox.h}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Parish minimap">
 			<defs>
 				{#each usedIcons as icon}
 					<symbol id="minimap-icon-{icon}" viewBox="0 0 256 256">
 						<path d={ICON_PATHS[icon]} />
 					</symbol>
 				{/each}
-				<!-- Night glow filter for lit locations -->
-				{#if nightFactor > 0}
-					<filter id="minimap-glow" x="-50%" y="-50%" width="200%" height="200%">
-						<feGaussianBlur in="SourceGraphic" stdDeviation={4 * s * nightFactor} result="blur" />
-						<feColorMatrix in="blur" type="matrix"
-							values="1 0 0 0 0.3  0 1 0 0 0.25  0 0 1 0 0.1  0 0 0 0.7 0"
-							result="glow" />
-						<feMerge>
-							<feMergeNode in="glow" />
-							<feMergeNode in="SourceGraphic" />
-						</feMerge>
-					</filter>
-				{/if}
+				<filter id="minimap-glow" x="-50%" y="-50%" width="200%" height="200%">
+					<feGaussianBlur in="SourceGraphic" stdDeviation={4 * s} result="blur" />
+					<feColorMatrix
+						in="blur"
+						type="matrix"
+						values="1 0 0 0 0.3  0 1 0 0 0.25  0 0 1 0 0.1  0 0 0 0.7 0"
+						result="glow"
+					/>
+					<feMerge>
+						<feMergeNode in="glow" />
+						<feMergeNode in="SourceGraphic" />
+					</feMerge>
+				</filter>
 			</defs>
 			<!-- Continuation stubs: short faded lines from nodes with off-map connections -->
 			{#each localProjected as loc}
@@ -333,13 +313,6 @@
 					/>
 				{/if}
 			{/each}
-
-			<!-- Night overlay — darkens the map at night -->
-			{#if nightFactor > 0}
-				<rect x="0" y="0" width={viewBox.w} height={viewBox.h}
-					fill="black" opacity={nightFactor * 0.45}
-					pointer-events="none" />
-			{/if}
 
 			<!-- Edges (with footprint thickness) -->
 			{#each visibleEdges as [src, dst]}
@@ -386,7 +359,7 @@
 				{@const r = isPlayer(loc) ? playerR : nodeR}
 				{@const icon = getLocationIcon(loc.name)}
 				{@const iconSize = r * 2}
-				{@const lit = nightFactor > 0 && isLit(loc.name) && loc.visited !== false}
+				{@const lit = isLit(loc.name) && loc.visited !== false}
 				<!-- svelte-ignore a11y_click_events_have_key_events -->
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
 				<g
@@ -586,22 +559,12 @@
 		to { opacity: 1; }
 	}
 
-	/* ── Night atmosphere ── */
 	.node.lit-node .node-icon {
 		fill: var(--color-accent);
 	}
 
 	.node.lit-node .node-label {
 		fill: var(--color-accent);
-	}
-
-	/* ── Weather tinting ── */
-	svg.weather-rain {
-		filter: saturate(0.85) brightness(0.92);
-	}
-
-	svg.weather-fog {
-		filter: saturate(0.6) contrast(0.85) brightness(1.05);
 	}
 
 	.tooltip-unexplored {

--- a/apps/ui/src/lib/theme.ts
+++ b/apps/ui/src/lib/theme.ts
@@ -1,0 +1,24 @@
+import type { ThemePalette } from './types';
+
+export const DEFAULT_THEME_PALETTE: ThemePalette = {
+	bg: '#fafad8',
+	fg: '#31240f',
+	accent: '#b08531',
+	panel_bg: '#f5f5d3',
+	input_bg: '#f0f0ce',
+	border: '#cec293',
+	muted: '#76663b'
+};
+
+export function applyThemePalette(palette: ThemePalette): void {
+	if (typeof document === 'undefined') return;
+
+	const root = document.documentElement;
+	root.style.setProperty('--color-bg', palette.bg);
+	root.style.setProperty('--color-fg', palette.fg);
+	root.style.setProperty('--color-accent', palette.accent);
+	root.style.setProperty('--color-panel-bg', palette.panel_bg);
+	root.style.setProperty('--color-input-bg', palette.input_bg);
+	root.style.setProperty('--color-border', palette.border);
+	root.style.setProperty('--color-muted', palette.muted);
+}

--- a/apps/ui/src/stores/game.ts
+++ b/apps/ui/src/stores/game.ts
@@ -35,7 +35,7 @@ export const nameHints = writable<LanguageHint[]>([]);
 
 export const uiConfig = writable<UiConfig>({
 	hints_label: 'Language Hints',
-	default_accent: '#c4a35a',
+	default_accent: '#b08531',
 	splash_text: ''
 });
 

--- a/apps/ui/src/stores/theme.ts
+++ b/apps/ui/src/stores/theme.ts
@@ -1,35 +1,17 @@
 import { writable } from 'svelte/store';
 import type { ThemePalette } from '$lib/types';
-
-const defaultPalette: ThemePalette = {
-	bg: '#fff5dc',
-	fg: '#32230f',
-	accent: '#b48232',
-	panel_bg: '#faf0d7',
-	input_bg: '#f5ebd2',
-	border: '#d2be96',
-	muted: '#78643c'
-};
+import { DEFAULT_THEME_PALETTE, applyThemePalette } from '$lib/theme';
 
 function createPaletteStore() {
-	const { subscribe, set } = writable<ThemePalette>(defaultPalette);
+	const { subscribe, set } = writable<ThemePalette>(DEFAULT_THEME_PALETTE);
 
 	function apply(palette: ThemePalette) {
 		set(palette);
-		if (typeof document !== 'undefined') {
-			const root = document.documentElement;
-			root.style.setProperty('--color-bg', palette.bg);
-			root.style.setProperty('--color-fg', palette.fg);
-			root.style.setProperty('--color-accent', palette.accent);
-			root.style.setProperty('--color-panel-bg', palette.panel_bg);
-			root.style.setProperty('--color-input-bg', palette.input_bg);
-			root.style.setProperty('--color-border', palette.border);
-			root.style.setProperty('--color-muted', palette.muted);
-		}
+		applyThemePalette(palette);
 	}
 
 	// Apply defaults immediately
-	apply(defaultPalette);
+	apply(DEFAULT_THEME_PALETTE);
 
 	return { subscribe, apply };
 }

--- a/crates/parish-core/src/game_mod.rs
+++ b/crates/parish-core/src/game_mod.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::error::ParishError;
+use crate::ipc::ThemePalette;
 use crate::npc::LanguageHint;
 use crate::world::transport::TransportConfig;
 
@@ -180,12 +181,69 @@ pub struct SidebarConfig {
     pub hints_label: String,
 }
 
+/// Theme palette configuration loaded from `ui.toml`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ThemePaletteConfig {
+    /// Main background colour.
+    #[serde(default = "default_theme_bg")]
+    pub bg: String,
+    /// Primary text colour.
+    #[serde(default = "default_theme_fg")]
+    pub fg: String,
+    /// Accent colour for highlights and status UI.
+    #[serde(default = "default_theme_accent")]
+    pub accent: String,
+    /// Panel background colour.
+    #[serde(default = "default_theme_panel_bg")]
+    pub panel_bg: String,
+    /// Input background colour.
+    #[serde(default = "default_theme_input_bg")]
+    pub input_bg: String,
+    /// Border and separator colour.
+    #[serde(default = "default_theme_border")]
+    pub border: String,
+    /// Secondary / muted text colour.
+    #[serde(default = "default_theme_muted")]
+    pub muted: String,
+}
+
+impl From<ThemePaletteConfig> for ThemePalette {
+    fn from(config: ThemePaletteConfig) -> Self {
+        ThemePalette {
+            bg: config.bg,
+            fg: config.fg,
+            accent: config.accent,
+            panel_bg: config.panel_bg,
+            input_bg: config.input_bg,
+            border: config.border,
+            muted: config.muted,
+        }
+    }
+}
+
+impl Default for ThemePaletteConfig {
+    fn default() -> Self {
+        Self {
+            bg: default_theme_bg(),
+            fg: default_theme_fg(),
+            accent: default_theme_accent(),
+            panel_bg: default_theme_panel_bg(),
+            input_bg: default_theme_input_bg(),
+            border: default_theme_border(),
+            muted: default_theme_muted(),
+        }
+    }
+}
+
 /// Theme section of the UI configuration.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ThemeConfig {
-    /// Default accent colour (CSS hex string).
-    #[serde(default = "default_accent")]
-    pub default_accent: String,
+    /// Legacy accent override for older mods.
+    #[serde(default)]
+    pub default_accent: Option<String>,
+    /// Fixed theme palette used by the frontend.
+    #[serde(default)]
+    pub palette: ThemePaletteConfig,
 }
 
 /// UI configuration loaded from `ui.toml`.
@@ -203,8 +261,37 @@ fn default_hints_label() -> String {
     "Language Hints".to_string()
 }
 
-fn default_accent() -> String {
-    "#c4a35a".to_string()
+fn default_theme_bg() -> String {
+    "#fafad8".to_string()
+}
+
+fn default_theme_fg() -> String {
+    "#31240f".to_string()
+}
+
+fn default_theme_accent() -> String {
+    "#b08531".to_string()
+}
+
+fn default_theme_panel_bg() -> String {
+    "#f5f5d3".to_string()
+}
+
+fn default_theme_input_bg() -> String {
+    "#f0f0ce".to_string()
+}
+
+fn default_theme_border() -> String {
+    "#cec293".to_string()
+}
+
+fn default_theme_muted() -> String {
+    "#76663b".to_string()
+}
+
+/// Returns the built-in fixed theme palette used when a mod does not provide one.
+pub fn default_theme_palette() -> ThemePalette {
+    ThemePaletteConfig::default().into()
 }
 
 impl Default for SidebarConfig {
@@ -218,8 +305,20 @@ impl Default for SidebarConfig {
 impl Default for ThemeConfig {
     fn default() -> Self {
         Self {
-            default_accent: default_accent(),
+            default_accent: None,
+            palette: ThemePaletteConfig::default(),
         }
+    }
+}
+
+impl ThemeConfig {
+    /// Returns the fully resolved theme palette, applying any legacy overrides.
+    pub fn resolved_palette(&self) -> ThemePalette {
+        let mut palette = ThemePalette::from(self.palette.clone());
+        if let Some(ref accent) = self.default_accent {
+            palette.accent = accent.clone();
+        }
+        palette
     }
 }
 
@@ -597,8 +696,8 @@ phrases = ["Loading...", "Please wait..."]
 [sidebar]
 hints_label = "Focail"
 
-[theme]
-default_accent = "#aabbcc"
+[theme.palette]
+accent = "#aabbcc"
 "##,
         )
         .unwrap();
@@ -727,7 +826,8 @@ phrases = ["Loading"]
         let toml_str = "";
         let ui: UiConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(ui.sidebar.hints_label, "Language Hints");
-        assert_eq!(ui.theme.default_accent, "#c4a35a");
+        assert_eq!(ui.theme.palette.bg, "#fafad8");
+        assert_eq!(ui.theme.palette.accent, "#b08531");
     }
 
     #[test]
@@ -736,12 +836,26 @@ phrases = ["Loading"]
 [sidebar]
 hints_label = "Custom"
 
-[theme]
-default_accent = "#ff0000"
+[theme.palette]
+accent = "#ff0000"
+bg = "#010203"
 "##;
         let ui: UiConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(ui.sidebar.hints_label, "Custom");
-        assert_eq!(ui.theme.default_accent, "#ff0000");
+        assert_eq!(ui.theme.palette.bg, "#010203");
+        assert_eq!(ui.theme.palette.accent, "#ff0000");
+        assert_eq!(ui.theme.palette.fg, "#31240f");
+    }
+
+    #[test]
+    fn test_ui_config_legacy_default_accent() {
+        let toml_str = r##"
+[theme]
+default_accent = "#112233"
+"##;
+        let ui: UiConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(ui.theme.resolved_palette().accent, "#112233");
+        assert_eq!(ui.theme.resolved_palette().bg, "#fafad8");
     }
 
     #[test]

--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -15,11 +15,10 @@ use crate::npc::mood::mood_emoji;
 use crate::npc::ticks;
 use crate::npc::{LanguageHint, Npc, NpcId};
 use crate::world::description::render_description;
-use crate::world::palette::compute_palette;
 use crate::world::transport::TransportMode;
 use crate::world::{LocationId, WorldState};
 
-use super::types::{MapData, MapLocation, NpcInfo, TextLogPayload, ThemePalette, WorldSnapshot};
+use super::types::{MapData, MapLocation, NpcInfo, TextLogPayload, WorldSnapshot};
 
 /// Builds a [`WorldSnapshot`] from the current world state.
 pub fn snapshot_from_world(world: &WorldState, _transport: &TransportMode) -> WorldSnapshot {
@@ -219,18 +218,6 @@ pub fn build_npcs_here(world: &WorldState, npc_manager: &NpcManager) -> Vec<NpcI
             }
         })
         .collect()
-}
-
-/// Builds the current [`ThemePalette`] from the world clock and weather.
-pub fn build_theme(world: &WorldState) -> ThemePalette {
-    let now = world.clock.now();
-    let raw = compute_palette(
-        now.hour(),
-        now.minute(),
-        world.clock.season(),
-        world.weather,
-    );
-    ThemePalette::from(raw)
 }
 
 /// Capitalizes the first character of a string slice.
@@ -783,15 +770,6 @@ mod tests {
         );
 
         assert_eq!(targets, vec![NpcId(2), NpcId(1)]);
-    }
-
-    #[test]
-    fn build_theme_returns_hex_colors() {
-        let world = WorldState::new();
-        let theme = build_theme(&world);
-        assert!(theme.bg.starts_with('#'));
-        assert_eq!(theme.bg.len(), 7);
-        assert!(theme.fg.starts_with('#'));
     }
 
     #[test]

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -81,10 +81,22 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         chrono::Local::now().format("%Y-%m-%d %H:%M"),
         short_sha,
     );
-    let ui_config = UiConfigSnapshot {
-        hints_label: "Language Hints".to_string(),
-        default_accent: "#c4a35a".to_string(),
-        splash_text,
+    let theme_palette = game_mod
+        .as_ref()
+        .map(|gm| gm.ui.theme.resolved_palette())
+        .unwrap_or_else(parish_core::game_mod::default_theme_palette);
+    let ui_config = if let Some(ref gm) = game_mod {
+        UiConfigSnapshot {
+            hints_label: gm.ui.sidebar.hints_label.clone(),
+            default_accent: theme_palette.accent.clone(),
+            splash_text,
+        }
+    } else {
+        UiConfigSnapshot {
+            hints_label: "Language Hints".to_string(),
+            default_accent: theme_palette.accent.clone(),
+            splash_text,
+        }
     };
 
     let saves_dir = parish_core::persistence::picker::ensure_saves_dir();
@@ -96,6 +108,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         cloud_client,
         transport,
         ui_config,
+        theme_palette,
         saves_dir,
         data_dir.clone(),
         game_mod,
@@ -223,18 +236,6 @@ fn spawn_background_ticks(state: Arc<AppState>) {
         }
     });
 
-    // Theme tick: broadcast updated palette every 500 ms
-    let state_theme = Arc::clone(&state);
-    tokio::spawn(async move {
-        tracing::debug!("Theme tick task started");
-        loop {
-            tokio::time::sleep(Duration::from_millis(500)).await;
-            let world = state_theme.world.lock().await;
-            let palette = parish_core::ipc::build_theme(&world);
-            state_theme.event_bus.emit("theme-update", &palette);
-        }
-    });
-
     // Inactivity tick: drive idle banter and auto-pause.
     let state_idle = Arc::clone(&state);
     tokio::spawn(async move {
@@ -243,7 +244,6 @@ fn spawn_background_ticks(state: Arc<AppState>) {
             routes::tick_inactivity(&state_idle).await;
         }
     });
-
     // Autosave tick: save snapshot every 60 seconds (if a save file is active)
     let state_autosave = Arc::clone(&state);
     tokio::spawn(async move {

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -65,10 +65,9 @@ pub async fn get_npcs_here(State(state): State<Arc<AppState>>) -> Json<Vec<NpcIn
     Json(parish_core::ipc::build_npcs_here(&world, &npc_manager))
 }
 
-/// `GET /api/theme` — returns the current time-of-day theme palette.
+/// `GET /api/theme` — returns the configured UI theme palette.
 pub async fn get_theme(State(state): State<Arc<AppState>>) -> Json<ThemePalette> {
-    let world = state.world.lock().await;
-    Json(parish_core::ipc::build_theme(&world))
+    Json(state.theme_palette.clone())
 }
 
 /// `GET /api/ui-config` — returns UI configuration (splash text, labels, accent).
@@ -1648,6 +1647,7 @@ mod tests {
             default_accent: "#000".to_string(),
             splash_text: String::new(),
         };
+        let theme_palette = parish_core::game_mod::default_theme_palette();
         let saves_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../saves");
         crate::state::build_app_state(
             world,
@@ -1674,6 +1674,7 @@ mod tests {
             None,
             transport,
             ui_config,
+            theme_palette,
             saves_dir,
             data_dir,
             None,

--- a/crates/parish-server/src/state.rs
+++ b/crates/parish-server/src/state.rs
@@ -10,6 +10,7 @@ use parish_core::game_mod::PronunciationEntry;
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceLog, InferenceQueue};
 use parish_core::ipc::ConversationLine;
+use parish_core::ipc::ThemePalette;
 use parish_core::npc::manager::NpcManager;
 use parish_core::world::transport::TransportConfig;
 use parish_core::world::{LocationId, WorldState};
@@ -113,6 +114,8 @@ pub struct AppState {
     pub transport: TransportConfig,
     /// UI configuration from the loaded game mod.
     pub ui_config: UiConfigSnapshot,
+    /// Fixed theme palette from the loaded game mod.
+    pub theme_palette: ThemePalette,
     /// Directory where save files are stored.
     pub saves_dir: PathBuf,
     /// Directory containing game data files (world.json, npcs.json, etc.).
@@ -199,6 +202,7 @@ pub fn build_app_state(
     cloud_client: Option<OpenAiClient>,
     transport: TransportConfig,
     ui_config: UiConfigSnapshot,
+    theme_palette: ThemePalette,
     saves_dir: PathBuf,
     data_dir: PathBuf,
     game_mod: Option<parish_core::game_mod::GameMod>,
@@ -220,6 +224,7 @@ pub fn build_app_state(
         event_bus: EventBus::new(256),
         transport,
         ui_config,
+        theme_palette,
         saves_dir,
         data_dir,
         save_path: Mutex::new(None),

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -146,11 +146,10 @@ pub async fn get_npcs_here(state: tauri::State<'_, Arc<AppState>>) -> Result<Vec
     Ok(parish_core::ipc::build_npcs_here(&world, &npc_manager))
 }
 
-/// Returns the current time-of-day theme palette as CSS hex colours.
+/// Returns the configured UI theme palette as CSS hex colours.
 #[tauri::command]
 pub async fn get_theme(state: tauri::State<'_, Arc<AppState>>) -> Result<ThemePalette, String> {
-    let world = state.world.lock().await;
-    Ok(parish_core::ipc::build_theme(&world))
+    Ok(state.theme_palette.clone())
 }
 
 /// Returns a debug snapshot of all game state for the debug panel.

--- a/crates/parish-tauri/src/events.rs
+++ b/crates/parish-tauri/src/events.rs
@@ -15,7 +15,7 @@ pub const EVENT_TEXT_LOG: &str = "text-log";
 pub const EVENT_WORLD_UPDATE: &str = "world-update";
 /// Event emitted to show/hide the loading indicator.
 pub const EVENT_LOADING: &str = "loading";
-/// Event emitted every 500 ms with the current theme palette.
+/// Event emitted when the UI theme palette changes.
 pub const EVENT_THEME_UPDATE: &str = "theme-update";
 /// Event emitted every 2 s with a debug snapshot (only when debug panel is open).
 pub const EVENT_DEBUG_UPDATE: &str = "debug-update";

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -24,7 +24,6 @@ use parish_core::inference::{
 use parish_core::ipc::ConversationLine;
 use parish_core::npc::manager::NpcManager;
 use parish_core::npc::reactions::ReactionTemplates;
-use parish_core::world::palette::compute_palette;
 use parish_core::world::transport::TransportConfig;
 use parish_core::world::{LocationId, WorldState};
 
@@ -214,6 +213,8 @@ pub struct AppState {
     pub inference_log: InferenceLog,
     /// UI configuration from the loaded game mod.
     pub ui_config: UiConfigSnapshot,
+    /// Fixed theme palette from the loaded game mod.
+    pub theme_palette: ThemePalette,
     /// Name pronunciation entries from the loaded game mod.
     pub pronunciations: Vec<PronunciationEntry>,
     /// NPC arrival reaction templates from the loaded game mod.
@@ -461,17 +462,22 @@ pub fn run() {
         .map(|gm| gm.transport.clone())
         .unwrap_or_default();
 
+    let theme_palette = game_mod
+        .as_ref()
+        .map(|gm| gm.ui.theme.resolved_palette())
+        .unwrap_or_else(parish_core::game_mod::default_theme_palette);
+
     // Build UI config from mod or defaults
     let ui_config = if let Some(ref gm) = game_mod {
         UiConfigSnapshot {
             hints_label: gm.ui.sidebar.hints_label.clone(),
-            default_accent: gm.ui.theme.default_accent.clone(),
+            default_accent: theme_palette.accent.clone(),
             splash_text: splash_text.clone(),
         }
     } else {
         UiConfigSnapshot {
             hints_label: "Language Hints".to_string(),
-            default_accent: "#c4a35a".to_string(),
+            default_accent: theme_palette.accent.clone(),
             splash_text,
         }
     };
@@ -500,6 +506,7 @@ pub fn run() {
         )),
         inference_log: new_inference_log(),
         ui_config,
+        theme_palette,
         pronunciations,
         reaction_templates,
         save_path: Mutex::new(None),
@@ -561,20 +568,11 @@ pub fn run() {
                     // before onMount data is rendered into the DOM.
                     tokio::time::sleep(Duration::from_secs(20)).await;
 
-                    // Emit an initial theme so the frontend has a palette painted
-                    // before the first capture (screenshot mode skips the normal
-                    // 500ms theme tick, leaving the WebView on its default white).
+                    // Emit the configured theme once so the frontend has a palette
+                    // painted before the first capture.
                     {
-                        use chrono::Timelike;
-                        let world = state_ss.world.lock().await;
-                        let now = world.clock.now();
-                        let raw = compute_palette(
-                            now.hour(),
-                            now.minute(),
-                            world.clock.season(),
-                            world.weather,
-                        );
-                        let _ = handle_ss.emit(events::EVENT_THEME_UPDATE, ThemePalette::from(raw));
+                        let palette = state_ss.theme_palette.clone();
+                        let _ = handle_ss.emit(events::EVENT_THEME_UPDATE, palette);
                     }
                     tokio::time::sleep(Duration::from_secs(3)).await;
 
@@ -591,16 +589,6 @@ pub fn run() {
                             let current_hour = world.clock.now().hour() as i64;
                             let delta = ((*target_hour as i64) - current_hour).rem_euclid(24) * 60;
                             world.clock.advance(delta);
-                            // Push updated theme to frontend
-                            let now = world.clock.now();
-                            let raw = compute_palette(
-                                now.hour(),
-                                now.minute(),
-                                world.clock.season(),
-                                world.weather,
-                            );
-                            let palette = ThemePalette::from(raw);
-                            let _ = handle_ss.emit(events::EVENT_THEME_UPDATE, palette);
                         }
 
                         // Wait for Svelte to re-render and WebKit to commit the frame
@@ -850,26 +838,6 @@ pub fn run() {
                     }
                 });
 
-                // Theme tick: emit updated palette every 500 ms
-                let state_theme = Arc::clone(&state_setup);
-                let handle_theme = handle.clone();
-                tokio::spawn(async move {
-                    loop {
-                        tokio::time::sleep(Duration::from_millis(500)).await;
-                        let world = state_theme.world.lock().await;
-                        use chrono::Timelike;
-                        let now = world.clock.now();
-                        let raw = compute_palette(
-                            now.hour(),
-                            now.minute(),
-                            world.clock.season(),
-                            world.weather,
-                        );
-                        let palette = ThemePalette::from(raw);
-                        let _ = handle_theme.emit(events::EVENT_THEME_UPDATE, palette);
-                    }
-                });
-
                 // Inactivity tick: drive idle banter and auto-pause.
                 let state_idle = Arc::clone(&state_setup);
                 let handle_idle = handle.clone();
@@ -879,7 +847,6 @@ pub fn run() {
                         crate::commands::tick_inactivity(&state_idle, &handle_idle).await;
                     }
                 });
-
                 // Debug tick: emit debug snapshot every 2 seconds
                 let state_debug = Arc::clone(&state_setup);
                 let handle_debug = handle.clone();

--- a/mods/kilteevan-1820/ui.toml
+++ b/mods/kilteevan-1820/ui.toml
@@ -1,5 +1,11 @@
 [sidebar]
 hints_label = "Focail (Irish Words)"
 
-[theme]
-default_accent = "#c4a35a"
+[theme.palette]
+bg = "#fafad8"
+fg = "#31240f"
+accent = "#b08531"
+panel_bg = "#f5f5d3"
+input_bg = "#f0f0ce"
+border = "#cec293"
+muted = "#76663b"


### PR DESCRIPTION
## Summary

This change removes the runtime day/night UI theme cycle and replaces it with a fixed, configurable theme palette.

It also removes the map's weather-driven visual tinting while preserving the location glow effect as a static visual treatment.

## What Changed

- moved the active theme palette into mod UI config
- added shared theme defaults/application helpers for the frontend
- changed the web and Tauri backends to serve a fixed resolved theme instead of recomputing it from time and weather
- removed the old backend theme tick and shared time-based theme builder
- removed map time/weather atmosphere effects and kept the map glow styling
- updated theme-related E2E mocks/tests to match the fixed theme behavior

## Why

The UI still changed color over time because the backend kept emitting time-of-day palettes, and the map had its own separate time/weather atmosphere logic.

This PR makes the app keep the startup palette for the whole session while leaving a config path in place for future themes.

## Validation

- `cargo fmt --all`
- `cargo test -p parish-core test_ui_config`
- `cargo test -p parish-server get_theme`
- `npm run test:e2e -- e2e/app.spec.ts --grep "Theme application"`
- `npm run check` still reports pre-existing unrelated UI typing issues in `ui/vite.config.ts`, `ui/src/components/InputField.test.ts`, `ui/src/components/StatusBar.test.ts`, and `ui/src/routes/+page.svelte`
