### PR TITLE
feat: add runtime feature flag system with /flag slash commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,6 +2605,7 @@ dependencies = [
  "dotenvy",
  "parish-types",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",

--- a/apps/ui/src/lib/slash-commands.ts
+++ b/apps/ui/src/lib/slash-commands.ts
@@ -35,7 +35,9 @@ export const SLASH_COMMANDS: SlashCommand[] = [
 	{ command: '/wait', description: 'Wait N minutes (default 15)', hasArgs: true },
 	{ command: '/tick', description: 'Advance NPC schedules', hasArgs: false },
 	{ command: '/new', description: 'Start a new game', hasArgs: false },
-	{ command: '/quit', description: 'Take your leave', hasArgs: false }
+	{ command: '/quit', description: 'Take your leave', hasArgs: false },
+	{ command: '/flag', description: 'Feature flags: enable/disable/list', hasArgs: true },
+	{ command: '/flags', description: 'List all feature flags', hasArgs: false }
 ];
 
 /// Filter commands by prefix query (the text after `/`).

--- a/crates/parish-cli/src/app.rs
+++ b/crates/parish-cli/src/app.rs
@@ -177,6 +177,10 @@ pub struct App {
     pub reaction_base_url: Option<String>,
     /// Loaded game mod data (None if no mod directory was found or specified).
     pub game_mod: Option<GameMod>,
+    /// Runtime feature flags (loaded from parish-flags.json at startup).
+    pub flags: crate::config::FeatureFlags,
+    /// Path to the flags persistence file (None disables persistence).
+    pub flags_path: Option<PathBuf>,
 }
 
 impl App {
@@ -231,6 +235,8 @@ impl App {
             reaction_api_key: None,
             reaction_base_url: None,
             game_mod: None,
+            flags: crate::config::FeatureFlags::default(),
+            flags_path: None,
         }
     }
 
@@ -365,6 +371,7 @@ impl App {
             max_follow_up_turns: 2,
             idle_banter_after_secs: 25,
             auto_pause_after_secs: 60,
+            flags: self.flags.clone(),
             ..GameConfig::default()
         };
 
@@ -398,6 +405,7 @@ impl App {
         self.cloud_api_key = cfg.cloud_api_key.clone();
         self.cloud_base_url = cfg.cloud_base_url.clone();
         self.improv_enabled = cfg.improv_enabled;
+        self.flags = cfg.flags.clone();
 
         // Apply per-category overrides
         for cat in InferenceCategory::ALL {

--- a/crates/parish-cli/src/config.rs
+++ b/crates/parish-cli/src/config.rs
@@ -12,9 +12,9 @@
 
 pub use parish_core::config::{
     CliCloudOverrides, CliOverrides, CloudConfig, CognitiveTierConfig, EncounterConfig,
-    EngineConfig, InferenceCategory, InferenceConfig, NpcConfig, PaletteConfig, PersistenceConfig,
-    Provider, ProviderConfig, RelationshipLabelConfig, SeasonTintConfig, SpeedConfig,
-    WeatherTintConfig, WorldConfig, resolve_cloud_config, resolve_config,
+    EngineConfig, FeatureFlags, InferenceCategory, InferenceConfig, NpcConfig, PaletteConfig,
+    PersistenceConfig, Provider, ProviderConfig, RelationshipLabelConfig, SeasonTintConfig,
+    SpeedConfig, WeatherTintConfig, WorldConfig, resolve_cloud_config, resolve_config,
 };
 
 use crate::error::ParishError;

--- a/crates/parish-cli/src/headless.rs
+++ b/crates/parish-cli/src/headless.rs
@@ -37,6 +37,7 @@ pub async fn run_headless(
     category_configs: &HashMap<InferenceCategory, CategoryConfig>,
     improv: bool,
     game_mod: Option<parish_core::game_mod::GameMod>,
+    data_dir: Option<std::path::PathBuf>,
 ) -> Result<()> {
     println!("=== Parish — Headless Mode ===");
     println!(
@@ -76,6 +77,13 @@ pub async fn run_headless(
     app.base_url = provider_config.base_url.clone();
     app.api_key = provider_config.api_key.clone();
     app.improv_enabled = improv;
+
+    // Load feature flags from disk
+    let flags_path = data_dir.map(|d| d.join("parish-flags.json"));
+    if let Some(ref p) = flags_path {
+        app.flags = crate::config::FeatureFlags::load_from_file(p);
+    }
+    app.flags_path = flags_path;
 
     // Set intent client/model
     let (intent_cl, intent_mdl) = clients.intent_client();
@@ -507,6 +515,13 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             }
             CommandEffect::NewGame => {
                 handle_headless_new_game(app).await;
+            }
+            CommandEffect::SaveFlags => {
+                if let Some(ref p) = app.flags_path
+                    && let Err(e) = app.flags.save_to_file(p)
+                {
+                    eprintln!("Warning: failed to save feature flags: {}", e);
+                }
             }
         }
     }

--- a/crates/parish-cli/src/main.rs
+++ b/crates/parish-cli/src/main.rs
@@ -236,6 +236,7 @@ async fn main() -> Result<()> {
     };
 
     // Headless REPL mode (default)
+    let headless_data_dir = find_data_dir();
     let result = headless::run_headless(
         clients.clone(),
         &provider_config,
@@ -243,6 +244,7 @@ async fn main() -> Result<()> {
         &category_configs,
         cli.improv,
         game_mod,
+        Some(headless_data_dir),
     )
     .await;
     ollama_process.stop();

--- a/crates/parish-cli/src/testing.rs
+++ b/crates/parish-cli/src/testing.rs
@@ -351,6 +351,11 @@ impl GameTestHarness {
         self.app.world.clock.is_paused()
     }
 
+    /// Returns whether a named feature flag is currently enabled.
+    pub fn is_flag_enabled(&self, name: &str) -> bool {
+        self.app.flags.is_enabled(name)
+    }
+
     /// Processes schedule events: debug log + player-visible text log messages.
     fn process_schedule_events(&mut self, events: &[crate::npc::manager::ScheduleEvent]) {
         use crate::npc::manager::ScheduleEventKind;
@@ -497,6 +502,9 @@ impl GameTestHarness {
                 }
                 CommandEffect::RebuildInference | CommandEffect::RebuildCloudClient => {
                     // No-op in test mode — no real inference clients
+                }
+                CommandEffect::SaveFlags => {
+                    // No-op in test mode — flags are in-memory only
                 }
             }
         }

--- a/crates/parish-cli/tests/headless_script_tests.rs
+++ b/crates/parish-cli/tests/headless_script_tests.rs
@@ -1239,3 +1239,89 @@ fn test_fixture_grand_tour_runs() {
 fn test_fixture_speed_assertions_runs() {
     fixture("test_speed_assertions.txt");
 }
+
+// ============================================================
+// Feature flag commands
+// ============================================================
+
+#[test]
+fn test_fixture_flags_runs() {
+    let results = fixture("test_flags.txt");
+    let system_cmds: Vec<&ScriptResult> = results
+        .iter()
+        .filter(|r| matches!(r.result, ActionResult::SystemCommand { .. }))
+        .collect();
+    assert!(
+        !system_cmds.is_empty(),
+        "Expected SystemCommand results from flag commands"
+    );
+}
+
+#[test]
+fn test_flag_enable_disable_via_harness() {
+    let mut h = GameTestHarness::new();
+
+    // No flags set yet
+    assert!(!h.is_flag_enabled("test-feature"));
+
+    // Enable via command
+    let r = h.execute("/flag enable test-feature");
+    assert!(
+        matches!(&r, ActionResult::SystemCommand { response } if response.contains("enabled")),
+        "Expected 'enabled' response, got {:?}",
+        r
+    );
+    assert!(h.is_flag_enabled("test-feature"));
+
+    // Disable via command
+    let r = h.execute("/flag disable test-feature");
+    assert!(
+        matches!(&r, ActionResult::SystemCommand { response } if response.contains("disabled")),
+        "Expected 'disabled' response, got {:?}",
+        r
+    );
+    assert!(!h.is_flag_enabled("test-feature"));
+}
+
+#[test]
+fn test_flag_list_empty() {
+    let mut h = GameTestHarness::new();
+    let r = h.execute("/flag list");
+    assert!(
+        matches!(&r, ActionResult::SystemCommand { response } if response.contains("No feature flags")),
+        "Expected 'No feature flags' message when list is empty, got {:?}",
+        r
+    );
+}
+
+#[test]
+fn test_flags_alias_works() {
+    let mut h = GameTestHarness::new();
+    let r = h.execute("/flags");
+    assert!(
+        matches!(r, ActionResult::SystemCommand { .. }),
+        "Expected SystemCommand from /flags alias"
+    );
+}
+
+#[test]
+fn test_flag_list_shows_enabled_flags() {
+    let mut h = GameTestHarness::new();
+    h.execute("/flag enable my-feature");
+    let r = h.execute("/flag list");
+    assert!(
+        matches!(&r, ActionResult::SystemCommand { response } if response.contains("my-feature")),
+        "Expected flag name in list output, got {:?}",
+        r
+    );
+}
+
+#[test]
+fn test_invalid_flag_name_returns_error() {
+    let mut h = GameTestHarness::new();
+    let r = h.execute("/flag enable bad flag!");
+    // Either the parser returns an error or the harness falls through
+    // The key requirement is: no crash, and the flag is NOT enabled
+    assert!(!h.is_flag_enabled("bad flag!"));
+    let _ = r; // result type may vary — just assert no panic
+}

--- a/crates/parish-cli/tests/world_graph_integration.rs
+++ b/crates/parish-cli/tests/world_graph_integration.rs
@@ -16,8 +16,7 @@ use parish::world::transport::TransportMode;
 
 fn load_parish_graph() -> WorldGraph {
     let path = Path::new("../../mods/rundale/world.json");
-    WorldGraph::load_from_file(path)
-        .expect("mods/rundale/world.json should load and validate")
+    WorldGraph::load_from_file(path).expect("mods/rundale/world.json should load and validate")
 }
 
 fn walking() -> TransportMode {

--- a/crates/parish-config/Cargo.toml
+++ b/crates/parish-config/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 parish-types = { path = "../parish-types" }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "0.8"
 dotenvy = "0.15"
 tracing = "0.1"

--- a/crates/parish-config/src/flags.rs
+++ b/crates/parish-config/src/flags.rs
@@ -1,0 +1,182 @@
+//! Runtime feature flags for safe deployment of in-progress features.
+//!
+//! Feature flags let you ship code to `main` with new functionality disabled
+//! by default. Use `/flag enable <name>` in-game to turn a feature on, and
+//! `/flag disable <name>` to turn it off. Changes are persisted to
+//! `parish-flags.json` in the data directory so they survive restarts.
+//!
+//! All unknown flags are treated as disabled (`false`), so checking a flag
+//! that has never been set is always safe.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Runtime feature flags — toggle code paths without redeploying.
+///
+/// Backed by a [`BTreeMap`] for deterministic, alphabetically-sorted output
+/// in both listings and JSON serialisation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FeatureFlags {
+    #[serde(default)]
+    flags: BTreeMap<String, bool>,
+}
+
+impl FeatureFlags {
+    /// Returns `true` if the named flag is enabled, `false` otherwise
+    /// (including when the flag has never been set).
+    pub fn is_enabled(&self, name: &str) -> bool {
+        *self.flags.get(name).unwrap_or(&false)
+    }
+
+    /// Enables the named flag.
+    pub fn enable(&mut self, name: &str) {
+        self.flags.insert(name.to_string(), true);
+    }
+
+    /// Disables the named flag.
+    pub fn disable(&mut self, name: &str) {
+        self.flags.insert(name.to_string(), false);
+    }
+
+    /// Returns all flags in alphabetical order as `(name, enabled)` pairs.
+    pub fn list(&self) -> Vec<(&str, bool)> {
+        self.flags.iter().map(|(k, v)| (k.as_str(), *v)).collect()
+    }
+
+    /// Returns `true` if no flags have been set yet.
+    pub fn is_empty(&self) -> bool {
+        self.flags.is_empty()
+    }
+
+    /// Loads flags from a JSON file.
+    ///
+    /// Returns `Default::default()` if the file does not exist or cannot be
+    /// parsed — this is not an error, since a missing file simply means no
+    /// flags have been persisted yet.
+    pub fn load_from_file(path: &Path) -> Self {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    /// Saves the current flag state to a JSON file, creating parent
+    /// directories as needed.
+    pub fn save_to_file(&self, path: &Path) -> Result<(), std::io::Error> {
+        let json = serde_json::to_string_pretty(self).map_err(std::io::Error::other)?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::write(path, json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_flags_default_disabled() {
+        let flags = FeatureFlags::default();
+        assert!(!flags.is_enabled("any-flag"));
+        assert!(!flags.is_enabled(""));
+    }
+
+    #[test]
+    fn test_flag_enable() {
+        let mut flags = FeatureFlags::default();
+        flags.enable("new-weather");
+        assert!(flags.is_enabled("new-weather"));
+    }
+
+    #[test]
+    fn test_flag_disable_after_enable() {
+        let mut flags = FeatureFlags::default();
+        flags.enable("feature-x");
+        flags.disable("feature-x");
+        assert!(!flags.is_enabled("feature-x"));
+    }
+
+    #[test]
+    fn test_flag_disable_nonexistent_is_noop() {
+        let mut flags = FeatureFlags::default();
+        flags.disable("never-existed");
+        // disable on an unknown flag inserts it as false
+        assert!(!flags.is_enabled("never-existed"));
+    }
+
+    #[test]
+    fn test_flag_list_sorted() {
+        let mut flags = FeatureFlags::default();
+        flags.enable("zebra");
+        flags.enable("apple");
+        flags.disable("mango");
+        let list = flags.list();
+        assert_eq!(list.len(), 3);
+        assert_eq!(list[0].0, "apple");
+        assert_eq!(list[1].0, "mango");
+        assert_eq!(list[2].0, "zebra");
+        assert!(list[0].1);
+        assert!(!list[1].1);
+        assert!(list[2].1);
+    }
+
+    #[test]
+    fn test_flag_roundtrip_json() {
+        let mut flags = FeatureFlags::default();
+        flags.enable("alpha");
+        flags.disable("beta");
+
+        let json = serde_json::to_string(&flags).unwrap();
+        let restored: FeatureFlags = serde_json::from_str(&json).unwrap();
+        assert_eq!(flags, restored);
+        assert!(restored.is_enabled("alpha"));
+        assert!(!restored.is_enabled("beta"));
+    }
+
+    #[test]
+    fn test_load_missing_file_returns_default() {
+        let path = std::path::Path::new("/nonexistent/path/parish-flags.json");
+        let flags = FeatureFlags::load_from_file(path);
+        assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn test_save_and_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("parish-flags.json");
+
+        let mut flags = FeatureFlags::default();
+        flags.enable("persist-test");
+        flags.disable("off-by-default");
+        flags.save_to_file(&path).unwrap();
+
+        let loaded = FeatureFlags::load_from_file(&path);
+        assert!(loaded.is_enabled("persist-test"));
+        assert!(!loaded.is_enabled("off-by-default"));
+        assert_eq!(loaded.list().len(), 2);
+    }
+
+    #[test]
+    fn test_save_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested/subdir/parish-flags.json");
+        let flags = FeatureFlags::default();
+        flags.save_to_file(&path).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_is_empty_on_default() {
+        let flags = FeatureFlags::default();
+        assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn test_is_not_empty_after_set() {
+        let mut flags = FeatureFlags::default();
+        flags.enable("x");
+        assert!(!flags.is_empty());
+    }
+}

--- a/crates/parish-config/src/lib.rs
+++ b/crates/parish-config/src/lib.rs
@@ -1,9 +1,11 @@
 //! Configuration types for the Parish game engine.
 
 pub mod engine;
+pub mod flags;
 pub mod provider;
 
 pub use engine::*;
+pub use flags::FeatureFlags;
 pub use provider::*;
 
 // Re-export SpeedConfig from parish-types so downstream crates can find it

--- a/crates/parish-core/src/game_mod.rs
+++ b/crates/parish-core/src/game_mod.rs
@@ -236,7 +236,7 @@ impl Default for ThemePaletteConfig {
 }
 
 /// Theme section of the UI configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct ThemeConfig {
     /// Legacy accent override for older mods.
     #[serde(default)]
@@ -298,15 +298,6 @@ impl Default for SidebarConfig {
     fn default() -> Self {
         Self {
             hints_label: default_hints_label(),
-        }
-    }
-}
-
-impl Default for ThemeConfig {
-    fn default() -> Self {
-        Self {
-            default_accent: None,
-            palette: ThemePaletteConfig::default(),
         }
     }
 }

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -12,7 +12,7 @@
 use chrono::Timelike;
 
 use crate::config::Provider;
-use crate::input::Command;
+use crate::input::{Command, FlagSubcommand};
 use crate::npc::manager::NpcManager;
 use crate::world::WorldState;
 
@@ -46,6 +46,8 @@ pub enum CommandEffect {
     NewGame,
     /// Rebuild the cloud/dialogue client specifically.
     RebuildCloudClient,
+    /// Persist the current feature flag state to disk.
+    SaveFlags,
 }
 
 /// The result of processing a system command.
@@ -361,6 +363,38 @@ pub fn handle_command(
             )
         }
 
+        // ── Feature flags ───────────────────────────────────────────────
+        Command::Flags | Command::Flag(FlagSubcommand::List) => {
+            let list = config.flags.list();
+            if list.is_empty() {
+                CommandResult::text(
+                    "No feature flags have been set. Use /flag enable <name> to enable one.",
+                )
+            } else {
+                let mut lines = vec!["Feature flags:".to_string()];
+                for (name, enabled) in &list {
+                    let status = if *enabled { "on " } else { "off" };
+                    lines.push(format!("  [{}] {}", status, name));
+                }
+                CommandResult::text(lines.join("\n"))
+            }
+        }
+        Command::Flag(FlagSubcommand::Enable(name)) => {
+            config.flags.enable(&name);
+            CommandResult::with_effect(
+                format!("Feature '{}' enabled.", name),
+                CommandEffect::SaveFlags,
+            )
+        }
+        Command::Flag(FlagSubcommand::Disable(name)) => {
+            config.flags.disable(&name);
+            CommandResult::with_effect(
+                format!("Feature '{}' disabled.", name),
+                CommandEffect::SaveFlags,
+            )
+        }
+        Command::InvalidFlagName(msg) => CommandResult::text(msg),
+
         // ── Mode-specific commands (delegated to backend) ───────────────
         Command::Quit => CommandResult::effect_only(CommandEffect::Quit),
         Command::Help => CommandResult::text(
@@ -378,6 +412,9 @@ pub fn handle_command(
                 "  /irish             — Toggle Irish pronunciation sidebar",
                 "  /improv            — Toggle improv craft mode",
                 "  /map               — Toggle the full map",
+                "  /flag list                  — List all feature flags",
+                "  /flag enable <name>         — Enable a feature flag",
+                "  /flag disable <name>        — Disable a feature flag",
                 "  /save              — Save the game",
                 "  /fork <name>       — Fork a new branch from here",
                 "  /load <name>       — Load a named branch",

--- a/crates/parish-core/src/ipc/config.rs
+++ b/crates/parish-core/src/ipc/config.rs
@@ -5,7 +5,7 @@
 //! and the headless CLI — eliminating the duplicate `GameConfig` structs that
 //! previously lived in each backend.
 
-use crate::config::InferenceCategory;
+use crate::config::{FeatureFlags, InferenceCategory};
 
 /// Mutable runtime configuration for provider, model, and cloud settings.
 ///
@@ -45,6 +45,8 @@ pub struct GameConfig {
     pub category_api_key: [Option<String>; 4],
     /// Per-category base URL overrides (None = inherits base).
     pub category_base_url: [Option<String>; 4],
+    /// Runtime feature flags for safe deployment of in-progress features.
+    pub flags: FeatureFlags,
 }
 
 impl GameConfig {
@@ -117,6 +119,7 @@ impl Default for GameConfig {
             category_model: Default::default(),
             category_api_key: Default::default(),
             category_base_url: Default::default(),
+            flags: FeatureFlags::default(),
         }
     }
 }

--- a/crates/parish-input/src/lib.rs
+++ b/crates/parish-input/src/lib.rs
@@ -10,6 +10,17 @@ use parish_types::GameSpeed;
 use parish_types::ParishError;
 use serde::Deserialize;
 
+/// Sub-command for the `/flag` feature-flag system.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FlagSubcommand {
+    /// Enable the named flag.
+    Enable(String),
+    /// Disable the named flag.
+    Disable(String),
+    /// List all known flags.
+    List,
+}
+
 /// A system command entered by the player.
 ///
 /// System commands use a `/` prefix and control game meta-operations
@@ -102,10 +113,19 @@ pub enum Command {
     Tick,
     /// Invalid branch name was provided.
     InvalidBranchName(String),
+    /// Feature flag management (`/flag enable|disable|list <name>`).
+    Flag(FlagSubcommand),
+    /// List all feature flags (alias for `Flag(List)`).
+    Flags,
+    /// Invalid flag name was provided.
+    InvalidFlagName(String),
 }
 
 /// Maximum allowed length for save branch names.
 const MAX_BRANCH_NAME_LEN: usize = 255;
+
+/// Maximum allowed length for feature flag names.
+const MAX_FLAG_NAME_LEN: usize = 64;
 
 /// Validates a save branch name for length and allowed characters.
 ///
@@ -124,6 +144,30 @@ fn validate_branch_name(name: &str) -> Result<String, String> {
         return Err(
             "Branch names may only contain letters, numbers, spaces, underscores, and hyphens."
                 .to_string(),
+        );
+    }
+    Ok(name.to_string())
+}
+
+/// Validates a feature flag name for length and allowed characters.
+///
+/// Flag names may contain alphanumerics, hyphens, and underscores only.
+fn validate_flag_name(name: &str) -> Result<String, String> {
+    if name.is_empty() {
+        return Err("Flag name cannot be empty.".to_string());
+    }
+    if name.len() > MAX_FLAG_NAME_LEN {
+        return Err(format!(
+            "Flag name too long (max {} characters).",
+            MAX_FLAG_NAME_LEN
+        ));
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(
+            "Flag names may only contain letters, digits, hyphens, and underscores.".to_string(),
         );
     }
     Ok(name.to_string())
@@ -360,6 +404,34 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
             Some(Command::ShowCloudKey)
         } else {
             Some(Command::ShowCloud)
+        }
+    } else if lower == "/flags" {
+        Some(Command::Flags)
+    } else if lower == "/flag" || lower == "/flag list" {
+        Some(Command::Flag(FlagSubcommand::List))
+    } else if lower.starts_with("/flag ") {
+        let rest = trimmed.get("/flag ".len()..).unwrap_or("").trim();
+        let rest_lower = rest.to_lowercase();
+        if rest_lower.starts_with("enable ") {
+            let name = rest.get("enable ".len()..).unwrap_or("").trim();
+            match validate_flag_name(name) {
+                Ok(valid) => Some(Command::Flag(FlagSubcommand::Enable(valid))),
+                Err(msg) => Some(Command::InvalidFlagName(msg)),
+            }
+        } else if rest_lower.starts_with("disable ") {
+            let name = rest.get("disable ".len()..).unwrap_or("").trim();
+            match validate_flag_name(name) {
+                Ok(valid) => Some(Command::Flag(FlagSubcommand::Disable(valid))),
+                Err(msg) => Some(Command::InvalidFlagName(msg)),
+            }
+        } else if rest_lower == "enable" || rest_lower == "disable" || rest_lower == "list" {
+            Some(Command::Flag(FlagSubcommand::List))
+        } else {
+            // `/flag <name>` without enable/disable — treat as usage error
+            Some(Command::InvalidFlagName(format!(
+                "Unknown flag sub-command '{}'. Use: /flag enable <name>, /flag disable <name>, /flag list",
+                rest
+            )))
         }
     } else {
         None

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -23,6 +23,7 @@ use parish_core::npc::manager::NpcManager;
 use parish_core::world::transport::TransportConfig;
 use parish_core::world::{LocationId, WorldState};
 
+use parish_core::config::FeatureFlags;
 use state::{AppState, GameConfig, UiConfigSnapshot, build_app_state};
 
 /// Starts the Parish web server on the given port.
@@ -99,6 +100,10 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         }
     };
 
+    // Load feature flags from disk and inject into config
+    let flags_path = data_dir.join("parish-flags.json");
+    config.flags = FeatureFlags::load_from_file(&flags_path);
+
     let saves_dir = parish_core::persistence::picker::ensure_saves_dir();
     let state = build_app_state(
         world,
@@ -112,6 +117,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         saves_dir,
         data_dir.clone(),
         game_mod,
+        flags_path,
     );
 
     // Initialize inference queue
@@ -315,6 +321,7 @@ fn build_client_and_config() -> (Option<OpenAiClient>, GameConfig) {
         category_model: [None, None, None, None],
         category_api_key: [None, None, None, None],
         category_base_url: [None, None, None, None],
+        flags: FeatureFlags::default(),
     };
 
     (client, config)

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -296,6 +296,15 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
                     );
                 }
             },
+            CommandEffect::SaveFlags => {
+                let flags = state.config.lock().await.flags.clone();
+                let path = state.flags_path.clone();
+                tokio::task::spawn_blocking(move || {
+                    if let Err(e) = flags.save_to_file(&path) {
+                        tracing::warn!("Failed to save feature flags: {}", e);
+                    }
+                });
+            }
         }
     }
 
@@ -1670,14 +1679,16 @@ mod tests {
                 category_model: [None, None, None, None],
                 category_api_key: [None, None, None, None],
                 category_base_url: [None, None, None, None],
+                flags: parish_core::config::FeatureFlags::default(),
             },
             None,
             transport,
             ui_config,
             theme_palette,
             saves_dir,
-            data_dir,
+            data_dir.clone(),
             None,
+            data_dir.join("parish-flags.json"),
         )
     }
 

--- a/crates/parish-server/src/state.rs
+++ b/crates/parish-server/src/state.rs
@@ -130,6 +130,8 @@ pub struct AppState {
     pub game_mod: Option<parish_core::game_mod::GameMod>,
     /// Name pronunciation entries from the game mod.
     pub pronunciations: Vec<PronunciationEntry>,
+    /// Path to the feature flags persistence file.
+    pub flags_path: PathBuf,
 }
 
 // GameConfig is now shared across all backends via parish-core.
@@ -206,6 +208,7 @@ pub fn build_app_state(
     saves_dir: PathBuf,
     data_dir: PathBuf,
     game_mod: Option<parish_core::game_mod::GameMod>,
+    flags_path: PathBuf,
 ) -> Arc<AppState> {
     // Extract pronunciations from game mod before moving it.
     let pronunciations = game_mod
@@ -232,6 +235,7 @@ pub fn build_app_state(
         current_branch_name: Mutex::new(None),
         game_mod,
         pronunciations,
+        flags_path,
     })
 }
 

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -370,6 +370,15 @@ async fn handle_system_command(
                     extra_response = Some(format!("New game failed: {}", e));
                 }
             },
+            CommandEffect::SaveFlags => {
+                let flags = state.config.lock().await.flags.clone();
+                let path = state.data_dir.join("parish-flags.json");
+                tokio::task::spawn_blocking(move || {
+                    if let Err(e) = flags.save_to_file(&path) {
+                        tracing::warn!("Failed to save feature flags: {}", e);
+                    }
+                });
+            }
         }
     }
 

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -14,7 +14,7 @@ use std::time::Instant;
 use tauri::Emitter;
 use tokio::sync::Mutex;
 
-use parish_core::config::Provider;
+use parish_core::config::{FeatureFlags, Provider};
 use parish_core::debug_snapshot::{DebugEvent, InferenceDebug};
 use parish_core::game_mod::PronunciationEntry;
 use parish_core::inference::openai_client::OpenAiClient;
@@ -227,6 +227,8 @@ pub struct AppState {
     pub current_branch_name: Mutex<Option<String>>,
     /// Transport mode configuration from the loaded game mod.
     pub transport: TransportConfig,
+    /// Data directory used to derive the feature-flags persistence path.
+    pub data_dir: PathBuf,
 }
 
 // ── Data path resolution ─────────────────────────────────────────────────────
@@ -494,6 +496,9 @@ pub fn run() {
         .map(|gm| gm.reactions.clone())
         .unwrap_or_default();
 
+    // Load feature flags from disk
+    let flags = FeatureFlags::load_from_file(&data_dir.join("parish-flags.json"));
+
     let state = Arc::new(AppState {
         world: Mutex::new(world),
         npc_manager: Mutex::new(npc_manager),
@@ -513,6 +518,7 @@ pub fn run() {
         current_branch_id: Mutex::new(None),
         current_branch_name: Mutex::new(None),
         transport,
+        data_dir: data_dir.clone(),
         config: Mutex::new(GameConfig {
             provider_name,
             base_url,
@@ -530,6 +536,7 @@ pub fn run() {
             category_model: [None, None, None, None],
             category_api_key: [None, None, None, None],
             category_base_url: [None, None, None, None],
+            flags,
         }),
     });
 

--- a/testing/fixtures/test_flags.txt
+++ b/testing/fixtures/test_flags.txt
@@ -1,0 +1,26 @@
+# Feature flag integration test
+# Verifies that /flag and /flags commands work end-to-end through the harness.
+
+# List flags when none are set
+/flags
+/flag list
+
+# Enable a flag and verify it shows in the list
+/flag enable test-feature
+/flag list
+
+# Disable that flag
+/flag disable test-feature
+/flag list
+
+# Enable multiple flags
+/flag enable alpha
+/flag enable beta
+/flag list
+
+# Disable one of them
+/flag disable alpha
+/flag list
+
+# Invalid flag name should return an error, not crash
+/flag enable bad flag name!


### PR DESCRIPTION
Introduces a persistent feature-flag mechanism so code can be shipped to
main safely behind dark flags and toggled at runtime via:

  /flag enable <name>   — enable a flag (persisted to parish-flags.json)
  /flag disable <name>  — disable a flag
  /flag list | /flags   — list all flags with on/off status

Flags are stored in a BTreeMap for deterministic ordering and serialised
as JSON to `parish-flags.json` in the data directory. All three backends
(headless CLI, web server, Tauri) load flags at startup and persist them
on every toggle via the new CommandEffect::SaveFlags dispatch.

- crates/parish-config/src/flags.rs: new FeatureFlags type with 11 tests
- crates/parish-input/src/lib.rs: FlagSubcommand enum + Command::Flag variants
- crates/parish-core/src/ipc/commands.rs: handlers + CommandEffect::SaveFlags
- crates/parish-core/src/ipc/config.rs: flags field on GameConfig
- crates/parish-cli/{app,headless,testing}.rs: flags field + SaveFlags handling
- crates/parish-server/{state,lib,routes}.rs: flags_path + startup load + save
- crates/parish-tauri/{lib,commands}.rs: data_dir + startup load + save
- apps/ui/src/lib/slash-commands.ts: /flag autocomplete entries
- testing/fixtures/test_flags.txt: integration fixture (12 commands)

https://claude.ai/code/session_01XWKja1gLR6paTaf8r5dX44