### PR TITLE
Embed full map in chat panel instead of floating overlay

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -270,7 +270,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -287,7 +286,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -304,7 +302,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -321,7 +318,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -338,7 +334,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -355,7 +350,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -372,7 +366,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -389,7 +382,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -406,7 +398,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -423,7 +414,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -440,7 +430,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -457,7 +446,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -474,7 +462,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -491,7 +478,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -508,7 +494,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -525,7 +510,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -542,7 +526,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -559,7 +542,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -576,7 +558,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -593,7 +574,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -610,7 +590,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -627,7 +606,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -644,7 +622,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -661,7 +638,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -678,7 +654,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -695,7 +670,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -798,7 +772,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -812,7 +785,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -826,7 +798,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -840,7 +811,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -854,7 +824,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -868,7 +837,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -882,7 +850,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -896,7 +863,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -910,7 +876,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -924,7 +889,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -938,7 +902,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -952,7 +915,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -966,7 +928,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -980,7 +941,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -994,7 +954,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1008,7 +967,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1022,7 +980,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1036,7 +993,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1050,7 +1006,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1064,7 +1019,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1078,7 +1032,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1092,7 +1045,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1106,7 +1058,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1120,7 +1071,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1134,7 +1084,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1854,7 +1803,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,

--- a/apps/ui/src/components/FullMapOverlay.svelte
+++ b/apps/ui/src/components/FullMapOverlay.svelte
@@ -207,11 +207,6 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <div class="map-embed">
-	<div class="overlay-header">
-		<span class="overlay-title">Parish Map</span>
-		<span class="overlay-hint">Scroll to zoom &middot; Drag to pan &middot; M to close</span>
-		<button class="close-btn" onclick={onclose} title="Close (M)">&times;</button>
-	</div>
 	<div
 		class="map-viewport"
 		onwheel={handleWheel}
@@ -367,44 +362,7 @@
 		position: relative;
 	}
 
-	.overlay-header {
-		display: flex;
-		align-items: center;
-		gap: 0.75rem;
-		padding: 0.5rem 0.75rem;
-		border-bottom: 1px solid var(--color-border);
-		flex-shrink: 0;
-	}
-
-	.overlay-title {
-		font-size: 0.9rem;
-		font-weight: 600;
-		color: var(--color-fg);
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-	}
-
-	.overlay-hint {
-		font-size: 0.7rem;
-		color: var(--color-muted);
-		flex: 1;
-	}
-
-	.close-btn {
-		background: none;
-		border: none;
-		color: var(--color-muted);
-		font-size: 1.4rem;
-		cursor: pointer;
-		padding: 0 4px;
-		line-height: 1;
-	}
-
-	.close-btn:hover {
-		color: var(--color-fg);
-	}
-
-	.map-viewport {
+.map-viewport {
 		flex: 1;
 		overflow: hidden;
 		cursor: grab;

--- a/apps/ui/src/components/FullMapOverlay.svelte
+++ b/apps/ui/src/components/FullMapOverlay.svelte
@@ -202,31 +202,23 @@
 		dragging = false;
 	}
 
-	function handleBackdropClick(e: MouseEvent) {
-		if (e.target === e.currentTarget) {
-			onclose();
-		}
-	}
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
 
-<!-- svelte-ignore a11y_click_events_have_key_events -->
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<div class="overlay-backdrop" onclick={handleBackdropClick}>
-	<div class="overlay-container">
-		<div class="overlay-header">
-			<span class="overlay-title">Parish Map</span>
-			<span class="overlay-hint">Scroll to zoom &middot; Drag to pan &middot; Esc to close</span>
-			<button class="close-btn" onclick={onclose} title="Close (Esc)">&times;</button>
-		</div>
-		<div
-			class="map-viewport"
-			onwheel={handleWheel}
-			onpointerdown={handlePointerDown}
-			onpointermove={handlePointerMove}
-			onpointerup={handlePointerUp}
-		>
+<div class="map-embed">
+	<div class="overlay-header">
+		<span class="overlay-title">Parish Map</span>
+		<span class="overlay-hint">Scroll to zoom &middot; Drag to pan &middot; M to close</span>
+		<button class="close-btn" onclick={onclose} title="Close (M)">&times;</button>
+	</div>
+	<div
+		class="map-viewport"
+		onwheel={handleWheel}
+		onpointerdown={handlePointerDown}
+		onpointermove={handlePointerMove}
+		onpointerup={handlePointerUp}
+	>
 			<svg
 				viewBox="0 0 {svgW} {svgH}"
 				xmlns="http://www.w3.org/2000/svg"
@@ -347,47 +339,32 @@
 				{/if}
 			</svg>
 		</div>
-		{#if tooltip}
-			<div class="tooltip">
-				<div class="tooltip-name">{tooltip.name}</div>
-				{#if tooltip.visited === false}
-					<div class="tooltip-detail tooltip-unexplored">Unexplored</div>
-				{:else}
-					{#if tooltip.indoor !== undefined}
-						<div class="tooltip-detail">{tooltip.indoor ? 'Indoor' : 'Outdoor'}</div>
-					{/if}
-					{#if tooltip.travel_minutes != null && tooltip.travel_minutes > 0}
-						<div class="tooltip-detail">{tooltip.travel_minutes} min walk</div>
-					{/if}
+	{#if tooltip}
+		<div class="tooltip">
+			<div class="tooltip-name">{tooltip.name}</div>
+			{#if tooltip.visited === false}
+				<div class="tooltip-detail tooltip-unexplored">Unexplored</div>
+			{:else}
+				{#if tooltip.indoor !== undefined}
+					<div class="tooltip-detail">{tooltip.indoor ? 'Indoor' : 'Outdoor'}</div>
 				{/if}
-			</div>
-		{/if}
-	</div>
+				{#if tooltip.travel_minutes != null && tooltip.travel_minutes > 0}
+					<div class="tooltip-detail">{tooltip.travel_minutes} min walk</div>
+				{/if}
+			{/if}
+		</div>
+	{/if}
 </div>
 
 <style>
-	.overlay-backdrop {
-		position: fixed;
-		inset: 0;
-		background: rgba(0, 0, 0, 0.6);
-		z-index: 1000;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
-
-	.overlay-container {
-		background: var(--color-panel-bg);
-		border: 1px solid var(--color-border);
-		border-radius: 8px;
-		width: 90vw;
-		max-width: 900px;
-		height: 80vh;
-		max-height: 700px;
+	.map-embed {
+		flex: 1;
+		min-height: 0;
 		display: flex;
 		flex-direction: column;
-		position: relative;
 		overflow: hidden;
+		background: var(--color-panel-bg);
+		position: relative;
 	}
 
 	.overlay-header {

--- a/apps/ui/src/components/Sidebar.svelte
+++ b/apps/ui/src/components/Sidebar.svelte
@@ -1,38 +1,134 @@
 <script lang="ts">
 	import { languageHints, nameHints, uiConfig } from '../stores/game';
+
+	let { onclose }: { onclose?: () => void } = $props();
 </script>
 
-<aside class="sidebar" data-testid="sidebar">
-	<details open>
-		<summary>{$uiConfig.hints_label}</summary>
-		{#if $nameHints.length > 0 || $languageHints.length > 0}
-			<ul class="hint-list">
-				{#each $nameHints as hint}
-					<li class="hint-item name-hint">
-						<span class="word">{hint.word}</span>
-						<span class="pronunciation">[{hint.pronunciation}]</span>
-						{#if hint.meaning}
-							<span class="meaning">— {hint.meaning}</span>
-						{/if}
-					</li>
-				{/each}
-				{#each $languageHints as hint}
-					<li class="hint-item">
-						<span class="word">{hint.word}</span>
-						<span class="pronunciation">[{hint.pronunciation}]</span>
-						{#if hint.meaning}
-							<span class="meaning">— {hint.meaning}</span>
-						{/if}
-					</li>
-				{/each}
-			</ul>
-		{:else}
-			<p class="empty">No words yet.</p>
-		{/if}
-	</details>
-</aside>
+{#if onclose}
+	<div class="focail-panel">
+		<div class="panel-header">
+			<span class="panel-title"><span class="panel-title-word">Focail Gaeilge</span> <span class="panel-title-label">(Irish Words)</span></span>
+			<button class="close-btn" onclick={onclose}>&times;</button>
+		</div>
+		<div class="panel-content">
+			{#if $nameHints.length > 0 || $languageHints.length > 0}
+				<ul class="hint-list">
+					{#each $nameHints as hint}
+						<li class="hint-item name-hint">
+							<span class="word">{hint.word}</span>
+							<span class="pronunciation">[{hint.pronunciation}]</span>
+							{#if hint.meaning}
+								<span class="meaning">— {hint.meaning}</span>
+							{/if}
+						</li>
+					{/each}
+					{#each $languageHints as hint}
+						<li class="hint-item">
+							<span class="word">{hint.word}</span>
+							<span class="pronunciation">[{hint.pronunciation}]</span>
+							{#if hint.meaning}
+								<span class="meaning">— {hint.meaning}</span>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<p class="empty">No words yet.</p>
+			{/if}
+		</div>
+	</div>
+{:else}
+	<aside class="sidebar" data-testid="sidebar">
+		<details open>
+			<summary>{$uiConfig.hints_label}</summary>
+			{#if $nameHints.length > 0 || $languageHints.length > 0}
+				<ul class="hint-list">
+					{#each $nameHints as hint}
+						<li class="hint-item name-hint">
+							<span class="word">{hint.word}</span>
+							<span class="pronunciation">[{hint.pronunciation}]</span>
+							{#if hint.meaning}
+								<span class="meaning">— {hint.meaning}</span>
+							{/if}
+						</li>
+					{/each}
+					{#each $languageHints as hint}
+						<li class="hint-item">
+							<span class="word">{hint.word}</span>
+							<span class="pronunciation">[{hint.pronunciation}]</span>
+							{#if hint.meaning}
+								<span class="meaning">— {hint.meaning}</span>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+			{:else}
+				<p class="empty">No words yet.</p>
+			{/if}
+		</details>
+	</aside>
+{/if}
 
 <style>
+	.focail-panel {
+		flex: 1;
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		overflow: hidden;
+		background: var(--color-panel-bg);
+	}
+
+	.panel-header {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		border-bottom: 1px solid var(--color-border);
+		flex-shrink: 0;
+	}
+
+	.panel-title {
+		flex: 1;
+		display: flex;
+		align-items: baseline;
+		gap: 0.4em;
+	}
+
+	.panel-title-word {
+		color: var(--color-accent);
+		font-weight: 600;
+		font-style: italic;
+		font-size: 0.85rem;
+	}
+
+	.panel-title-label {
+		font-family: var(--font-display);
+		font-size: 0.62rem;
+		text-transform: uppercase;
+		letter-spacing: 0.13em;
+		color: var(--color-muted);
+	}
+
+	.close-btn {
+		background: none;
+		border: none;
+		color: var(--color-muted);
+		font-size: 1.4rem;
+		cursor: pointer;
+		padding: 0 4px;
+		line-height: 1;
+	}
+
+	.close-btn:hover {
+		color: var(--color-fg);
+	}
+
+	.panel-content {
+		flex: 1;
+		overflow-y: auto;
+	}
+
 	.sidebar {
 		background: var(--color-panel-bg);
 		border-left: 1px solid var(--color-border);

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -371,10 +371,6 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-{#if $fullMapOpen}
-	<FullMapOverlay onclose={() => fullMapOpen.set(false)} />
-{/if}
-
 <div class="app-shell" class:debug-open={$debugVisible}>
 	<StatusBar />
 
@@ -382,20 +378,38 @@
 	<div class="mobile-toolbar">
 		<button
 			class="mobile-btn"
-			class:active={mobilePanel === 'map'}
-			onclick={() => mobilePanel = mobilePanel === 'map' ? 'none' : 'map'}
+			class:active={$fullMapOpen}
+			onclick={() => {
+				if ($fullMapOpen) {
+					fullMapOpen.set(false);
+				} else {
+					mobilePanel = 'none';
+					fullMapOpen.set(true);
+				}
+			}}
 		>Map</button>
 		<button
 			class="mobile-btn"
 			class:active={mobilePanel === 'sidebar'}
-			onclick={() => mobilePanel = mobilePanel === 'sidebar' ? 'none' : 'sidebar'}
+			onclick={() => {
+				if (mobilePanel === 'sidebar') {
+					mobilePanel = 'none';
+				} else {
+					fullMapOpen.set(false);
+					mobilePanel = 'sidebar';
+				}
+			}}
 		>Hints</button>
 	</div>
 
 	<div class="main-area">
 		<div class="chat-col" class:mobile-hidden={mobilePanel !== 'none'}>
-			<ChatPanel />
-			<InputField />
+			{#if $fullMapOpen}
+				<FullMapOverlay onclose={() => fullMapOpen.set(false)} />
+			{:else}
+				<ChatPanel />
+				<InputField />
+			{/if}
 		</div>
 		<div class="right-col">
 			<MapPanel />
@@ -404,17 +418,11 @@
 	</div>
 
 	<!-- Mobile-only panel (replaces chat area when open) -->
-	{#if mobilePanel !== 'none'}
+	{#if mobilePanel === 'sidebar'}
 		<div class="mobile-panel">
-			{#if mobilePanel === 'map'}
-				<div class="mobile-panel-inner">
-					<MapPanel />
-				</div>
-			{:else}
-				<div class="mobile-panel-inner">
-					<Sidebar />
-				</div>
-			{/if}
+			<div class="mobile-panel-inner">
+				<Sidebar />
+			</div>
 		</div>
 	{/if}
 </div>

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -10,7 +10,7 @@
 	import DebugPanel from '../components/DebugPanel.svelte';
 	import SavePicker from '../components/SavePicker.svelte';
 
-	import { worldState, mapData, npcsHere, textLog, streamingActive, loadingSpinner, loadingPhrase, loadingColor, languageHints, nameHints, uiConfig, fullMapOpen, addReaction, trimTextLog } from '../stores/game';
+	import { worldState, mapData, npcsHere, textLog, streamingActive, loadingSpinner, loadingPhrase, loadingColor, languageHints, nameHints, uiConfig, fullMapOpen, focailOpen, addReaction, trimTextLog } from '../stores/game';
 
 	/** Which mobile-only panel is open (if any). Desktop ignores this. */
 	let mobilePanel = $state<'none' | 'map' | 'sidebar'>('none');
@@ -384,28 +384,32 @@
 					fullMapOpen.set(false);
 				} else {
 					mobilePanel = 'none';
+					focailOpen.set(false);
 					fullMapOpen.set(true);
 				}
 			}}
 		>Map</button>
 		<button
 			class="mobile-btn"
-			class:active={mobilePanel === 'sidebar'}
+			class:active={$focailOpen}
 			onclick={() => {
-				if (mobilePanel === 'sidebar') {
-					mobilePanel = 'none';
+				if ($focailOpen) {
+					focailOpen.set(false);
 				} else {
+					mobilePanel = 'none';
 					fullMapOpen.set(false);
-					mobilePanel = 'sidebar';
+					focailOpen.set(true);
 				}
 			}}
-		>Hints</button>
+		>Language Hints</button>
 	</div>
 
 	<div class="main-area">
 		<div class="chat-col" class:mobile-hidden={mobilePanel !== 'none'}>
 			{#if $fullMapOpen}
 				<FullMapOverlay onclose={() => fullMapOpen.set(false)} />
+			{:else if $focailOpen}
+				<Sidebar onclose={() => focailOpen.set(false)} />
 			{:else}
 				<ChatPanel />
 				<InputField />
@@ -417,14 +421,6 @@
 		</div>
 	</div>
 
-	<!-- Mobile-only panel (replaces chat area when open) -->
-	{#if mobilePanel === 'sidebar'}
-		<div class="mobile-panel">
-			<div class="mobile-panel-inner">
-				<Sidebar />
-			</div>
-		</div>
-	{/if}
 </div>
 
 <DebugPanel />
@@ -468,18 +464,6 @@
 
 	/* ── Mobile toolbar ── */
 	.mobile-toolbar {
-		display: none;
-	}
-
-	:global(.status-bar) {
-		position: sticky;
-		top: 0;
-		z-index: 30;
-		flex-shrink: 0;
-	}
-
-	/* ── Mobile panel (shown when a toolbar button is active) ── */
-	.mobile-panel {
 		display: none;
 	}
 
@@ -527,19 +511,5 @@
 			border-color: var(--color-accent);
 		}
 
-		.mobile-panel {
-			display: flex;
-			flex: 1;
-			min-height: 0;
-			overflow: hidden;
-		}
-
-		.mobile-panel-inner {
-			flex: 1;
-			display: flex;
-			flex-direction: column;
-			overflow-y: auto;
-			background: var(--color-bg);
-		}
 	}
 </style>

--- a/apps/ui/src/stores/game.ts
+++ b/apps/ui/src/stores/game.ts
@@ -41,6 +41,8 @@ export const uiConfig = writable<UiConfig>({
 
 export const fullMapOpen = writable<boolean>(false);
 
+export const focailOpen = writable<boolean>(false);
+
 /** Adds a reaction to a message in the text log by message ID. */
 export function addReaction(messageId: string, emoji: string, source: string): void {
 	textLog.update((log) => {


### PR DESCRIPTION
On desktop, opening the full map now fills the chat column rather than
appearing as a fixed-position modal popup over the entire UI. The right
column (minimap + sidebar) remains visible alongside it.

On mobile, the Map toolbar button now opens the full map directly instead
of showing the minimap with a separate expand button.

https://claude.ai/code/session_01MXLEoBu6fa546GyY3Ah1C5