### PR TITLE
fix: abort old inference worker on provider rebuild — resolves #51

### DIFF
--- a/crates/parish-inference/src/lib.rs
+++ b/crates/parish-inference/src/lib.rs
@@ -823,4 +823,54 @@ mod tests {
         assert_eq!(second.priority, InferencePriority::Batch);
         assert_eq!(second.id, 20);
     }
+
+    /// Verifies that aborting the JoinHandle from `spawn_inference_worker` actually
+    /// stops the worker task, preventing orphaned tasks from accumulating across
+    /// provider/key rebuilds (fix for issue #51).
+    #[tokio::test]
+    async fn test_spawn_inference_worker_abort_stops_task() {
+        use tokio::time::{Duration, timeout};
+
+        let (interactive_tx, interactive_rx) = mpsc::channel::<InferenceRequest>(4);
+        let (_background_tx, background_rx) = mpsc::channel::<InferenceRequest>(4);
+        let (_batch_tx, batch_rx) = mpsc::channel::<InferenceRequest>(4);
+        let log = new_inference_log();
+        let handle = spawn_inference_worker(
+            AnyClient::simulator(),
+            interactive_rx,
+            background_rx,
+            batch_rx,
+            log,
+        );
+
+        // Worker is running — abort it.
+        handle.abort();
+
+        // The handle should resolve quickly after abort (the task is cancelled).
+        let result = timeout(Duration::from_millis(200), handle).await;
+        assert!(
+            result.is_ok(),
+            "aborted worker task did not finish within timeout"
+        );
+
+        // After abort the sender should detect the receiver is gone; sending fails.
+        let (resp_tx, _resp_rx) = oneshot::channel();
+        let req = InferenceRequest {
+            id: 99,
+            model: "model".to_string(),
+            prompt: "hi".to_string(),
+            system: None,
+            token_tx: None,
+            response_tx: resp_tx,
+            max_tokens: None,
+            temperature: None,
+            priority: InferencePriority::Interactive,
+        };
+        // send returns Err when the receiver has been dropped by the aborted task.
+        let send_result = interactive_tx.send(req).await;
+        assert!(
+            send_result.is_err(),
+            "expected send to fail after worker abort"
+        );
+    }
 }

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -286,11 +286,20 @@ async fn rebuild_inference(state: &Arc<AppState>) {
         AnyClient::open_ai(oai)
     };
 
-    // Respawn inference worker with the new client
+    // Abort the old inference worker before spawning a replacement to prevent
+    // orphaned tasks from accumulating (each holds an HTTP client and channel).
+    {
+        let mut wh = state.worker_handle.lock().await;
+        if let Some(old) = wh.take() {
+            old.abort();
+        }
+    }
+
+    // Respawn inference worker with the new client and store the handle.
     let (interactive_tx, interactive_rx) = tokio::sync::mpsc::channel(16);
     let (background_tx, background_rx) = tokio::sync::mpsc::channel(32);
     let (batch_tx, batch_rx) = tokio::sync::mpsc::channel(64);
-    let _worker = spawn_inference_worker(
+    let worker = spawn_inference_worker(
         any_client,
         interactive_rx,
         background_rx,
@@ -300,6 +309,9 @@ async fn rebuild_inference(state: &Arc<AppState>) {
     let queue = InferenceQueue::new(interactive_tx, background_tx, batch_tx);
     let mut iq = state.inference_queue.lock().await;
     *iq = Some(queue);
+    drop(iq);
+    let mut wh = state.worker_handle.lock().await;
+    *wh = Some(worker);
 }
 
 async fn touch_player_activity(state: &Arc<AppState>) {

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -13,6 +13,7 @@ use std::time::Instant;
 
 use tauri::Emitter;
 use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
 
 use parish_core::config::{FeatureFlags, Provider};
 use parish_core::debug_snapshot::{DebugEvent, InferenceDebug};
@@ -232,6 +233,8 @@ pub struct AppState {
     pub transport: TransportConfig,
     /// Data directory used to derive the feature-flags persistence path.
     pub data_dir: PathBuf,
+    /// Handle for the active inference worker task; used to abort it on rebuild.
+    pub worker_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
 // ── Data path resolution ─────────────────────────────────────────────────────
@@ -525,6 +528,7 @@ pub fn run() {
         current_branch_name: Mutex::new(None),
         transport,
         data_dir: data_dir.clone(),
+        worker_handle: Mutex::new(None),
         config: Mutex::new(GameConfig {
             provider_name,
             base_url,
@@ -648,7 +652,7 @@ pub fn run() {
                         let (background_tx, background_rx) =
                             tokio::sync::mpsc::channel(32);
                         let (batch_tx, batch_rx) = tokio::sync::mpsc::channel(64);
-                        let _worker = spawn_inference_worker(
+                        let worker = spawn_inference_worker(
                             ac,
                             interactive_rx,
                             background_rx,
@@ -659,6 +663,9 @@ pub fn run() {
                             InferenceQueue::new(interactive_tx, background_tx, batch_tx);
                         let mut iq = state_setup.inference_queue.lock().await;
                         *iq = Some(queue);
+                        drop(iq);
+                        let mut wh = state_setup.worker_handle.lock().await;
+                        *wh = Some(worker);
                     }
                 }
 


### PR DESCRIPTION
Each /provider or /key command in the Tauri GUI now aborts the previous
inference worker task (via stored JoinHandle) before spawning a
replacement, preventing orphaned tasks from accumulating.

Changes:
- Add `worker_handle: Mutex<Option<JoinHandle<()>>>` to `AppState`
- Initial setup stores the handle; `rebuild_inference` aborts the old
  handle before spawning and stores the new one
- Add `test_spawn_inference_worker_abort_stops_task` to parish-inference
  to verify abort stops the task and closes the channel

https://claude.ai/code/session_01ApRacyzwQ2x7tf8NxEutoe