### PR TITLE
feat: implement time-of-day shimmer pulse effect

### DIFF
--- a/apps/ui/src/lib/day-shift-effect.test.ts
+++ b/apps/ui/src/lib/day-shift-effect.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { shouldTriggerDayShiftPulse } from './day-shift-effect';
+
+describe('shouldTriggerDayShiftPulse', () => {
+	it('does not trigger on first snapshot', () => {
+		expect(shouldTriggerDayShiftPulse(null, 7)).toBe(false);
+	});
+
+	it('triggers when crossing a boundary hour', () => {
+		expect(shouldTriggerDayShiftPulse(6, 7)).toBe(true);
+		expect(shouldTriggerDayShiftPulse(11, 12)).toBe(true);
+	});
+
+	it('does not trigger when hour changes inside the same phase', () => {
+		expect(shouldTriggerDayShiftPulse(8, 9)).toBe(false);
+	});
+
+	it('triggers when an update skips over a boundary', () => {
+		expect(shouldTriggerDayShiftPulse(4, 8)).toBe(true);
+	});
+
+	it('handles overnight wraparound transitions', () => {
+		expect(shouldTriggerDayShiftPulse(22, 0)).toBe(true);
+	});
+});

--- a/apps/ui/src/lib/day-shift-effect.ts
+++ b/apps/ui/src/lib/day-shift-effect.ts
@@ -1,0 +1,26 @@
+const DAY_SHIFT_BOUNDARIES = [5, 7, 12, 17, 20, 23] as const;
+
+/**
+ * Returns true when the latest world update crosses a major day-phase boundary.
+ *
+ * Boundaries are expressed in 24-hour clock local game time and treated as
+ * half-open intervals [boundary, nextBoundary).
+ */
+export function shouldTriggerDayShiftPulse(previousHour: number | null, nextHour: number): boolean {
+	if (previousHour === null) return false;
+	if (previousHour === nextHour) return false;
+
+	const from = Math.max(0, Math.min(23, Math.floor(previousHour)));
+	const to = Math.max(0, Math.min(23, Math.floor(nextHour)));
+	const delta = (to - from + 24) % 24;
+	if (delta === 0) return false;
+
+	for (const boundary of DAY_SHIFT_BOUNDARIES) {
+		const distance = (boundary - from + 24) % 24;
+		if (distance > 0 && distance <= delta) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -42,11 +42,36 @@
 	} from '$lib/ipc';
 	import { createAutoPauseTracker } from '$lib/auto-pause';
 	import { getStreamChunkDelayMs, takeNextStreamChunk } from '$lib/stream-pacing';
+	import { shouldTriggerDayShiftPulse } from '$lib/day-shift-effect';
 	import type { LanguageHint } from '$lib/types';
 
 	const AUTO_PAUSE_MS = 60_000;
 	const MOUSEMOVE_THROTTLE_MS = 1000;
 	const STREAM_WAIT_FOR_WORD_MS = 70;
+	const DAY_SHIFT_PULSE_MS = 1600;
+	let dayShiftPulseActive = $state(false);
+	let dayShiftPulseKey = $state(0);
+	let dayShiftPulseColor = $state('var(--color-accent)');
+	let prefersReducedMotion = $state(false);
+	let previousWorldHour: number | null = null;
+	let dayShiftPulseHandle: ReturnType<typeof setTimeout> | null = null;
+
+	function triggerDayShiftPulse() {
+		if (prefersReducedMotion) return;
+		const cssAccent = getComputedStyle(document.documentElement)
+			.getPropertyValue('--color-accent')
+			.trim();
+		dayShiftPulseColor = cssAccent || 'var(--color-accent)';
+		dayShiftPulseKey += 1;
+		dayShiftPulseActive = true;
+		if (dayShiftPulseHandle !== null) {
+			clearTimeout(dayShiftPulseHandle);
+		}
+		dayShiftPulseHandle = setTimeout(() => {
+			dayShiftPulseActive = false;
+			dayShiftPulseHandle = null;
+		}, DAY_SHIFT_PULSE_MS);
+	}
 
 	type PendingNpcTurn = {
 		turnId: number;
@@ -154,6 +179,13 @@
 	});
 
 	async function setupMount(): Promise<() => void> {
+		const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+		const syncReducedMotion = () => {
+			prefersReducedMotion = reducedMotionQuery.matches;
+		};
+		syncReducedMotion();
+		reducedMotionQuery.addEventListener('change', syncReducedMotion);
+
 		// Frontend auto-pause tracker — fires /pause after 60s of true UI
 		// inactivity (no key/mouse/touch). The server-side tick_inactivity
 		// backstop in parish-server still runs for the tab-close case.
@@ -188,6 +220,7 @@
 		if (snapRes.status === 'fulfilled') {
 			const snap = snapRes.value;
 			worldState.set(snap);
+			previousWorldHour = snap.hour;
 			palette.applyGameHour(snap.hour);
 			if (snap.name_hints) nameHints.set(snap.name_hints);
 			if (snap.location_description) {
@@ -396,6 +429,10 @@
 		const listeners: Array<() => void> = [];
 		try {
 			listeners.push(await onWorldUpdate(async (snap) => {
+				if (shouldTriggerDayShiftPulse(previousWorldHour, snap.hour)) {
+					triggerDayShiftPulse();
+				}
+				previousWorldHour = snap.hour;
 				worldState.set(snap);
 				tracker.onWorldStateChange(snap.paused);
 				palette.applyGameHour(snap.hour);
@@ -506,7 +543,11 @@
 			window.removeEventListener('mousedown', onTrackerMousedown);
 			window.removeEventListener('touchstart', onTrackerTouch);
 			window.removeEventListener('mousemove', onTrackerMousemove);
+			reducedMotionQuery.removeEventListener('change', syncReducedMotion);
 			tracker.dispose();
+			if (dayShiftPulseHandle !== null) {
+				clearTimeout(dayShiftPulseHandle);
+			}
 			pendingNpcTurns.forEach((turn) => stopTurnPump(turn));
 			listeners.forEach((fn) => fn());
 		};
@@ -516,6 +557,13 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <div class="app-shell" class:debug-open={$debugVisible}>
+	{#if dayShiftPulseActive}
+		<div class="day-shift-layer">
+			{#key dayShiftPulseKey}
+				<div class="day-shift-pulse" style={`--pulse-color: ${dayShiftPulseColor}`}></div>
+			{/key}
+		</div>
+	{/if}
 	<StatusBar />
 
 	<!-- Mobile-only toggle toolbar -->
@@ -578,6 +626,45 @@
 		overflow: hidden;
 		transition: height 0.15s ease;
 		padding-bottom: env(safe-area-inset-bottom);
+		position: relative;
+	}
+
+	.day-shift-layer {
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		z-index: 2;
+		overflow: hidden;
+	}
+
+	.day-shift-pulse {
+		position: absolute;
+		width: 20vmax;
+		aspect-ratio: 1;
+		left: calc(50% - 10vmax);
+		top: calc(50% - 10vmax);
+		border-radius: 50%;
+		background: radial-gradient(
+			circle,
+			color-mix(in oklab, var(--pulse-color) 55%, white 45%) 0%,
+			color-mix(in oklab, var(--pulse-color) 35%, transparent 65%) 46%,
+			transparent 70%
+		);
+		mix-blend-mode: soft-light;
+		opacity: 0;
+		transform: scale(0.12);
+		animation: day-shift-pulse 1.5s ease-out forwards;
+	}
+
+	@keyframes day-shift-pulse {
+		0% {
+			opacity: 0.28;
+			transform: scale(0.12);
+		}
+		100% {
+			opacity: 0;
+			transform: scale(3.2);
+		}
 	}
 
 	.app-shell.debug-open {

--- a/docs/design/visual-effects-system.md
+++ b/docs/design/visual-effects-system.md
@@ -298,21 +298,41 @@ On weather change away from frost conditions, they fade and retract (reverse ani
 
 ### 10. Time-of-Day Shimmer
 
-**Trigger:** Hour transitions (automatically, as the clock crosses 5:00, 7:00, 12:00,
-17:00, 20:00, 23:00 — the palette keyframe boundaries).
+**Intent:** make world-time progression legible without feeling like a UI notification.
+
+**Trigger (revised):**
+- Evaluate only on `world-update` events where `hour` changed.
+- Fire when crossing one of the phase boundaries: `05:00`, `07:00`, `12:00`, `17:00`,
+  `20:00`, `23:00`.
+- Crossing is edge-based, not equality-based (e.g. `04 → 08` still triggers once).
+- The first snapshot after load never triggers (prevents opening flash).
 
 **What it does:**
-At each major time-of-day boundary, the palette transition (which already happens) is
-accompanied by a brief, subtle radial pulse from the centre of the screen — a wash of
-the incoming palette's dominant colour that expands outward and fades in 1.5 seconds.
+A soft radial wash blooms from the viewport centre and dissipates over ~1.5s, tinted by
+the *incoming* accent colour. This should read as atmospheric "light shift," not a
+notification badge or spell effect.
 
-**Implementation:**
-A `<div class="dayshift-pulse">` with `border-radius: 50%; transform: scale(0)` transitions
-to `scale(3)` while `opacity` goes from 0.3 to 0, using `mix-blend-mode: soft-light`.
-The colour is derived from the new palette's `--color-accent`.
+**Implementation notes:**
+- Render a temporary overlay layer with `pointer-events: none`.
+- Animate one pulse element:
+  - start `scale(0.12), opacity ~0.28`
+  - end `scale(3.2), opacity 0`
+  - `mix-blend-mode: soft-light`
+- Colour source: current CSS token `--color-accent` (so mod themes and dynamic palettes
+  are automatically respected).
+- Re-trigger via keyed remount (not class toggling) to guarantee deterministic replay.
 
-This is the most "always-on" ambient effect — subtle enough that most players won't consciously
-notice it, but it makes the world feel like it breathes.
+**Accessibility & constraints:**
+- Disabled entirely when `prefers-reduced-motion: reduce`.
+- Never blocks text selection/clicks.
+- One active pulse at a time; retrigger resets the animation instead of stacking.
+
+**Acceptance criteria:**
+1. No pulse on initial app load.
+2. Pulse appears exactly once when crossing each boundary in normal simulation.
+3. Pulse still appears when updates skip hours (fast-forward / catch-up ticks).
+4. No pulse while reduced-motion is enabled.
+5. No measurable input latency regression while pulse is active.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Make the Time-of-Day Shimmer a production-ready effect by tightening trigger semantics, accessibility constraints, and acceptance criteria in the design doc.
- Ship one full effect end-to-end (design, trigger logic, UI rendering, and tests) as a concrete example for future visual effects work.

### Description
- Revised the `Time-of-Day Shimmer` section in `docs/design/visual-effects-system.md` with explicit boundary-crossing semantics, accessibility rules, and acceptance criteria.
- Added a small deterministic trigger utility `shouldTriggerDayShiftPulse` in `apps/ui/src/lib/day-shift-effect.ts` that detects hour-boundary crossings (including skipped hours and overnight wraparound).
- Wired the effect into the UI shell by updating `apps/ui/src/routes/+page.svelte` to listen for `world-update` hour changes, respect `prefers-reduced-motion`, render a keyed pulse overlay, and clean up listeners/timeouts on unmount.
- Added unit tests `apps/ui/src/lib/day-shift-effect.test.ts` that exercise first-snapshot no-op behavior, boundary hits, non-boundary hour changes, skipped-hour transitions, and overnight wraparound.

### Testing
- Ran the unit tests with `cd apps/ui && npx vitest run src/lib/day-shift-effect.test.ts`, and all tests passed.
- Ran the repo type/check step with `cd apps/ui && npm run check`, which failed due to pre-existing TypeScript/Svelte-check issues in unrelated files; the failure is not caused by the new day-shift files.
- All automated tests added by this change (the new Vitest suite) succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ccc0a8d88325b7ef626205579c15)