### PR TITLE
fix: resolve #52 — verify no busy-poll loop; fix clippy/fmt issues found in audit

### DIFF
--- a/crates/parish-cli/tests/world_graph_integration.rs
+++ b/crates/parish-cli/tests/world_graph_integration.rs
@@ -16,8 +16,7 @@ use parish::world::transport::TransportMode;
 
 fn load_parish_graph() -> WorldGraph {
     let path = Path::new("../../mods/rundale/world.json");
-    WorldGraph::load_from_file(path)
-        .expect("mods/rundale/world.json should load and validate")
+    WorldGraph::load_from_file(path).expect("mods/rundale/world.json should load and validate")
 }
 
 fn walking() -> TransportMode {

--- a/crates/parish-core/src/game_mod.rs
+++ b/crates/parish-core/src/game_mod.rs
@@ -236,7 +236,7 @@ impl Default for ThemePaletteConfig {
 }
 
 /// Theme section of the UI configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct ThemeConfig {
     /// Legacy accent override for older mods.
     #[serde(default)]
@@ -298,15 +298,6 @@ impl Default for SidebarConfig {
     fn default() -> Self {
         Self {
             hints_label: default_hints_label(),
-        }
-    }
-}
-
-impl Default for ThemeConfig {
-    fn default() -> Self {
-        Self {
-            default_accent: None,
-            palette: ThemePaletteConfig::default(),
         }
     }
 }


### PR DESCRIPTION
The oneshot receiver in run_npc_turn (parish-tauri/src/commands.rs:747)
already uses .await correctly. Audit also found:
- ThemeConfig::Default impl was manually written but derivable; replaced
  with #[derive(Default)] to satisfy clippy::derivable_impls
- world_graph_integration.rs had a fmt line-break inconsistency; fixed

https://claude.ai/code/session_01LYizr1W2AeTQDfpeK2f85a