### PR TITLE
Fix NPC arrival reactions showing "npc" instead of speaker name

### DIFF
--- a/crates/parish-cli/tests/world_graph_integration.rs
+++ b/crates/parish-cli/tests/world_graph_integration.rs
@@ -16,8 +16,7 @@ use parish::world::transport::TransportMode;
 
 fn load_parish_graph() -> WorldGraph {
     let path = Path::new("../../mods/rundale/world.json");
-    WorldGraph::load_from_file(path)
-        .expect("mods/rundale/world.json should load and validate")
+    WorldGraph::load_from_file(path).expect("mods/rundale/world.json should load and validate")
 }
 
 fn walking() -> TransportMode {

--- a/crates/parish-core/src/game_session.rs
+++ b/crates/parish-core/src/game_session.rs
@@ -370,7 +370,7 @@ pub async fn resolve_reaction_texts(
     client: Option<&OpenAiClient>,
     model: &str,
     inference_log: Option<&InferenceLog>,
-) -> Vec<String> {
+) -> Vec<(String, String)> {
     use crate::npc::reactions::build_reaction_prompt;
 
     let timeout_secs = ReactionConfig::default().llm_timeout_secs;
@@ -452,7 +452,7 @@ pub async fn resolve_reaction_texts(
         } else {
             reaction.canned_text.clone()
         };
-        texts.push(text);
+        texts.push((reaction.npc_display_name.clone(), text));
     }
     texts
 }

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -510,8 +510,9 @@ async fn handle_movement(target: &str, state: &Arc<AppState>) {
         )
         .await;
 
-        for text in texts {
-            state.event_bus.emit("text-log", &text_log("npc", text));
+        for (display_name, text) in texts {
+            let label = capitalize_first(&display_name);
+            state.event_bus.emit("text-log", &text_log(label, text));
         }
     }
 

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -593,8 +593,9 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
         )
         .await;
 
-        for text in texts {
-            let _ = app.emit(EVENT_TEXT_LOG, text_log("npc", &text));
+        for (display_name, text) in texts {
+            let label = capitalize_first(&display_name);
+            let _ = app.emit(EVENT_TEXT_LOG, text_log(label, &text));
         }
     }
 


### PR DESCRIPTION
resolve_reaction_texts() was returning Vec<String> (text only), causing
both the Tauri and server callers to fall back to the hardcoded "npc"
label. Changed the return type to Vec<(String, String)> (display_name,
text) so each reaction carries its speaker name through. Callers now
use capitalize_first on the name, matching the existing pattern for
LLM dialogue labels.

https://claude.ai/code/session_016o5YWLJ2LYgX8KZLX246AL