### PR TITLE
feat: surface engine internals in debug panel

### DIFF
--- a/apps/ui/src/components/DebugPanel.svelte
+++ b/apps/ui/src/components/DebugPanel.svelte
@@ -2,7 +2,16 @@
 	import { debugVisible, debugSnapshot, debugTab, selectedNpcId } from '../stores/debug';
 	import type { NpcDebug, ScheduleVariantDebug } from '$lib/types';
 
-	const tabs = ['Overview', 'NPCs', 'World', 'Events', 'Inference'];
+	const tabs = [
+		'Overview',
+		'NPCs',
+		'World',
+		'Weather',
+		'Gossip',
+		'Conv',
+		'Events',
+		'Inference'
+	];
 
 	function selectTab(index: number) {
 		debugTab.set(index);
@@ -70,15 +79,25 @@
 					<div class="field">{snap.clock.time_of_day} | {snap.clock.day_of_week} | {snap.clock.season}</div>
 					<div class="field muted">Schedule day: {snap.clock.day_type}</div>
 					<div class="field">Weather: {snap.clock.weather}</div>
-					<div class="field">Speed: {snap.clock.speed_factor}x {snap.clock.paused ? '(PAUSED)' : ''}</div>
+					<div class="field">
+						Speed: {snap.clock.speed_factor}x
+						{#if snap.clock.speed_name}<span class="muted">({snap.clock.speed_name})</span>{/if}
+						{#if snap.clock.paused}<span class="accent"> PAUSED</span>{/if}
+						{#if snap.clock.inference_paused}<span class="accent"> INFER-PAUSED</span>{/if}
+					</div>
 					{#if snap.clock.festival}
 						<div class="field accent">Festival: {snap.clock.festival}</div>
 					{/if}
+					<div class="field muted">Anchor: {snap.clock.start_game_time}</div>
+					{#if snap.clock.paused}
+						<div class="field muted">Frozen at: {snap.clock.paused_game_time}</div>
+					{/if}
+					<div class="field muted">Real elapsed: {snap.clock.real_elapsed_secs.toFixed(1)}s</div>
 				</div>
 				<div class="section">
 					<h4>Location</h4>
 					<div class="field accent"># {snap.world.player_location_name}</div>
-					<div class="field muted">{snap.world.location_count} locations total</div>
+					<div class="field muted">{snap.world.visited_count}/{snap.world.location_count} visited</div>
 				</div>
 				<div class="section">
 					<h4>Tiers</h4>
@@ -86,9 +105,16 @@
 					{#if snap.tier_summary.tier1_names.length > 0}
 						<div class="field muted">T1: {snap.tier_summary.tier1_names.join(', ')}</div>
 					{/if}
+					{#if snap.tier_summary.tier2_names.length > 0}
+						<div class="field muted">T2: {snap.tier_summary.tier2_names.join(', ')}</div>
+					{/if}
 					{#if snap.tier_summary.tier3_names.length > 0}
 						<div class="field muted">T3: {snap.tier_summary.tier3_names.join(', ')}</div>
 					{/if}
+					{#if snap.tier_summary.tier4_names.length > 0}
+						<div class="field muted">T4: {snap.tier_summary.tier4_names.join(', ')}</div>
+					{/if}
+					<div class="field muted">Introduced: {snap.tier_summary.introduced_count}</div>
 					<div class="field">T3 batch:
 						{#if snap.tier_summary.tier3_in_flight}
 							<span class="accent">IN FLIGHT</span>
@@ -100,6 +126,17 @@
 						{:else}
 							| (never run)
 						{/if}
+					</div>
+					<div class="field muted">
+						T2 last: {snap.tier_summary.last_tier2_tick ?? '(never)'}
+						| T4 last: {snap.tier_summary.last_tier4_tick ?? '(never)'}
+					</div>
+				</div>
+				<div class="section">
+					<h4>Event Bus</h4>
+					<div class="field muted">
+						Subscribers: {snap.event_bus.subscriber_count}
+						| Captured: {snap.event_bus.recent_events.length}
 					</div>
 				</div>
 
@@ -114,6 +151,11 @@
 							<h5>Identity</h5>
 							<div class="field">Age: {selectedNpc.age} | {selectedNpc.occupation}</div>
 							<div class="field muted">{selectedNpc.personality.length > 120 ? selectedNpc.personality.slice(0, 117) + '...' : selectedNpc.personality}</div>
+							<div class="field muted">Brief: {selectedNpc.brief_description}</div>
+							<div class="field">
+								Introduced: {selectedNpc.introduced ? 'yes' : 'no'}
+								{#if selectedNpc.is_ill}<span class="accent"> ILL</span>{/if}
+							</div>
 						</div>
 
 						<div class="section">
@@ -168,16 +210,56 @@
 							<div class="section">
 								<h5>Relationships</h5>
 								{#each selectedNpc.relationships as rel}
-									<div class="field"><span class="mono">{strengthBar(rel.strength)}</span> {rel.target_name} ({rel.kind}, {rel.strength.toFixed(1)})</div>
+									<div class="field"><span class="mono">{strengthBar(rel.strength)}</span> {rel.target_name} ({rel.kind}, {rel.strength.toFixed(1)}, {rel.history_count} events)</div>
+									{#if rel.history.length > 0}
+										{#each rel.history as evt}
+											<div class="field indent muted">[{evt.timestamp}] {evt.description}</div>
+										{/each}
+									{/if}
 								{/each}
 							</div>
 						{/if}
 
 						{#if selectedNpc.memories.length > 0}
 							<div class="section">
-								<h5>Memory ({selectedNpc.memories.length})</h5>
+								<h5>Short-term Memory ({selectedNpc.memories.length})</h5>
 								{#each selectedNpc.memories as mem}
 									<div class="field"><span class="muted">[{mem.timestamp}]</span> {mem.content} <span class="muted">({mem.location_name})</span></div>
+								{/each}
+							</div>
+						{/if}
+
+						{#if selectedNpc.long_term_memories.length > 0}
+							<div class="section">
+								<h5>Long-term Memory ({selectedNpc.long_term_memories.length})</h5>
+								{#each selectedNpc.long_term_memories as ltm}
+									<div class="field"><span class="muted">[{ltm.timestamp}]</span> ({ltm.importance.toFixed(2)}) {ltm.content}</div>
+									{#if ltm.keywords.length > 0}
+										<div class="field indent muted">kw: {ltm.keywords.join(', ')}</div>
+									{/if}
+								{/each}
+							</div>
+						{/if}
+
+						{#if selectedNpc.reactions.length > 0}
+							<div class="section">
+								<h5>Reactions ({selectedNpc.reactions.length})</h5>
+								{#each selectedNpc.reactions as r}
+									<div class="field"><span class="muted">[{r.timestamp}]</span> {r.emoji} {r.description}</div>
+									<div class="field indent muted">context: {r.context}</div>
+								{/each}
+							</div>
+						{/if}
+
+						{#if selectedNpc.deflated_summary}
+							<div class="section">
+								<h5>Deflated Summary</h5>
+								<div class="field">@ {selectedNpc.deflated_summary.location_name} — {selectedNpc.deflated_summary.mood}</div>
+								{#each selectedNpc.deflated_summary.recent_activity as act}
+									<div class="field indent muted">- {act}</div>
+								{/each}
+								{#each selectedNpc.deflated_summary.key_relationship_changes as ch}
+									<div class="field indent muted">~ {ch}</div>
 								{/each}
 							</div>
 						{/if}
@@ -213,25 +295,109 @@
 			{:else if tab === 2}
 				<!-- World -->
 				<div class="section">
-					<h4>{snap.world.location_count} Locations</h4>
+					<h4>Locations ({snap.world.visited_count}/{snap.world.location_count} visited)</h4>
 					{#each snap.world.locations as loc}
 						<div class="loc-row" class:player-here={loc.id === snap.world.player_location_id}>
 							<div class="field">
 								{#if loc.id === snap.world.player_location_id}<strong>>>> </strong>{/if}
 								{loc.name}
-								<span class="muted">({loc.indoor ? 'indoor' : 'outdoor'}/{loc.public ? 'pub' : 'prv'}, {loc.connection_count} exits)</span>
+								<span class="muted">({loc.indoor ? 'indoor' : 'outdoor'}/{loc.public ? 'pub' : 'prv'}, {loc.connection_count} exits{#if !loc.visited}, unvisited{/if})</span>
 							</div>
 							{#if loc.npcs_here.length > 0}
 								<div class="field muted indent">NPCs: {loc.npcs_here.join(', ')}</div>
 							{/if}
+							{#if loc.edges.length > 0}
+								{#each loc.edges as edge}
+									<div class="field muted indent">→ {edge.target_name} ({edge.walking_minutes}m walk) — {edge.path_description}</div>
+								{/each}
+							{/if}
 						</div>
 					{/each}
 				</div>
+				{#if snap.world.edge_traversals.length > 0}
+					<div class="section">
+						<h4>Worn Paths (top edges)</h4>
+						{#each snap.world.edge_traversals.slice(0, 20) as edge}
+							<div class="field">{edge.from_name} ↔ {edge.to_name} <span class="muted">×{edge.count}</span></div>
+						{/each}
+					</div>
+				{/if}
+				<div class="section">
+					<h4>Text Log (tail {snap.world.text_log_tail.length}/{snap.world.text_log_len})</h4>
+					{#if snap.world.text_log_tail.length === 0}
+						<div class="field muted">(empty)</div>
+					{:else}
+						{#each snap.world.text_log_tail as line}
+							<div class="field muted">{line}</div>
+						{/each}
+					{/if}
+				</div>
 
 			{:else if tab === 3}
+				<!-- Weather -->
+				<div class="section">
+					<h4>Weather Engine</h4>
+					<div class="field">Current: <span class="accent">{snap.weather.current}</span></div>
+					<div class="field">Since: {snap.weather.since}</div>
+					<div class="field">Duration: {snap.weather.duration_hours.toFixed(2)}h</div>
+					<div class="field muted">Min duration before next transition: {snap.weather.min_duration_hours}h</div>
+					<div class="field muted">Last check hour: {snap.weather.last_check_hour ?? '(never)'}</div>
+				</div>
+
+			{:else if tab === 4}
+				<!-- Gossip -->
+				<div class="section">
+					<h4>Gossip Network ({snap.gossip.item_count})</h4>
+					{#if snap.gossip.items.length === 0}
+						<div class="field muted">(no gossip)</div>
+					{:else}
+						{#each snap.gossip.items as item}
+							<div class="gossip-item">
+								<div class="field">
+									<span class="muted">#{item.id}</span>
+									{#if item.distortion_level > 0}
+										<span class="accent">[distortion {item.distortion_level}]</span>
+									{/if}
+									{item.content}
+								</div>
+								<div class="field muted indent">source: {item.source_name} | known by {item.known_by.length}: {item.known_by.join(', ')}</div>
+								<div class="field muted indent">at {item.timestamp}</div>
+							</div>
+						{/each}
+					{/if}
+				</div>
+
+			{:else if tab === 5}
+				<!-- Conversations -->
+				<div class="section">
+					<h4>Conversation Log ({snap.conversations.exchange_count})</h4>
+					{#if snap.conversations.exchanges.length === 0}
+						<div class="field muted">(no exchanges)</div>
+					{:else}
+						{#each [...snap.conversations.exchanges].reverse() as ex}
+							<div class="conv-entry">
+								<div class="field muted">[{ex.timestamp}] @ {ex.location_name}</div>
+								<div class="field">Player: {ex.player_input}</div>
+								<div class="field accent">{ex.speaker_name}: {ex.npc_dialogue}</div>
+							</div>
+						{/each}
+					{/if}
+				</div>
+
+			{:else if tab === 6}
 				<!-- Events -->
 				<div class="section">
-					<h4>Events ({snap.events.length})</h4>
+					<h4>Game Events ({snap.event_bus.recent_events.length}) — subscribers: {snap.event_bus.subscriber_count}</h4>
+					{#if snap.event_bus.recent_events.length === 0}
+						<div class="field muted">(no game events captured)</div>
+					{:else}
+						{#each [...snap.event_bus.recent_events].reverse() as evt}
+							<div class="field"><span class="muted">[{evt.timestamp}]</span> <span class="event-cat">[{evt.kind}]</span> {evt.summary}</div>
+						{/each}
+					{/if}
+				</div>
+				<div class="section">
+					<h4>Debug Events ({snap.events.length})</h4>
 					{#if snap.events.length === 0}
 						<div class="field muted">(no events yet)</div>
 					{:else}
@@ -241,7 +407,7 @@
 					{/if}
 				</div>
 
-			{:else if tab === 4}
+			{:else if tab === 7}
 				<!-- Inference -->
 				{#if selectedLog}
 					<!-- Detail view for a single inference call -->
@@ -304,6 +470,7 @@
 					</div>
 					<div class="section">
 						<div class="field">Improv: {snap.inference.improv_enabled ? 'ON' : 'OFF'}</div>
+						<div class="field muted">Reaction req id: {snap.inference.reaction_req_id}</div>
 					</div>
 					<div class="section">
 						<h4>Call Log ({snap.inference.call_log.length})</h4>
@@ -389,6 +556,14 @@
 		gap: 0;
 		border-bottom: 1px solid var(--color-border);
 		background: var(--color-bg);
+		overflow-x: auto;
+	}
+
+	.gossip-item,
+	.conv-entry {
+		margin-bottom: 0.3rem;
+		padding-bottom: 0.3rem;
+		border-bottom: 1px dashed var(--color-border);
 	}
 
 	.tab-btn {

--- a/apps/ui/src/lib/types.ts
+++ b/apps/ui/src/lib/types.ts
@@ -140,9 +140,13 @@ export interface LoadingPayload {
 
 export interface DebugSnapshot {
 	clock: ClockDebug;
+	weather: WeatherDebug;
 	world: WorldDebug;
 	npcs: NpcDebug[];
 	tier_summary: TierSummary;
+	event_bus: EventBusDebug;
+	gossip: GossipDebug;
+	conversations: ConversationsDebug;
 	events: DebugEvent[];
 	inference: InferenceDebug;
 }
@@ -154,16 +158,40 @@ export interface ClockDebug {
 	festival: string | null;
 	weather: string;
 	paused: boolean;
+	inference_paused: boolean;
 	speed_factor: number;
+	speed_name: string | null;
 	day_of_week: string;
 	day_type: string;
+	start_game_time: string;
+	paused_game_time: string;
+	real_elapsed_secs: number;
+}
+
+export interface WeatherDebug {
+	current: string;
+	since: string;
+	duration_hours: number;
+	min_duration_hours: number;
+	last_check_hour: number | null;
 }
 
 export interface WorldDebug {
 	player_location_name: string;
 	player_location_id: number;
 	location_count: number;
+	visited_count: number;
+	visited_locations: string[];
+	edge_traversals: EdgeTraversalDebug[];
+	text_log_tail: string[];
+	text_log_len: number;
 	locations: LocationDebug[];
+}
+
+export interface EdgeTraversalDebug {
+	from_name: string;
+	to_name: string;
+	count: number;
 }
 
 export interface LocationDebug {
@@ -173,11 +201,22 @@ export interface LocationDebug {
 	public: boolean;
 	connection_count: number;
 	npcs_here: string[];
+	visited: boolean;
+	edges: GraphEdgeDebug[];
+}
+
+export interface GraphEdgeDebug {
+	target_id: number;
+	target_name: string;
+	path_description: string;
+	walking_minutes: number;
 }
 
 export interface NpcDebug {
 	id: number;
 	name: string;
+	brief_description: string;
+	introduced: boolean;
 	age: number;
 	occupation: string;
 	personality: string;
@@ -186,14 +225,39 @@ export interface NpcDebug {
 	home_name: string | null;
 	workplace_name: string | null;
 	mood: string;
+	is_ill: boolean;
 	state: string;
 	tier: string;
 	schedule: ScheduleVariantDebug[];
 	relationships: RelationshipDebug[];
 	memories: MemoryDebug[];
+	long_term_memories: LongTermMemoryDebug[];
+	reactions: ReactionDebug[];
+	deflated_summary: DeflatedSummaryDebug | null;
 	knowledge: string[];
 	intelligence: IntelligenceDebug;
 	last_activity: string | null;
+}
+
+export interface LongTermMemoryDebug {
+	timestamp: string;
+	content: string;
+	importance: number;
+	keywords: string[];
+}
+
+export interface ReactionDebug {
+	timestamp: string;
+	emoji: string;
+	description: string;
+	context: string;
+}
+
+export interface DeflatedSummaryDebug {
+	location_name: string;
+	mood: string;
+	recent_activity: string[];
+	key_relationship_changes: string[];
 }
 
 export interface ScheduleVariantDebug {
@@ -225,6 +289,12 @@ export interface RelationshipDebug {
 	kind: string;
 	strength: number;
 	history_count: number;
+	history: RelationshipEventDebug[];
+}
+
+export interface RelationshipEventDebug {
+	timestamp: string;
+	description: string;
 }
 
 export interface MemoryDebug {
@@ -241,8 +311,51 @@ export interface TierSummary {
 	tier1_names: string[];
 	tier2_names: string[];
 	tier3_names: string[];
+	tier4_names: string[];
 	tier3_in_flight: boolean;
+	last_tier2_tick: string | null;
 	last_tier3_tick: string | null;
+	last_tier4_tick: string | null;
+	introduced_count: number;
+}
+
+export interface EventBusDebug {
+	subscriber_count: number;
+	recent_events: GameEventDebug[];
+}
+
+export interface GameEventDebug {
+	timestamp: string;
+	kind: string;
+	summary: string;
+}
+
+export interface GossipDebug {
+	item_count: number;
+	items: GossipItemDebug[];
+}
+
+export interface GossipItemDebug {
+	id: number;
+	content: string;
+	source_name: string;
+	distortion_level: number;
+	known_by: string[];
+	timestamp: string;
+}
+
+export interface ConversationsDebug {
+	exchange_count: number;
+	exchanges: ConversationExchangeDebug[];
+}
+
+export interface ConversationExchangeDebug {
+	timestamp: string;
+	speaker_id: number;
+	speaker_name: string;
+	location_name: string;
+	player_input: string;
+	npc_dialogue: string;
 }
 
 export interface DebugEvent {
@@ -258,6 +371,7 @@ export interface InferenceDebug {
 	cloud_provider: string | null;
 	cloud_model: string | null;
 	has_queue: boolean;
+	reaction_req_id: number;
 	improv_enabled: boolean;
 	call_log: InferenceLogEntry[];
 }

--- a/crates/parish-cli/tests/world_graph_integration.rs
+++ b/crates/parish-cli/tests/world_graph_integration.rs
@@ -16,8 +16,7 @@ use parish::world::transport::TransportMode;
 
 fn load_parish_graph() -> WorldGraph {
     let path = Path::new("../../mods/rundale/world.json");
-    WorldGraph::load_from_file(path)
-        .expect("mods/rundale/world.json should load and validate")
+    WorldGraph::load_from_file(path).expect("mods/rundale/world.json should load and validate")
 }
 
 fn walking() -> TransportMode {

--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -24,13 +24,21 @@ use crate::world::time::{DayType, Season};
 pub struct DebugSnapshot {
     /// Game clock and timing information.
     pub clock: ClockDebug,
+    /// Dynamic weather state machine internals.
+    pub weather: WeatherDebug,
     /// World graph and player position.
     pub world: WorldDebug,
     /// Full NPC state for every NPC.
     pub npcs: Vec<NpcDebug>,
     /// Tier assignment summary.
     pub tier_summary: TierSummary,
-    /// Recent debug events.
+    /// Event bus + recent game events flowing through it.
+    pub event_bus: EventBusDebug,
+    /// Gossip network state.
+    pub gossip: GossipDebug,
+    /// Conversation log (player–NPC exchanges).
+    pub conversations: ConversationsDebug,
+    /// Recent debug events (schedule, tier, inference).
     pub events: Vec<DebugEvent>,
     /// Inference pipeline configuration.
     pub inference: InferenceDebug,
@@ -49,14 +57,39 @@ pub struct ClockDebug {
     pub festival: Option<String>,
     /// Current weather.
     pub weather: String,
-    /// Whether the clock is paused.
+    /// Whether the clock is player-paused.
     pub paused: bool,
-    /// Clock speed multiplier.
+    /// Whether the clock is paused while waiting on an inference call.
+    pub inference_paused: bool,
+    /// Clock speed multiplier (game seconds per real second).
     pub speed_factor: f64,
+    /// Named speed preset matching the current factor, if any (e.g. "Normal").
+    pub speed_name: Option<String>,
     /// Full day-of-week name (e.g. "Monday").
     pub day_of_week: String,
     /// Schedule day type label (e.g. "Weekday", "Sunday", "Market Day").
     pub day_type: String,
+    /// Origin game-time anchor (creation or last resume).
+    pub start_game_time: String,
+    /// Frozen game time captured when the clock was paused (valid while frozen).
+    pub paused_game_time: String,
+    /// Real-world elapsed seconds since the anchor (for drift diagnostics).
+    pub real_elapsed_secs: f64,
+}
+
+/// Dynamic weather engine internals for debug display.
+#[derive(Debug, Clone, Serialize)]
+pub struct WeatherDebug {
+    /// Current weather label (e.g. "LightRain").
+    pub current: String,
+    /// Game time when the current weather state began.
+    pub since: String,
+    /// Game-hours the current state has persisted.
+    pub duration_hours: f64,
+    /// Minimum duration before a transition is allowed (game-hours).
+    pub min_duration_hours: f64,
+    /// Game-hour cursor of the last transition evaluation, if any.
+    pub last_check_hour: Option<u32>,
 }
 
 /// World graph summary for debug display.
@@ -68,8 +101,29 @@ pub struct WorldDebug {
     pub player_location_id: u32,
     /// Total number of locations in the graph.
     pub location_count: usize,
+    /// Number of locations the player has visited (fog-of-war reveal set).
+    pub visited_count: usize,
+    /// Names of all visited locations.
+    pub visited_locations: Vec<String>,
+    /// Edge traversal counts (player "worn path" footprints).
+    pub edge_traversals: Vec<EdgeTraversalDebug>,
+    /// Most recent player-facing text log lines (tail).
+    pub text_log_tail: Vec<String>,
+    /// Total number of lines currently in the text log.
+    pub text_log_len: usize,
     /// Per-location debug info.
     pub locations: Vec<LocationDebug>,
+}
+
+/// A single edge in the player "worn path" map.
+#[derive(Debug, Clone, Serialize)]
+pub struct EdgeTraversalDebug {
+    /// Name of the first endpoint (lower id).
+    pub from_name: String,
+    /// Name of the second endpoint (higher id).
+    pub to_name: String,
+    /// Times the player has walked along this edge.
+    pub count: u32,
 }
 
 /// Per-location debug info.
@@ -87,6 +141,23 @@ pub struct LocationDebug {
     pub connection_count: usize,
     /// Names of NPCs currently present here.
     pub npcs_here: Vec<String>,
+    /// Whether the player has visited this location.
+    pub visited: bool,
+    /// Outgoing graph edges from this location.
+    pub edges: Vec<GraphEdgeDebug>,
+}
+
+/// A single outgoing edge in the world graph.
+#[derive(Debug, Clone, Serialize)]
+pub struct GraphEdgeDebug {
+    /// Destination location id.
+    pub target_id: u32,
+    /// Destination location name.
+    pub target_name: String,
+    /// Prose path description (e.g. "a narrow boreen lined with hawthorn").
+    pub path_description: String,
+    /// Travel time in game-minutes on foot.
+    pub walking_minutes: u16,
 }
 
 /// Full NPC state for deep-dive inspection.
@@ -96,6 +167,10 @@ pub struct NpcDebug {
     pub id: u32,
     /// Full name.
     pub name: String,
+    /// Brief anonymous descriptor shown before introduction.
+    pub brief_description: String,
+    /// Whether the player has been introduced to this NPC.
+    pub introduced: bool,
     /// Age in years.
     pub age: u8,
     /// Occupation.
@@ -112,6 +187,8 @@ pub struct NpcDebug {
     pub workplace_name: Option<String>,
     /// Current mood.
     pub mood: String,
+    /// Whether the Tier 4 rules engine currently flags this NPC as ill.
+    pub is_ill: bool,
     /// Current state description ("Present" or "InTransit -> Dest @HH:MM").
     pub state: String,
     /// Cognitive tier label ("Tier1", "Tier2", etc.).
@@ -120,14 +197,59 @@ pub struct NpcDebug {
     pub schedule: Vec<ScheduleVariantDebug>,
     /// Relationships with other NPCs.
     pub relationships: Vec<RelationshipDebug>,
-    /// Recent memory entries.
+    /// Recent short-term memory entries.
     pub memories: Vec<MemoryDebug>,
+    /// Importance-weighted long-term memories.
+    pub long_term_memories: Vec<LongTermMemoryDebug>,
+    /// Recent player emoji reactions directed at this NPC.
+    pub reactions: Vec<ReactionDebug>,
+    /// Deflated summary captured at the last tier drop, if any.
+    pub deflated_summary: Option<DeflatedSummaryDebug>,
     /// Knowledge entries.
     pub knowledge: Vec<String>,
     /// Intelligence profile dimensions (each 1–5).
     pub intelligence: IntelligenceDebug,
     /// Last Tier 3 batch activity summary, if this NPC has received one.
     pub last_activity: Option<String>,
+}
+
+/// A long-term memory entry for debug display.
+#[derive(Debug, Clone, Serialize)]
+pub struct LongTermMemoryDebug {
+    /// Formatted game timestamp.
+    pub timestamp: String,
+    /// What happened.
+    pub content: String,
+    /// Importance score in [0.0, 1.0].
+    pub importance: f32,
+    /// Retrieval keywords.
+    pub keywords: Vec<String>,
+}
+
+/// A player reaction entry for debug display.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReactionDebug {
+    /// Formatted game timestamp.
+    pub timestamp: String,
+    /// Emoji used.
+    pub emoji: String,
+    /// Natural-language description (e.g. "looked angry").
+    pub description: String,
+    /// Truncated context — what the NPC said that was reacted to.
+    pub context: String,
+}
+
+/// Summary captured when an NPC was deflated to a lower tier.
+#[derive(Debug, Clone, Serialize)]
+pub struct DeflatedSummaryDebug {
+    /// Location name at the time of deflation.
+    pub location_name: String,
+    /// Mood at the time of deflation.
+    pub mood: String,
+    /// Short summaries of recent activity.
+    pub recent_activity: Vec<String>,
+    /// Notable relationship changes since last inflation.
+    pub key_relationship_changes: Vec<String>,
 }
 
 /// Compact intelligence profile for debug display.
@@ -186,6 +308,17 @@ pub struct RelationshipDebug {
     pub strength: f64,
     /// Number of history entries.
     pub history_count: usize,
+    /// Recent history entries (up to 10, newest first).
+    pub history: Vec<RelationshipEventDebug>,
+}
+
+/// A single relationship history entry for debug display.
+#[derive(Debug, Clone, Serialize)]
+pub struct RelationshipEventDebug {
+    /// Formatted game timestamp.
+    pub timestamp: String,
+    /// Description of what happened.
+    pub description: String,
 }
 
 /// A memory entry for debug display.
@@ -216,10 +349,90 @@ pub struct TierSummary {
     pub tier2_names: Vec<String>,
     /// Names of Tier 3 NPCs (distant, batch-simulated).
     pub tier3_names: Vec<String>,
+    /// Names of Tier 4 NPCs (rules-engine tick).
+    pub tier4_names: Vec<String>,
     /// Whether a Tier 3 batch inference is currently in flight.
     pub tier3_in_flight: bool,
-    /// Formatted game time of last Tier 3 batch tick, or null if never run.
+    /// Formatted game time of last Tier 2 schedule tick.
+    pub last_tier2_tick: Option<String>,
+    /// Formatted game time of last Tier 3 batch tick.
     pub last_tier3_tick: Option<String>,
+    /// Formatted game time of last Tier 4 rules engine tick.
+    pub last_tier4_tick: Option<String>,
+    /// Number of NPCs the player has been introduced to.
+    pub introduced_count: usize,
+}
+
+/// Event bus + recent event stream for debug display.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct EventBusDebug {
+    /// Number of active subscribers on the game event bus.
+    pub subscriber_count: usize,
+    /// Recent `GameEvent`s captured from the bus (newest last).
+    pub recent_events: Vec<GameEventDebug>,
+}
+
+/// A single game event for debug display.
+#[derive(Debug, Clone, Serialize)]
+pub struct GameEventDebug {
+    /// Formatted game timestamp.
+    pub timestamp: String,
+    /// Event discriminant name (e.g. "WeatherChanged").
+    pub kind: String,
+    /// Human-readable event summary.
+    pub summary: String,
+}
+
+/// Gossip network state for debug display.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct GossipDebug {
+    /// Total number of gossip items in the network.
+    pub item_count: usize,
+    /// All gossip items (newest first, capped).
+    pub items: Vec<GossipItemDebug>,
+}
+
+/// A single gossip item for debug display.
+#[derive(Debug, Clone, Serialize)]
+pub struct GossipItemDebug {
+    /// Unique gossip id.
+    pub id: u32,
+    /// Current (possibly distorted) content.
+    pub content: String,
+    /// Name of the original source NPC.
+    pub source_name: String,
+    /// How many times this item has been distorted (0 = original).
+    pub distortion_level: u8,
+    /// Names of NPCs who know this gossip.
+    pub known_by: Vec<String>,
+    /// Formatted game timestamp of creation.
+    pub timestamp: String,
+}
+
+/// Conversation log state for debug display.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct ConversationsDebug {
+    /// Total number of stored exchanges.
+    pub exchange_count: usize,
+    /// All exchanges in chronological order.
+    pub exchanges: Vec<ConversationExchangeDebug>,
+}
+
+/// A single conversation exchange for debug display.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConversationExchangeDebug {
+    /// Formatted game timestamp.
+    pub timestamp: String,
+    /// Speaker NPC id.
+    pub speaker_id: u32,
+    /// Speaker display name.
+    pub speaker_name: String,
+    /// Location name where the exchange happened.
+    pub location_name: String,
+    /// What the player said.
+    pub player_input: String,
+    /// What the NPC replied.
+    pub npc_dialogue: String,
 }
 
 /// A timestamped debug event for the event log.
@@ -248,6 +461,8 @@ pub struct InferenceDebug {
     pub cloud_model: Option<String>,
     /// Whether an inference queue is active.
     pub has_queue: bool,
+    /// Current value of the reaction request ID counter (monotonic).
+    pub reaction_req_id: u64,
     /// Whether improv mode is enabled.
     pub improv_enabled: bool,
     /// Recent inference call log entries (newest last).
@@ -262,13 +477,17 @@ pub use crate::inference::InferenceLogEntry;
 /// Pure query function — reads but never mutates any state.
 /// The `events` parameter is a ring buffer of recent debug events
 /// maintained by the caller (TUI App or Tauri AppState).
+/// The `game_events` parameter is an optional ring buffer of recent
+/// `GameEvent`s captured from the world event bus by the caller.
 pub fn build_debug_snapshot(
     world: &WorldState,
     npc_manager: &NpcManager,
     events: &VecDeque<DebugEvent>,
+    game_events: &VecDeque<crate::world::events::GameEvent>,
     inference: &InferenceDebug,
 ) -> DebugSnapshot {
     let clock = build_clock_debug(world);
+    let weather = build_weather_debug(world);
     let world_debug = build_world_debug(world, npc_manager);
     let current_hour = world.clock.now().hour() as u8;
     let current_season = world.clock.season();
@@ -282,12 +501,19 @@ pub fn build_debug_snapshot(
     );
     let tier_summary = build_tier_summary(npc_manager);
     let event_list: Vec<DebugEvent> = events.iter().cloned().collect();
+    let event_bus = build_event_bus_debug(world, game_events, npc_manager);
+    let gossip = build_gossip_debug(world, npc_manager);
+    let conversations = build_conversations_debug(world);
 
     DebugSnapshot {
         clock,
+        weather,
         world: world_debug,
         npcs,
         tier_summary,
+        event_bus,
+        gossip,
+        conversations,
         events: event_list,
         inference: inference.clone(),
     }
@@ -318,11 +544,171 @@ fn build_clock_debug(world: &WorldState) -> ClockDebug {
         festival: world.clock.check_festival().map(|f| f.to_string()),
         weather: world.weather.to_string(),
         paused: world.clock.is_paused(),
+        inference_paused: world.clock.is_inference_paused(),
         speed_factor: world.clock.speed_factor(),
+        speed_name: world.clock.current_speed().map(|s| s.to_string()),
         day_of_week,
         day_type: world.clock.day_type().to_string(),
+        start_game_time: world
+            .clock
+            .start_game()
+            .format("%H:%M %Y-%m-%d")
+            .to_string(),
+        paused_game_time: world
+            .clock
+            .paused_game_time()
+            .format("%H:%M %Y-%m-%d")
+            .to_string(),
+        real_elapsed_secs: world.clock.real_elapsed_secs(),
     }
 }
+
+/// Builds weather engine debug info from world state.
+fn build_weather_debug(world: &WorldState) -> WeatherDebug {
+    let now = world.clock.now();
+    WeatherDebug {
+        current: world.weather_engine.current().to_string(),
+        since: world
+            .weather_engine
+            .since()
+            .format("%H:%M %Y-%m-%d")
+            .to_string(),
+        duration_hours: world.weather_engine.duration_hours(now),
+        min_duration_hours: world.weather_engine.min_duration_hours(),
+        last_check_hour: world.weather_engine.last_check_hour(),
+    }
+}
+
+/// Builds event bus debug info from the captured game-event ring buffer.
+fn build_event_bus_debug(
+    world: &WorldState,
+    game_events: &VecDeque<crate::world::events::GameEvent>,
+    npc_manager: &NpcManager,
+) -> EventBusDebug {
+    use crate::world::events::GameEvent;
+
+    let name_of = |id: crate::npc::NpcId| -> String {
+        npc_manager
+            .get(id)
+            .map(|n| n.name.clone())
+            .unwrap_or_else(|| format!("NPC({})", id.0))
+    };
+    let loc_of = |id: crate::world::LocationId| -> String { loc_name(id, &world.graph) };
+
+    let recent_events: Vec<GameEventDebug> = game_events
+        .iter()
+        .map(|e| {
+            let timestamp = e.timestamp().format("%H:%M %Y-%m-%d").to_string();
+            let kind = e.event_type().to_string();
+            let summary = match e {
+                GameEvent::DialogueOccurred {
+                    npc_id, summary, ..
+                } => format!("{}: {}", name_of(*npc_id), summary),
+                GameEvent::MoodChanged {
+                    npc_id, new_mood, ..
+                } => format!("{} → {}", name_of(*npc_id), new_mood),
+                GameEvent::RelationshipChanged {
+                    npc_a,
+                    npc_b,
+                    delta,
+                    ..
+                } => format!("{} ↔ {} ({:+.2})", name_of(*npc_a), name_of(*npc_b), delta),
+                GameEvent::NpcArrived {
+                    npc_id, location, ..
+                } => format!("{} arrived at {}", name_of(*npc_id), loc_of(*location)),
+                GameEvent::NpcDeparted {
+                    npc_id, location, ..
+                } => format!("{} departed from {}", name_of(*npc_id), loc_of(*location)),
+                GameEvent::WeatherChanged { new_weather, .. } => {
+                    format!("Weather: {}", new_weather)
+                }
+                GameEvent::FestivalStarted { name, .. } => format!("Festival: {}", name),
+                GameEvent::LifeEvent {
+                    npc_id,
+                    description,
+                    ..
+                } => format!("{}: {}", name_of(*npc_id), description),
+            };
+            GameEventDebug {
+                timestamp,
+                kind,
+                summary,
+            }
+        })
+        .collect();
+
+    EventBusDebug {
+        subscriber_count: world.event_bus.subscriber_count(),
+        recent_events,
+    }
+}
+
+/// Builds gossip network debug info.
+fn build_gossip_debug(world: &WorldState, npc_manager: &NpcManager) -> GossipDebug {
+    let name_of = |id: crate::npc::NpcId| -> String {
+        npc_manager
+            .get(id)
+            .map(|n| n.name.clone())
+            .unwrap_or_else(|| format!("NPC({})", id.0))
+    };
+
+    let mut items: Vec<GossipItemDebug> = world
+        .gossip_network
+        .all_items()
+        .iter()
+        .map(|item| {
+            let mut known_names: Vec<String> =
+                item.known_by.iter().map(|id| name_of(*id)).collect();
+            known_names.sort();
+            GossipItemDebug {
+                id: item.id,
+                content: item.content.clone(),
+                source_name: name_of(item.source),
+                distortion_level: item.distortion_level,
+                known_by: known_names,
+                timestamp: item.timestamp.format("%H:%M %Y-%m-%d").to_string(),
+            }
+        })
+        .collect();
+    // Newest first
+    items.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+
+    GossipDebug {
+        item_count: world.gossip_network.len(),
+        items,
+    }
+}
+
+/// Builds the conversation log debug view.
+fn build_conversations_debug(world: &WorldState) -> ConversationsDebug {
+    let exchanges: Vec<ConversationExchangeDebug> = world
+        .conversation_log
+        .all()
+        .map(|e| ConversationExchangeDebug {
+            timestamp: e.timestamp.format("%H:%M %Y-%m-%d").to_string(),
+            speaker_id: e.speaker_id.0,
+            speaker_name: e.speaker_name.clone(),
+            location_name: loc_name(e.location, &world.graph),
+            player_input: e.player_input.clone(),
+            npc_dialogue: e.npc_dialogue.clone(),
+        })
+        .collect();
+    ConversationsDebug {
+        exchange_count: world.conversation_log.len(),
+        exchanges,
+    }
+}
+
+/// Walking speed used to compute debug edge travel times (meters/second).
+///
+/// The real walking speed lives in each mod's transport config but is not
+/// threaded through to the debug snapshot — we use a canonical fallback
+/// that matches the default "on foot" preset so the panel can surface a
+/// representative travel time per edge.
+const DEBUG_WALKING_SPEED_M_PER_S: f64 = 1.25;
+
+/// Maximum number of text-log lines included in the snapshot.
+const TEXT_LOG_TAIL_LEN: usize = 50;
 
 /// Builds world debug info including per-location NPC presence.
 fn build_world_debug(world: &WorldState, npc_manager: &NpcManager) -> WorldDebug {
@@ -340,6 +726,20 @@ fn build_world_debug(world: &WorldState, npc_manager: &NpcManager) -> WorldDebug
                 .iter()
                 .map(|n| n.name.clone())
                 .collect();
+            let edges: Vec<GraphEdgeDebug> = data
+                .connections
+                .iter()
+                .map(|c| GraphEdgeDebug {
+                    target_id: c.target.0,
+                    target_name: loc_name(c.target, &world.graph),
+                    path_description: c.path_description.clone(),
+                    walking_minutes: world.graph.edge_travel_minutes(
+                        loc_id,
+                        c.target,
+                        DEBUG_WALKING_SPEED_M_PER_S,
+                    ),
+                })
+                .collect();
             locations.push(LocationDebug {
                 id: loc_id.0,
                 name: data.name.clone(),
@@ -347,15 +747,52 @@ fn build_world_debug(world: &WorldState, npc_manager: &NpcManager) -> WorldDebug
                 public: data.public,
                 connection_count: data.connections.len(),
                 npcs_here,
+                visited: world.visited_locations.contains(&loc_id),
+                edges,
             });
         }
     }
     locations.sort_by_key(|l| l.id);
 
+    let mut visited_locations: Vec<String> = world
+        .visited_locations
+        .iter()
+        .filter_map(|id| world.graph.get(*id).map(|d| d.name.clone()))
+        .collect();
+    visited_locations.sort();
+
+    let mut edge_traversals: Vec<EdgeTraversalDebug> = world
+        .edge_traversals
+        .iter()
+        .map(|((a, b), count)| EdgeTraversalDebug {
+            from_name: loc_name(*a, &world.graph),
+            to_name: loc_name(*b, &world.graph),
+            count: *count,
+        })
+        .collect();
+    edge_traversals.sort_by(|a, b| b.count.cmp(&a.count));
+
+    let text_log_len = world.text_log.len();
+    let text_log_tail: Vec<String> = world
+        .text_log
+        .iter()
+        .rev()
+        .take(TEXT_LOG_TAIL_LEN)
+        .cloned()
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+
     WorldDebug {
         player_location_name: player_loc_name,
         player_location_id: world.player_location.0,
         location_count: world.graph.location_count(),
+        visited_count: world.visited_locations.len(),
+        visited_locations,
+        edge_traversals,
+        text_log_tail,
+        text_log_len,
         locations,
     }
 }
@@ -443,11 +880,24 @@ fn build_npc_debug_list(
                         .get(*target_id)
                         .map(|n| n.name.clone())
                         .unwrap_or_else(|| format!("NPC({})", target_id.0));
+                    // Newest-first, cap at 10 entries
+                    let mut history: Vec<RelationshipEventDebug> = rel
+                        .history
+                        .iter()
+                        .rev()
+                        .take(10)
+                        .map(|e| RelationshipEventDebug {
+                            timestamp: e.timestamp.format("%H:%M %Y-%m-%d").to_string(),
+                            description: e.description.clone(),
+                        })
+                        .collect();
+                    history.reverse(); // Back to oldest-first for display stability
                     RelationshipDebug {
                         target_name,
                         kind: rel.kind.to_string(),
                         strength: rel.strength,
                         history_count: rel.history.len(),
+                        history,
                     }
                 })
                 .collect();
@@ -468,9 +918,43 @@ fn build_npc_debug_list(
                 })
                 .collect();
 
+            let long_term_memories: Vec<LongTermMemoryDebug> = npc
+                .long_term_memory
+                .all_entries()
+                .iter()
+                .map(|e| LongTermMemoryDebug {
+                    timestamp: e.timestamp.format("%H:%M %Y-%m-%d").to_string(),
+                    content: e.content.clone(),
+                    importance: e.importance,
+                    keywords: e.keywords.clone(),
+                })
+                .collect();
+
+            let reactions: Vec<ReactionDebug> = npc
+                .reaction_log
+                .entries()
+                .iter()
+                .rev()
+                .map(|r| ReactionDebug {
+                    timestamp: r.timestamp.format("%H:%M %Y-%m-%d").to_string(),
+                    emoji: r.emoji.clone(),
+                    description: r.description.clone(),
+                    context: r.context.clone(),
+                })
+                .collect();
+
+            let deflated_summary = npc.deflated_summary.as_ref().map(|s| DeflatedSummaryDebug {
+                location_name: loc_name(s.location, graph),
+                mood: s.mood.clone(),
+                recent_activity: s.recent_activity.clone(),
+                key_relationship_changes: s.key_relationship_changes.clone(),
+            });
+
             NpcDebug {
                 id: npc.id.0,
                 name: npc.name.clone(),
+                brief_description: npc.brief_description.clone(),
+                introduced: npc_manager.is_introduced(npc.id),
                 age: npc.age,
                 occupation: npc.occupation.clone(),
                 personality: npc.personality.clone(),
@@ -479,11 +963,15 @@ fn build_npc_debug_list(
                 home_name: npc.home.map(|h| loc_name(h, graph)),
                 workplace_name: npc.workplace.map(|w| loc_name(w, graph)),
                 mood: npc.mood.clone(),
+                is_ill: npc.is_ill,
                 state: state_str,
                 tier,
                 schedule,
                 relationships,
                 memories,
+                long_term_memories,
+                reactions,
+                deflated_summary,
                 knowledge: npc.knowledge.clone(),
                 intelligence: IntelligenceDebug {
                     verbal: npc.intelligence.verbal,
@@ -508,31 +996,36 @@ fn build_tier_summary(npc_manager: &NpcManager) -> TierSummary {
     let mut t1 = Vec::new();
     let mut t2 = Vec::new();
     let mut t3: Vec<String> = Vec::new();
-    let mut t4: usize = 0;
+    let mut t4: Vec<String> = Vec::new();
 
     for npc in npc_manager.all_npcs() {
         match npc_manager.tier_of(npc.id) {
             Some(CogTier::Tier1) => t1.push(npc.name.clone()),
             Some(CogTier::Tier2) => t2.push(npc.name.clone()),
             Some(CogTier::Tier3) | None => t3.push(npc.name.clone()),
-            Some(CogTier::Tier4) => t4 += 1,
+            Some(CogTier::Tier4) => t4.push(npc.name.clone()),
         }
     }
 
-    let last_tier3_tick = npc_manager
-        .last_tier3_game_time()
-        .map(|t| t.format("%H:%M %Y-%m-%d").to_string());
+    let fmt_tick = |t: chrono::DateTime<chrono::Utc>| t.format("%H:%M %Y-%m-%d").to_string();
+    let last_tier2_tick = npc_manager.last_tier2_game_time().map(fmt_tick);
+    let last_tier3_tick = npc_manager.last_tier3_game_time().map(fmt_tick);
+    let last_tier4_tick = npc_manager.last_tier4_game_time().map(fmt_tick);
 
     TierSummary {
         tier1_count: t1.len(),
         tier2_count: t2.len(),
         tier3_count: t3.len(),
-        tier4_count: t4,
+        tier4_count: t4.len(),
         tier1_names: t1,
         tier2_names: t2,
         tier3_names: t3,
+        tier4_names: t4,
         tier3_in_flight: npc_manager.tier3_in_flight(),
+        last_tier2_tick,
         last_tier3_tick,
+        last_tier4_tick,
+        introduced_count: npc_manager.introduced_count(),
     }
 }
 
@@ -540,32 +1033,45 @@ fn build_tier_summary(npc_manager: &NpcManager) -> TierSummary {
 mod tests {
     use super::*;
     use crate::npc::{Npc, NpcId};
+    use crate::world::events::GameEvent;
     use std::collections::VecDeque;
 
-    #[test]
-    fn test_build_debug_snapshot_empty() {
-        let world = WorldState::new();
-        let npc_manager = NpcManager::new();
-        let events = VecDeque::new();
-        let inference = InferenceDebug {
+    /// Helper: build a minimal `InferenceDebug` for tests.
+    fn test_inference() -> InferenceDebug {
+        InferenceDebug {
             provider_name: "ollama".to_string(),
             model_name: "test-model".to_string(),
             base_url: "http://localhost:11434".to_string(),
             cloud_provider: None,
             cloud_model: None,
             has_queue: false,
+            reaction_req_id: 100_000,
             improv_enabled: false,
             call_log: vec![],
-        };
+        }
+    }
 
-        let snapshot = build_debug_snapshot(&world, &npc_manager, &events, &inference);
+    #[test]
+    fn test_build_debug_snapshot_empty() {
+        let world = WorldState::new();
+        let npc_manager = NpcManager::new();
+        let events = VecDeque::new();
+        let game_events: VecDeque<GameEvent> = VecDeque::new();
+        let inference = test_inference();
+
+        let snapshot =
+            build_debug_snapshot(&world, &npc_manager, &events, &game_events, &inference);
 
         assert!(snapshot.clock.game_time.contains("08:00"));
         assert_eq!(snapshot.clock.weather, "Clear");
         assert!(!snapshot.clock.paused);
+        assert!(!snapshot.clock.inference_paused);
+        assert_eq!(snapshot.weather.current, "Clear");
         assert!(snapshot.npcs.is_empty());
         assert_eq!(snapshot.tier_summary.tier1_count, 0);
         assert_eq!(snapshot.inference.provider_name, "ollama");
+        assert_eq!(snapshot.gossip.item_count, 0);
+        assert_eq!(snapshot.conversations.exchange_count, 0);
     }
 
     #[test]
@@ -576,23 +1082,22 @@ mod tests {
         npc_manager.assign_tiers(&world, &[]);
 
         let events = VecDeque::new();
-        let inference = InferenceDebug {
-            provider_name: "ollama".to_string(),
-            model_name: "test".to_string(),
-            base_url: "http://localhost:11434".to_string(),
-            cloud_provider: None,
-            cloud_model: None,
-            has_queue: true,
-            improv_enabled: false,
-            call_log: vec![],
-        };
+        let game_events: VecDeque<GameEvent> = VecDeque::new();
+        let mut inference = test_inference();
+        inference.has_queue = true;
 
-        let snapshot = build_debug_snapshot(&world, &npc_manager, &events, &inference);
+        let snapshot =
+            build_debug_snapshot(&world, &npc_manager, &events, &game_events, &inference);
 
         assert_eq!(snapshot.npcs.len(), 1);
         assert_eq!(snapshot.npcs[0].name, "Padraig O'Brien");
         assert_eq!(snapshot.npcs[0].mood, "content");
         assert_eq!(snapshot.npcs[0].state, "Present");
+        assert!(!snapshot.npcs[0].introduced);
+        assert_eq!(
+            snapshot.npcs[0].brief_description,
+            "an older man behind the bar"
+        );
         // Intelligence matches new_test_npc: Intelligence::new(3, 3, 4, 4, 5, 4)
         let intel = &snapshot.npcs[0].intelligence;
         assert_eq!(intel.verbal, 3);
@@ -708,6 +1213,7 @@ mod tests {
         let world = WorldState::new();
         let mgr = NpcManager::new();
         let events = VecDeque::new();
+        let game_events: VecDeque<GameEvent> = VecDeque::new();
         let entry = InferenceLogEntry {
             request_id: 1,
             timestamp: "10:00:00".to_string(),
@@ -722,18 +1228,10 @@ mod tests {
             response_text: "response".to_string(),
             max_tokens: None,
         };
-        let inference = InferenceDebug {
-            provider_name: "test".to_string(),
-            model_name: "test".to_string(),
-            base_url: "http://localhost".to_string(),
-            cloud_provider: None,
-            cloud_model: None,
-            has_queue: false,
-            improv_enabled: false,
-            call_log: vec![entry],
-        };
+        let mut inference = test_inference();
+        inference.call_log = vec![entry];
 
-        let snapshot = build_debug_snapshot(&world, &mgr, &events, &inference);
+        let snapshot = build_debug_snapshot(&world, &mgr, &events, &game_events, &inference);
         assert_eq!(snapshot.inference.call_log.len(), 1);
         assert_eq!(snapshot.inference.call_log[0].request_id, 1);
         assert_eq!(snapshot.inference.call_log[0].duration_ms, 500);
@@ -744,6 +1242,7 @@ mod tests {
         let world = WorldState::new();
         let mgr = NpcManager::new();
         let mut events = VecDeque::new();
+        let game_events: VecDeque<GameEvent> = VecDeque::new();
         events.push_back(DebugEvent {
             timestamp: "08:00".to_string(),
             category: "system".to_string(),
@@ -754,18 +1253,9 @@ mod tests {
             category: "schedule".to_string(),
             message: "NPC moved".to_string(),
         });
-        let inference = InferenceDebug {
-            provider_name: "test".to_string(),
-            model_name: "test".to_string(),
-            base_url: "http://localhost".to_string(),
-            cloud_provider: None,
-            cloud_model: None,
-            has_queue: false,
-            improv_enabled: false,
-            call_log: vec![],
-        };
+        let inference = test_inference();
 
-        let snapshot = build_debug_snapshot(&world, &mgr, &events, &inference);
+        let snapshot = build_debug_snapshot(&world, &mgr, &events, &game_events, &inference);
         assert_eq!(snapshot.events.len(), 2);
         assert_eq!(snapshot.events[0].message, "Test event");
         assert_eq!(snapshot.events[1].category, "schedule");

--- a/crates/parish-core/src/game_session.rs
+++ b/crates/parish-core/src/game_session.rs
@@ -22,15 +22,23 @@ use crate::ipc::{build_travel_start, types::TravelStartPayload};
 use crate::npc::manager::{NpcManager, TierTransition};
 use crate::npc::reactions::{NpcReaction, ReactionTemplates, generate_arrival_reactions};
 use crate::npc::{Npc, NpcId};
-
-/// Monotonically increasing request ID counter for reaction inference calls.
-/// Starts at 100_000 to stay visually distinct from the dialogue queue IDs.
-static REACTION_REQ_ID: AtomicU64 = AtomicU64::new(100_000);
 use crate::world::description::{format_exits, render_description};
 use crate::world::movement::{MovementResult, resolve_movement};
 use crate::world::time::TimeOfDay;
 use crate::world::transport::TransportMode;
 use crate::world::{Location, LocationId, WorldState};
+
+/// Monotonically increasing request ID counter for reaction inference calls.
+/// Starts at 100_000 to stay visually distinct from the dialogue queue IDs.
+static REACTION_REQ_ID: AtomicU64 = AtomicU64::new(100_000);
+
+/// Returns the current value of the reaction request ID counter.
+///
+/// Read-only accessor used by the debug panel to report how many reaction
+/// inference calls have been issued this session.
+pub fn reaction_req_id_peek() -> u64 {
+    REACTION_REQ_ID.load(Ordering::Relaxed)
+}
 
 // ── Public types ─────────────────────────────────────────────────────────────
 

--- a/crates/parish-npc/src/manager.rs
+++ b/crates/parish-npc/src/manager.rs
@@ -682,6 +682,16 @@ impl NpcManager {
         self.last_tier4_game_time = Some(time);
     }
 
+    /// Returns the game time of the last Tier 4 tick, if any.
+    pub fn last_tier4_game_time(&self) -> Option<DateTime<Utc>> {
+        self.last_tier4_game_time
+    }
+
+    /// Returns the number of NPCs that have introduced themselves to the player.
+    pub fn introduced_count(&self) -> usize {
+        self.introduced_npcs.len()
+    }
+
     /// Applies the results of a Tier 4 tick to NPC state.
     ///
     /// Returns a list of `GameEvent`s to publish on the event bus.

--- a/crates/parish-npc/src/memory.rs
+++ b/crates/parish-npc/src/memory.rs
@@ -242,6 +242,13 @@ impl LongTermMemory {
         self.entries.is_empty()
     }
 
+    /// Returns all entries for debug display, sorted newest first.
+    pub fn all_entries(&self) -> Vec<&LongTermEntry> {
+        let mut entries: Vec<&LongTermEntry> = self.entries.iter().collect();
+        entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        entries
+    }
+
     /// Formats recalled memories into a context string for LLM prompts.
     ///
     /// Returns an empty string if no memories match.

--- a/crates/parish-npc/src/reactions.rs
+++ b/crates/parish-npc/src/reactions.rs
@@ -139,6 +139,11 @@ impl ReactionLog {
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
+
+    /// Returns the stored entries in chronological order (oldest first).
+    pub fn entries(&self) -> &[ReactionEntry] {
+        &self.entries
+    }
 }
 
 /// Keyword groups that trigger NPC reactions, with the corresponding emoji.

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -159,6 +159,31 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
 
 /// Spawns the background tick tasks (world update + theme update).
 fn spawn_background_ticks(state: Arc<AppState>) {
+    // Event bus fan-in: subscribe to world.event_bus and buffer the last N
+    // GameEvents in AppState.game_events for the debug panel.
+    {
+        let state_events = Arc::clone(&state);
+        tokio::spawn(async move {
+            let mut rx = {
+                let world = state_events.world.lock().await;
+                world.event_bus.subscribe()
+            };
+            loop {
+                match rx.recv().await {
+                    Ok(evt) => {
+                        let mut buf = state_events.game_events.lock().await;
+                        if buf.len() >= crate::state::DEBUG_EVENT_CAPACITY {
+                            buf.pop_front();
+                        }
+                        buf.push_back(evt);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+    }
+
     // Idle tick: broadcast world snapshot every 5 seconds
     let state_tick = Arc::clone(&state);
     tokio::spawn(async move {
@@ -184,17 +209,19 @@ fn spawn_background_ticks(state: Arc<AppState>) {
                 // Tick weather engine
                 let season = world.clock.season();
                 let now = world.clock.now();
-                let mut rng = rand::thread_rng();
-                if let Some(new_weather) = world.weather_engine.tick(now, season, &mut rng) {
-                    let old = world.weather;
-                    world.weather = new_weather;
-                    world.event_bus.publish(
-                        parish_core::world::events::GameEvent::WeatherChanged {
-                            new_weather: new_weather.to_string(),
-                            timestamp: world.clock.now(),
-                        },
-                    );
-                    tracing::info!(old = %old, new = %new_weather, "Weather changed");
+                {
+                    let mut rng = rand::thread_rng();
+                    if let Some(new_weather) = world.weather_engine.tick(now, season, &mut rng) {
+                        let old = world.weather;
+                        world.weather = new_weather;
+                        world.event_bus.publish(
+                            parish_core::world::events::GameEvent::WeatherChanged {
+                                new_weather: new_weather.to_string(),
+                                timestamp: world.clock.now(),
+                            },
+                        );
+                        tracing::info!(old = %old, new = %new_weather, "Weather changed");
+                    }
                 }
 
                 // Tick NPC schedules and assign tiers
@@ -203,8 +230,18 @@ fn spawn_background_ticks(state: Arc<AppState>) {
                 let tier_transitions = npc_mgr.assign_tiers(&world, &[]);
 
                 if !schedule_events.is_empty() || !tier_transitions.is_empty() {
+                    let ts = world.clock.now().format("%H:%M %Y-%m-%d").to_string();
+                    let mut debug_events = state_tick.debug_events.lock().await;
                     for evt in &schedule_events {
                         tracing::debug!("NPC schedule: {}", evt.debug_string());
+                        if debug_events.len() >= crate::state::DEBUG_EVENT_CAPACITY {
+                            debug_events.pop_front();
+                        }
+                        debug_events.push_back(parish_core::debug_snapshot::DebugEvent {
+                            timestamp: ts.clone(),
+                            category: "schedule".to_string(),
+                            message: evt.debug_string(),
+                        });
                     }
                     for tt in &tier_transitions {
                         let direction = if tt.promoted { "promoted" } else { "demoted" };
@@ -215,6 +252,17 @@ fn spawn_background_ticks(state: Arc<AppState>) {
                             tt.old_tier,
                             tt.new_tier,
                         );
+                        if debug_events.len() >= crate::state::DEBUG_EVENT_CAPACITY {
+                            debug_events.pop_front();
+                        }
+                        debug_events.push_back(parish_core::debug_snapshot::DebugEvent {
+                            timestamp: ts.clone(),
+                            category: "tier".to_string(),
+                            message: format!(
+                                "{} {} {:?} → {:?}",
+                                tt.npc_name, direction, tt.old_tier, tt.new_tier,
+                            ),
+                        });
                     }
                 }
 

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -82,7 +82,8 @@ pub async fn get_debug_snapshot(State(state): State<Arc<AppState>>) -> Json<Debu
     let world = state.world.lock().await;
     let npc_manager = state.npc_manager.lock().await;
     let config = state.config.lock().await;
-    let events = std::collections::VecDeque::new();
+    let events = state.debug_events.lock().await;
+    let game_events = state.game_events.lock().await;
     let call_log: Vec<parish_core::debug_snapshot::InferenceLogEntry> =
         state.inference_log.lock().await.iter().cloned().collect();
     let inference = InferenceDebug {
@@ -92,6 +93,7 @@ pub async fn get_debug_snapshot(State(state): State<Arc<AppState>>) -> Json<Debu
         cloud_provider: config.cloud_provider_name.clone(),
         cloud_model: config.cloud_model_name.clone(),
         has_queue: state.inference_queue.lock().await.is_some(),
+        reaction_req_id: parish_core::game_session::reaction_req_id_peek(),
         improv_enabled: config.improv_enabled,
         call_log,
     };
@@ -99,6 +101,7 @@ pub async fn get_debug_snapshot(State(state): State<Arc<AppState>>) -> Json<Debu
         &world,
         &npc_manager,
         &events,
+        &game_events,
         &inference,
     ))
 }

--- a/crates/parish-server/src/state.rs
+++ b/crates/parish-server/src/state.rs
@@ -6,14 +6,19 @@ use std::time::Instant;
 
 use tokio::sync::{Mutex, broadcast};
 
+use parish_core::debug_snapshot::DebugEvent;
 use parish_core::game_mod::PronunciationEntry;
 use parish_core::inference::openai_client::OpenAiClient;
 use parish_core::inference::{InferenceLog, InferenceQueue};
 use parish_core::ipc::ConversationLine;
 use parish_core::ipc::ThemePalette;
 use parish_core::npc::manager::NpcManager;
+use parish_core::world::events::GameEvent;
 use parish_core::world::transport::TransportConfig;
 use parish_core::world::{LocationId, WorldState};
+
+/// Maximum number of debug/game events retained in the server's ring buffer.
+pub const DEBUG_EVENT_CAPACITY: usize = 100;
 
 /// UI configuration snapshot returned by the `/api/ui-config` endpoint.
 #[derive(serde::Serialize, Clone)]
@@ -108,6 +113,11 @@ pub struct AppState {
     pub config: Mutex<GameConfig>,
     /// Local conversation transcript and inactivity tracking.
     pub conversation: Mutex<ConversationRuntimeState>,
+    /// Rolling ring buffer of debug events (schedule ticks, tier transitions,
+    /// inference errors) surfaced to the debug panel.
+    pub debug_events: Mutex<std::collections::VecDeque<DebugEvent>>,
+    /// Rolling ring buffer of `GameEvent`s captured from the world event bus.
+    pub game_events: Mutex<std::collections::VecDeque<GameEvent>>,
     /// Broadcast channel for pushing events to WebSocket clients.
     pub event_bus: EventBus,
     /// Transport mode configuration from the loaded game mod.
@@ -221,6 +231,12 @@ pub fn build_app_state(
         cloud_client: Mutex::new(cloud_client),
         config: Mutex::new(config),
         conversation: Mutex::new(ConversationRuntimeState::new()),
+        debug_events: Mutex::new(std::collections::VecDeque::with_capacity(
+            DEBUG_EVENT_CAPACITY,
+        )),
+        game_events: Mutex::new(std::collections::VecDeque::with_capacity(
+            DEBUG_EVENT_CAPACITY,
+        )),
         event_bus: EventBus::new(256),
         transport,
         ui_config,

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -33,6 +33,14 @@ use crate::{AppState, MapData, MapLocation, NpcInfo, SaveState, ThemePalette, Wo
 /// Monotonically increasing request ID counter for inference requests.
 static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 
+/// Returns a formatted game-time string (`HH:MM YYYY-MM-DD`) snapshotted
+/// from the shared world clock. Used for debug event timestamps so the
+/// Events tab no longer renders blank times.
+async fn debug_event_timestamp(state: &Arc<AppState>) -> String {
+    let world = state.world.lock().await;
+    world.clock.now().format("%H:%M %Y-%m-%d").to_string()
+}
+
 // ── Helper: build a WorldSnapshot from locked world state ────────────────────
 
 /// Builds a [`WorldSnapshot`] from a locked world state reference.
@@ -163,6 +171,7 @@ pub async fn get_debug_snapshot(
     let world = state.world.lock().await;
     let npc_manager = state.npc_manager.lock().await;
     let events = state.debug_events.lock().await;
+    let game_events = state.game_events.lock().await;
     let config = state.config.lock().await;
 
     let call_log: Vec<parish_core::debug_snapshot::InferenceLogEntry> =
@@ -175,6 +184,7 @@ pub async fn get_debug_snapshot(
         cloud_provider: config.cloud_provider_name.clone(),
         cloud_model: config.cloud_model_name.clone(),
         has_queue: state.inference_queue.lock().await.is_some(),
+        reaction_req_id: parish_core::game_session::reaction_req_id_peek(),
         improv_enabled: config.improv_enabled,
         call_log,
     };
@@ -183,6 +193,7 @@ pub async fn get_debug_snapshot(
         &world,
         &npc_manager,
         &events,
+        &game_events,
         &inference,
     ))
 }
@@ -600,6 +611,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
 
     // Record tier transitions in the debug event log
     if !effects.tier_transitions.is_empty() {
+        let ts = debug_event_timestamp(&state).await;
         let mut debug_events = state.debug_events.lock().await;
         for tt in &effects.tier_transitions {
             if debug_events.len() >= crate::DEBUG_EVENT_CAPACITY {
@@ -607,7 +619,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
             }
             let direction = if tt.promoted { "promoted" } else { "demoted" };
             debug_events.push_back(DebugEvent {
-                timestamp: String::new(),
+                timestamp: ts.clone(),
                 category: "tier".to_string(),
                 message: format!(
                     "{} {} {:?} → {:?}",
@@ -716,12 +728,13 @@ async fn run_npc_turn(
         Ok(rx) => rx,
         Err(e) => {
             tracing::error!("Failed to submit inference request: {}", e);
+            let ts = debug_event_timestamp(state).await;
             let mut events = state.debug_events.lock().await;
             if events.len() >= crate::DEBUG_EVENT_CAPACITY {
                 events.pop_front();
             }
             events.push_back(DebugEvent {
-                timestamp: String::new(),
+                timestamp: ts,
                 category: "inference".to_string(),
                 message: format!("Queue submit failed: {e}"),
             });
@@ -762,12 +775,13 @@ async fn run_npc_turn(
 
     if let Some(ref err) = response.error {
         tracing::warn!("Inference error: {:?}", err);
+        let ts = debug_event_timestamp(state).await;
         let mut events = state.debug_events.lock().await;
         if events.len() >= crate::DEBUG_EVENT_CAPACITY {
             events.pop_front();
         }
         events.push_back(DebugEvent {
-            timestamp: String::new(),
+            timestamp: ts,
             category: "inference".to_string(),
             message: format!("Dialogue error: {err}"),
         });

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -209,6 +209,9 @@ pub struct AppState {
     pub conversation: Mutex<ConversationRuntimeState>,
     /// Rolling debug event log for the debug panel.
     pub debug_events: Mutex<std::collections::VecDeque<DebugEvent>>,
+    /// Rolling `GameEvent` ring buffer captured from the world event bus.
+    /// Populated by a background task that subscribes to `world.event_bus`.
+    pub game_events: Mutex<std::collections::VecDeque<parish_core::world::events::GameEvent>>,
     /// Shared inference call log for the debug panel.
     pub inference_log: InferenceLog,
     /// UI configuration from the loaded game mod.
@@ -504,6 +507,9 @@ pub fn run() {
         debug_events: Mutex::new(std::collections::VecDeque::with_capacity(
             DEBUG_EVENT_CAPACITY,
         )),
+        game_events: Mutex::new(std::collections::VecDeque::with_capacity(
+            DEBUG_EVENT_CAPACITY,
+        )),
         inference_log: new_inference_log(),
         ui_config,
         theme_palette,
@@ -743,6 +749,35 @@ pub fn run() {
 
                 // ── Background ticks ─────────────────────────────────────────
 
+                // Event bus fan-in: subscribe to world.event_bus and buffer the
+                // last N events in AppState.game_events for the debug panel.
+                {
+                    let state_events = Arc::clone(&state_setup);
+                    let mut rx = {
+                        let world = state_events.world.lock().await;
+                        world.event_bus.subscribe()
+                    };
+                    tokio::spawn(async move {
+                        loop {
+                            match rx.recv().await {
+                                Ok(evt) => {
+                                    let mut buf = state_events.game_events.lock().await;
+                                    if buf.len() >= DEBUG_EVENT_CAPACITY {
+                                        buf.pop_front();
+                                    }
+                                    buf.push_back(evt);
+                                }
+                                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                                    continue;
+                                }
+                                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                                    break;
+                                }
+                            }
+                        }
+                    });
+                }
+
                 // Idle tick: emit world snapshot every 5 seconds.
                 // The GameClock already flows via speed_factor — no manual advance needed.
                 let state_tick = Arc::clone(&state_setup);
@@ -792,13 +827,15 @@ pub fn run() {
 
                             // Log schedule events and tier transitions to debug panel
                             if !schedule_events.is_empty() || !tier_transitions.is_empty() {
+                                let ts =
+                                    world.clock.now().format("%H:%M %Y-%m-%d").to_string();
                                 let mut debug_events = state_tick.debug_events.lock().await;
                                 for evt in &schedule_events {
                                     if debug_events.len() >= crate::DEBUG_EVENT_CAPACITY {
                                         debug_events.pop_front();
                                     }
                                     debug_events.push_back(DebugEvent {
-                                        timestamp: String::new(),
+                                        timestamp: ts.clone(),
                                         category: "schedule".to_string(),
                                         message: evt.debug_string(),
                                     });
@@ -810,7 +847,7 @@ pub fn run() {
                                     let direction =
                                         if tt.promoted { "promoted" } else { "demoted" };
                                     debug_events.push_back(DebugEvent {
-                                        timestamp: String::new(),
+                                        timestamp: ts.clone(),
                                         category: "tier".to_string(),
                                         message: format!(
                                             "{} {} {:?} → {:?}",
@@ -856,6 +893,7 @@ pub fn run() {
                         let world = state_debug.world.lock().await;
                         let npc_manager = state_debug.npc_manager.lock().await;
                         let debug_events = state_debug.debug_events.lock().await;
+                        let game_events = state_debug.game_events.lock().await;
                         let config = state_debug.config.lock().await;
 
                         let call_log: Vec<parish_core::debug_snapshot::InferenceLogEntry> =
@@ -874,6 +912,7 @@ pub fn run() {
                             cloud_provider: config.cloud_provider_name.clone(),
                             cloud_model: config.cloud_model_name.clone(),
                             has_queue: state_debug.inference_queue.lock().await.is_some(),
+                            reaction_req_id: parish_core::game_session::reaction_req_id_peek(),
                             improv_enabled: config.improv_enabled,
                             call_log,
                         };
@@ -882,6 +921,7 @@ pub fn run() {
                             &world,
                             &npc_manager,
                             &debug_events,
+                            &game_events,
                             &inference,
                         );
                         let _ = handle_debug.emit(events::EVENT_DEBUG_UPDATE, snapshot);

--- a/crates/parish-types/src/conversation.rs
+++ b/crates/parish-types/src/conversation.rs
@@ -126,6 +126,13 @@ impl ConversationLog {
     pub fn is_empty(&self) -> bool {
         self.exchanges.is_empty()
     }
+
+    /// Returns all stored exchanges in chronological order (oldest first).
+    ///
+    /// Used by the debug panel to surface the full ring buffer.
+    pub fn all(&self) -> impl Iterator<Item = &ConversationExchange> {
+        self.exchanges.iter()
+    }
 }
 
 #[cfg(test)]

--- a/crates/parish-types/src/time.rs
+++ b/crates/parish-types/src/time.rs
@@ -500,6 +500,28 @@ impl GameClock {
             .find(|s| (self.speed_factor - s.factor()).abs() < EPSILON)
             .copied()
     }
+
+    /// Returns the game-time origin anchor (creation or last resume).
+    ///
+    /// Exposed for the debug panel so it can report real-vs-game drift.
+    pub fn start_game(&self) -> DateTime<Utc> {
+        self.start_game
+    }
+
+    /// Returns the frozen game time captured when the clock was paused.
+    ///
+    /// When the clock is running this is the last pause anchor; when paused
+    /// (by player or inference) it matches `now()`.
+    pub fn paused_game_time(&self) -> DateTime<Utc> {
+        self.paused_game_time
+    }
+
+    /// Returns the real-world elapsed seconds since the last resume/create.
+    ///
+    /// Useful for the debug panel to compare real vs. accelerated time.
+    pub fn real_elapsed_secs(&self) -> f64 {
+        self.start_real.elapsed().as_secs_f64()
+    }
 }
 
 /// Trait for types that have a festival month and day.

--- a/crates/parish-world/src/weather.rs
+++ b/crates/parish-world/src/weather.rs
@@ -116,6 +116,21 @@ impl WeatherEngine {
         elapsed.num_minutes() as f64 / 60.0
     }
 
+    /// Returns the game time when the current weather state began.
+    pub fn since(&self) -> DateTime<Utc> {
+        self.since
+    }
+
+    /// Returns the minimum duration (game-hours) before a transition is allowed.
+    pub fn min_duration_hours(&self) -> f64 {
+        self.min_duration_hours
+    }
+
+    /// Returns the game-hour of the last transition check, or `None` if unchecked.
+    pub fn last_check_hour(&self) -> Option<u32> {
+        self.last_check_hour
+    }
+
     /// Ticks the weather engine. Returns `Some(new_weather)` if a
     /// transition occurred, `None` if the weather is unchanged.
     ///


### PR DESCRIPTION
Extend DebugSnapshot with the full set of runtime engine internals that
were previously invisible:

- Clock: inference_paused, speed_name, start/paused game time, real
  elapsed secs
- Weather engine: since, duration, min_duration, last_check_hour
- World: visited_locations, edge_traversals (worn paths), text_log tail,
  per-location graph edges
- Event bus: subscriber count + GameEvent ring buffer fed from the
  world's broadcast channel
- Gossip network: all items with distortion, source, known_by
- Conversation log: recent player<->NPC exchanges
- NpcManager: Tier 2/4 names and tick timestamps, introduced_count
- Npc: brief_description, introduced/is_ill flags, long-term memory,
  reaction log, deflated summary, full relationship history
- Inference: reaction_req_id counter

Wire the new game-event ring buffer through both backends (Tauri +
axum server) with a fan-in task subscribing to EventBus. Fix empty
DebugEvent.timestamp strings in tier/inference/dialogue error paths by
formatting the current game clock. Stop the web server's
/api/debug-snapshot endpoint from dropping debug_events entirely.

Mirror the new Rust types in apps/ui/src/lib/types.ts and extend
DebugPanel.svelte with new Weather, Gossip, and Conversations tabs,
plus expanded Overview / NPC / World / Events / Inference sections
rendering every new field.

https://claude.ai/code/session_01HWcGYBhj2DVoDygk2UDX2a