### PR TITLE
[codex] Preserve smooth multi-NPC streaming

### DIFF
--- a/apps/ui/e2e/interactions.spec.ts
+++ b/apps/ui/e2e/interactions.spec.ts
@@ -47,11 +47,12 @@ test.describe('Streaming simulation', () => {
 		await page.waitForTimeout(100);
 
 		// Send tokens
-		await emitEvent(page, 'stream-token', { token: 'Ah, ' });
+		await emitEvent(page, 'stream-token', { token: 'Ah, ', turn_id: 1, source: 'Siobhan Murphy' });
 		await page.waitForTimeout(50);
-		await emitEvent(page, 'stream-token', { token: "you're " });
+		await emitEvent(page, 'stream-token', { token: "you're ", turn_id: 1, source: 'Siobhan Murphy' });
 		await page.waitForTimeout(50);
-		await emitEvent(page, 'stream-token', { token: 'welcome!' });
+		await emitEvent(page, 'stream-token', { token: 'welcome!', turn_id: 1, source: 'Siobhan Murphy' });
+		await emitEvent(page, 'stream-turn-end', { turn_id: 1 });
 		await page.waitForTimeout(100);
 
 		await expect(page.getByText("Ah, you're welcome!")).toBeVisible();
@@ -59,6 +60,64 @@ test.describe('Streaming simulation', () => {
 		// End stream
 		await emitEvent(page, 'stream-end', { hints: IRISH_HINTS });
 		await page.waitForTimeout(100);
+	});
+
+	test('keeps overlapping multi-npc streams attached to the right speaker', async ({ page }) => {
+		await installTauriMock(page, 'morning');
+		await page.goto('/');
+		await page.waitForLoadState('networkidle');
+
+		await emitEvent(page, 'loading', { active: true });
+		await page.waitForTimeout(100);
+
+		await emitEvent(page, 'text-log', {
+			id: 'msg-1',
+			source: 'Siobhan Murphy',
+			content: '',
+			stream_turn_id: 11
+		});
+		await emitEvent(page, 'stream-token', {
+			token: 'I heard the fair will be lively tonight ',
+			turn_id: 11,
+			source: 'Siobhan Murphy'
+		});
+		await page.waitForTimeout(80);
+		await expect(page.locator('.bubble-row.npc').nth(0).locator('.label')).toHaveText('Siobhan Murphy');
+
+		// Queue Padraig before Siobhan has finished animating.
+		await emitEvent(page, 'text-log', {
+			id: 'msg-2',
+			source: 'Padraig Darcy',
+			content: '',
+			stream_turn_id: 12
+		});
+		await emitEvent(page, 'stream-token', {
+			token: "If it is, I'll bring the cart before sunset.",
+			turn_id: 12,
+			source: 'Padraig Darcy'
+		});
+
+		await emitEvent(page, 'stream-token', {
+			token: 'with music by the square.',
+			turn_id: 11,
+			source: 'Siobhan Murphy'
+		});
+		await emitEvent(page, 'stream-turn-end', { turn_id: 11 });
+		await emitEvent(page, 'stream-turn-end', { turn_id: 12 });
+		await emitEvent(page, 'stream-end', { hints: IRISH_HINTS });
+
+		await page.waitForTimeout(1500);
+
+		const npcRows = page.locator('.bubble-row.npc');
+		await expect(npcRows).toHaveCount(2);
+		await expect(npcRows.nth(0).locator('.label')).toHaveText('Siobhan Murphy');
+		await expect(npcRows.nth(0).locator('.content')).toContainText(
+			'I heard the fair will be lively tonight with music by the square.'
+		);
+		await expect(npcRows.nth(1).locator('.label')).toHaveText('Padraig Darcy');
+		await expect(npcRows.nth(1).locator('.content')).toContainText(
+			"If it is, I'll bring the cart before sunset."
+		);
 	});
 });
 

--- a/apps/ui/src/components/ChatPanel.svelte
+++ b/apps/ui/src/components/ChatPanel.svelte
@@ -116,7 +116,7 @@
 </script>
 
 <div class="chat-panel" data-testid="chat-panel" bind:this={logEl} role="log" aria-live="polite" aria-label="Game chat log">
-	{#each $textLog as entry (entry)}
+	{#each $textLog as entry, index (entry.id ?? entry.stream_turn_id ?? `${entry.source}:${index}`)}
 		{#if entryType(entry) === 'system'}
 			{@const isSplash = entry.content.includes('Copyright \u00A9')}
 			{@const lines = entry.content.split('\n')}

--- a/apps/ui/src/lib/ipc.ts
+++ b/apps/ui/src/lib/ipc.ts
@@ -13,6 +13,7 @@ import type {
 	ThemePalette,
 	UiConfig,
 	StreamTokenPayload,
+	StreamTurnEndPayload,
 	StreamEndPayload,
 	TextLogPayload,
 	NpcReactionPayload,
@@ -165,6 +166,9 @@ async function onEvent<T>(event: string, cb: EventCallback<T>): Promise<Unlisten
 
 export const onStreamToken = (cb: (payload: StreamTokenPayload) => void) =>
 	onEvent<StreamTokenPayload>('stream-token', cb);
+
+export const onStreamTurnEnd = (cb: (payload: StreamTurnEndPayload) => void) =>
+	onEvent<StreamTurnEndPayload>('stream-turn-end', cb);
 
 export const onStreamEnd = (cb: (payload: StreamEndPayload) => void) =>
 	onEvent<StreamEndPayload>('stream-end', cb);

--- a/apps/ui/src/lib/types.ts
+++ b/apps/ui/src/lib/types.ts
@@ -101,6 +101,7 @@ export interface TextLogEntry {
 	id?: string;
 	source: string;
 	content: string;
+	stream_turn_id?: number;
 	streaming?: boolean;
 	latest_chunk?: string;
 	stream_chunk_id?: number;
@@ -109,6 +110,12 @@ export interface TextLogEntry {
 
 export interface StreamTokenPayload {
 	token: string;
+	turn_id: number;
+	source: string;
+}
+
+export interface StreamTurnEndPayload {
+	turn_id: number;
 }
 
 export interface StreamEndPayload {
@@ -117,6 +124,7 @@ export interface StreamEndPayload {
 
 export interface TextLogPayload {
 	id?: string;
+	stream_turn_id?: number;
 	source: string;
 	content: string;
 }

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -27,6 +27,7 @@
 		getDebugSnapshot,
 		onWorldUpdate,
 		onStreamToken,
+		onStreamTurnEnd,
 		onStreamEnd,
 		onTextLog,
 		onLoading,
@@ -45,6 +46,16 @@
 	const AUTO_PAUSE_MS = 60_000;
 	const MOUSEMOVE_THROTTLE_MS = 1000;
 	const STREAM_WAIT_FOR_WORD_MS = 70;
+
+	type PendingNpcTurn = {
+		turnId: number;
+		source: string;
+		messageId?: string;
+		buffer: string;
+		placeholderInserted: boolean;
+		complete: boolean;
+		pumpHandle: ReturnType<typeof setTimeout> | null;
+	};
 
 	// F5 toggle for save picker, F12 toggle for debug panel, M toggle for map
 	function handleKeydown(e: KeyboardEvent) {
@@ -94,49 +105,34 @@
 		}
 	});
 
-	function appendStreamToken(token: string) {
+	function appendStreamToken(turnId: number, source: string, token: string, messageId?: string) {
 		textLog.update((log) => {
-			if (log.length > 0 && log[log.length - 1].streaming) {
-				const last = log[log.length - 1];
+			const entryIndex = log.findIndex((entry) => entry.stream_turn_id === turnId);
+			if (entryIndex >= 0) {
+				const current = log[entryIndex];
+				const nextEntry = {
+					...current,
+					id: current.id ?? messageId,
+					source,
+					content: current.content + token,
+					stream_turn_id: turnId,
+					streaming: true,
+					latest_chunk: token,
+					stream_chunk_id: (current.stream_chunk_id ?? 0) + 1
+				};
 				return [
-					...log.slice(0, -1),
-					{
-						...last,
-						content: last.content + token,
-						latest_chunk: token,
-						stream_chunk_id: (last.stream_chunk_id ?? 0) + 1
-					}
+					...log.slice(0, entryIndex),
+					nextEntry,
+					...log.slice(entryIndex + 1)
 				];
 			}
-			// Merge with the empty NPC name placeholder emitted by Rust
-			const last = log.length > 0 ? log[log.length - 1] : null;
-			if (
-				last &&
-				last.content === '' &&
-				last.source !== 'player' &&
-				last.source !== 'system'
-			) {
-				return [
-					...log.slice(0, -1),
-					{
-						...last,
-						content: token,
-						streaming: true,
-						latest_chunk: token,
-						stream_chunk_id: 1
-					}
-				];
-			}
-			// Use the most recent NPC source name if available, otherwise fall back
-			const npcSource =
-				last && last.source !== 'player' && last.source !== 'system'
-					? last.source
-					: 'NPC';
 			return trimTextLog([
 				...log,
 				{
-					source: npcSource,
+					id: messageId,
+					source,
 					content: token,
+					stream_turn_id: turnId,
 					streaming: true,
 					latest_chunk: token,
 					stream_chunk_id: 1
@@ -208,71 +204,156 @@
 			debugSnapshot.set(debugSnap);
 		} catch (_) {}
 
-		let streamBuffer = '';
-		let streamPumpHandle: ReturnType<typeof setTimeout> | null = null;
+		let pendingNpcTurns = new Map<number, PendingNpcTurn>();
 		let pendingStreamEndHints: LanguageHint[] | null = null;
 
-		const finishNpcStream = () => {
-			textLog.update((log) => {
-				if (log.length > 0 && log[log.length - 1].streaming) {
-					const last = log[log.length - 1];
-					return [
-						...log.slice(0, -1),
-						{
-							...last,
-							streaming: false,
-							latest_chunk: undefined,
-							stream_chunk_id: undefined
-						}
-					];
+		function findPendingTurn(turnId: number) {
+			return pendingNpcTurns.get(turnId);
+		}
+
+		function queuePendingTurn(turnId: number, source: string, messageId?: string) {
+			const existing = findPendingTurn(turnId);
+			if (existing) {
+				existing.source = source;
+				existing.messageId = existing.messageId ?? messageId;
+				if (messageId && existing.placeholderInserted) {
+					textLog.update((log) => {
+						const entryIndex = log.findIndex((entry) => entry.stream_turn_id === turnId);
+						if (entryIndex < 0) return log;
+						return [
+							...log.slice(0, entryIndex),
+							{ ...log[entryIndex], id: log[entryIndex].id ?? messageId, source },
+							...log.slice(entryIndex + 1)
+						];
+					});
 				}
-				return log;
-			});
-			languageHints.set(pendingStreamEndHints ?? []);
-			pendingStreamEndHints = null;
-			streamingActive.set(false);
-		};
-
-		const stopStreamPump = () => {
-			if (streamPumpHandle !== null) {
-				clearTimeout(streamPumpHandle);
-				streamPumpHandle = null;
+				return existing;
 			}
-		};
 
-		const scheduleStreamPump = (delayMs: number) => {
-			streamPumpHandle = setTimeout(() => {
-				streamPumpHandle = null;
-				pumpStream();
+			const turn: PendingNpcTurn = {
+				turnId,
+				source,
+				messageId,
+				buffer: '',
+				placeholderInserted: false,
+				complete: false,
+				pumpHandle: null
+			};
+			pendingNpcTurns.set(turnId, turn);
+			return turn;
+		}
+
+		function ensureTurnEntry(turn: PendingNpcTurn) {
+			if (turn.placeholderInserted) return;
+
+			textLog.update((log) =>
+				trimTextLog([
+					...log,
+					{
+						id: turn.messageId,
+						source: turn.source,
+						content: '',
+						stream_turn_id: turn.turnId
+					}
+				])
+			);
+			turn.placeholderInserted = true;
+		}
+
+		function finalizeStreamingEntry(turnId: number) {
+			textLog.update((log) => {
+				const entryIndex = log.findIndex((entry) => entry.stream_turn_id === turnId);
+				if (entryIndex < 0) {
+					return log;
+				}
+
+				const entry = log[entryIndex];
+				if (entry.content === '') {
+					return [...log.slice(0, entryIndex), ...log.slice(entryIndex + 1)];
+				}
+
+				return [
+					...log.slice(0, entryIndex),
+					{
+						...entry,
+						streaming: false,
+						latest_chunk: undefined,
+						stream_chunk_id: undefined
+					},
+					...log.slice(entryIndex + 1)
+				];
+			});
+		}
+
+		function finishNpcStream(hints = []) {
+			languageHints.set(hints);
+			streamingActive.set(false);
+		}
+
+		function maybeFinishNpcStream() {
+			if (pendingStreamEndHints === null || pendingNpcTurns.size > 0) return;
+			finishNpcStream(pendingStreamEndHints);
+			pendingStreamEndHints = null;
+		}
+
+		function stopTurnPump(turn: PendingNpcTurn) {
+			if (turn.pumpHandle !== null) {
+				clearTimeout(turn.pumpHandle);
+				turn.pumpHandle = null;
+			}
+		}
+
+		function scheduleTurnPump(turn: PendingNpcTurn, delayMs: number) {
+			turn.pumpHandle = setTimeout(() => {
+				turn.pumpHandle = null;
+				pumpTurn(turn.turnId);
 			}, delayMs);
-		};
+		}
 
-		const pumpStream = () => {
-			if (streamBuffer.length === 0) {
-				stopStreamPump();
-				if (pendingStreamEndHints !== null) finishNpcStream();
+		function finalizePendingTurn(turnId: number) {
+			const turn = findPendingTurn(turnId);
+			if (!turn) return;
+			stopTurnPump(turn);
+			finalizeStreamingEntry(turnId);
+			pendingNpcTurns.delete(turnId);
+			maybeFinishNpcStream();
+		}
+
+		function startTurnPumpIfNeeded(turn: PendingNpcTurn) {
+			if (turn.pumpHandle !== null) return;
+			pumpTurn(turn.turnId);
+		}
+
+		function pumpTurn(turnId: number) {
+			const turn = findPendingTurn(turnId);
+			if (!turn) return;
+
+			if (turn.buffer.length === 0) {
+				stopTurnPump(turn);
+				if (turn.complete) {
+					finalizePendingTurn(turnId);
+				}
 				return;
 			}
 
-			const { chunk, rest } = takeNextStreamChunk(
-				streamBuffer,
-				pendingStreamEndHints !== null
-			);
+			ensureTurnEntry(turn);
+
+			const { chunk, rest } = takeNextStreamChunk(turn.buffer, turn.complete);
 
 			if (chunk === null) {
-				scheduleStreamPump(STREAM_WAIT_FOR_WORD_MS);
+				scheduleTurnPump(turn, STREAM_WAIT_FOR_WORD_MS);
 				return;
 			}
 
-			streamBuffer = rest;
-			appendStreamToken(chunk);
-			scheduleStreamPump(getStreamChunkDelayMs(chunk));
-		};
-
-		const startStreamPumpIfNeeded = () => {
-			if (streamPumpHandle !== null) return;
-			pumpStream();
-		};
+			turn.buffer = rest;
+			appendStreamToken(
+				turn.turnId,
+				turn.source,
+				chunk,
+				turn.messageId
+			);
+			scheduleTurnPump(turn, getStreamChunkDelayMs(chunk));
+		}
 
 		const listeners: Array<() => void> = [];
 		try {
@@ -288,12 +369,32 @@
 			}));
 
 			listeners.push(await onTextLog((payload) => {
+				const isNpcPlaceholder =
+					payload.content === '' &&
+					payload.source !== 'player' &&
+					payload.source !== 'system' &&
+					payload.stream_turn_id != null;
+				if (isNpcPlaceholder) {
+					queuePendingTurn(payload.stream_turn_id, payload.source, payload.id);
+					return;
+				}
+
 				// Strip "> " prefix from player messages — bubble alignment shows speaker
 				const content =
 					payload.source === 'player' && payload.content.startsWith('> ')
 						? payload.content.slice(2)
 						: payload.content;
-				textLog.update((log) => trimTextLog([...log, { id: payload.id, source: payload.source, content }]));
+				textLog.update((log) =>
+					trimTextLog([
+						...log,
+						{
+							id: payload.id,
+							source: payload.source,
+							content,
+							stream_turn_id: payload.stream_turn_id ?? undefined
+						}
+					])
+				);
 			}));
 
 			listeners.push(await onNpcReaction((payload) => {
@@ -301,36 +402,32 @@
 			}));
 
 			listeners.push(await onStreamToken((payload) => {
-				streamBuffer += payload.token;
-				startStreamPumpIfNeeded();
+				const turn = queuePendingTurn(payload.turn_id, payload.source);
+				turn.buffer += payload.token;
+				startTurnPumpIfNeeded(turn);
+			}));
+
+			listeners.push(await onStreamTurnEnd((payload) => {
+				const turn = findPendingTurn(payload.turn_id);
+				if (!turn) return;
+				turn.complete = true;
+				startTurnPumpIfNeeded(turn);
 			}));
 
 			listeners.push(await onStreamEnd((payload) => {
 				pendingStreamEndHints = payload.hints;
-				if (streamBuffer.length === 0 && streamPumpHandle === null) {
-					finishNpcStream();
-				}
+				maybeFinishNpcStream();
 			}));
 
 			listeners.push(await onLoading((payload) => {
-				const wasActive = get(streamingActive);
 				streamingActive.set(payload.active);
 				if (payload.active) {
 					// Update animated loading phrase and spinner
 					if (payload.spinner) loadingSpinner.set(payload.spinner);
 					if (payload.phrase) loadingPhrase.set(payload.phrase);
 					if (payload.color) loadingColor.set(payload.color);
-					// Only clean up stale streaming entries on the *first*
-					// loading event (transition from inactive → active), not
-					// on every animation tick, to avoid erasing in-progress text.
-					if (!wasActive) {
-						textLog.update((log) => {
-							if (log.length > 0 && log[log.length - 1].streaming) {
-								return log.slice(0, -1);
-							}
-							return log;
-						});
-					}
+					// The loading animation ticks repeatedly while a turn is in
+					// flight; don't mutate chat state on those frames.
 				}
 			}));
 
@@ -363,7 +460,7 @@
 			window.removeEventListener('touchstart', onTrackerTouch);
 			window.removeEventListener('mousemove', onTrackerMousemove);
 			tracker.dispose();
-			stopStreamPump();
+			pendingNpcTurns.forEach((turn) => stopTurnPump(turn));
 			listeners.forEach((fn) => fn());
 		};
 	});

--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -249,6 +249,21 @@ static MESSAGE_ID: AtomicU64 = AtomicU64::new(1);
 pub fn text_log(source: impl Into<String>, content: impl Into<String>) -> TextLogPayload {
     TextLogPayload {
         id: format!("msg-{}", MESSAGE_ID.fetch_add(1, Ordering::SeqCst)),
+        stream_turn_id: None,
+        source: source.into(),
+        content: content.into(),
+    }
+}
+
+/// Creates a [`TextLogPayload`] tied to a specific NPC stream turn.
+pub fn text_log_for_stream_turn(
+    source: impl Into<String>,
+    content: impl Into<String>,
+    stream_turn_id: u64,
+) -> TextLogPayload {
+    TextLogPayload {
+        id: format!("msg-{}", MESSAGE_ID.fetch_add(1, Ordering::SeqCst)),
+        stream_turn_id: Some(stream_turn_id),
         source: source.into(),
         content: content.into(),
     }

--- a/crates/parish-core/src/ipc/types.rs
+++ b/crates/parish-core/src/ipc/types.rs
@@ -163,6 +163,17 @@ impl From<RawPalette> for ThemePalette {
 pub struct StreamTokenPayload {
     /// The batch of token text to append to the current chat entry.
     pub token: String,
+    /// Stable ID for the NPC turn this token batch belongs to.
+    pub turn_id: u64,
+    /// Speaker label for this stream turn.
+    pub source: String,
+}
+
+/// Payload for `stream-turn-end` events.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct StreamTurnEndPayload {
+    /// Stable ID for the NPC turn that has finished streaming tokens.
+    pub turn_id: u64,
 }
 
 /// Payload for `stream-end` events.
@@ -178,6 +189,9 @@ pub struct TextLogPayload {
     /// Unique message ID for reaction targeting.
     #[serde(default)]
     pub id: String,
+    /// Stable ID for the NPC turn this placeholder belongs to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_turn_id: Option<u64>,
     /// Who produced this text: "player", "system", or the NPC's name.
     pub source: String,
     /// The log entry text.
@@ -341,12 +355,16 @@ mod tests {
     fn event_payload_serialization() {
         let token = StreamTokenPayload {
             token: "hello".to_string(),
+            turn_id: 7,
+            source: "Siobhan Murphy".to_string(),
         };
         let json = serde_json::to_string(&token).unwrap();
         assert!(json.contains("hello"));
+        assert!(json.contains("turn_id"));
 
         let log = TextLogPayload {
             id: "msg-1".to_string(),
+            stream_turn_id: Some(7),
             source: "system".to_string(),
             content: "Welcome".to_string(),
         };

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -18,8 +18,9 @@ use parish_core::inference::{InferenceQueue, spawn_inference_worker};
 use parish_core::input::{InputResult, classify_input, parse_intent};
 use parish_core::ipc::{
     ConversationLine, IDLE_MESSAGES, INFERENCE_FAILURE_MESSAGES, LoadingPayload, MapData, NpcInfo,
-    NpcReactionPayload, ReactRequest, StreamEndPayload, StreamTokenPayload, ThemePalette,
-    WorldSnapshot, capitalize_first, text_log,
+    NpcReactionPayload, ReactRequest, StreamEndPayload, StreamTokenPayload,
+    StreamTurnEndPayload, ThemePalette, WorldSnapshot, capitalize_first, text_log,
+    text_log_for_stream_turn,
 };
 use parish_core::npc::NpcId;
 use parish_core::npc::manager::NpcManager;
@@ -583,11 +584,13 @@ async fn run_npc_turn(
 
     let (token_tx, token_rx) = mpsc::unbounded_channel::<String>();
     let display_label = capitalize_first(&setup.display_name);
+    let req_id = REQUEST_ID.fetch_add(1, Ordering::SeqCst);
     state
         .event_bus
-        .emit("text-log", &text_log(display_label.clone(), String::new()));
-
-    let req_id = REQUEST_ID.fetch_add(1, Ordering::SeqCst);
+        .emit(
+            "text-log",
+            &text_log_for_stream_turn(display_label.clone(), String::new(), req_id),
+        );
     let send_result = queue
         .send(
             req_id,
@@ -604,6 +607,10 @@ async fn run_npc_turn(
         Err(e) => {
             tracing::error!("Failed to submit inference request: {}", e);
             state.event_bus.emit(
+                "stream-turn-end",
+                &StreamTurnEndPayload { turn_id: req_id },
+            );
+            state.event_bus.emit(
                 "text-log",
                 &text_log(
                     "system",
@@ -618,6 +625,7 @@ async fn run_npc_turn(
     let stream_handle = tokio::spawn({
         let state_clone = Arc::clone(state);
         let cancel = loading_cancel.clone();
+        let source = display_label.clone();
         async move {
             parish_core::ipc::stream_npc_tokens(token_rx, |batch| {
                 cancel.cancel();
@@ -625,6 +633,8 @@ async fn run_npc_turn(
                     "stream-token",
                     &StreamTokenPayload {
                         token: batch.to_string(),
+                        turn_id: req_id,
+                        source: source.clone(),
                     },
                 );
             })
@@ -634,6 +644,10 @@ async fn run_npc_turn(
 
     let response = response_rx.await.ok();
     let _ = stream_handle.await;
+    state.event_bus.emit(
+        "stream-turn-end",
+        &StreamTurnEndPayload { turn_id: req_id },
+    );
     loading_cancel.cancel();
 
     let Some(response) = response else {

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -16,7 +16,7 @@ use parish_core::inference::{InferenceQueue, spawn_inference_worker};
 use parish_core::input::{InputResult, classify_input, parse_intent};
 use parish_core::ipc::{
     ConversationLine, IDLE_MESSAGES, INFERENCE_FAILURE_MESSAGES, capitalize_first,
-    compute_name_hints, text_log,
+    compute_name_hints, text_log, text_log_for_stream_turn,
 };
 use parish_core::npc::NpcId;
 use parish_core::npc::parse_npc_stream_response;
@@ -25,8 +25,9 @@ use parish_core::npc::ticks::apply_tier1_response;
 use parish_core::world::transport::TransportMode;
 
 use crate::events::{
-    EVENT_SAVE_PICKER, EVENT_STREAM_END, EVENT_TEXT_LOG, EVENT_TRAVEL_START, EVENT_WORLD_UPDATE,
-    NpcReactionPayload, StreamEndPayload, TextLogPayload, spawn_loading_animation,
+    EVENT_SAVE_PICKER, EVENT_STREAM_END, EVENT_STREAM_TURN_END, EVENT_TEXT_LOG,
+    EVENT_TRAVEL_START, EVENT_WORLD_UPDATE, NpcReactionPayload, StreamEndPayload,
+    StreamTokenPayload, StreamTurnEndPayload, TextLogPayload, spawn_loading_animation,
 };
 use crate::{AppState, MapData, MapLocation, NpcInfo, SaveState, ThemePalette, WorldSnapshot};
 
@@ -381,6 +382,7 @@ async fn handle_system_command(
             EVENT_TEXT_LOG,
             TextLogPayload {
                 id: String::new(),
+                stream_turn_id: None,
                 source: "system".to_string(),
                 content: response,
             },
@@ -456,6 +458,7 @@ async fn handle_game_input(
                 EVENT_TEXT_LOG,
                 TextLogPayload {
                     id: String::new(),
+                    stream_turn_id: None,
                     source: "system".to_string(),
                     content: "And where would ye be off to?".to_string(),
                 },
@@ -653,6 +656,7 @@ async fn handle_look(state: &Arc<AppState>, app: &tauri::AppHandle) {
         EVENT_TEXT_LOG,
         TextLogPayload {
             id: String::new(),
+            stream_turn_id: None,
             source: "system".to_string(),
             content: text,
         },
@@ -696,12 +700,11 @@ async fn run_npc_turn(
 
     let (token_tx, token_rx) = mpsc::unbounded_channel::<String>();
     let display_label = capitalize_first(&setup.display_name);
+    let req_id = REQUEST_ID.fetch_add(1, Ordering::Relaxed);
     let _ = app.emit(
         EVENT_TEXT_LOG,
-        text_log(display_label.clone(), String::new()),
+        text_log_for_stream_turn(display_label.clone(), String::new(), req_id),
     );
-
-    let req_id = REQUEST_ID.fetch_add(1, Ordering::Relaxed);
     let send_result = queue
         .send(
             req_id,
@@ -727,9 +730,14 @@ async fn run_npc_turn(
                 message: format!("Queue submit failed: {e}"),
             });
             let _ = app.emit(
+                EVENT_STREAM_TURN_END,
+                StreamTurnEndPayload { turn_id: req_id },
+            );
+            let _ = app.emit(
                 EVENT_TEXT_LOG,
                 TextLogPayload {
                     id: String::new(),
+                    stream_turn_id: None,
                     source: "system".to_string(),
                     content: "The parish storyteller has wandered off. Try again in a moment."
                         .to_string(),
@@ -742,11 +750,28 @@ async fn run_npc_turn(
 
     let stream_handle = tokio::spawn({
         let app_clone = app.clone();
-        async move { crate::events::stream_npc_response(app_clone, token_rx).await }
+        let source = display_label.clone();
+        async move {
+            parish_core::ipc::stream_npc_tokens(token_rx, |batch| {
+                let _ = app_clone.emit(
+                    crate::events::EVENT_STREAM_TOKEN,
+                    StreamTokenPayload {
+                        token: batch.to_string(),
+                        turn_id: req_id,
+                        source: source.clone(),
+                    },
+                );
+            })
+            .await
+        }
     });
 
     let response = response_rx.await.ok();
     let _ = stream_handle.await;
+    let _ = app.emit(
+        EVENT_STREAM_TURN_END,
+        StreamTurnEndPayload { turn_id: req_id },
+    );
     loading_cancel.cancel();
 
     let Some(response) = response else {
@@ -754,6 +779,7 @@ async fn run_npc_turn(
             EVENT_TEXT_LOG,
             TextLogPayload {
                 id: String::new(),
+                stream_turn_id: None,
                 source: "system".to_string(),
                 content: "The storyteller has wandered off mid-tale.".to_string(),
             },
@@ -777,6 +803,7 @@ async fn run_npc_turn(
             EVENT_TEXT_LOG,
             TextLogPayload {
                 id: String::new(),
+                stream_turn_id: None,
                 source: "system".to_string(),
                 content: INFERENCE_FAILURE_MESSAGES[idx].to_string(),
             },
@@ -847,6 +874,7 @@ async fn handle_npc_conversation(
             EVENT_TEXT_LOG,
             TextLogPayload {
                 id: String::new(),
+                stream_turn_id: None,
                 source: "system".to_string(),
                 content: IDLE_MESSAGES[idx].to_string(),
             },
@@ -859,6 +887,7 @@ async fn handle_npc_conversation(
             EVENT_TEXT_LOG,
             TextLogPayload {
                 id: String::new(),
+                stream_turn_id: None,
                 source: "system".to_string(),
                 content: "There are ears enough for ye here, but say something first.".to_string(),
             },
@@ -871,6 +900,7 @@ async fn handle_npc_conversation(
             EVENT_TEXT_LOG,
             TextLogPayload {
                 id: String::new(),
+                stream_turn_id: None,
                 source: "system".to_string(),
                 content:
                     "There's someone here, but the LLM is not configured — set a provider with /provider."
@@ -885,6 +915,7 @@ async fn handle_npc_conversation(
             EVENT_TEXT_LOG,
             TextLogPayload {
                 id: String::new(),
+                stream_turn_id: None,
                 source: "system".to_string(),
                 content: "No one here answers to that name just now.".to_string(),
             },
@@ -1184,6 +1215,7 @@ pub(crate) async fn tick_inactivity(state: &Arc<AppState>, app: &tauri::AppHandl
             EVENT_TEXT_LOG,
             TextLogPayload {
                 id: String::new(),
+                stream_turn_id: None,
                 source: "system".to_string(),
                 content:
                     "The parish falls quiet after a full minute of silence. Time is now paused."
@@ -1348,6 +1380,7 @@ pub async fn load_branch(
         EVENT_TEXT_LOG,
         TextLogPayload {
             id: String::new(),
+            stream_turn_id: None,
             source: "system".to_string(),
             content: format!("Loaded {} (branch: {}).", filename, branch_name),
         },
@@ -1519,6 +1552,7 @@ pub async fn new_game(
         EVENT_TEXT_LOG,
         TextLogPayload {
             id: String::new(),
+            stream_turn_id: None,
             source: "system".to_string(),
             content: "A new chapter begins in the parish...".to_string(),
         },

--- a/crates/parish-tauri/src/events.rs
+++ b/crates/parish-tauri/src/events.rs
@@ -7,6 +7,8 @@ use tauri::Emitter;
 
 /// Event emitted with each streamed NPC response token (batched).
 pub const EVENT_STREAM_TOKEN: &str = "stream-token";
+/// Event emitted when an individual NPC turn has finished streaming tokens.
+pub const EVENT_STREAM_TURN_END: &str = "stream-turn-end";
 /// Event emitted when an NPC response stream ends.
 pub const EVENT_STREAM_END: &str = "stream-end";
 /// Event emitted to add a line to the chat log.
@@ -38,6 +40,17 @@ pub const BATCH_MS: u64 = 16;
 pub struct StreamTokenPayload {
     /// The batch of token text to append to the current chat entry.
     pub token: String,
+    /// Stable ID for the NPC turn this token batch belongs to.
+    pub turn_id: u64,
+    /// Speaker label for this stream turn.
+    pub source: String,
+}
+
+/// Payload for `stream-turn-end` events.
+#[derive(serde::Serialize, Clone)]
+pub struct StreamTurnEndPayload {
+    /// Stable ID for the NPC turn that has finished streaming tokens.
+    pub turn_id: u64,
 }
 
 /// Payload for `stream-end` events.
@@ -53,6 +66,9 @@ pub struct TextLogPayload {
     /// Unique message ID for reaction targeting.
     #[serde(default)]
     pub id: String,
+    /// Stable ID for the NPC turn this placeholder belongs to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_turn_id: Option<u64>,
     /// Who produced this text: "player", "system", or the NPC's name.
     pub source: String,
     /// The log entry text.
@@ -143,12 +159,16 @@ pub fn spawn_loading_animation(app: tauri::AppHandle, cancel: tokio_util::sync::
 pub async fn stream_npc_response(
     app: tauri::AppHandle,
     token_rx: tokio::sync::mpsc::UnboundedReceiver<String>,
+    turn_id: u64,
+    source: String,
 ) -> String {
     parish_core::ipc::stream_npc_tokens(token_rx, |batch| {
         let _ = app.emit(
             EVENT_STREAM_TOKEN,
             StreamTokenPayload {
                 token: batch.to_string(),
+                turn_id,
+                source: source.clone(),
             },
         );
     })


### PR DESCRIPTION
## Summary
This fixes the multi-NPC streaming regression where one NPC's remaining streamed text could be cut off, spill into the next speaker's bubble, or lose the smooth reveal animation.

## What Changed
- added per-turn streaming metadata and end-of-turn events across core IPC, the web server, Tauri, and the UI
- updated the Svelte page to pace streamed text per NPC turn instead of using one shared client-side stream buffer
- keyed chat rows by stable message/turn identity so streamed entries stay attached to the correct bubble while they update
- added a Playwright regression that overlaps two NPC streams and asserts each speaker keeps the right text

## Root Cause
The client-side smooth-streaming implementation buffered all NPC text in one shared queue and updated whichever streaming placeholder happened to be treated as the current bubble. When multiple NPCs responded in sequence before the first reveal finished, later placeholders could steal earlier buffered text.

## Impact
- preserves the smooth incremental response animation
- keeps overlapping or back-to-back NPC turns attached to the correct speaker
- makes streamed turn ownership explicit across both web and Tauri transports

## Validation
- `cargo test -p parish-server handle_npc_conversation_preserves_order_and_follow_up_context`
- `cargo check -p parish-tauri`
- `cd apps/ui && npm run build`
- `cd apps/ui && npx vitest run src/components/ChatPanel.test.ts`
- `cd apps/ui && npx playwright test e2e/interactions.spec.ts -g "Streaming simulation" --reporter=list`
