### PR TITLE
Add per-visitor ledger isolation, Google OAuth, and tab-visibility pause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,8 +1353,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1746,6 +1754,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2227,6 +2236,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2848,15 +2863,20 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "dashmap",
  "dotenvy",
  "parish-core",
  "rand 0.8.5",
+ "reqwest 0.12.28",
+ "rusqlite",
  "serde",
  "serde_json",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-http",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3312,6 +3332,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3551,6 +3626,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3558,6 +3635,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3567,6 +3645,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3666,6 +3745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3678,6 +3758,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4787,6 +4868,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5603,6 +5699,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,6 +2871,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tower",

--- a/apps/ui/src/components/AuthStatus.svelte
+++ b/apps/ui/src/components/AuthStatus.svelte
@@ -23,9 +23,11 @@
 {#if status?.oauth_enabled}
 	<span class="sep">·</span>
 	{#if status.logged_in}
-		<span class="auth-indicator" title="Signed in with Google">
+		<span class="auth-indicator" title="Signed in with Google — your saves are synced">
 			✓ {status.display_name ?? 'Google'}
 		</span>
+		<span class="sep">·</span>
+		<a href="/auth/logout" class="auth-link">Sign out</a>
 	{:else}
 		<a href="/auth/login/google" class="auth-link">Login with Google</a>
 	{/if}

--- a/apps/ui/src/components/AuthStatus.svelte
+++ b/apps/ui/src/components/AuthStatus.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	interface AuthStatus {
+		oauth_enabled: boolean;
+		logged_in: boolean;
+		provider?: string;
+		display_name?: string;
+	}
+
+	let status = $state<AuthStatus | null>(null);
+
+	onMount(async () => {
+		try {
+			const resp = await fetch('/api/auth/status');
+			if (resp.ok) status = await resp.json();
+		} catch {
+			// Not critical — auth UI is optional
+		}
+	});
+</script>
+
+{#if status?.oauth_enabled}
+	<span class="sep">·</span>
+	{#if status.logged_in}
+		<span class="auth-indicator" title="Signed in with Google">
+			✓ {status.display_name ?? 'Google'}
+		</span>
+	{:else}
+		<a href="/auth/login/google" class="auth-link">Login with Google</a>
+	{/if}
+{/if}
+
+<style>
+	.auth-indicator {
+		color: var(--color-muted);
+		font-size: 0.6rem;
+		letter-spacing: 0.07em;
+		white-space: nowrap;
+	}
+
+	.auth-link {
+		color: var(--color-muted);
+		font-size: 0.6rem;
+		letter-spacing: 0.07em;
+		text-decoration: none;
+		border-bottom: 1px solid var(--color-border);
+		transition: color 0.2s, border-color 0.2s;
+		white-space: nowrap;
+	}
+
+	.auth-link:hover {
+		color: var(--color-accent);
+		border-color: var(--color-accent);
+	}
+
+	.sep {
+		color: var(--color-border);
+		font-size: 0.7rem;
+		letter-spacing: 0;
+		opacity: 0.8;
+	}
+</style>

--- a/apps/ui/src/components/DebugPanel.svelte
+++ b/apps/ui/src/components/DebugPanel.svelte
@@ -173,6 +173,27 @@
 						{/each}
 					{/if}
 				</div>
+				<div class="section">
+					<h4>Auth</h4>
+					{#if snap.auth.oauth_enabled}
+						{#if snap.auth.logged_in}
+							<div class="field">
+								<span class="accent">✓ Signed in</span>
+								{#if snap.auth.provider}<span class="muted"> via {snap.auth.provider}</span>{/if}
+							</div>
+							{#if snap.auth.display_name}
+								<div class="field muted">User: {snap.auth.display_name}</div>
+							{/if}
+						{:else}
+							<div class="field muted">OAuth enabled · not signed in</div>
+						{/if}
+					{:else}
+						<div class="field muted">OAuth disabled (no credentials configured)</div>
+					{/if}
+					{#if snap.auth.session_id}
+						<div class="field muted">Session: {snap.auth.session_id}</div>
+					{/if}
+				</div>
 
 			{:else if tab === 1}
 				<!-- NPCs -->

--- a/apps/ui/src/components/DebugPanel.svelte
+++ b/apps/ui/src/components/DebugPanel.svelte
@@ -61,7 +61,7 @@
 	<div class="debug-panel">
 		<div class="debug-header">
 			<span class="debug-title">Debug</span>
-			<button class="debug-close" on:click={() => debugVisible.set(false)}>X</button>
+			<button class="debug-close" onclick={() => debugVisible.set(false)}>X</button>
 		</div>
 
 		<div class="tab-bar">
@@ -69,7 +69,7 @@
 				<button
 					class="tab-btn"
 					class:active={tab === i}
-					on:click={() => selectTab(i)}
+					onclick={() => selectTab(i)}
 				>
 					{tabName}
 				</button>
@@ -178,7 +178,7 @@
 				<!-- NPCs -->
 				{#if selectedNpc}
 					<div class="npc-detail">
-						<button class="back-btn" on:click={deselectNpc}>Back to list</button>
+						<button class="back-btn" onclick={deselectNpc}>Back to list</button>
 						<h4 class="accent">{selectedNpc.name}</h4>
 
 						<div class="section">
@@ -316,7 +316,7 @@
 				{:else}
 					<div class="npc-list">
 						{#each snap.npcs as npc}
-							<button class="npc-row" on:click={() => selectNpc(npc.id)}>
+							<button class="npc-row" onclick={() => selectNpc(npc.id)}>
 								<span class="npc-name">{npc.name}</span>
 								<span class="npc-tier">[{npc.tier}]</span>
 								<span class="npc-mood">{npc.mood}</span>
@@ -455,7 +455,7 @@
 				{@const selectedEntry = snap.inference.call_log.find(e => e.request_id === selectedLogId) ?? null}
 				{#if selectedEntry}
 					<!-- Detail view: one long scrollable page -->
-					<button class="back-btn" on:click={deselectLog}>Back to list</button>
+					<button class="back-btn" onclick={deselectLog}>Back to list</button>
 					{@const npcLabel = npcLabelFromEntry(selectedEntry)}
 					<div class="log-detail-header">
 						<span class="muted">[{selectedEntry.timestamp}]</span>
@@ -499,7 +499,7 @@
 							<div class="field muted">Avg latency: {avgMs}ms | Errors: {errorCount}</div>
 							{#each [...snap.inference.call_log].reverse() as entry}
 								{@const npcLabel = npcLabelFromEntry(entry)}
-								<button class="log-row" class:log-row-error={entry.error} on:click={() => selectLog(entry.request_id)}>
+								<button class="log-row" class:log-row-error={entry.error} onclick={() => selectLog(entry.request_id)}>
 									<span class="muted">[{entry.timestamp}]</span>
 									<span class="log-id">#{entry.request_id}</span>
 									{#if npcLabel}<span class="log-npc accent">{npcLabel}</span>{:else}<span class="log-model">{entry.model}</span>{/if}

--- a/apps/ui/src/components/StatusBar.svelte
+++ b/apps/ui/src/components/StatusBar.svelte
@@ -3,6 +3,7 @@
 	import { debugVisible } from '../stores/debug';
 	import { savePickerVisible } from '../stores/save';
 	import { onMount, onDestroy } from 'svelte';
+	import AuthStatus from './AuthStatus.svelte';
 
 	let displayHour = $state(0);
 	let displayMinute = $state(0);
@@ -86,6 +87,7 @@
 		<button class="save-toggle" class:save-active={$savePickerVisible} onclick={() => savePickerVisible.update(v => !v)} title="Save/Load picker (F5)">Ledger</button>
 		<a class="designer-link" href="/editor" title="Parish Designer — edit mod data">Designer</a>
 		<button class="debug-toggle" class:debug-active={$debugVisible} onclick={() => debugVisible.update(v => !v)} title="Toggle debug panel (F12)">Dbg</button>
+		<AuthStatus />
 		<span class="clock">{#each displayHour.toString().padStart(2, '0').split('') as d}<span class="digit">{d}</span>{/each}<span class="colon">:</span>{#each displayMinute.toString().padStart(2, '0').split('') as d}<span class="digit">{d}</span>{/each}</span>
 	{:else}
 		<span class="muted">Loading…</span>

--- a/apps/ui/src/lib/types.ts
+++ b/apps/ui/src/lib/types.ts
@@ -176,6 +176,15 @@ export interface DebugSnapshot {
 	conversations: ConversationsDebug;
 	events: DebugEvent[];
 	inference: InferenceDebug;
+	auth: AuthDebug;
+}
+
+export interface AuthDebug {
+	oauth_enabled: boolean;
+	logged_in: boolean;
+	provider: string | null;
+	display_name: string | null;
+	session_id: string | null;
 }
 
 export interface ClockDebug {

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -182,6 +182,24 @@
 		window.addEventListener('touchstart', onTrackerTouch);
 		window.addEventListener('mousemove', onTrackerMousemove);
 
+		// Pause immediately when the tab is hidden; resume when it returns.
+		// Only pauses if the game wasn't already paused, and only resumes if
+		// this handler was the one that paused it.
+		let visibilityPaused = false;
+		const handleVisibilityChange = () => {
+			if (document.hidden) {
+				const alreadyPaused = get(worldState)?.paused ?? false;
+				if (!alreadyPaused) {
+					void submitInput('/pause');
+					visibilityPaused = true;
+				}
+			} else if (visibilityPaused) {
+				void submitInput('/resume');
+				visibilityPaused = false;
+			}
+		};
+		document.addEventListener('visibilitychange', handleVisibilityChange);
+
 		// Initial data fetch (theme first to avoid color flash).
 		//
 		// Use `allSettled` so a single failed endpoint doesn't block the
@@ -524,6 +542,7 @@
 			window.removeEventListener('mousedown', onTrackerMousedown);
 			window.removeEventListener('touchstart', onTrackerTouch);
 			window.removeEventListener('mousemove', onTrackerMousemove);
+			document.removeEventListener('visibilitychange', handleVisibilityChange);
 			tracker.dispose();
 			pendingNpcTurns.forEach((turn) => stopTurnPump(turn));
 			listeners.forEach((fn) => fn());

--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -42,6 +42,40 @@ pub struct DebugSnapshot {
     pub events: Vec<DebugEvent>,
     /// Inference pipeline configuration.
     pub inference: InferenceDebug,
+    /// Auth state for this session (web-server only; disabled on Tauri).
+    pub auth: AuthDebug,
+}
+
+/// Auth state for debug display.
+///
+/// On the web server, reflects the current visitor's session + OAuth linkage.
+/// On Tauri (single local user), `oauth_enabled` is always `false`.
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthDebug {
+    /// Whether the server has Google OAuth credentials configured.
+    pub oauth_enabled: bool,
+    /// Whether the current session is linked to an OAuth account.
+    pub logged_in: bool,
+    /// OAuth provider name when `logged_in` (currently always `"google"`).
+    pub provider: Option<String>,
+    /// Display name or stable id for the linked account.
+    pub display_name: Option<String>,
+    /// Current session id (the `parish_sid` cookie). `None` on Tauri.
+    pub session_id: Option<String>,
+}
+
+impl AuthDebug {
+    /// Returns an `AuthDebug` for contexts where OAuth is not applicable
+    /// (e.g. the Tauri desktop app).
+    pub fn disabled() -> Self {
+        Self {
+            oauth_enabled: false,
+            logged_in: false,
+            provider: None,
+            display_name: None,
+            session_id: None,
+        }
+    }
 }
 
 /// Game clock state for debug display.
@@ -495,6 +529,7 @@ pub fn build_debug_snapshot(
     events: &VecDeque<DebugEvent>,
     game_events: &VecDeque<crate::world::events::GameEvent>,
     inference: &InferenceDebug,
+    auth: &AuthDebug,
 ) -> DebugSnapshot {
     let clock = build_clock_debug(world);
     let weather = build_weather_debug(world);
@@ -526,6 +561,7 @@ pub fn build_debug_snapshot(
         conversations,
         events: event_list,
         inference: inference.clone(),
+        auth: auth.clone(),
     }
 }
 
@@ -1079,8 +1115,14 @@ mod tests {
         let game_events: VecDeque<GameEvent> = VecDeque::new();
         let inference = test_inference();
 
-        let snapshot =
-            build_debug_snapshot(&world, &npc_manager, &events, &game_events, &inference);
+        let snapshot = build_debug_snapshot(
+            &world,
+            &npc_manager,
+            &events,
+            &game_events,
+            &inference,
+            &AuthDebug::disabled(),
+        );
 
         assert!(snapshot.clock.game_time.contains("08:00"));
         assert_eq!(snapshot.clock.weather, "Clear");
@@ -1106,8 +1148,14 @@ mod tests {
         let mut inference = test_inference();
         inference.has_queue = true;
 
-        let snapshot =
-            build_debug_snapshot(&world, &npc_manager, &events, &game_events, &inference);
+        let snapshot = build_debug_snapshot(
+            &world,
+            &npc_manager,
+            &events,
+            &game_events,
+            &inference,
+            &AuthDebug::disabled(),
+        );
 
         assert_eq!(snapshot.npcs.len(), 1);
         assert_eq!(snapshot.npcs[0].name, "Padraig O'Brien");
@@ -1251,7 +1299,14 @@ mod tests {
         let mut inference = test_inference();
         inference.call_log = vec![entry];
 
-        let snapshot = build_debug_snapshot(&world, &mgr, &events, &game_events, &inference);
+        let snapshot = build_debug_snapshot(
+            &world,
+            &mgr,
+            &events,
+            &game_events,
+            &inference,
+            &AuthDebug::disabled(),
+        );
         assert_eq!(snapshot.inference.call_log.len(), 1);
         assert_eq!(snapshot.inference.call_log[0].request_id, 1);
         assert_eq!(snapshot.inference.call_log[0].duration_ms, 500);
@@ -1275,7 +1330,14 @@ mod tests {
         });
         let inference = test_inference();
 
-        let snapshot = build_debug_snapshot(&world, &mgr, &events, &game_events, &inference);
+        let snapshot = build_debug_snapshot(
+            &world,
+            &mgr,
+            &events,
+            &game_events,
+            &inference,
+            &AuthDebug::disabled(),
+        );
         assert_eq!(snapshot.events.len(), 2);
         assert_eq!(snapshot.events[0].message, "Test event");
         assert_eq!(snapshot.events[1].category, "schedule");
@@ -1358,7 +1420,14 @@ mod tests {
             improv_enabled: false,
             call_log: vec![],
         };
-        let snapshot = build_debug_snapshot(&world, &mgr, &events, &game_events, &inference);
+        let snapshot = build_debug_snapshot(
+            &world,
+            &mgr,
+            &events,
+            &game_events,
+            &inference,
+            &AuthDebug::disabled(),
+        );
         let json = serde_json::to_string(&snapshot).unwrap();
         assert!(json.contains("gossip"));
         assert!(json.contains("item_count"));

--- a/crates/parish-core/src/ipc/config.rs
+++ b/crates/parish-core/src/ipc/config.rs
@@ -12,6 +12,7 @@ use crate::inference::InferenceRateLimiter;
 ///
 /// Each backend wraps this in the appropriate synchronisation primitive
 /// (`Mutex<GameConfig>` for Tauri/web, direct field for headless `App`).
+#[derive(Clone)]
 pub struct GameConfig {
     /// Display name of the current base provider (e.g. "ollama", "openrouter").
     pub provider_name: String,

--- a/crates/parish-server/Cargo.toml
+++ b/crates/parish-server/Cargo.toml
@@ -9,6 +9,7 @@ parish-core = { path = "../parish-core" }
 axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["fs", "cors"] }
+tower = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"
@@ -17,3 +18,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "0.15"
 rand = "0.8"
 tokio-util = "0.7"
+uuid = { version = "1", features = ["v4"] }
+dashmap = "6"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/crates/parish-server/Cargo.toml
+++ b/crates/parish-server/Cargo.toml
@@ -22,3 +22,6 @@ uuid = { version = "1", features = ["v4"] }
 dashmap = "6"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 rusqlite = { version = "0.32", features = ["bundled"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/parish-server/src/auth.rs
+++ b/crates/parish-server/src/auth.rs
@@ -126,7 +126,7 @@ pub async fn callback_google(
     };
 
     // Fetch user info.
-    let (provider_user_id, _display_name) = match fetch_user_info(&access_token).await {
+    let (provider_user_id, display_name) = match fetch_user_info(&access_token).await {
         Ok(u) => u,
         Err(e) => {
             tracing::warn!("Userinfo fetch failed: {}", e);
@@ -155,8 +155,8 @@ pub async fn callback_google(
         };
         global
             .sessions
-            .link_oauth("google", &provider_user_id, &sid);
-        tracing::info!(session_id = %sid, google_id = %provider_user_id, "Google account linked");
+            .link_oauth("google", &provider_user_id, &sid, &display_name);
+        tracing::info!(session_id = %sid, google_id = %provider_user_id, name = %display_name, "Google account linked");
         sid
     };
 
@@ -177,6 +177,26 @@ pub async fn callback_google(
     }
     if let Ok(v) = HeaderValue::from_str(&clear_state_cookie) {
         response.headers_mut().append(header::SET_COOKIE, v);
+    }
+    response
+}
+
+/// `GET /auth/logout` — ends the current Google session.
+///
+/// Creates a fresh anonymous session and issues a new cookie so the browser
+/// starts clean.  The old session (and its saves) remain intact: the user can
+/// recover it by logging in again with the same Google account.
+pub async fn logout(State(global): State<Arc<GlobalState>>) -> Response {
+    let (new_session_id, _, _) = get_or_create_session(&global, None).await;
+    global.sessions.persist_new(&new_session_id);
+
+    let cookie = format!(
+        "{}={}; HttpOnly; SameSite=Lax; Max-Age=31536000; Path=/",
+        SESSION_COOKIE, new_session_id
+    );
+    let mut response = Redirect::to("/").into_response();
+    if let Ok(v) = HeaderValue::from_str(&cookie) {
+        response.headers_mut().insert(header::SET_COOKIE, v);
     }
     response
 }
@@ -269,16 +289,12 @@ async fn fetch_user_info(access_token: &str) -> Result<(String, String), String>
 
 /// Looks up the Google account linked to `session_id`.
 ///
-/// Returns `(provider_user_id, display_name)` if found.  The Google `sub`
-/// doubles as the display name since we don't persist the user's name.
+/// Returns `(provider_user_id, display_name)` if found.
 fn find_oauth_account_for_session(
     global: &GlobalState,
     session_id: &str,
 ) -> Option<(String, String)> {
-    global
-        .sessions
-        .google_account_for_session(session_id)
-        .map(|uid| (uid.clone(), uid))
+    global.sessions.google_account_for_session(session_id)
 }
 
 /// Reads a named cookie value from a `HeaderMap`.

--- a/crates/parish-server/src/auth.rs
+++ b/crates/parish-server/src/auth.rs
@@ -1,0 +1,316 @@
+//! Google OAuth 2.0 login flow and auth status endpoint.
+//!
+//! Routes are only registered when `GOOGLE_CLIENT_ID` and
+//! `GOOGLE_CLIENT_SECRET` environment variables are set.
+//!
+//! Flow:
+//!   1. `GET /auth/login/google`   — redirect to Google's consent screen
+//!   2. `GET /auth/callback/google` — exchange code, link session, redirect to /
+//!   3. `GET /api/auth/status`     — returns current auth state (for UI)
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Redirect, Response};
+
+use crate::middleware::SESSION_COOKIE;
+use crate::session::{GlobalState, get_or_create_session};
+
+// ── Request / response types ──────────────────────────────────────────────────
+
+#[derive(serde::Deserialize)]
+pub struct CallbackParams {
+    pub code: Option<String>,
+    pub state: Option<String>,
+    pub error: Option<String>,
+}
+
+/// Response body for `GET /api/auth/status`.
+#[derive(serde::Serialize)]
+pub struct AuthStatus {
+    /// Whether Google OAuth is configured on this server instance.
+    pub oauth_enabled: bool,
+    /// Whether the current session is linked to a Google account.
+    pub logged_in: bool,
+    /// OAuth provider name (always `"google"` when `logged_in` is true).
+    pub provider: Option<String>,
+    /// Google display name or email.
+    pub display_name: Option<String>,
+}
+
+// ── OAuth cookie name for CSRF state ─────────────────────────────────────────
+
+const OAUTH_STATE_COOKIE: &str = "parish_oauth_state";
+
+// ── Google OAuth endpoints ────────────────────────────────────────────────────
+
+const GOOGLE_AUTH_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+const GOOGLE_USERINFO_URL: &str = "https://www.googleapis.com/oauth2/v3/userinfo";
+
+// ── Handlers ──────────────────────────────────────────────────────────────────
+
+/// `GET /auth/login/google` — redirects to Google's OAuth consent screen.
+pub async fn login_google(State(global): State<Arc<GlobalState>>) -> Response {
+    let Some(ref cfg) = global.oauth_config else {
+        return (StatusCode::NOT_FOUND, "OAuth not configured").into_response();
+    };
+
+    let csrf_state = uuid::Uuid::new_v4().to_string();
+    let redirect_uri = format!(
+        "{}/auth/callback/google",
+        cfg.base_url.trim_end_matches('/')
+    );
+
+    let url = format!(
+        "{}?client_id={}&redirect_uri={}&response_type=code\
+         &scope=openid%20email%20profile&state={}",
+        GOOGLE_AUTH_URL,
+        urlenccode(&cfg.client_id),
+        urlenccode(&redirect_uri),
+        urlenccode(&csrf_state),
+    );
+
+    let state_cookie = format!(
+        "{}={}; HttpOnly; SameSite=Lax; Max-Age=600; Path=/",
+        OAUTH_STATE_COOKIE, csrf_state
+    );
+
+    let mut response = Redirect::to(&url).into_response();
+    if let Ok(v) = HeaderValue::from_str(&state_cookie) {
+        response.headers_mut().insert(header::SET_COOKIE, v);
+    }
+    response
+}
+
+/// `GET /auth/callback/google` — handles the OAuth redirect from Google.
+pub async fn callback_google(
+    State(global): State<Arc<GlobalState>>,
+    Query(params): Query<CallbackParams>,
+    headers: HeaderMap,
+) -> Response {
+    let Some(ref cfg) = global.oauth_config else {
+        return (StatusCode::NOT_FOUND, "OAuth not configured").into_response();
+    };
+
+    // Surface provider errors gracefully.
+    if let Some(err) = params.error {
+        tracing::warn!("Google OAuth error: {}", err);
+        return Redirect::to("/?oauth_error=1").into_response();
+    }
+
+    let Some(code) = params.code else {
+        return (StatusCode::BAD_REQUEST, "Missing code").into_response();
+    };
+
+    // CSRF check: the state param must match the cookie.
+    let expected_state = cookie_value(&headers, OAUTH_STATE_COOKIE);
+    if params.state.as_deref() != expected_state.as_deref() {
+        tracing::warn!("OAuth CSRF mismatch");
+        return (StatusCode::BAD_REQUEST, "Invalid state").into_response();
+    }
+
+    // Exchange the authorization code for an access token.
+    let redirect_uri = format!(
+        "{}/auth/callback/google",
+        cfg.base_url.trim_end_matches('/')
+    );
+    let access_token = match exchange_code(cfg, &code, &redirect_uri).await {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::warn!("Token exchange failed: {}", e);
+            return Redirect::to("/?oauth_error=1").into_response();
+        }
+    };
+
+    // Fetch user info.
+    let (provider_user_id, _display_name) = match fetch_user_info(&access_token).await {
+        Ok(u) => u,
+        Err(e) => {
+            tracing::warn!("Userinfo fetch failed: {}", e);
+            return Redirect::to("/?oauth_error=1").into_response();
+        }
+    };
+
+    // Determine which session to use.
+    let current_session_id = cookie_value(&headers, SESSION_COOKIE);
+
+    let target_session_id = if let Some(existing) =
+        global.sessions.find_by_oauth("google", &provider_user_id)
+    {
+        // A session is already linked to this Google account — use it.
+        existing
+    } else {
+        // Link the current anonymous session to this Google account.
+        let sid = match current_session_id.as_deref() {
+            Some(id) if global.sessions.exists_in_db(id) => id.to_string(),
+            _ => {
+                // No current session — create a fresh one.
+                let (new_id, _, _) = get_or_create_session(&global, None).await;
+                global.sessions.persist_new(&new_id);
+                new_id
+            }
+        };
+        global
+            .sessions
+            .link_oauth("google", &provider_user_id, &sid);
+        tracing::info!(session_id = %sid, google_id = %provider_user_id, "Google account linked");
+        sid
+    };
+
+    // Build the response: set the parish_sid cookie to the target session,
+    // clear the CSRF state cookie, and redirect to the game.
+    let session_cookie = format!(
+        "{}={}; HttpOnly; SameSite=Lax; Max-Age=31536000; Path=/",
+        SESSION_COOKIE, target_session_id
+    );
+    let clear_state_cookie = format!(
+        "{}=; HttpOnly; SameSite=Lax; Max-Age=0; Path=/",
+        OAUTH_STATE_COOKIE
+    );
+
+    let mut response = Redirect::to("/").into_response();
+    if let Ok(v) = HeaderValue::from_str(&session_cookie) {
+        response.headers_mut().insert(header::SET_COOKIE, v);
+    }
+    if let Ok(v) = HeaderValue::from_str(&clear_state_cookie) {
+        response.headers_mut().append(header::SET_COOKIE, v);
+    }
+    response
+}
+
+/// `GET /api/auth/status` — returns OAuth configuration and login state.
+pub async fn get_auth_status(
+    State(global): State<Arc<GlobalState>>,
+    headers: HeaderMap,
+) -> Json<AuthStatus> {
+    let oauth_enabled = global.oauth_config.is_some();
+
+    let session_id = match cookie_value(&headers, SESSION_COOKIE) {
+        Some(id) => id,
+        None => {
+            return Json(AuthStatus {
+                oauth_enabled,
+                logged_in: false,
+                provider: None,
+                display_name: None,
+            });
+        }
+    };
+
+    // Check whether this session has a linked OAuth account.
+    let linked = find_oauth_account_for_session(&global, &session_id);
+
+    Json(AuthStatus {
+        oauth_enabled,
+        logged_in: linked.is_some(),
+        provider: linked.as_ref().map(|_| "google".to_string()),
+        display_name: linked.map(|(_, name)| name),
+    })
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/// Exchanges an authorization code for a Google access token.
+async fn exchange_code(
+    cfg: &crate::session::OAuthConfig,
+    code: &str,
+    redirect_uri: &str,
+) -> Result<String, String> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(GOOGLE_TOKEN_URL)
+        .form(&[
+            ("code", code),
+            ("client_id", &cfg.client_id),
+            ("client_secret", &cfg.client_secret),
+            ("redirect_uri", redirect_uri),
+            ("grant_type", "authorization_code"),
+        ])
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let body: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
+    body["access_token"]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| format!("no access_token in response: {body}"))
+}
+
+/// Fetches the Google user's `sub` (stable ID) and display name.
+async fn fetch_user_info(access_token: &str) -> Result<(String, String), String> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(GOOGLE_USERINFO_URL)
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let body: serde_json::Value = resp.json().await.map_err(|e| e.to_string())?;
+
+    let sub = body["sub"]
+        .as_str()
+        .ok_or_else(|| "missing sub".to_string())?
+        .to_string();
+
+    // Prefer `name`; fall back to `email`.
+    let display_name = body["name"]
+        .as_str()
+        .or_else(|| body["email"].as_str())
+        .unwrap_or("Google user")
+        .to_string();
+
+    Ok((sub, display_name))
+}
+
+/// Looks up the Google account linked to `session_id`.
+///
+/// Returns `(provider_user_id, display_name)` if found.  The Google `sub`
+/// doubles as the display name since we don't persist the user's name.
+fn find_oauth_account_for_session(
+    global: &GlobalState,
+    session_id: &str,
+) -> Option<(String, String)> {
+    global
+        .sessions
+        .google_account_for_session(session_id)
+        .map(|uid| (uid.clone(), uid))
+}
+
+/// Reads a named cookie value from a `HeaderMap`.
+fn cookie_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers
+        .get(header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|cookies| {
+            for pair in cookies.split(';') {
+                let pair = pair.trim();
+                if let Some(rest) = pair.strip_prefix(name) {
+                    if let Some(rest) = rest.strip_prefix('=') {
+                        return Some(rest.trim().to_string());
+                    }
+                }
+            }
+            None
+        })
+}
+
+/// Minimal percent-encoding for OAuth URL parameters.
+fn urlenccode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => out.push(ch),
+            _ => {
+                for byte in ch.to_string().as_bytes() {
+                    out.push_str(&format!("%{byte:02X}"));
+                }
+            }
+        }
+    }
+    out
+}

--- a/crates/parish-server/src/auth.rs
+++ b/crates/parish-server/src/auth.rs
@@ -108,9 +108,14 @@ pub async fn callback_google(
     // CSRF check: the state param must match the cookie.
     let expected_state = cookie_value(&headers, OAUTH_STATE_COOKIE);
     if params.state.as_deref() != expected_state.as_deref() {
-        tracing::warn!("OAuth CSRF mismatch");
+        tracing::warn!(
+            received_state = ?params.state,
+            cookie_state = ?expected_state,
+            "OAuth CSRF mismatch"
+        );
         return (StatusCode::BAD_REQUEST, "Invalid state").into_response();
     }
+    tracing::info!(state = ?params.state, "OAuth CSRF state matched");
 
     // Exchange the authorization code for an access token.
     let redirect_uri = format!(
@@ -143,33 +148,46 @@ pub async fn callback_google(
         "OAuth callback: resolving target session"
     );
 
-    let target_session_id = if let Some(existing) =
-        global.sessions.find_by_oauth("google", &provider_user_id)
-    {
-        // A session is already linked to this Google account — use it.
-        tracing::info!(
-            existing_session_id = %existing,
-            "OAuth callback: found existing session linked to this Google account"
-        );
-        existing
-    } else {
-        // Link the current anonymous session to this Google account.
-        let sid = match current_session_id.as_deref() {
-            Some(id) if global.sessions.exists_in_db(id) => id.to_string(),
-            _ => {
-                // No current session — create a fresh one.
-                tracing::info!("OAuth callback: no valid current session, creating a new one");
-                let (new_id, _, _) = get_or_create_session(&global, None).await;
-                global.sessions.persist_new(&new_id);
-                new_id
+    let target_session_id =
+        if let Some(existing) = global.sessions.find_by_oauth("google", &provider_user_id) {
+            // Try to actually resolve the linked session.  If it comes back
+            // as `is_new` the session's save data is gone (e.g. different
+            // worktree, wiped saves/) and the middleware will overwrite
+            // whatever cookie we set.  Re-link to the caller's current
+            // session instead so the user isn't stuck in a login loop.
+            let (resolved_id, _, is_new) = get_or_create_session(&global, Some(&existing)).await;
+            if !is_new {
+                resolved_id
+            } else {
+                tracing::info!(
+                    stale_session = %existing,
+                    replacement = %resolved_id,
+                    "OAuth: linked session unrestorable, re-linking"
+                );
+                let sid = match current_session_id.as_deref() {
+                    Some(id) if global.sessions.exists_in_db(id) => id.to_string(),
+                    _ => resolved_id,
+                };
+                global
+                    .sessions
+                    .link_oauth("google", &provider_user_id, &sid, &display_name);
+                sid
             }
+        } else {
+            // Link the current anonymous session to this Google account.
+            let sid = match current_session_id.as_deref() {
+                Some(id) if global.sessions.exists_in_db(id) => id.to_string(),
+                _ => {
+                    let (new_id, _, _) = get_or_create_session(&global, None).await;
+                    global.sessions.persist_new(&new_id);
+                    new_id
+                }
+            };
+            global
+                .sessions
+                .link_oauth("google", &provider_user_id, &sid, &display_name);
+            sid
         };
-        global
-            .sessions
-            .link_oauth("google", &provider_user_id, &sid, &display_name);
-        tracing::info!(session_id = %sid, google_id = %provider_user_id, name = %display_name, "Google account linked");
-        sid
-    };
 
     tracing::info!(
         target_session_id = %target_session_id,

--- a/crates/parish-server/src/auth.rs
+++ b/crates/parish-server/src/auth.rs
@@ -136,11 +136,21 @@ pub async fn callback_google(
 
     // Determine which session to use.
     let current_session_id = cookie_value(&headers, SESSION_COOKIE);
+    tracing::info!(
+        current_session_id = ?current_session_id,
+        provider_user_id = %provider_user_id,
+        display_name = %display_name,
+        "OAuth callback: resolving target session"
+    );
 
     let target_session_id = if let Some(existing) =
         global.sessions.find_by_oauth("google", &provider_user_id)
     {
         // A session is already linked to this Google account — use it.
+        tracing::info!(
+            existing_session_id = %existing,
+            "OAuth callback: found existing session linked to this Google account"
+        );
         existing
     } else {
         // Link the current anonymous session to this Google account.
@@ -148,6 +158,7 @@ pub async fn callback_google(
             Some(id) if global.sessions.exists_in_db(id) => id.to_string(),
             _ => {
                 // No current session — create a fresh one.
+                tracing::info!("OAuth callback: no valid current session, creating a new one");
                 let (new_id, _, _) = get_or_create_session(&global, None).await;
                 global.sessions.persist_new(&new_id);
                 new_id
@@ -159,6 +170,11 @@ pub async fn callback_google(
         tracing::info!(session_id = %sid, google_id = %provider_user_id, name = %display_name, "Google account linked");
         sid
     };
+
+    tracing::info!(
+        target_session_id = %target_session_id,
+        "OAuth callback: setting parish_sid cookie and redirecting to /"
+    );
 
     // Build the response: set the parish_sid cookie to the target session,
     // clear the CSRF state cookie, and redirect to the game.
@@ -211,6 +227,7 @@ pub async fn get_auth_status(
     let session_id = match cookie_value(&headers, SESSION_COOKIE) {
         Some(id) => id,
         None => {
+            tracing::debug!("auth/status: no parish_sid cookie, anonymous");
             return Json(AuthStatus {
                 oauth_enabled,
                 logged_in: false,
@@ -222,6 +239,11 @@ pub async fn get_auth_status(
 
     // Check whether this session has a linked OAuth account.
     let linked = find_oauth_account_for_session(&global, &session_id);
+    tracing::debug!(
+        session_id = %session_id,
+        linked = linked.is_some(),
+        "auth/status resolved"
+    );
 
     Json(AuthStatus {
         oauth_enabled,

--- a/crates/parish-server/src/auth.rs
+++ b/crates/parish-server/src/auth.rs
@@ -327,10 +327,10 @@ fn cookie_value(headers: &HeaderMap, name: &str) -> Option<String> {
         .and_then(|cookies| {
             for pair in cookies.split(';') {
                 let pair = pair.trim();
-                if let Some(rest) = pair.strip_prefix(name) {
-                    if let Some(rest) = rest.strip_prefix('=') {
-                        return Some(rest.trim().to_string());
-                    }
+                if let Some(rest) = pair.strip_prefix(name)
+                    && let Some(rest) = rest.strip_prefix('=')
+                {
+                    return Some(rest.trim().to_string());
                 }
             }
             None

--- a/crates/parish-server/src/editor_routes.rs
+++ b/crates/parish-server/src/editor_routes.rs
@@ -7,8 +7,8 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use axum::Extension;
 use axum::Json;
-use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 
@@ -34,7 +34,7 @@ fn mods_root(state: &AppState) -> PathBuf {
 
 /// `GET /api/editor-list-mods`
 pub async fn editor_list_mods(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
 ) -> Result<Json<Vec<ModSummary>>, (StatusCode, String)> {
     editor::handle_editor_list_mods(&mods_root(&state))
         .map(Json)
@@ -43,7 +43,7 @@ pub async fn editor_list_mods(
 
 /// `POST /api/editor-open-mod` with JSON body `{ "modPath": "..." }`
 pub async fn editor_open_mod(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
     Json(body): Json<EditorOpenModBody>,
 ) -> Result<Json<EditorModSnapshot>, (StatusCode, String)> {
     let path = PathBuf::from(&body.mod_path);
@@ -63,7 +63,7 @@ pub struct EditorOpenModBody {
 
 /// `GET /api/editor-get-snapshot`
 pub async fn editor_get_snapshot(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
 ) -> Result<Json<EditorModSnapshot>, (StatusCode, String)> {
     editor::handle_editor_get_snapshot(&state.editor)
         .map(Json)
@@ -72,7 +72,7 @@ pub async fn editor_get_snapshot(
 
 /// `GET /api/editor-validate`
 pub async fn editor_validate(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
 ) -> Result<Json<ValidationReport>, (StatusCode, String)> {
     editor::handle_editor_validate(&state.editor)
         .map(Json)
@@ -81,7 +81,7 @@ pub async fn editor_validate(
 
 /// `POST /api/editor-update-npcs` with JSON body `{ "npcs": ... }`
 pub async fn editor_update_npcs(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
     Json(body): Json<EditorUpdateNpcsBody>,
 ) -> Result<Json<ValidationReport>, (StatusCode, String)> {
     let npcs = serde_json::from_value(body.npcs)
@@ -98,7 +98,7 @@ pub struct EditorUpdateNpcsBody {
 
 /// `POST /api/editor-update-locations` with JSON body `{ "locations": [...] }`
 pub async fn editor_update_locations(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
     Json(body): Json<EditorUpdateLocationsBody>,
 ) -> Result<Json<ValidationReport>, (StatusCode, String)> {
     let locations = serde_json::from_value(body.locations).map_err(|e| {
@@ -119,7 +119,7 @@ pub struct EditorUpdateLocationsBody {
 
 /// `POST /api/editor-save` with JSON body `{ "docs": ["npcs", "world", ...] }`
 pub async fn editor_save(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
     Json(body): Json<EditorSaveBody>,
 ) -> Result<Json<EditorSaveResponse>, (StatusCode, String)> {
     editor::handle_editor_save(&state.editor, body.docs)
@@ -134,7 +134,7 @@ pub struct EditorSaveBody {
 
 /// `POST /api/editor-reload`
 pub async fn editor_reload(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
 ) -> Result<Json<EditorModSnapshot>, (StatusCode, String)> {
     editor::handle_editor_reload(&state.editor)
         .map(Json)
@@ -143,7 +143,7 @@ pub async fn editor_reload(
 
 /// `POST /api/editor-close`
 pub async fn editor_close(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
     editor::handle_editor_close(&state.editor)
         .map(|_| StatusCode::NO_CONTENT)
@@ -154,7 +154,7 @@ pub async fn editor_close(
 
 /// `GET /api/editor-list-saves`
 pub async fn editor_list_saves(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
 ) -> Result<Json<Vec<SaveFileSummary>>, (StatusCode, String)> {
     editor::handle_editor_list_saves(&state.saves_dir)
         .map(Json)
@@ -169,7 +169,7 @@ pub struct SavePathBody {
 
 /// `POST /api/editor-list-branches`
 pub async fn editor_list_branches(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
     Json(body): Json<SavePathBody>,
 ) -> Result<Json<Vec<BranchSummary>>, (StatusCode, String)> {
     let raw = PathBuf::from(&body.save_path);
@@ -189,7 +189,7 @@ pub struct SavePathBranchBody {
 
 /// `POST /api/editor-list-snapshots`
 pub async fn editor_list_snapshots(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
     Json(body): Json<SavePathBranchBody>,
 ) -> Result<Json<Vec<SnapshotSummary>>, (StatusCode, String)> {
     let raw = PathBuf::from(&body.save_path);
@@ -202,7 +202,7 @@ pub async fn editor_list_snapshots(
 
 /// `POST /api/editor-read-snapshot`
 pub async fn editor_read_snapshot(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
     Json(body): Json<SavePathBranchBody>,
 ) -> Result<Json<Option<SnapshotDetail>>, (StatusCode, String)> {
     let raw = PathBuf::from(&body.save_path);
@@ -216,7 +216,7 @@ pub async fn editor_read_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::extract::State;
+    use axum::Extension;
 
     #[tokio::test]
     async fn editor_open_mod_rejects_path_traversal() {
@@ -224,7 +224,7 @@ mod tests {
         let body = EditorOpenModBody {
             mod_path: "../../etc/passwd".to_string(),
         };
-        let result = editor_open_mod(State(state), Json(body)).await;
+        let result = editor_open_mod(Extension(state), Json(body)).await;
         assert!(result.is_err());
         let (status, _msg) = result.unwrap_err();
         assert_eq!(status, StatusCode::BAD_REQUEST);
@@ -236,7 +236,7 @@ mod tests {
         let body = SavePathBody {
             save_path: "../../etc/passwd".to_string(),
         };
-        let result = editor_list_branches(State(state), Json(body)).await;
+        let result = editor_list_branches(Extension(state), Json(body)).await;
         assert!(result.is_err());
         let (status, _msg) = result.unwrap_err();
         assert_eq!(status, StatusCode::BAD_REQUEST);
@@ -249,7 +249,7 @@ mod tests {
             save_path: "../../etc/passwd".to_string(),
             branch_id: 1,
         };
-        let result = editor_list_snapshots(State(state), Json(body)).await;
+        let result = editor_list_snapshots(Extension(state), Json(body)).await;
         assert!(result.is_err());
         let (status, _msg) = result.unwrap_err();
         assert_eq!(status, StatusCode::BAD_REQUEST);
@@ -262,7 +262,7 @@ mod tests {
             save_path: "../../etc/passwd".to_string(),
             branch_id: 1,
         };
-        let result = editor_read_snapshot(State(state), Json(body)).await;
+        let result = editor_read_snapshot(Extension(state), Json(body)).await;
         assert!(result.is_err());
         let (status, _msg) = result.unwrap_err();
         assert_eq!(status, StatusCode::BAD_REQUEST);

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -1,11 +1,17 @@
 //! Parish web server — serves the Svelte UI in a browser via axum.
 //!
 //! Provides the same game experience as the Tauri desktop app, but over
-//! standard HTTP + WebSocket so it can run in any browser. Primarily
-//! intended for automated Chrome testing via Playwright.
+//! standard HTTP + WebSocket so it can run in any browser.
+//!
+//! Each browser visitor gets their own isolated game session, identified by
+//! a `parish_sid` cookie.  Sessions are persisted across server restarts via
+//! `saves/<session_id>/` directories and `saves/sessions.db`.
 
+pub mod auth;
 pub mod editor_routes;
+pub mod middleware;
 pub mod routes;
+pub mod session;
 pub mod state;
 pub mod ws;
 
@@ -17,21 +23,18 @@ use std::time::Duration;
 use axum::Router;
 use axum::extract::ConnectInfo;
 use axum::http::{Request, StatusCode};
-use axum::middleware::{self, Next};
+use axum::middleware as axum_mw;
+use axum::middleware::Next;
 use axum::response::Response;
 use axum::routing::{get, post};
 use tower_http::services::ServeDir;
 
-use parish_core::debug_snapshot::DebugEvent;
 use parish_core::game_mod::{GameMod, find_default_mod};
-use parish_core::inference::openai_client::OpenAiClient;
-use parish_core::inference::{AnyClient, InferenceQueue, spawn_inference_worker};
-use parish_core::npc::manager::NpcManager;
 use parish_core::world::transport::TransportConfig;
-use parish_core::world::{LocationId, WorldState};
 
 use parish_core::config::FeatureFlags;
-use state::{AppState, DEBUG_EVENT_CAPACITY, GameConfig, UiConfigSnapshot, build_app_state};
+use session::{GlobalState, OAuthConfig, SessionRegistry};
+use state::{GameConfig, UiConfigSnapshot};
 
 /// Middleware that enforces Cloudflare Access authentication on non-localhost traffic.
 ///
@@ -61,51 +64,31 @@ async fn cf_access_guard(
 }
 
 /// Starts the Parish web server on the given port.
-///
-/// Loads game data from `data_dir`, serves the Svelte frontend from
-/// `static_dir` (typically `ui/dist/`), and exposes REST + WebSocket
-/// endpoints for the game.
 pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
-    // Load world — try legacy `parish.json` first, then mod `world.json`.
+    // ── World path ────────────────────────────────────────────────────────────
     let world_path = {
         let parish = data_dir.join("parish.json");
         let world = data_dir.join("world.json");
         if parish.exists() { parish } else { world }
     };
-    let world = WorldState::from_parish_file(&world_path, LocationId(15)).unwrap_or_else(|e| {
-        tracing::warn!("Failed to load world data: {}. Using default world.", e);
-        WorldState::new()
-    });
 
-    // Load NPCs
-    let mut npc_manager =
-        NpcManager::load_from_file(&data_dir.join("npcs.json")).unwrap_or_else(|e| {
-            tracing::warn!("Failed to load npcs.json: {}. No NPCs.", e);
-            NpcManager::new()
-        });
-    npc_manager.assign_tiers(&world, &[]);
-
-    // Build client from env
-    let (client, mut config) = build_client_and_config();
+    // ── LLM client + config (template, cloned per session) ───────────────────
+    let (_, mut config) = build_client_and_config();
     let cloud_env = build_cloud_client_from_env();
-    let cloud_client = cloud_env.client;
     config.cloud_provider_name = cloud_env.provider_name;
     config.cloud_model_name = cloud_env.model_name;
     config.cloud_api_key = cloud_env.api_key;
     config.cloud_base_url = cloud_env.base_url;
 
-    let transport = TransportConfig::default();
-
-    // Load game mod (if available) for splash text and reaction templates
+    // ── Game mod ──────────────────────────────────────────────────────────────
     let game_mod = find_default_mod().and_then(|dir| GameMod::load(&dir).ok());
     let game_title = game_mod
         .as_ref()
         .and_then(|gm| gm.manifest.meta.title.clone())
         .unwrap_or_else(|| "Parish".to_string());
-    // Railway injects RAILWAY_GIT_COMMIT_SHA at runtime; also accept a
-    // generic PARISH_COMMIT_SHA override. Short-hash for display.
+
     let commit_sha = std::env::var("RAILWAY_GIT_COMMIT_SHA")
         .or_else(|_| std::env::var("PARISH_COMMIT_SHA"))
         .unwrap_or_else(|_| "unknown".to_string());
@@ -116,6 +99,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         chrono::Local::now().format("%Y-%m-%d %H:%M"),
         short_sha,
     );
+
     let theme_palette = game_mod
         .as_ref()
         .map(|gm| gm.ui.theme.resolved_palette())
@@ -128,7 +112,6 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     let tile_sources_snapshot =
         parish_core::ipc::TileSourceSnapshot::list_from_map_config(&engine_config.map);
     let active_tile_source = engine_config.map.default_tile_source.clone();
-    // Populate the /tiles command's registry on the runtime GameConfig.
     config.active_tile_source = active_tile_source.clone();
     config.tile_sources = engine_config.map.id_label_pairs();
 
@@ -150,61 +133,60 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         }
     };
 
-    // Load feature flags from disk and inject into config
+    // ── Feature flags ──────────────────────────────────────────────────────
     let flags_path = data_dir.join("parish-flags.json");
     config.flags = FeatureFlags::load_from_file(&flags_path);
 
+    // ── Saves directory ───────────────────────────────────────────────────────
     let saves_dir = parish_core::persistence::picker::ensure_saves_dir();
-    // Capture provider name before config is moved into build_app_state.
-    let provider_name = config.provider_name.clone();
-    let state = build_app_state(
-        world,
-        npc_manager,
-        client.clone(),
-        config,
-        cloud_client,
-        transport,
-        ui_config,
-        theme_palette,
-        saves_dir,
-        data_dir.clone(),
-        game_mod,
-        flags_path,
-    );
 
-    // Initialize inference queue — use the simulator if configured, else the real client.
-    let any_client: Option<AnyClient> = if provider_name == "simulator" {
-        Some(AnyClient::simulator())
-    } else {
-        client.map(AnyClient::open_ai)
-    };
-    if let Some(ac) = any_client {
-        let (interactive_tx, interactive_rx) = tokio::sync::mpsc::channel(16);
-        let (background_tx, background_rx) = tokio::sync::mpsc::channel(32);
-        let (batch_tx, batch_rx) = tokio::sync::mpsc::channel(64);
-        // Store the worker JoinHandle on AppState so a later rebuild_inference
-        // call can abort this initial worker — otherwise it leaks for the
-        // lifetime of the process (bug #231).
-        let worker = spawn_inference_worker(
-            ac,
-            interactive_rx,
-            background_rx,
-            batch_rx,
-            state.inference_log.clone(),
-        );
-        let queue = InferenceQueue::new(interactive_tx, background_tx, batch_tx);
-        let mut iq = state.inference_queue.lock().await;
-        *iq = Some(queue);
-        drop(iq);
-        let mut wh = state.worker_handle.lock().await;
-        *wh = Some(worker);
+    // ── Session registry ──────────────────────────────────────────────────────
+    let sessions = SessionRegistry::open(&saves_dir)
+        .map_err(|e| anyhow::anyhow!("Failed to open sessions.db: {}", e))?;
+
+    // ── Pronunciations (shared, loaded once) ──────────────────────────────────
+    let pronunciations = game_mod
+        .as_ref()
+        .map(|gm| gm.pronunciations.clone())
+        .unwrap_or_default();
+
+    // ── Google OAuth config (optional) ────────────────────────────────────────
+    let oauth_config = build_oauth_config();
+    if oauth_config.is_some() {
+        tracing::info!("Google OAuth enabled");
     }
 
-    // Spawn background ticks
-    spawn_background_ticks(Arc::clone(&state));
+    // ── Global state ──────────────────────────────────────────────────────────
+    let global = Arc::new(GlobalState {
+        sessions,
+        oauth_config,
+        data_dir: data_dir.clone(),
+        world_path,
+        saves_dir,
+        game_mod,
+        pronunciations,
+        ui_config,
+        theme_palette,
+        transport: TransportConfig::default(),
+        template_config: config,
+    });
 
-    // Build router
-    let app = Router::new()
+    // ── Session cleanup background task ───────────────────────────────────────
+    {
+        let g = Arc::clone(&global);
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(3600)).await;
+                g.sessions.cleanup_stale(Duration::from_secs(86400));
+                tracing::debug!("Session cleanup ran");
+            }
+        });
+    }
+
+    // ── Build router ──────────────────────────────────────────────────────────
+    let oauth_enabled = global.oauth_config.is_some();
+
+    let mut app = Router::new()
         .route("/api/world-snapshot", get(routes::get_world_snapshot))
         .route("/api/map", get(routes::get_map))
         .route("/api/npcs-here", get(routes::get_npcs_here))
@@ -259,9 +241,22 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
             "/api/editor-read-snapshot",
             post(editor_routes::editor_read_snapshot),
         )
+        .route("/api/auth/status", get(auth::get_auth_status));
+
+    if oauth_enabled {
+        app = app
+            .route("/auth/login/google", get(auth::login_google))
+            .route("/auth/callback/google", get(auth::callback_google));
+    }
+
+    let app = app
         .fallback_service(ServeDir::new(&static_dir).append_index_html_on_directories(true))
-        .layer(middleware::from_fn(cf_access_guard))
-        .with_state(state);
+        .layer(axum_mw::from_fn(cf_access_guard))
+        .with_state(Arc::clone(&global))
+        .layer(axum_mw::from_fn_with_state(
+            Arc::clone(&global),
+            middleware::session_middleware,
+        ));
 
     let addr = format!("0.0.0.0:{}", port);
     tracing::info!("Parish web server listening on http://{}", addr);
@@ -277,502 +272,29 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     Ok(())
 }
 
-/// Spawns the background tick tasks (world update + theme update).
-fn spawn_background_ticks(state: Arc<AppState>) {
-    // Event bus fan-in: subscribe to world.event_bus and buffer the last N
-    // GameEvents in AppState.game_events for the debug panel.
-    {
-        let state_events = Arc::clone(&state);
-        tokio::spawn(async move {
-            let mut rx = {
-                let world = state_events.world.lock().await;
-                world.event_bus.subscribe()
-            };
-            loop {
-                match rx.recv().await {
-                    Ok(evt) => {
-                        let mut buf = state_events.game_events.lock().await;
-                        if buf.len() >= crate::state::DEBUG_EVENT_CAPACITY {
-                            buf.pop_front();
-                        }
-                        buf.push_back(evt);
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
-                }
-            }
-        });
-    }
-
-    // Idle tick: broadcast world snapshot every 5 seconds
-    let state_tick = Arc::clone(&state);
-    tokio::spawn(async move {
-        tracing::debug!("World tick task started");
-        let mut last_palette: Option<parish_core::world::palette::RawPalette> = None;
-        loop {
-            tokio::time::sleep(Duration::from_secs(5)).await;
-            {
-                let world = state_tick.world.lock().await;
-                let npc_manager = state_tick.npc_manager.lock().await;
-                let transport = state_tick.transport.default_mode();
-                let mut snapshot = parish_core::ipc::snapshot_from_world(&world, transport);
-                snapshot.name_hints = parish_core::ipc::compute_name_hints(
-                    &world,
-                    &npc_manager,
-                    &state_tick.pronunciations,
-                );
-                state_tick.event_bus.emit("world-update", &snapshot);
-                // Emit current time-of-day palette (weather + season tinted)
-                {
-                    use chrono::Timelike;
-                    use parish_core::ipc::ThemePalette;
-                    use parish_core::world::palette::compute_palette;
-                    let now = world.clock.now();
-                    let raw = compute_palette(
-                        now.hour(),
-                        now.minute(),
-                        world.clock.season(),
-                        world.weather,
-                    );
-                    if last_palette != Some(raw) {
-                        state_tick
-                            .event_bus
-                            .emit("theme-update", &ThemePalette::from(raw));
-                        last_palette = Some(raw);
-                    }
-                }
-            }
-            {
-                let mut world = state_tick.world.lock().await;
-                let mut npc_mgr = state_tick.npc_manager.lock().await;
-
-                // Tick weather engine
-                let season = world.clock.season();
-                let now = world.clock.now();
-                // Scope thread_rng tightly so it is dropped before any await.
-                let new_weather_opt = {
-                    let mut rng = rand::thread_rng();
-                    world.weather_engine.tick(now, season, &mut rng)
-                };
-                if let Some(new_weather) = new_weather_opt {
-                    let old = world.weather;
-                    world.weather = new_weather;
-                    world.event_bus.publish(
-                        parish_core::world::events::GameEvent::WeatherChanged {
-                            new_weather: new_weather.to_string(),
-                            timestamp: world.clock.now(),
-                        },
-                    );
-                    tracing::info!(old = %old, new = %new_weather, "Weather changed");
-                    // Emit weather debug event
-                    let mut debug_events = state_tick.debug_events.lock().await;
-                    if debug_events.len() >= DEBUG_EVENT_CAPACITY {
-                        debug_events.pop_front();
-                    }
-                    debug_events.push_back(DebugEvent {
-                        timestamp: String::new(),
-                        category: "weather".to_string(),
-                        message: format!("Weather: {} → {}", old, new_weather),
-                    });
-                }
-
-                // Tick NPC schedules and assign tiers
-                let schedule_events =
-                    npc_mgr.tick_schedules(&world.clock, &world.graph, world.weather);
-                let tier_transitions = npc_mgr.assign_tiers(&world, &[]);
-
-                if !schedule_events.is_empty() || !tier_transitions.is_empty() {
-                    let mut debug_events = state_tick.debug_events.lock().await;
-                    for evt in &schedule_events {
-                        tracing::debug!("NPC schedule: {}", evt.debug_string());
-                        if debug_events.len() >= DEBUG_EVENT_CAPACITY {
-                            debug_events.pop_front();
-                        }
-                        debug_events.push_back(DebugEvent {
-                            timestamp: String::new(),
-                            category: "schedule".to_string(),
-                            message: evt.debug_string(),
-                        });
-                    }
-                    for tt in &tier_transitions {
-                        let direction = if tt.promoted { "promoted" } else { "demoted" };
-                        tracing::debug!(
-                            "NPC tier: {} {} {:?} → {:?}",
-                            tt.npc_name,
-                            direction,
-                            tt.old_tier,
-                            tt.new_tier,
-                        );
-                        if debug_events.len() >= DEBUG_EVENT_CAPACITY {
-                            debug_events.pop_front();
-                        }
-                        debug_events.push_back(DebugEvent {
-                            timestamp: String::new(),
-                            category: "tier".to_string(),
-                            message: format!(
-                                "{} {} {:?} → {:?}",
-                                tt.npc_name, direction, tt.old_tier, tt.new_tier
-                            ),
-                        });
-                    }
-                }
-
-                // Propagate gossip between co-located Tier 2 NPCs.
-                // Scope thread_rng tightly so it is dropped before any await.
-                let total_gossip = if !world.gossip_network.is_empty() {
-                    let groups = npc_mgr.tier2_groups();
-                    let mut rng = rand::thread_rng();
-                    let mut total = 0usize;
-                    for npc_ids in groups.values() {
-                        if npc_ids.len() >= 2 {
-                            total += parish_core::npc::ticks::propagate_gossip_at_location(
-                                npc_ids,
-                                &mut world.gossip_network,
-                                &mut rng,
-                            );
-                        }
-                    }
-                    total
-                } else {
-                    0
-                };
-                if total_gossip > 0 {
-                    let mut debug_events = state_tick.debug_events.lock().await;
-                    if debug_events.len() >= DEBUG_EVENT_CAPACITY {
-                        debug_events.pop_front();
-                    }
-                    debug_events.push_back(DebugEvent {
-                        timestamp: String::new(),
-                        category: "gossip".to_string(),
-                        message: format!("{} rumor(s) spread among co-located NPCs", total_gossip),
-                    });
-                }
-
-                // Dispatch Tier 4 rules engine if enough game time has elapsed.
-                // tick_tier4 is sub-ms CPU work; runs inline inside the lock scope.
-                if npc_mgr.needs_tier4_tick(now) {
-                    let tier4_ids: std::collections::HashSet<parish_core::npc::NpcId> =
-                        npc_mgr.tier4_npcs().into_iter().collect();
-                    let events = {
-                        let mut tier4_refs: Vec<&mut parish_core::npc::Npc> = npc_mgr
-                            .npcs_mut()
-                            .values_mut()
-                            .filter(|n| tier4_ids.contains(&n.id))
-                            .collect();
-                        let game_date = now.date_naive();
-                        let mut rng = rand::thread_rng();
-                        parish_core::npc::tier4::tick_tier4(
-                            &mut tier4_refs,
-                            season,
-                            game_date,
-                            &mut rng,
-                        )
-                    };
-                    let game_events = npc_mgr.apply_tier4_events(&events, now);
-                    // Collect life event descriptions before publishing
-                    let life_descriptions: Vec<String> = game_events
-                        .iter()
-                        .filter_map(|ge| {
-                            if let parish_core::world::events::GameEvent::LifeEvent {
-                                description,
-                                ..
-                            } = ge
-                            {
-                                Some(description.clone())
-                            } else {
-                                None
-                            }
-                        })
-                        .collect();
-                    for evt in game_events {
-                        world.event_bus.publish(evt);
-                    }
-                    npc_mgr.record_tier4_tick(now);
-                    tracing::debug!("Tier 4 tick: {} events", events.len());
-                    // Emit per-event life_event debug entries + aggregate tier4 entry
-                    let mut debug_events = state_tick.debug_events.lock().await;
-                    for desc in &life_descriptions {
-                        if debug_events.len() >= DEBUG_EVENT_CAPACITY {
-                            debug_events.pop_front();
-                        }
-                        debug_events.push_back(DebugEvent {
-                            timestamp: String::new(),
-                            category: "life_event".to_string(),
-                            message: desc.clone(),
-                        });
-                    }
-                    if debug_events.len() >= DEBUG_EVENT_CAPACITY {
-                        debug_events.pop_front();
-                    }
-                    debug_events.push_back(DebugEvent {
-                        timestamp: String::new(),
-                        category: "tier4".to_string(),
-                        message: format!("Tier 4 tick: {} events", events.len()),
-                    });
-                }
-
-                // Dispatch Tier 3 batch LLM simulation for distant NPCs.
-                // The LLM call can take 10-30 s, so we spawn a detached task
-                // and release the world/npc_mgr locks before awaiting.
-                if npc_mgr.needs_tier3_tick(now) && !npc_mgr.tier3_in_flight() {
-                    use parish_core::npc::ticks::Tier3Snapshot;
-                    use parish_core::npc::ticks::tier3_snapshot_from_npc;
-
-                    let tier3_ids = npc_mgr.tier3_npcs();
-                    let snapshots: Vec<Tier3Snapshot> = tier3_ids
-                        .iter()
-                        .filter_map(|id| npc_mgr.get(*id))
-                        .map(|npc| tier3_snapshot_from_npc(npc, &world.graph))
-                        .collect();
-
-                    if !snapshots.is_empty() {
-                        let time_desc = world.clock.time_of_day().to_string();
-                        let weather_str = world.weather.to_string();
-                        let season_str = format!("{:?}", world.clock.season());
-                        let hours = 24u32;
-
-                        npc_mgr.set_tier3_in_flight(true);
-
-                        let state_t3 = Arc::clone(&state_tick);
-                        tokio::spawn(async move {
-                            // Briefly lock to clone the queue + resolve the model.
-                            // NOTE: queue submissions go through the base worker client;
-                            // per-category Simulation overrides are not honored for batch
-                            // inference. TODO: per-category routing through the queue worker.
-                            let (queue_opt, model) = {
-                                let cfg = state_t3.config.lock().await;
-                                let queue_guard = state_t3.inference_queue.lock().await;
-                                let queue = queue_guard.clone();
-                                let idx = parish_core::ipc::GameConfig::cat_idx(
-                                    parish_core::config::InferenceCategory::Simulation,
-                                );
-                                let model = cfg.category_model[idx]
-                                    .clone()
-                                    .unwrap_or_else(|| cfg.model_name.clone());
-                                (queue, model)
-                            };
-
-                            let Some(queue) = queue_opt else {
-                                state_t3.npc_manager.lock().await.set_tier3_in_flight(false);
-                                return;
-                            };
-
-                            let ctx = parish_core::npc::ticks::Tier3Context {
-                                snapshots: &snapshots,
-                                queue: &queue,
-                                model: &model,
-                                time_desc: &time_desc,
-                                weather: &weather_str,
-                                season: &season_str,
-                                hours,
-                                batch_size: 0,
-                            };
-
-                            let result = parish_core::npc::ticks::tick_tier3(&ctx).await;
-
-                            // Re-acquire locks to apply updates.
-                            let mut npc_mgr = state_t3.npc_manager.lock().await;
-                            let world = state_t3.world.lock().await;
-                            let game_time = world.clock.now();
-
-                            match result {
-                                Ok(updates) => {
-                                    let _events = parish_core::npc::ticks::apply_tier3_updates(
-                                        &updates,
-                                        npc_mgr.npcs_mut(),
-                                        &world.graph,
-                                        game_time,
-                                    );
-                                    npc_mgr.record_tier3_tick(game_time);
-                                    tracing::debug!(
-                                        "Tier 3 tick: {} updates applied",
-                                        updates.len()
-                                    );
-                                    let mut debug_events = state_t3.debug_events.lock().await;
-                                    if debug_events.len() >= DEBUG_EVENT_CAPACITY {
-                                        debug_events.pop_front();
-                                    }
-                                    debug_events.push_back(DebugEvent {
-                                        timestamp: String::new(),
-                                        category: "tier3".to_string(),
-                                        message: format!("Tier 3 tick: {} updates", updates.len()),
-                                    });
-                                }
-                                Err(e) => {
-                                    tracing::warn!("Tier 3 tick failed: {}", e);
-                                }
-                            }
-
-                            npc_mgr.set_tier3_in_flight(false);
-                        });
-                    }
-                }
-
-                // Dispatch Tier 2 background simulation for nearby NPCs.
-                // Submits one LLM call per location group via the priority queue
-                // (Background lane, yields to Tier 1 dialogue).
-                if npc_mgr.needs_tier2_tick(now) && !npc_mgr.tier2_in_flight() {
-                    use parish_core::npc::ticks::{Tier2Group, npc_snapshot_from_npc};
-
-                    let groups_map = npc_mgr.tier2_groups();
-                    if !groups_map.is_empty() {
-                        // Build owned snapshots inside the lock scope.
-                        let groups: Vec<Tier2Group> = groups_map
-                            .into_iter()
-                            .filter_map(|(loc, npc_ids)| {
-                                let location_name = world
-                                    .graph
-                                    .get(loc)
-                                    .map(|d| d.name.clone())
-                                    .unwrap_or_else(|| format!("Location {}", loc.0));
-                                let npcs: Vec<_> = npc_ids
-                                    .iter()
-                                    .filter_map(|id| npc_mgr.get(*id))
-                                    .map(npc_snapshot_from_npc)
-                                    .collect();
-                                if npcs.is_empty() {
-                                    return None;
-                                }
-                                Some(Tier2Group {
-                                    location: loc,
-                                    location_name,
-                                    npcs,
-                                })
-                            })
-                            .collect();
-
-                        if !groups.is_empty() {
-                            let time_desc = world.clock.time_of_day().to_string();
-                            let weather_str = world.weather.to_string();
-
-                            npc_mgr.set_tier2_in_flight(true);
-
-                            let state_t2 = Arc::clone(&state_tick);
-                            tokio::spawn(async move {
-                                // Briefly lock to clone the queue + resolve model.
-                                // NOTE: queue submissions go through the base worker client;
-                                // per-category Simulation overrides are not honored for batch
-                                // inference. TODO: per-category routing through the queue worker.
-                                let (queue_opt, model) = {
-                                    let cfg = state_t2.config.lock().await;
-                                    let queue_guard = state_t2.inference_queue.lock().await;
-                                    let queue = queue_guard.clone();
-                                    let idx = parish_core::ipc::GameConfig::cat_idx(
-                                        parish_core::config::InferenceCategory::Simulation,
-                                    );
-                                    let model = cfg.category_model[idx]
-                                        .clone()
-                                        .unwrap_or_else(|| cfg.model_name.clone());
-                                    (queue, model)
-                                };
-
-                                let Some(queue) = queue_opt else {
-                                    state_t2.npc_manager.lock().await.set_tier2_in_flight(false);
-                                    return;
-                                };
-
-                                // Submit each group sequentially (one LLM call per group).
-                                let mut events = Vec::new();
-                                for group in &groups {
-                                    if let Some(evt) = parish_core::npc::ticks::run_tier2_for_group(
-                                        &queue,
-                                        &model,
-                                        group,
-                                        &time_desc,
-                                        &weather_str,
-                                    )
-                                    .await
-                                    {
-                                        events.push(evt);
-                                    }
-                                }
-
-                                // Re-acquire locks to apply events.
-                                let mut npc_mgr = state_t2.npc_manager.lock().await;
-                                let mut world = state_t2.world.lock().await;
-                                let game_time = world.clock.now();
-
-                                for event in &events {
-                                    let _dbg = parish_core::npc::ticks::apply_tier2_event(
-                                        event,
-                                        npc_mgr.npcs_mut(),
-                                        game_time,
-                                    );
-                                    // Push gossip so it can propagate to other NPCs.
-                                    parish_core::npc::ticks::create_gossip_from_tier2_event(
-                                        event,
-                                        &mut world.gossip_network,
-                                        game_time,
-                                    );
-                                }
-                                npc_mgr.record_tier2_tick(game_time);
-                                npc_mgr.set_tier2_in_flight(false);
-
-                                tracing::debug!(
-                                    "Tier 2 tick: {} events from {} groups",
-                                    events.len(),
-                                    groups.len()
-                                );
-                                let mut debug_events = state_t2.debug_events.lock().await;
-                                if debug_events.len() >= DEBUG_EVENT_CAPACITY {
-                                    debug_events.pop_front();
-                                }
-                                debug_events.push_back(DebugEvent {
-                                    timestamp: String::new(),
-                                    category: "tier2".to_string(),
-                                    message: format!(
-                                        "Tier 2 tick: {} events from {} groups",
-                                        events.len(),
-                                        groups.len()
-                                    ),
-                                });
-                            });
-                        }
-                    }
-                }
-            }
-        }
-    });
-
-    // Inactivity tick: drive idle banter and auto-pause.
-    let state_idle = Arc::clone(&state);
-    tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(Duration::from_secs(1)).await;
-            routes::tick_inactivity(&state_idle).await;
-        }
-    });
-    // Autosave tick: save snapshot every 60 seconds (if a save file is active)
-    let state_autosave = Arc::clone(&state);
-    tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(Duration::from_secs(60)).await;
-
-            let save_path = state_autosave.save_path.lock().await.clone();
-            let branch_id = *state_autosave.current_branch_id.lock().await;
-
-            if let (Some(path), Some(bid)) = (save_path, branch_id) {
-                let world = state_autosave.world.lock().await;
-                let npc_manager = state_autosave.npc_manager.lock().await;
-                let snapshot =
-                    parish_core::persistence::snapshot::GameSnapshot::capture(&world, &npc_manager);
-                drop(npc_manager);
-                drop(world);
-
-                match parish_core::persistence::Database::open(&path) {
-                    Ok(db) => match db.save_snapshot(bid, &snapshot) {
-                        Ok(_) => tracing::debug!("Autosave complete"),
-                        Err(e) => tracing::warn!("Autosave failed: {}", e),
-                    },
-                    Err(e) => tracing::warn!("Autosave DB open failed: {}", e),
-                }
-            }
-        }
-    });
+/// Reads Google OAuth credentials from environment variables.
+fn build_oauth_config() -> Option<OAuthConfig> {
+    let client_id = std::env::var("GOOGLE_CLIENT_ID")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    let client_secret = std::env::var("GOOGLE_CLIENT_SECRET")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    let base_url =
+        std::env::var("PARISH_BASE_URL").unwrap_or_else(|_| "http://localhost:3001".to_string());
+    Some(OAuthConfig {
+        client_id,
+        client_secret,
+        base_url,
+    })
 }
-
 /// Builds the local LLM client and config from environment variables.
-fn build_client_and_config() -> (Option<OpenAiClient>, GameConfig) {
+fn build_client_and_config() -> (
+    Option<parish_core::inference::openai_client::OpenAiClient>,
+    GameConfig,
+) {
+    use parish_core::inference::openai_client::OpenAiClient;
+
     let provider = std::env::var("PARISH_PROVIDER").unwrap_or_else(|_| "simulator".to_string());
     let model = std::env::var("PARISH_MODEL").unwrap_or_default();
     let base_url = std::env::var("PARISH_BASE_URL").unwrap_or_else(|_| {
@@ -825,19 +347,12 @@ fn build_client_and_config() -> (Option<OpenAiClient>, GameConfig) {
 
 /// Cloud LLM environment configuration loaded from `PARISH_CLOUD_*` vars.
 struct CloudEnvConfig {
-    client: Option<OpenAiClient>,
     provider_name: Option<String>,
     model_name: Option<String>,
     api_key: Option<String>,
     base_url: Option<String>,
 }
 
-/// Builds the cloud LLM client and associated config from environment variables.
-///
-/// Without populating `cloud_provider_name`/`cloud_model_name` on the
-/// `GameConfig`, `resolve_category_client` would never route Dialogue
-/// inference to the cloud client — so even with `PARISH_CLOUD_API_KEY` set,
-/// no requests would actually be sent (e.g. on Railway with Groq configured).
 fn build_cloud_client_from_env() -> CloudEnvConfig {
     let provider = std::env::var("PARISH_CLOUD_PROVIDER")
         .ok()
@@ -856,12 +371,7 @@ fn build_cloud_client_from_env() -> CloudEnvConfig {
         .ok()
         .filter(|s| !s.is_empty());
 
-    let client = api_key
-        .as_deref()
-        .map(|key| OpenAiClient::new(&base_url, Some(key)));
-
     CloudEnvConfig {
-        client,
         provider_name: provider.or_else(|| api_key.as_ref().map(|_| "openrouter".to_string())),
         model_name: model,
         api_key,
@@ -878,5 +388,16 @@ mod tests {
         // In test env, PARISH_PROVIDER is usually not set → defaults to "simulator"
         let (_client, config) = build_client_and_config();
         assert_eq!(config.provider_name, "simulator");
+    }
+
+    #[test]
+    fn build_oauth_config_missing_returns_none() {
+        // Ensure env vars are not set in the test environment.
+        // SAFETY: single-threaded test; no other thread reads these vars.
+        unsafe {
+            std::env::remove_var("GOOGLE_CLIENT_ID");
+            std::env::remove_var("GOOGLE_CLIENT_SECRET");
+        }
+        assert!(build_oauth_config().is_none());
     }
 }

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -246,7 +246,8 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     if oauth_enabled {
         app = app
             .route("/auth/login/google", get(auth::login_google))
-            .route("/auth/callback/google", get(auth::callback_google));
+            .route("/auth/callback/google", get(auth::callback_google))
+            .route("/auth/logout", get(auth::logout));
     }
 
     let app = app

--- a/crates/parish-server/src/middleware.rs
+++ b/crates/parish-server/src/middleware.rs
@@ -20,6 +20,12 @@ use crate::session::{GlobalState, get_or_create_session};
 /// Cookie name used to identify a visitor's session.
 pub const SESSION_COOKIE: &str = "parish_sid";
 
+/// Current visitor's session id, injected by [`session_middleware`] so that
+/// route handlers (e.g. debug) can look up per-session metadata in the
+/// global [`crate::session::SessionRegistry`].
+#[derive(Clone, Debug)]
+pub struct SessionId(pub String);
+
 /// Axum middleware that resolves (or creates) a per-visitor session.
 pub async fn session_middleware(
     State(global): State<Arc<GlobalState>>,
@@ -35,19 +41,20 @@ pub async fn session_middleware(
 
     let (session_id, entry, is_new) = get_or_create_session(&global, cookie_id.as_deref()).await;
 
-    // Inject the per-session AppState as an Axum extension.
+    // Inject the per-session AppState and the session id as Axum extensions.
     req.extensions_mut().insert(Arc::clone(&entry.app_state));
+    req.extensions_mut().insert(SessionId(session_id.clone()));
 
     let mut response = next.run(req).await;
 
     // Set the cookie when a new session was created.
-    if is_new {
-        if let Ok(value) = HeaderValue::from_str(&format!(
+    if is_new
+        && let Ok(value) = HeaderValue::from_str(&format!(
             "{}={}; HttpOnly; SameSite=Lax; Max-Age=31536000; Path=/",
             SESSION_COOKIE, session_id
-        )) {
-            response.headers_mut().insert(header::SET_COOKIE, value);
-        }
+        ))
+    {
+        response.headers_mut().insert(header::SET_COOKIE, value);
     }
 
     response
@@ -57,10 +64,10 @@ pub async fn session_middleware(
 fn extract_cookie_value(cookies: &str, name: &str) -> Option<String> {
     for pair in cookies.split(';') {
         let pair = pair.trim();
-        if let Some(rest) = pair.strip_prefix(name) {
-            if let Some(rest) = rest.strip_prefix('=') {
-                return Some(rest.trim().to_string());
-            }
+        if let Some(rest) = pair.strip_prefix(name)
+            && let Some(rest) = rest.strip_prefix('=')
+        {
+            return Some(rest.trim().to_string());
         }
     }
     None

--- a/crates/parish-server/src/middleware.rs
+++ b/crates/parish-server/src/middleware.rs
@@ -1,0 +1,93 @@
+//! Session cookie middleware.
+//!
+//! Reads the `parish_sid` cookie, resolves (or creates) the per-visitor
+//! [`AppState`] via [`SessionRegistry`], and injects it as an Axum
+//! [`Extension`] so every downstream route handler can access it.
+//!
+//! If a new session was created (no valid cookie was present), the middleware
+//! adds a `Set-Cookie` header to the response.
+
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{HeaderValue, Request, header};
+use axum::middleware::Next;
+use axum::response::Response;
+
+use crate::session::{GlobalState, get_or_create_session};
+
+/// Cookie name used to identify a visitor's session.
+pub const SESSION_COOKIE: &str = "parish_sid";
+
+/// Axum middleware that resolves (or creates) a per-visitor session.
+pub async fn session_middleware(
+    State(global): State<Arc<GlobalState>>,
+    mut req: Request<Body>,
+    next: Next,
+) -> Response {
+    // Extract the session ID from the incoming Cookie header.
+    let cookie_id = req
+        .headers()
+        .get(header::COOKIE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|cookies| extract_cookie_value(cookies, SESSION_COOKIE));
+
+    let (session_id, entry, is_new) = get_or_create_session(&global, cookie_id.as_deref()).await;
+
+    // Inject the per-session AppState as an Axum extension.
+    req.extensions_mut().insert(Arc::clone(&entry.app_state));
+
+    let mut response = next.run(req).await;
+
+    // Set the cookie when a new session was created.
+    if is_new {
+        if let Ok(value) = HeaderValue::from_str(&format!(
+            "{}={}; HttpOnly; SameSite=Lax; Max-Age=31536000; Path=/",
+            SESSION_COOKIE, session_id
+        )) {
+            response.headers_mut().insert(header::SET_COOKIE, value);
+        }
+    }
+
+    response
+}
+
+/// Extracts the value of a named cookie from a raw `Cookie:` header string.
+fn extract_cookie_value(cookies: &str, name: &str) -> Option<String> {
+    for pair in cookies.split(';') {
+        let pair = pair.trim();
+        if let Some(rest) = pair.strip_prefix(name) {
+            if let Some(rest) = rest.strip_prefix('=') {
+                return Some(rest.trim().to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_cookie_value_single() {
+        assert_eq!(
+            extract_cookie_value("parish_sid=abc123", "parish_sid"),
+            Some("abc123".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_cookie_value_multiple() {
+        assert_eq!(
+            extract_cookie_value("foo=bar; parish_sid=xyz789; baz=qux", "parish_sid"),
+            Some("xyz789".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_cookie_value_missing() {
+        assert_eq!(extract_cookie_value("foo=bar; baz=qux", "parish_sid"), None);
+    }
+}

--- a/crates/parish-server/src/middleware.rs
+++ b/crates/parish-server/src/middleware.rs
@@ -32,6 +32,15 @@ pub async fn session_middleware(
     mut req: Request<Body>,
     next: Next,
 ) -> Response {
+    // Auth routes (/auth/login/*, /auth/callback/*, /auth/logout) manage
+    // their own `parish_sid` cookies.  If the session middleware also runs
+    // on these paths it creates a throwaway session whose Set-Cookie header
+    // competes with the handler's — breaking the OAuth flow.
+    let path = req.uri().path().to_string();
+    if path.starts_with("/auth/") {
+        return next.run(req).await;
+    }
+
     // Extract the session ID from the incoming Cookie header.
     let cookie_id = req
         .headers()
@@ -41,7 +50,7 @@ pub async fn session_middleware(
 
     let (session_id, entry, is_new) = get_or_create_session(&global, cookie_id.as_deref()).await;
 
-    // Inject the per-session AppState and the session id as Axum extensions.
+    // Inject the per-session AppState and session id as Axum extensions.
     req.extensions_mut().insert(Arc::clone(&entry.app_state));
     req.extensions_mut().insert(SessionId(session_id.clone()));
 

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -2336,7 +2336,7 @@ pub(crate) mod tests {
             file_path: "../../etc/passwd".to_string(),
             branch_id: 1,
         };
-        let result = load_branch(State(state), Json(body)).await;
+        let result = load_branch(Extension(state), Json(body)).await;
         assert!(result.is_err());
         let (status, _msg) = result.unwrap_err();
         assert_eq!(status, StatusCode::BAD_REQUEST);

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use axum::Json;
-use axum::extract::State;
+use axum::extract::Extension;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use tokio::sync::mpsc;
@@ -44,7 +44,7 @@ static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 // ── Query endpoints ─────────────────────────────────────────────────────────
 
 /// `GET /api/world-snapshot` — returns the current world snapshot.
-pub async fn get_world_snapshot(State(state): State<Arc<AppState>>) -> Json<WorldSnapshot> {
+pub async fn get_world_snapshot(Extension(state): Extension<Arc<AppState>>) -> Json<WorldSnapshot> {
     let world = state.world.lock().await;
     let npc_manager = state.npc_manager.lock().await;
     let transport = state.transport.default_mode();
@@ -55,21 +55,21 @@ pub async fn get_world_snapshot(State(state): State<Arc<AppState>>) -> Json<Worl
 }
 
 /// `GET /api/map` — returns visited locations, edges, and player position.
-pub async fn get_map(State(state): State<Arc<AppState>>) -> Json<MapData> {
+pub async fn get_map(Extension(state): Extension<Arc<AppState>>) -> Json<MapData> {
     let world = state.world.lock().await;
     let transport = state.transport.default_mode();
     Json(parish_core::ipc::build_map_data(&world, transport))
 }
 
 /// `GET /api/npcs-here` — returns NPCs at the player's current location.
-pub async fn get_npcs_here(State(state): State<Arc<AppState>>) -> Json<Vec<NpcInfo>> {
+pub async fn get_npcs_here(Extension(state): Extension<Arc<AppState>>) -> Json<Vec<NpcInfo>> {
     let world = state.world.lock().await;
     let npc_manager = state.npc_manager.lock().await;
     Json(parish_core::ipc::build_npcs_here(&world, &npc_manager))
 }
 
 /// `GET /api/theme` — returns the current time-of-day palette (weather + season tinted).
-pub async fn get_theme(State(state): State<Arc<AppState>>) -> Json<ThemePalette> {
+pub async fn get_theme(Extension(state): Extension<Arc<AppState>>) -> Json<ThemePalette> {
     use chrono::Timelike;
     use parish_core::world::palette::compute_palette;
     let world = state.world.lock().await;
@@ -85,13 +85,13 @@ pub async fn get_theme(State(state): State<Arc<AppState>>) -> Json<ThemePalette>
 
 /// `GET /api/ui-config` — returns UI configuration (splash text, labels, accent).
 pub async fn get_ui_config(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
 ) -> Json<crate::state::UiConfigSnapshot> {
     Json(state.ui_config.clone())
 }
 
 /// `GET /api/debug-snapshot` — returns full debug state for the debug panel.
-pub async fn get_debug_snapshot(State(state): State<Arc<AppState>>) -> Json<DebugSnapshot> {
+pub async fn get_debug_snapshot(Extension(state): Extension<Arc<AppState>>) -> Json<DebugSnapshot> {
     let world = state.world.lock().await;
     let npc_manager = state.npc_manager.lock().await;
     let config = state.config.lock().await;
@@ -134,7 +134,7 @@ pub struct SubmitInputRequest {
 
 /// `POST /api/submit-input` — processes player text input.
 pub async fn submit_input(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
     Json(body): Json<SubmitInputRequest>,
 ) -> impl IntoResponse {
     let text = body.text.trim().to_string();
@@ -1269,7 +1269,7 @@ fn spawn_loading_animation(state: Arc<AppState>, cancel: tokio_util::sync::Cance
 
 /// `POST /api/react-to-message` — player reacts to an NPC message with an emoji.
 pub async fn react_to_message(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
     Json(body): Json<ReactRequest>,
 ) -> impl IntoResponse {
     // Validate emoji is in the palette
@@ -1593,7 +1593,7 @@ async fn do_new_game_inner(state: &Arc<AppState>) -> Result<(), String> {
 
 /// `GET /api/discover-save-files` — returns all save files with branch metadata.
 pub async fn discover_save_files(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
 ) -> Result<Json<Vec<SaveFileInfo>>, (StatusCode, String)> {
     let graph = {
         let world = state.world.lock().await;
@@ -1610,7 +1610,7 @@ pub async fn discover_save_files(
 
 /// `POST /api/save-game` — saves the current game state to the active save file.
 pub async fn save_game(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
 ) -> Result<Json<String>, (StatusCode, String)> {
     let msg = do_save_game_inner(&state)
         .await
@@ -1631,7 +1631,7 @@ pub struct LoadBranchRequest {
 
 /// `POST /api/load-branch` — loads a branch from a save file.
 pub async fn load_branch(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
     Json(body): Json<LoadBranchRequest>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     let path = std::path::PathBuf::from(&body.file_path);
@@ -1724,7 +1724,7 @@ pub struct CreateBranchRequest {
 
 /// `POST /api/create-branch` — creates a new branch forked from a parent.
 pub async fn create_branch(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
     Json(body): Json<CreateBranchRequest>,
 ) -> Result<Json<String>, (StatusCode, String)> {
     let msg = do_fork_branch_inner(&state, &body.name, body.parent_branch_id)
@@ -1735,7 +1735,7 @@ pub async fn create_branch(
 
 /// `POST /api/new-save-file` — creates a new save file and saves current state.
 pub async fn new_save_file(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     let saves_dir = state.saves_dir.clone();
     let path = new_save_path(&saves_dir);
@@ -1770,7 +1770,7 @@ pub async fn new_save_file(
 
 /// `POST /api/new-game` — reloads world/NPCs from data files and saves fresh state.
 pub async fn new_game(
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
 ) -> Result<StatusCode, (StatusCode, String)> {
     do_new_game_inner(&state)
         .await
@@ -1785,7 +1785,7 @@ pub async fn new_game(
 }
 
 /// `GET /api/save-state` — returns the current save state for the StatusBar.
-pub async fn get_save_state(State(state): State<Arc<AppState>>) -> Json<SaveState> {
+pub async fn get_save_state(Extension(state): Extension<Arc<AppState>>) -> Json<SaveState> {
     let save_path = state.save_path.lock().await;
     let branch_id = state.current_branch_id.lock().await;
     let branch_name = state.current_branch_name.lock().await;
@@ -2021,7 +2021,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn get_save_state_initial_is_empty() {
         let state = test_app_state();
-        let result = get_save_state(axum::extract::State(state)).await;
+        let result = get_save_state(axum::extract::Extension(state)).await;
         let save_state = result.0;
         assert!(save_state.filename.is_none());
         assert!(save_state.branch_id.is_none());
@@ -2033,7 +2033,7 @@ pub(crate) mod tests {
     async fn discover_save_files_empty_dir() {
         let state = test_app_state();
         // saves_dir points to ../../saves which may or may not exist — either way should not panic
-        let result = discover_save_files(axum::extract::State(state)).await;
+        let result = discover_save_files(axum::extract::Extension(state)).await;
         assert!(result.is_ok());
     }
 

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use axum::Json;
-use axum::extract::Extension;
+use axum::extract::{Extension, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use tokio::sync::mpsc;
@@ -31,11 +31,13 @@ use parish_core::npc::reactions;
 use parish_core::npc::ticks::apply_tier1_response_with_config;
 use parish_core::world::{LocationId, WorldState};
 
-use parish_core::debug_snapshot::{self, DebugSnapshot, InferenceDebug};
+use parish_core::debug_snapshot::{self, AuthDebug, DebugSnapshot, InferenceDebug};
 use parish_core::persistence::Database;
 use parish_core::persistence::picker::{SaveFileInfo, discover_saves, new_save_path};
 use parish_core::persistence::snapshot::GameSnapshot;
 
+use crate::middleware::SessionId;
+use crate::session::GlobalState;
 use crate::state::{AppState, ConversationRuntimeState, SaveState};
 
 /// Monotonically increasing request ID counter for inference requests.
@@ -91,7 +93,11 @@ pub async fn get_ui_config(
 }
 
 /// `GET /api/debug-snapshot` — returns full debug state for the debug panel.
-pub async fn get_debug_snapshot(Extension(state): Extension<Arc<AppState>>) -> Json<DebugSnapshot> {
+pub async fn get_debug_snapshot(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(session_id): Extension<SessionId>,
+    State(global): State<Arc<GlobalState>>,
+) -> Json<DebugSnapshot> {
     let world = state.world.lock().await;
     let npc_manager = state.npc_manager.lock().await;
     let config = state.config.lock().await;
@@ -110,12 +116,21 @@ pub async fn get_debug_snapshot(Extension(state): Extension<Arc<AppState>>) -> J
         improv_enabled: config.improv_enabled,
         call_log,
     };
+    let linked = global.sessions.google_account_for_session(&session_id.0);
+    let auth = AuthDebug {
+        oauth_enabled: global.oauth_config.is_some(),
+        logged_in: linked.is_some(),
+        provider: linked.as_ref().map(|_| "google".to_string()),
+        display_name: linked.map(|(_sub, name)| name),
+        session_id: Some(session_id.0.clone()),
+    };
     Json(debug_snapshot::build_debug_snapshot(
         &world,
         &npc_manager,
         &events,
         &game_events,
         &inference,
+        &auth,
     ))
 }
 

--- a/crates/parish-server/src/session.rs
+++ b/crates/parish-server/src/session.rs
@@ -1,0 +1,583 @@
+//! Per-visitor session management.
+//!
+//! Each visitor gets an isolated [`AppState`], identified by a UUID stored in
+//! a `parish_sid` cookie.  Sessions survive server restarts because they are
+//! persisted in `saves/sessions.db` and their game state lives in
+//! `saves/<session_id>/parish_NNN.db`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use dashmap::DashMap;
+use tokio::task::JoinHandle;
+
+use parish_core::game_mod::{GameMod, PronunciationEntry};
+use parish_core::inference::openai_client::OpenAiClient;
+use parish_core::ipc::{GameConfig, ThemePalette};
+use parish_core::npc::manager::NpcManager;
+use parish_core::world::transport::TransportConfig;
+use parish_core::world::{LocationId, WorldState};
+
+use crate::state::{AppState, UiConfigSnapshot, build_app_state};
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+/// Google OAuth credentials (optional — feature disabled when absent).
+pub struct OAuthConfig {
+    pub client_id: String,
+    pub client_secret: String,
+    /// Public base URL of the server, e.g. `https://yourapp.railway.app`.
+    /// Used to construct the OAuth redirect URI.
+    pub base_url: String,
+}
+
+/// Server-wide state shared by all sessions — one instance per process.
+pub struct GlobalState {
+    /// All active sessions, backed by `saves/sessions.db`.
+    pub sessions: SessionRegistry,
+    /// Google OAuth config; `None` disables the login flow.
+    pub oauth_config: Option<OAuthConfig>,
+    /// Directory containing game data files (`world.json`, `npcs.json`, …).
+    pub data_dir: PathBuf,
+    /// Resolved path to the world file (`parish.json` or `world.json`).
+    pub world_path: PathBuf,
+    /// Root saves directory (`saves/`).
+    pub saves_dir: PathBuf,
+    /// Loaded game mod (for themes, reaction templates, pronunciations).
+    pub game_mod: Option<GameMod>,
+    /// Pronunciation entries extracted from the game mod.
+    pub pronunciations: Vec<PronunciationEntry>,
+    /// UI config (splash text, hints label, accent colour).
+    pub ui_config: UiConfigSnapshot,
+    /// Fixed UI theme palette.
+    pub theme_palette: ThemePalette,
+    /// Transport mode configuration.
+    pub transport: TransportConfig,
+    /// Template game config cloned into each new session.
+    pub template_config: GameConfig,
+}
+
+/// A single visitor's isolated game session.
+pub struct SessionEntry {
+    /// The game state for this visitor.
+    pub app_state: Arc<AppState>,
+    /// Unix timestamp of the last API request from this session.
+    pub last_active: AtomicU64,
+    /// Background tick task handles — dropped when the session is evicted.
+    _tick_handles: Vec<JoinHandle<()>>,
+}
+
+// ── SessionRegistry ──────────────────────────────────────────────────────────
+
+/// In-memory session map backed by a SQLite persistence store.
+pub struct SessionRegistry {
+    sessions: DashMap<String, Arc<SessionEntry>>,
+    db: std::sync::Mutex<rusqlite::Connection>,
+}
+
+impl SessionRegistry {
+    /// Opens (or creates) `saves/sessions.db` and runs schema migrations.
+    pub fn open(saves_dir: &Path) -> rusqlite::Result<Self> {
+        let db_path = saves_dir.join("sessions.db");
+        let conn = rusqlite::Connection::open(&db_path)?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS sessions (
+                id           TEXT PRIMARY KEY,
+                created_at   TEXT NOT NULL,
+                last_active  TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS oauth_accounts (
+                provider         TEXT NOT NULL,
+                provider_user_id TEXT NOT NULL,
+                session_id       TEXT NOT NULL,
+                PRIMARY KEY (provider, provider_user_id)
+            );",
+        )?;
+        Ok(Self {
+            sessions: DashMap::new(),
+            db: std::sync::Mutex::new(conn),
+        })
+    }
+
+    pub fn now_unix() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    }
+
+    fn now_iso() -> String {
+        chrono::Utc::now().to_rfc3339()
+    }
+
+    /// Returns `true` if `session_id` is recorded in sessions.db.
+    pub fn exists_in_db(&self, session_id: &str) -> bool {
+        let db = self.db.lock().unwrap();
+        db.query_row("SELECT 1 FROM sessions WHERE id = ?1", [session_id], |_| {
+            Ok(())
+        })
+        .is_ok()
+    }
+
+    /// Inserts a new session row into sessions.db.
+    pub fn persist_new(&self, session_id: &str) {
+        let now = Self::now_iso();
+        let db = self.db.lock().unwrap();
+        let _ = db.execute(
+            "INSERT OR IGNORE INTO sessions (id, created_at, last_active) VALUES (?1, ?2, ?2)",
+            rusqlite::params![session_id, now],
+        );
+    }
+
+    /// Updates the `last_active` timestamp for a session in sessions.db.
+    pub fn update_last_active(&self, session_id: &str) {
+        let now = Self::now_iso();
+        let db = self.db.lock().unwrap();
+        let _ = db.execute(
+            "UPDATE sessions SET last_active = ?1 WHERE id = ?2",
+            rusqlite::params![now, session_id],
+        );
+    }
+
+    /// Returns the session_id linked to an OAuth identity, if any.
+    pub fn find_by_oauth(&self, provider: &str, provider_user_id: &str) -> Option<String> {
+        let db = self.db.lock().unwrap();
+        db.query_row(
+            "SELECT session_id FROM oauth_accounts
+             WHERE provider = ?1 AND provider_user_id = ?2",
+            rusqlite::params![provider, provider_user_id],
+            |row| row.get(0),
+        )
+        .ok()
+    }
+
+    /// Associates an OAuth identity with a session_id.
+    pub fn link_oauth(&self, provider: &str, provider_user_id: &str, session_id: &str) {
+        let db = self.db.lock().unwrap();
+        let _ = db.execute(
+            "INSERT OR REPLACE INTO oauth_accounts
+             (provider, provider_user_id, session_id) VALUES (?1, ?2, ?3)",
+            rusqlite::params![provider, provider_user_id, session_id],
+        );
+    }
+
+    /// Returns a session from the in-memory map.
+    pub fn get_in_memory(&self, session_id: &str) -> Option<Arc<SessionEntry>> {
+        self.sessions.get(session_id).map(|e| Arc::clone(&*e))
+    }
+
+    /// Inserts a session into the in-memory map.
+    pub fn insert(&self, session_id: String, entry: Arc<SessionEntry>) {
+        self.sessions.insert(session_id, entry);
+    }
+
+    /// Returns the Google `sub` linked to `session_id`, if any.
+    ///
+    /// Used by `GET /api/auth/status` to check whether the session has a
+    /// linked Google account.
+    pub fn google_account_for_session(&self, session_id: &str) -> Option<String> {
+        let db = self.db.lock().unwrap();
+        db.query_row(
+            "SELECT provider_user_id FROM oauth_accounts \
+             WHERE session_id = ?1 AND provider = 'google'",
+            rusqlite::params![session_id],
+            |row: &rusqlite::Row<'_>| row.get::<_, String>(0),
+        )
+        .ok()
+    }
+
+    /// Removes sessions that have been idle longer than `max_age`.
+    ///
+    /// The sessions' background tick tasks are implicitly cancelled when
+    /// their `JoinHandle`s are dropped via the evicted `SessionEntry`.
+    pub fn cleanup_stale(&self, max_age: Duration) {
+        let cutoff = Self::now_unix().saturating_sub(max_age.as_secs());
+        self.sessions
+            .retain(|_, entry| entry.last_active.load(Ordering::Relaxed) >= cutoff);
+    }
+}
+
+// ── Public session resolution ─────────────────────────────────────────────────
+
+/// Returns the session for `cookie_id`, restoring or creating one as needed.
+///
+/// Returns `(session_id, entry, is_new)` where `is_new` is `true` when a
+/// fresh `parish_sid` cookie must be set on the response.
+pub async fn get_or_create_session(
+    global: &Arc<GlobalState>,
+    cookie_id: Option<&str>,
+) -> (String, Arc<SessionEntry>, bool) {
+    // 1. Hot path: session already in memory.
+    if let Some(id) = cookie_id {
+        if let Some(entry) = global.sessions.get_in_memory(id) {
+            entry
+                .last_active
+                .store(SessionRegistry::now_unix(), Ordering::Relaxed);
+            global.sessions.update_last_active(id);
+            return (id.to_string(), entry, false);
+        }
+        // 2. Session known in DB but evicted from memory — restore it.
+        if global.sessions.exists_in_db(id) {
+            match restore_session(global, id).await {
+                Ok(entry) => {
+                    global.sessions.insert(id.to_string(), Arc::clone(&entry));
+                    global.sessions.update_last_active(id);
+                    return (id.to_string(), entry, false);
+                }
+                Err(e) => {
+                    tracing::warn!(session_id = %id, "Session restore failed: {}. Starting fresh.", e);
+                }
+            }
+        }
+    }
+
+    // 3. No usable session — create a new one.
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let entry = create_session(global, &session_id).await;
+    global.sessions.persist_new(&session_id);
+    global
+        .sessions
+        .insert(session_id.clone(), Arc::clone(&entry));
+    (session_id, entry, true)
+}
+
+// ── Session creation ──────────────────────────────────────────────────────────
+
+async fn create_session(global: &Arc<GlobalState>, session_id: &str) -> Arc<SessionEntry> {
+    let session_saves = global.saves_dir.join(session_id);
+    std::fs::create_dir_all(&session_saves).ok();
+
+    let world_path = global.world_path.clone();
+    let data_dir = global.data_dir.clone();
+    let (world, npc_manager) = tokio::task::spawn_blocking(move || {
+        let world = WorldState::from_parish_file(&world_path, LocationId(15)).unwrap_or_else(|e| {
+            tracing::warn!("Session init: failed to load world: {}. Using default.", e);
+            WorldState::new()
+        });
+        let mut npc_manager = NpcManager::load_from_file(&data_dir.join("npcs.json"))
+            .unwrap_or_else(|e| {
+                tracing::warn!("Session init: failed to load npcs.json: {}. No NPCs.", e);
+                NpcManager::new()
+            });
+        npc_manager.assign_tiers(&world, &[]);
+        (world, npc_manager)
+    })
+    .await
+    .expect("session init blocking task panicked");
+
+    let (client, config) = build_session_client(global);
+    let cloud_client = build_session_cloud_client(global);
+    let game_mod = global.game_mod.clone();
+
+    let flags_path = global.data_dir.join("parish-flags.json");
+    let app_state = build_app_state(
+        world,
+        npc_manager,
+        client.clone(),
+        config,
+        cloud_client,
+        global.transport.clone(),
+        global.ui_config.clone(),
+        global.theme_palette.clone(),
+        session_saves.clone(),
+        global.data_dir.clone(),
+        game_mod,
+        flags_path,
+    );
+
+    if let Some(ref c) = client {
+        init_inference_queue(&app_state, c).await;
+    }
+
+    if let Err(e) = init_session_save(&app_state, &session_saves).await {
+        tracing::warn!("Session initial save failed: {}", e);
+    }
+
+    let handles = spawn_session_ticks(Arc::clone(&app_state));
+
+    Arc::new(SessionEntry {
+        app_state,
+        last_active: AtomicU64::new(SessionRegistry::now_unix()),
+        _tick_handles: handles,
+    })
+}
+
+// ── Session restoration ───────────────────────────────────────────────────────
+
+async fn restore_session(
+    global: &Arc<GlobalState>,
+    session_id: &str,
+) -> Result<Arc<SessionEntry>, String> {
+    let session_saves = global.saves_dir.join(session_id);
+    if !session_saves.exists() {
+        return Err(format!(
+            "saves directory {} does not exist",
+            session_saves.display()
+        ));
+    }
+
+    // Find the first (alphabetically) .db file.
+    let db_path = {
+        let mut files: Vec<PathBuf> = std::fs::read_dir(&session_saves)
+            .map_err(|e| e.to_string())?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|ext| ext == "db"))
+            .collect();
+        files.sort();
+        files.into_iter().next().ok_or("no save files found")?
+    };
+
+    // Load snapshot from the first branch.
+    let db_path_clone = db_path.clone();
+    let (snapshot, branch_id, branch_name) = tokio::task::spawn_blocking(move || {
+        use parish_core::persistence::Database;
+        let db = Database::open(&db_path_clone).map_err(|e| e.to_string())?;
+        let branches = db.list_branches().map_err(|e| e.to_string())?;
+        let branch = branches.into_iter().next().ok_or("no branches")?;
+        let (_, snapshot) = db
+            .load_latest_snapshot(branch.id)
+            .map_err(|e| e.to_string())?
+            .ok_or("no snapshots")?;
+        Ok::<_, String>((snapshot, branch.id, branch.name))
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+
+    // Load fresh static world data, then apply the saved snapshot.
+    let world_path = global.world_path.clone();
+    let data_dir = global.data_dir.clone();
+    let (mut world, mut npc_manager) = tokio::task::spawn_blocking(move || {
+        let world = WorldState::from_parish_file(&world_path, LocationId(15))
+            .unwrap_or_else(|_| WorldState::new());
+        let npc_manager = NpcManager::load_from_file(&data_dir.join("npcs.json"))
+            .unwrap_or_else(|_| NpcManager::new());
+        (world, npc_manager)
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+
+    snapshot.restore(&mut world, &mut npc_manager);
+    npc_manager.assign_tiers(&world, &[]);
+
+    let (client, config) = build_session_client(global);
+    let cloud_client = build_session_cloud_client(global);
+    let game_mod = global.game_mod.clone();
+
+    let flags_path = global.data_dir.join("parish-flags.json");
+    let app_state = build_app_state(
+        world,
+        npc_manager,
+        client.clone(),
+        config,
+        cloud_client,
+        global.transport.clone(),
+        global.ui_config.clone(),
+        global.theme_palette.clone(),
+        session_saves.clone(),
+        global.data_dir.clone(),
+        game_mod,
+        flags_path,
+    );
+
+    if let Some(ref c) = client {
+        init_inference_queue(&app_state, c).await;
+    }
+
+    *app_state.save_path.lock().await = Some(db_path);
+    *app_state.current_branch_id.lock().await = Some(branch_id);
+    *app_state.current_branch_name.lock().await = Some(branch_name);
+
+    let handles = spawn_session_ticks(Arc::clone(&app_state));
+
+    Ok(Arc::new(SessionEntry {
+        app_state,
+        last_active: AtomicU64::new(SessionRegistry::now_unix()),
+        _tick_handles: handles,
+    }))
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async fn init_inference_queue(app_state: &Arc<AppState>, client: &OpenAiClient) {
+    use parish_core::inference::{InferenceQueue, spawn_inference_worker};
+    let (interactive_tx, interactive_rx) = tokio::sync::mpsc::channel(16);
+    let (background_tx, background_rx) = tokio::sync::mpsc::channel(32);
+    let (batch_tx, batch_rx) = tokio::sync::mpsc::channel(64);
+    let _worker = spawn_inference_worker(
+        client.clone(),
+        interactive_rx,
+        background_rx,
+        batch_rx,
+        app_state.inference_log.clone(),
+    );
+    let queue = InferenceQueue::new(interactive_tx, background_tx, batch_tx);
+    *app_state.inference_queue.lock().await = Some(queue);
+}
+
+/// Saves the initial world snapshot into `saves/<session_id>/parish_001.db`.
+async fn init_session_save(app_state: &Arc<AppState>, session_saves: &Path) -> Result<(), String> {
+    use parish_core::persistence::Database;
+    use parish_core::persistence::picker::new_save_path;
+    use parish_core::persistence::snapshot::GameSnapshot;
+
+    let snapshot = {
+        let world = app_state.world.lock().await;
+        let npc_manager = app_state.npc_manager.lock().await;
+        GameSnapshot::capture(&world, &npc_manager)
+    };
+
+    let save_path = new_save_path(session_saves);
+    let save_path_clone = save_path.clone();
+
+    let branch_id = tokio::task::spawn_blocking(move || -> Result<i64, String> {
+        let db = Database::open(&save_path_clone).map_err(|e| e.to_string())?;
+        let branch_id = db.create_branch("main", None).map_err(|e| e.to_string())?;
+        db.save_snapshot(branch_id, &snapshot)
+            .map_err(|e| e.to_string())?;
+        Ok(branch_id)
+    })
+    .await
+    .map_err(|e| e.to_string())??;
+
+    *app_state.save_path.lock().await = Some(save_path);
+    *app_state.current_branch_id.lock().await = Some(branch_id);
+    *app_state.current_branch_name.lock().await = Some("main".to_string());
+
+    Ok(())
+}
+
+/// Spawns the three per-session background tasks and returns their handles.
+fn spawn_session_ticks(state: Arc<AppState>) -> Vec<JoinHandle<()>> {
+    let mut handles = Vec::with_capacity(3);
+
+    // ── World tick (5 s) ─────────────────────────────────────────────────────
+    {
+        let s = Arc::clone(&state);
+        handles.push(tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+
+                {
+                    let world = s.world.lock().await;
+                    let npc_manager = s.npc_manager.lock().await;
+                    let transport = s.transport.default_mode();
+                    let mut snap = parish_core::ipc::snapshot_from_world(&world, transport);
+                    snap.name_hints = parish_core::ipc::compute_name_hints(
+                        &world,
+                        &npc_manager,
+                        &s.pronunciations,
+                    );
+                    s.event_bus.emit("world-update", &snap);
+                }
+
+                {
+                    let mut world = s.world.lock().await;
+                    let mut npc_mgr = s.npc_manager.lock().await;
+
+                    let season = world.clock.season();
+                    let now = world.clock.now();
+                    let mut rng = rand::thread_rng();
+                    if let Some(new_weather) = world.weather_engine.tick(now, season, &mut rng) {
+                        world.weather = new_weather;
+                        world.event_bus.publish(
+                            parish_core::world::events::GameEvent::WeatherChanged {
+                                new_weather: new_weather.to_string(),
+                                timestamp: world.clock.now(),
+                            },
+                        );
+                    }
+
+                    npc_mgr.tick_schedules(&world.clock, &world.graph, world.weather);
+                    npc_mgr.assign_tiers(&world, &[]);
+
+                    if !world.gossip_network.is_empty() {
+                        let groups = npc_mgr.tier2_groups();
+                        let mut rng = rand::thread_rng();
+                        for npc_ids in groups.values() {
+                            if npc_ids.len() >= 2 {
+                                parish_core::npc::ticks::propagate_gossip_at_location(
+                                    npc_ids,
+                                    &mut world.gossip_network,
+                                    &mut rng,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }));
+    }
+
+    // ── Inactivity tick (1 s) ────────────────────────────────────────────────
+    {
+        let s = Arc::clone(&state);
+        handles.push(tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                crate::routes::tick_inactivity(&s).await;
+            }
+        }));
+    }
+
+    // ── Autosave tick (60 s) ─────────────────────────────────────────────────
+    {
+        let s = Arc::clone(&state);
+        handles.push(tokio::spawn(async move {
+            use parish_core::persistence::Database;
+            use parish_core::persistence::snapshot::GameSnapshot;
+            loop {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+
+                let save_path = s.save_path.lock().await.clone();
+                let branch_id = *s.current_branch_id.lock().await;
+
+                if let (Some(path), Some(bid)) = (save_path, branch_id) {
+                    let world = s.world.lock().await;
+                    let npc_manager = s.npc_manager.lock().await;
+                    let snapshot = GameSnapshot::capture(&world, &npc_manager);
+                    drop(npc_manager);
+                    drop(world);
+
+                    match Database::open(&path) {
+                        Ok(db) => match db.save_snapshot(bid, &snapshot) {
+                            Ok(_) => tracing::debug!("Session autosave complete"),
+                            Err(e) => tracing::warn!("Session autosave failed: {}", e),
+                        },
+                        Err(e) => tracing::warn!("Session autosave DB open failed: {}", e),
+                    }
+                }
+            }
+        }));
+    }
+
+    handles
+}
+
+fn build_session_client(global: &GlobalState) -> (Option<OpenAiClient>, GameConfig) {
+    let config = global.template_config.clone();
+    let client = if config.model_name.is_empty() && config.provider_name != "ollama" {
+        None
+    } else {
+        Some(OpenAiClient::new(
+            &config.base_url,
+            config.api_key.as_deref(),
+        ))
+    };
+    (client, config)
+}
+
+fn build_session_cloud_client(global: &GlobalState) -> Option<OpenAiClient> {
+    let config = &global.template_config;
+    config.cloud_api_key.as_deref().map(|key| {
+        OpenAiClient::new(
+            config
+                .cloud_base_url
+                .as_deref()
+                .unwrap_or("https://openrouter.ai/api"),
+            Some(key),
+        )
+    })
+}

--- a/crates/parish-server/src/session.rs
+++ b/crates/parish-server/src/session.rs
@@ -92,9 +92,14 @@ impl SessionRegistry {
                 provider         TEXT NOT NULL,
                 provider_user_id TEXT NOT NULL,
                 session_id       TEXT NOT NULL,
+                display_name     TEXT NOT NULL DEFAULT '',
                 PRIMARY KEY (provider, provider_user_id)
             );",
         )?;
+        // Idempotent migration: add display_name to existing DBs that predate this column.
+        let _ = conn.execute_batch(
+            "ALTER TABLE oauth_accounts ADD COLUMN display_name TEXT NOT NULL DEFAULT ''",
+        );
         Ok(Self {
             sessions: DashMap::new(),
             db: std::sync::Mutex::new(conn),
@@ -153,13 +158,19 @@ impl SessionRegistry {
         .ok()
     }
 
-    /// Associates an OAuth identity with a session_id.
-    pub fn link_oauth(&self, provider: &str, provider_user_id: &str, session_id: &str) {
+    /// Associates an OAuth identity with a session_id, storing the user's display name.
+    pub fn link_oauth(
+        &self,
+        provider: &str,
+        provider_user_id: &str,
+        session_id: &str,
+        display_name: &str,
+    ) {
         let db = self.db.lock().unwrap();
         let _ = db.execute(
             "INSERT OR REPLACE INTO oauth_accounts
-             (provider, provider_user_id, session_id) VALUES (?1, ?2, ?3)",
-            rusqlite::params![provider, provider_user_id, session_id],
+             (provider, provider_user_id, session_id, display_name) VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![provider, provider_user_id, session_id, display_name],
         );
     }
 
@@ -173,17 +184,17 @@ impl SessionRegistry {
         self.sessions.insert(session_id, entry);
     }
 
-    /// Returns the Google `sub` linked to `session_id`, if any.
+    /// Returns the Google `(sub, display_name)` linked to `session_id`, if any.
     ///
     /// Used by `GET /api/auth/status` to check whether the session has a
-    /// linked Google account.
-    pub fn google_account_for_session(&self, session_id: &str) -> Option<String> {
+    /// linked Google account and what name to display.
+    pub fn google_account_for_session(&self, session_id: &str) -> Option<(String, String)> {
         let db = self.db.lock().unwrap();
         db.query_row(
-            "SELECT provider_user_id FROM oauth_accounts \
+            "SELECT provider_user_id, display_name FROM oauth_accounts \
              WHERE session_id = ?1 AND provider = 'google'",
             rusqlite::params![session_id],
-            |row: &rusqlite::Row<'_>| row.get::<_, String>(0),
+            |row: &rusqlite::Row<'_>| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
         )
         .ok()
     }

--- a/crates/parish-server/src/session.rs
+++ b/crates/parish-server/src/session.rs
@@ -130,20 +130,24 @@ impl SessionRegistry {
     pub fn persist_new(&self, session_id: &str) {
         let now = Self::now_iso();
         let db = self.db.lock().unwrap();
-        let _ = db.execute(
+        if let Err(e) = db.execute(
             "INSERT OR IGNORE INTO sessions (id, created_at, last_active) VALUES (?1, ?2, ?2)",
             rusqlite::params![session_id, now],
-        );
+        ) {
+            tracing::warn!(session_id = %session_id, error = %e, "persist_new failed");
+        }
     }
 
     /// Updates the `last_active` timestamp for a session in sessions.db.
     pub fn update_last_active(&self, session_id: &str) {
         let now = Self::now_iso();
         let db = self.db.lock().unwrap();
-        let _ = db.execute(
+        if let Err(e) = db.execute(
             "UPDATE sessions SET last_active = ?1 WHERE id = ?2",
             rusqlite::params![now, session_id],
-        );
+        ) {
+            tracing::warn!(session_id = %session_id, error = %e, "update_last_active failed");
+        }
     }
 
     /// Returns the session_id linked to an OAuth identity, if any.
@@ -167,11 +171,27 @@ impl SessionRegistry {
         display_name: &str,
     ) {
         let db = self.db.lock().unwrap();
-        let _ = db.execute(
+        match db.execute(
             "INSERT OR REPLACE INTO oauth_accounts
              (provider, provider_user_id, session_id, display_name) VALUES (?1, ?2, ?3, ?4)",
             rusqlite::params![provider, provider_user_id, session_id, display_name],
-        );
+        ) {
+            Ok(rows) => tracing::info!(
+                provider = %provider,
+                provider_user_id = %provider_user_id,
+                session_id = %session_id,
+                display_name = %display_name,
+                rows = rows,
+                "link_oauth stored account"
+            ),
+            Err(e) => tracing::error!(
+                provider = %provider,
+                provider_user_id = %provider_user_id,
+                session_id = %session_id,
+                error = %e,
+                "link_oauth DB write failed"
+            ),
+        }
     }
 
     /// Returns a session from the in-memory map.
@@ -591,4 +611,88 @@ fn build_session_cloud_client(global: &GlobalState) -> Option<OpenAiClient> {
             Some(key),
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verifies that a fresh DB round-trips the Google OAuth link:
+    /// after `link_oauth`, both `find_by_oauth` and
+    /// `google_account_for_session` return the stored values.
+    ///
+    /// This is the exact flow the callback + status endpoint use, so if
+    /// this test passes but the UI shows the user as signed out, the bug
+    /// is elsewhere (cookies, middleware, frontend).
+    #[test]
+    fn oauth_link_round_trips_on_fresh_db() {
+        let tmp = tempfile::tempdir().unwrap();
+        let reg = SessionRegistry::open(tmp.path()).unwrap();
+        reg.persist_new("sess_abc");
+        reg.link_oauth("google", "sub_123", "sess_abc", "John Doe");
+
+        assert_eq!(
+            reg.find_by_oauth("google", "sub_123"),
+            Some("sess_abc".to_string()),
+            "find_by_oauth should return the linked session_id"
+        );
+        assert_eq!(
+            reg.google_account_for_session("sess_abc"),
+            Some(("sub_123".to_string(), "John Doe".to_string())),
+            "google_account_for_session should return (sub, display_name)"
+        );
+    }
+
+    /// Verifies the migration from a pre-display_name schema to the
+    /// current schema: opening a DB that was created with the old schema
+    /// should add the `display_name` column, and subsequent link_oauth
+    /// + google_account_for_session calls should work end-to-end.
+    #[test]
+    fn oauth_link_round_trips_on_migrated_db() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("sessions.db");
+
+        // Simulate an existing DB created with the pre-display_name schema.
+        {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.execute_batch(
+                "CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY,
+                    created_at TEXT NOT NULL,
+                    last_active TEXT NOT NULL
+                );
+                CREATE TABLE oauth_accounts (
+                    provider         TEXT NOT NULL,
+                    provider_user_id TEXT NOT NULL,
+                    session_id       TEXT NOT NULL,
+                    PRIMARY KEY (provider, provider_user_id)
+                );",
+            )
+            .unwrap();
+            // Insert a row that predates the display_name column.
+            conn.execute(
+                "INSERT INTO oauth_accounts (provider, provider_user_id, session_id) \
+                 VALUES ('google', 'legacy_sub', 'legacy_sess')",
+                [],
+            )
+            .unwrap();
+        }
+
+        // Re-open through SessionRegistry — this should ADD COLUMN display_name.
+        let reg = SessionRegistry::open(tmp.path()).unwrap();
+
+        // Legacy row has empty display_name (default).
+        assert_eq!(
+            reg.google_account_for_session("legacy_sess"),
+            Some(("legacy_sub".to_string(), String::new())),
+        );
+
+        // New link writes the display_name column correctly.
+        reg.persist_new("sess_new");
+        reg.link_oauth("google", "sub_new", "sess_new", "Jane Doe");
+        assert_eq!(
+            reg.google_account_for_session("sess_new"),
+            Some(("sub_new".to_string(), "Jane Doe".to_string())),
+        );
+    }
 }

--- a/crates/parish-server/src/session.rs
+++ b/crates/parish-server/src/session.rs
@@ -437,8 +437,9 @@ async fn init_inference_queue(app_state: &Arc<AppState>, client: &OpenAiClient) 
     let (interactive_tx, interactive_rx) = tokio::sync::mpsc::channel(16);
     let (background_tx, background_rx) = tokio::sync::mpsc::channel(32);
     let (batch_tx, batch_rx) = tokio::sync::mpsc::channel(64);
+    use parish_core::inference::AnyClient;
     let _worker = spawn_inference_worker(
-        client.clone(),
+        AnyClient::open_ai(client.clone()),
         interactive_rx,
         background_rx,
         batch_rx,

--- a/crates/parish-server/src/ws.rs
+++ b/crates/parish-server/src/ws.rs
@@ -1,11 +1,11 @@
 //! WebSocket handler for server-push events.
 //!
 //! Each connected client gets a WebSocket that receives JSON-encoded
-//! [`ServerEvent`] frames from the [`EventBus`].
+//! [`ServerEvent`] frames from the per-session [`EventBus`].
 
 use std::sync::Arc;
 
-use axum::extract::State;
+use axum::extract::Extension;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::response::IntoResponse;
 
@@ -14,15 +14,15 @@ use crate::state::AppState;
 /// Upgrades the HTTP connection to a WebSocket.
 pub async fn ws_handler(
     ws: WebSocketUpgrade,
-    State(state): State<Arc<AppState>>,
+    Extension(state): Extension<Arc<AppState>>,
 ) -> impl IntoResponse {
     ws.on_upgrade(|socket| handle_socket(socket, state))
 }
 
 /// Handles a single WebSocket connection.
 ///
-/// Subscribes to the [`EventBus`] and forwards each event as a JSON text
-/// frame until the client disconnects or the bus is dropped.
+/// Subscribes to the per-session [`EventBus`] and forwards each event as a
+/// JSON text frame until the client disconnects or the bus is dropped.
 async fn handle_socket(mut socket: WebSocket, state: Arc<AppState>) {
     let mut rx = state.event_bus.subscribe();
     tracing::info!("WebSocket client connected");

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -10,7 +10,7 @@ use tauri::Emitter;
 use tokio::sync::mpsc;
 
 use parish_core::config::InferenceCategory;
-use parish_core::debug_snapshot::{self, DebugEvent, DebugSnapshot, InferenceDebug};
+use parish_core::debug_snapshot::{self, AuthDebug, DebugEvent, DebugSnapshot, InferenceDebug};
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{
     AnyClient, INFERENCE_RESPONSE_TIMEOUT_SECS, InferenceAwaitOutcome, InferenceQueue,
@@ -212,6 +212,7 @@ pub async fn get_debug_snapshot(
         &events,
         &game_events,
         &inference,
+        &AuthDebug::disabled(),
     ))
 }
 

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -1428,6 +1428,7 @@ pub fn run() {
                             &debug_events,
                             &game_events,
                             &inference,
+                            &parish_core::debug_snapshot::AuthDebug::disabled(),
                         );
                         let _ = handle_debug.emit(events::EVENT_DEBUG_UPDATE, snapshot);
                     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,6 +101,7 @@ Detailed, implementation-ready plans for each development phase.
 | [macOS Setup](macos-setup.md) | Native macOS setup, Apple Silicon GPU, terminal tips |
 | [Linux Setup](linux-setup.md) | Native Linux setup, NVIDIA/AMD GPU, headless screenshots |
 | [Windows Setup](windows-setup.md) | Native Windows setup, terminal tips, troubleshooting |
+| [Google OAuth Setup](oauth-setup.md) | Obtaining Google credentials for the web server's sign-in flow |
 
 ## Development
 

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -1,0 +1,73 @@
+# Google OAuth Setup
+
+The Parish web server supports optional Google sign-in so visitors can claim their anonymous session across devices. This doc walks through obtaining credentials from Google Cloud Console and wiring them into the server.
+
+## What the server expects
+
+The web server (`crates/parish-server/`) reads three environment variables on startup:
+
+| Variable | Purpose |
+|----------|---------|
+| `GOOGLE_CLIENT_ID` | OAuth client ID from Google Cloud Console |
+| `GOOGLE_CLIENT_SECRET` | OAuth client secret from Google Cloud Console |
+| `PARISH_BASE_URL` | Public base URL of the server (defaults to `http://localhost:3001`) |
+
+These are loaded via `dotenvy::dotenv()`, so a `.env` file at the repo root works. If either `GOOGLE_CLIENT_ID` or `GOOGLE_CLIENT_SECRET` is missing or empty, OAuth is silently disabled and the `/auth/login/google` + `/auth/callback/google` routes are not registered.
+
+Relevant code:
+- `crates/parish-server/src/lib.rs` — `build_oauth_config()` reads the env vars
+- `crates/parish-server/src/auth.rs` — OAuth flow, hard-codes the `openid email profile` scopes and the `/auth/callback/google` redirect path
+
+## Google Cloud Console walkthrough
+
+1. **Create or select a project** at https://console.cloud.google.com/. Click the project dropdown at the top → "New Project" → name it (e.g. "Parish") → Create.
+
+2. **Configure the OAuth consent screen:**
+   - Navigation menu → "APIs & Services" → "OAuth consent screen"
+   - User type: **External** (unless you have a Google Workspace org and want internal-only)
+   - Fill in app name, user support email, and developer contact email
+   - Add scopes: `openid`, `email`, `profile`
+   - Add your own Google account as a **test user** — while the app is in "Testing" status, only listed test users can log in
+
+3. **Create OAuth credentials:**
+   - "APIs & Services" → "Credentials" → "Create Credentials" → **"OAuth client ID"**
+   - Application type: **Web application**
+   - Name: anything (e.g. "Parish Web Server")
+   - **Authorized redirect URIs** — add one per environment you'll run in:
+     - Local dev: `http://localhost:3001/auth/callback/google`
+     - Production: `https://your-domain.example.com/auth/callback/google`
+   - Click Create
+
+4. **Copy the Client ID and Client Secret** from the dialog that appears.
+
+## Local testing
+
+Put the credentials into a `.env` file at the repo root:
+
+```env
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-client-secret
+PARISH_BASE_URL=http://localhost:3001
+```
+
+Start the web server. On startup you should see:
+
+```
+INFO Google OAuth enabled
+```
+
+in the logs — that confirms both credentials were picked up. Then visit http://localhost:3001, trigger login, and verify you're redirected back to `/` after consenting.
+
+## Gotchas
+
+- **Test users only.** While the consent screen is in "Testing" status, Google rejects logins from accounts not on the test user list. Publish the app (or add more test users) to widen access.
+- **Redirect URI must match exactly.** The code builds the callback URL as `${PARISH_BASE_URL}/auth/callback/google` (with any trailing slash on `PARISH_BASE_URL` trimmed via `trim_end_matches('/')`). Whatever you register in Google Cloud must match byte-for-byte, including scheme (`http` vs `https`) and port.
+- **Silent disable.** Missing or empty credentials don't raise an error — the auth routes just aren't registered. If `/auth/login/google` returns 404, check that both env vars are actually set in the process's environment.
+
+## Railway deployment
+
+When deploying to Railway (or any other host):
+
+1. Set `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `PARISH_BASE_URL` in the service's environment variables. `PARISH_BASE_URL` must be the public URL Railway assigns you (e.g. `https://parish-production.up.railway.app`).
+2. Add the production callback URL (`${PARISH_BASE_URL}/auth/callback/google`) to the authorized redirect URIs list in Google Cloud Console **before** the first production login attempt — Google rejects unregistered redirect URIs.
+3. You can reuse the same OAuth client for local and production by listing both redirect URIs on the same credential, or create separate clients per environment.

--- a/justfile
+++ b/justfile
@@ -99,7 +99,12 @@ run-headless:
     cargo run -p parish -- --headless
 
 # Run the axum web server (serves the Svelte UI in a browser)
-web PORT="3001":
+#
+# Always rebuilds the frontend first with a clean cache, because Vite's
+# `.svelte-kit/` cache can hold stale compiled output after git operations
+# (rebase/checkout/merge), making source edits appear invisible in the served
+# UI and spuriously re-emitting already-fixed build warnings.
+web PORT="3001": ui-build
     cargo run -p parish -- --web {{PORT}}
 
 # ─── Tauri & Frontend ────────────────────────────────────────────────────────
@@ -117,8 +122,12 @@ ui-dev:
     eval "$(fnm env)" && cd apps/ui && npm run dev
 
 # Build the Svelte frontend for production
+#
+# Clears `.svelte-kit/` and `dist/` before building so Vite can't serve
+# stale compiled output after git operations (rebase/checkout/merge) that
+# shuffle file mtimes in ways that confuse Vite's cache invalidation.
 ui-build:
-    eval "$(fnm env)" && cd apps/ui && npm run build
+    eval "$(fnm env)" && cd apps/ui && rm -rf .svelte-kit dist && npm run build
 
 # Run svelte-check (TypeScript + Svelte validation)
 ui-check:


### PR DESCRIPTION
Each browser visitor now gets their own isolated game session on the web
server, identified by a `parish_sid` cookie (HttpOnly, 1-year max-age).

Session behaviour:
- First visit: fresh WorldState + NpcManager loaded, auto-saved to
  saves/<session-id>/parish_001.db, three background ticks spawned.
- Return visit: cookie resolved → session in memory (hot path) or
  restored from saves/<session-id>/ (after server restart).
- Sessions idle >24 hours are evicted from memory hourly; save files
  remain on disk.
- Persistence state lives in saves/sessions.db (sessions + oauth_accounts
  tables).

Google OAuth (optional):
- Enable by setting GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET + PARISH_BASE_URL.
- GET /auth/login/google → consent screen; GET /auth/callback/google → link
  session to Google account, or restore an already-linked session from another
  browser.
- GET /api/auth/status → {oauth_enabled, logged_in, provider, display_name}
  consumed by the new AuthStatus.svelte widget in the status bar.

Visibility pause:
- document.visibilitychange handler in +page.svelte sends /pause immediately
  when the tab is hidden (if not already paused) and /resume when it returns.
  Coordinates cleanly with the existing auto-pause tracker.

Architecture:
- New GlobalState (router state) holds session registry + shared template
  data; AppState is now per-session (same shape as before).
- Session cookie middleware (middleware.rs) resolves/creates the session and
  injects Arc<AppState> as an Axum Extension for all route handlers.
- All route handlers updated: State<Arc<AppState>> → Extension<Arc<AppState>>.
- GameConfig derives Clone (all fields are String/Option<String>/primitives).
- New crates: uuid, dashmap, reqwest (rustls-tls), rusqlite 0.32.

https://claude.ai/code/session_01VrDfarUX2jpXTaerwmEcze