### PR TITLE
docs: remove TUI and egui references

### DIFF
--- a/docs/design/gui-design.md
+++ b/docs/design/gui-design.md
@@ -2,9 +2,7 @@
 
 > Parent: [Architecture Overview](overview.md) | [Docs Index](../index.md)
 
-> **Note:** The desktop GUI has been migrated from egui to **Tauri 2 + Svelte 5**. See [Phase 8 plan](../plans/phase-8-tauri-gui.md) and [ADR 016](../adr/016-tauri-svelte-gui.md) for the Tauri architecture. The Svelte component source lives in `apps/ui/src/components/`. The egui documentation below is retained for historical reference.
-
-## Tauri / Svelte — Loading Spinner
+## Loading Spinner
 
 The `ChatPanel.svelte` component displays an animated **Celtic triquetra (Trinity knot)** SVG while waiting for LLM responses (`$streamingActive === true`). The animation uses the `stroke-dasharray` / `stroke-dashoffset` CSS technique:
 
@@ -17,49 +15,9 @@ The `ChatPanel.svelte` component displays an animated **Celtic triquetra (Trinit
 
 Once streaming tokens begin arriving, the spinner is replaced by a blinking cursor (`▋`) at the end of the streaming text. The streaming source label is derived from the last non-player, non-system log entry so the correct NPC name appears during token streaming.
 
-The headless and TUI modes continue to use the Rust `LoadingAnimation` (`crates/parish-core/src/loading.rs`) with Celtic cross Unicode characters and Irish-themed phrases.
+Headless mode continues to use the Rust `LoadingAnimation` (`crates/parish-core/src/loading.rs`) with Celtic cross Unicode characters and Irish-themed phrases.
 
 ---
-
-## Legacy egui GUI
-
-## Overview
-
-Rundale (via the Parish engine) has three UI modes, selectable via CLI flags:
-
-| Mode | Flag | Framework | Description |
-|------|------|-----------|-------------|
-| **GUI** | *(default)* | egui + eframe | Windowed GUI with map, chat, and sidebars |
-| **TUI** | `--tui` | Ratatui + Crossterm | Terminal UI with 24-bit true color |
-| **Headless** | `--headless` | stdin/stdout | Plain REPL for testing and scripting |
-
-The GUI mode provides an enhanced visual experience beyond what the terminal allows: an interactive location map, collapsible sidebars, and a proper windowed interface — while reusing all shared game logic.
-
-## Architecture
-
-The GUI is built on [egui](https://github.com/emilk/egui), an immediate-mode GUI library, via the [eframe](https://github.com/emilk/egui/tree/master/crates/eframe) framework (winit + wgpu backend). This gives us a cross-platform native window with GPU-accelerated rendering.
-
-### Key Design Decision: Immediate Mode
-
-egui redraws the entire UI every frame based on current state — no retained widget tree. This maps naturally to the game loop: each frame reads `WorldState`, `NpcManager`, and the text log, then renders panels. No synchronization between UI widgets and game state is needed.
-
-### Async Bridge
-
-The game uses Tokio for async inference calls, but egui runs a synchronous event loop. The bridge works the same way as the TUI:
-
-```
-Tokio Runtime (inference worker)
-    ↓ tokens via mpsc::unbounded_channel
-Token Accumulator Task (tokio::spawn)
-    ↓ writes to Arc<Mutex<String>>
-GuiApp::update() (egui frame)
-    ↓ drains buffer into world.text_log
-Panel Rendering
-```
-
-- `ctx.request_repaint()` is called when streaming is active (forces continuous redraw)
-- `ctx.request_repaint_after(500ms)` provides periodic updates for the game clock
-- The `tokio::runtime::Handle` is stored in `GuiApp` for spawning async tasks
 
 ## Layout
 
@@ -81,16 +39,6 @@ Panel Rendering
 │  > Input field                                               │
 └──────────────────────────────────────────────────────────────┘
 ```
-
-### Panel Details
-
-| Panel | egui Widget | Description |
-|-------|-------------|-------------|
-| **Status Bar** | `TopBottomPanel::top` | Location, game time, weather, season, festival, pause indicator |
-| **Chat Panel** | `CentralPanel` | Scrollable text log with `stick_to_bottom(true)` auto-scroll |
-| **Map Panel** | `SidePanel::right` (upper) | Location graph rendered via `Painter` API |
-| **Sidebar** | `SidePanel::right` (lower) | Collapsible sections for Irish words and NPC info |
-| **Input Field** | `TopBottomPanel::bottom` | Single-line `TextEdit` with Enter-to-submit |
 
 ### Map Panel
 
@@ -138,14 +86,14 @@ See [Map Evolution](map-evolution.md) for future map improvements (fog of war, a
 
 ### Sidebar
 
-Two collapsible sections (`CollapsingHeader`):
+Two collapsible sections:
 
 1. **Focail — Words**: Shows the 15 most recent `IrishWordHint` entries from NPC dialogue, each with the Irish word, phonetic pronunciation, and English meaning
 2. **NPCs Here**: Lists all NPCs at the player's current location with name, occupation, and current mood
 
 ## Color System
 
-The GUI uses smoothly interpolated time-of-day palettes with season and weather tinting, computed by the shared `src/world/palette.rs` engine and converted to `egui::Color32`. The 7 base keyframe palettes define colors at anchor hours, with linear interpolation between them for gradual transitions:
+The GUI uses time-of-day palettes with season and weather tinting, computed by the shared `src/world/palette.rs` engine. The 7 defined palettes cover the major times of day:
 
 | Time | Background | Text | Accent |
 |------|-----------|------|--------|
@@ -157,46 +105,11 @@ The GUI uses smoothly interpolated time-of-day palettes with season and weather 
 | Night | `(20,25,40)` near-black | `(180,180,190)` silver | `(100,110,140)` blue-grey |
 | Midnight | `(10,12,20)` darkest | `(150,150,165)` muted | `(70,75,100)` dark blue |
 
-The `GuiPalette` struct extends the TUI's 3-color palette to 7 colors, adding derived values for panels, inputs, borders, and muted text. Palettes are computed each frame by `compute_palette()` (from `src/world/palette.rs`), which smoothly interpolates between keyframes and applies season/weather tinting, then applied via `ctx.set_visuals()`. See [Weather System](weather-system.md) for tint parameters.
-
-## GuiApp Struct
-
-`GuiApp` mirrors the TUI's `App` struct but implements `eframe::App` instead of driving a terminal render loop:
-
-```rust
-pub struct GuiApp {
-    // Shared game state (identical to TUI)
-    pub world: WorldState,
-    pub npc_manager: NpcManager,
-    pub inference_queue: Option<InferenceQueue>,
-    pub client: Option<OpenAiClient>,
-    // ... provider config fields ...
-
-    // GUI-specific state
-    pub input_buffer: String,
-    pub show_map: bool,
-    pub show_sidebar: bool,
-    pub show_debug: bool,
-
-    // Async bridge
-    pub tokio_handle: tokio::runtime::Handle,
-    pub streaming_buf: Arc<Mutex<String>>,
-    pub streaming_active: Arc<Mutex<bool>>,
-}
-```
-
-The `eframe::App::update()` method runs each frame:
-
-1. Drain streaming buffer → append to `world.text_log`
-2. Check idle tick (20-second interval for NPC schedule simulation)
-3. Compute smoothly interpolated palette (time + season + weather) and apply to `ctx.set_visuals()`
-4. Render all panels
-5. Process submitted input through `classify_input()` / game logic
-6. Request repaint if streaming or after 500ms for clock updates
+Palettes are selected by `compute_palette()` (from `src/world/palette.rs`) and season/weather tinting is applied on top. See [Weather System](weather-system.md) for tint parameters.
 
 ## Input Processing
 
-Input follows the same pipeline as TUI and headless modes:
+Input follows the same pipeline as headless mode:
 
 ```
 Text from input field
@@ -210,71 +123,22 @@ GameInput → process_game_input()
     └─ NPC conversation → inference queue → token streaming
 ```
 
-The GUI uses **synchronous local intent parsing** for movement and look commands (no LLM needed), keeping the UI responsive. NPC conversations are dispatched asynchronously via `tokio_handle.spawn()`.
+The GUI uses **synchronous local intent parsing** for movement and look commands (no LLM needed), keeping the UI responsive. NPC conversations are dispatched asynchronously.
 
 ## System Commands
 
 All `/commands` work in GUI mode. The `/irish` and `/debug panel` commands toggle sidebar and debug panel visibility respectively.
 
-## Entry Point
-
-```
-cargo run
-```
-
-The `run_gui()` function in `src/gui/mod.rs`:
-
-1. Initializes the inference pipeline (tokio channel + worker)
-2. Loads world data from `mods/rundale/world.json` and NPCs from `mods/rundale/npcs.json`
-3. Creates a `GuiApp` with the tokio runtime handle
-4. Launches `eframe::run_native()` with a 1200x800 window (min 800x500)
-
-## Window Properties
-
-| Property | Value |
-|----------|-------|
-| Title | "Rundale — An Irish Living World Text Adventure" |
-| Default size | 1200 x 800 |
-| Minimum size | 800 x 500 |
-| Right panel width | 250–320px |
-| Map height | 55% of right panel |
-
-## Screenshots
-
-Automated screenshot capture is built into the GUI via `--screenshot`:
-
-```sh
-xvfb-run -a cargo run -- --screenshot docs/screenshots
-```
-
-This opens the GUI in a virtual framebuffer, renders at 4 times of day (morning, midday, dusk, night), captures each as a 1200x800 PNG, and exits. Screenshots are saved to `docs/screenshots/`:
-
-| File | Time of Day |
-|------|-------------|
-| `gui-morning.png` | 08:00 — warm gold palette |
-| `gui-midday.png` | 12:00 — bright warm palette |
-| `gui-dusk.png` | 17:00 — deep blue/amber palette |
-| `gui-night.png` | 21:00 — near-black palette |
-
-The capture uses egui's `ViewportCommand::Screenshot` API with `image` crate for PNG encoding. Sample game content (location descriptions, NPC dialogue, Irish word hints) is populated automatically so screenshots look representative.
-
-**Screenshots must be regenerated any time `src/gui/` changes.** See `CLAUDE.md` for the command.
-
 ## Related
 
-- [TUI Design](tui-design.md) — Terminal UI layout and color system (parallel implementation)
 - [Time System](time-system.md) — Day/night cycle drives palette selection
 - [Player Input](player-input.md) — Input parsing shared across all UI modes
 - [Inference Pipeline](inference-pipeline.md) — Async LLM integration and token streaming
+- [ADR 016](../adr/016-tauri-svelte-gui.md) — Tauri 2 + Svelte 5 architecture decision
 
 ## Source Modules
 
-- [`src/gui/mod.rs`](../../src/gui/mod.rs) — `GuiApp` struct, `eframe::App` impl, game loop
-- [`src/gui/theme.rs`](../../src/gui/theme.rs) — Smooth time-of-day color palettes for egui
-- [`src/world/palette.rs`](../../src/world/palette.rs) — Shared color interpolation engine
-- [`src/gui/chat_panel.rs`](../../src/gui/chat_panel.rs) — Scrollable text log
-- [`src/gui/map_panel.rs`](../../src/gui/map_panel.rs) — Interactive location graph
-- [`src/gui/status_bar.rs`](../../src/gui/status_bar.rs) — Top status bar
-- [`src/gui/sidebar.rs`](../../src/gui/sidebar.rs) — Irish words + NPC info
-- [`src/gui/input_field.rs`](../../src/gui/input_field.rs) — Text input widget
-- [`src/gui/screenshot.rs`](../../src/gui/screenshot.rs) — Automated screenshot capture
+- [`apps/ui/src/components/`](../../apps/ui/src/components/) — Svelte UI components (ChatPanel, MapPanel, FullMapOverlay, Sidebar, StatusBar)
+- [`apps/ui/src/lib/map-labels.ts`](../../apps/ui/src/lib/map-labels.ts) — Label placement algorithm
+- [`apps/ui/src/lib/map-projection.ts`](../../apps/ui/src/lib/map-projection.ts) — Mercator projection
+- [`src/world/palette.rs`](../../src/world/palette.rs) — Time-of-day palette engine

--- a/docs/design/weather-system.md
+++ b/docs/design/weather-system.md
@@ -54,12 +54,11 @@ Weather modifies the base time-of-day color palette via multiplicative tinting i
 | Autumn  | (1.06, 1.00, 0.92)    | 0%          |
 | Winter  | (0.94, 0.96, 1.04)    | 8%          |
 
-Both the GUI (`src/gui/theme.rs`) and TUI (`src/tui/mod.rs`) consume the same `RawPalette` from the interpolation engine.
+The GUI consumes `RawPalette` from the engine.
 
 ## Related
 
-- [TUI Design](tui-design.md) — Weather palette modifiers and visual atmosphere
-- [GUI Design](gui-design.md) — GUI color theming with smooth transitions
+- [GUI Design](gui-design.md) — GUI color theming
 - [Time System](time-system.md) — Seasons drive weather patterns
 - [NPC System](npc-system.md) — Weather affects NPC schedules, behavior, and dialogue
 
@@ -67,6 +66,5 @@ Both the GUI (`src/gui/theme.rs`) and TUI (`src/tui/mod.rs`) consume the same `R
 
 - [`src/world/mod.rs`](../../src/world/mod.rs) — `Weather` enum definition
 - [`src/world/palette.rs`](../../src/world/palette.rs) — Smooth interpolation engine, season/weather tinting
-- [`src/gui/theme.rs`](../../src/gui/theme.rs) — GUI palette conversion and application
-- [`src/tui/mod.rs`](../../src/tui/mod.rs) — TUI palette conversion
+- [`src/world/palette.rs`](../../src/world/palette.rs) — Palette engine, season/weather tinting
 - [`src/npc/`](../../src/npc/) — Weather-aware NPC behavior

--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -145,12 +145,6 @@ For a production bundle:
 cargo tauri build
 ```
 
-### TUI Mode (Terminal)
-
-```sh
-cargo run
-```
-
 ### Headless Mode
 
 For piping input/output or running without a UI:
@@ -171,17 +165,6 @@ sudo dnf install xorg-x11-server-Xvfb  # Fedora
 # Capture screenshots at 4 times of day
 xvfb-run -a cargo tauri dev -- -- --screenshot docs/screenshots
 ```
-
-## Terminal Recommendations (TUI Mode)
-
-Rundale uses a TUI with 24-bit true color. For the best experience:
-
-- **GNOME Terminal** — full true-color support, default on many distros.
-- **Konsole** — KDE's terminal, excellent color and Unicode support.
-- **kitty** — fast GPU-accelerated terminal with full 24-bit color.
-- **Alacritty** — GPU-accelerated, minimal, full true-color support.
-
-Ensure your terminal window is at least **120 columns x 40 rows** for the intended layout.
 
 ## Configuration (Optional)
 

--- a/docs/macos-setup.md
+++ b/docs/macos-setup.md
@@ -102,12 +102,6 @@ For a production bundle:
 cargo tauri build
 ```
 
-### TUI Mode (Terminal)
-
-```sh
-cargo run
-```
-
 ### Headless Mode
 
 For piping input/output or running without a UI:
@@ -115,16 +109,6 @@ For piping input/output or running without a UI:
 ```sh
 cargo run -- --headless
 ```
-
-## Terminal Recommendations (TUI Mode)
-
-Rundale uses a TUI with 24-bit true color. For the best experience:
-
-- **iTerm2** — full true-color and Unicode support, highly recommended.
-- **kitty** — fast GPU-accelerated terminal with excellent color support.
-- **Terminal.app** — works, but verify 24-bit color is enabled.
-
-Ensure your terminal window is at least **120 columns x 40 rows** for the intended layout.
 
 ## Configuration (Optional)
 
@@ -153,12 +137,6 @@ sudo xcode-select --reset
 - Ensure the Ollama app is running (check the menu bar icon).
 - Verify the port: `curl http://localhost:11434/api/tags`.
 - If you installed via Homebrew, start the service: `brew services start ollama`.
-
-### TUI looks garbled or has no color
-
-- Switch to iTerm2 or kitty if using Terminal.app.
-- Ensure your terminal supports 24-bit true color. Test with: `printf "\x1b[38;2;255;100;0mTRUECOLOR\x1b[0m\n"` — you should see orange text.
-- Resize your terminal to at least 120x40.
 
 ### Model runs slowly
 

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -84,12 +84,6 @@ For a production bundle:
 cargo tauri build
 ```
 
-### TUI Mode (Terminal)
-
-```powershell
-cargo run
-```
-
 ### Headless Mode
 
 For piping input/output or running without a terminal UI:
@@ -97,16 +91,6 @@ For piping input/output or running without a terminal UI:
 ```powershell
 cargo run -- --headless
 ```
-
-## Terminal Recommendations (TUI Mode)
-
-Rundale uses a TUI with 24-bit true color. For the best experience:
-
-- **Windows Terminal** (default on Windows 11, available from the Microsoft Store on Windows 10) — full true-color and Unicode support.
-- **PowerShell 7+** in Windows Terminal works well.
-- **Older terminals** (cmd.exe, legacy conhost) may have limited color support.
-
-Ensure your terminal window is at least **120 columns x 40 rows** for the intended layout.
 
 ## Configuration (Optional)
 
@@ -131,11 +115,6 @@ You need the MSVC C++ Build Tools. Install them via:
 - Check that the Ollama service is running in the system tray.
 - Verify the port: `curl http://localhost:11434/api/tags`.
 - Firewall software may block localhost connections — add an exception if needed.
-
-### TUI looks garbled or has no color
-
-- Switch to Windows Terminal if you are using cmd.exe or legacy conhost.
-- Ensure your terminal font supports Unicode (e.g., Cascadia Code, Consolas).
 
 ### Model runs slowly
 


### PR DESCRIPTION
The TUI (Ratatui/Crossterm) was cut in March 2026 and the GUI moved
from egui to Tauri 2 + Svelte 5. Update docs to reflect reality:

- setup guides (windows/macos/linux): remove TUI Mode sections,
  Terminal Recommendations (TUI Mode) sections, and TUI
  troubleshooting entries
- gui-design.md: drop the legacy egui section entirely; keep the
  current Svelte content (loading spinner, map panels, label
  placement, sidebar, input pipeline); update Related/Sources
- weather-system.md: remove TUI source reference and TUI Design link

https://claude.ai/code/session_01BeH7h31xjkDumiyrbVaYSS