### PR TITLE
fix: resolve #53 — mask_key panics on non-ASCII API keys

### DIFF
--- a/crates/parish-cli/tests/world_graph_integration.rs
+++ b/crates/parish-cli/tests/world_graph_integration.rs
@@ -16,8 +16,7 @@ use parish::world::transport::TransportMode;
 
 fn load_parish_graph() -> WorldGraph {
     let path = Path::new("../../mods/rundale/world.json");
-    WorldGraph::load_from_file(path)
-        .expect("mods/rundale/world.json should load and validate")
+    WorldGraph::load_from_file(path).expect("mods/rundale/world.json should load and validate")
 }
 
 fn walking() -> TransportMode {

--- a/crates/parish-core/src/game_mod.rs
+++ b/crates/parish-core/src/game_mod.rs
@@ -236,7 +236,7 @@ impl Default for ThemePaletteConfig {
 }
 
 /// Theme section of the UI configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct ThemeConfig {
     /// Legacy accent override for older mods.
     #[serde(default)]
@@ -298,15 +298,6 @@ impl Default for SidebarConfig {
     fn default() -> Self {
         Self {
             hints_label: default_hints_label(),
-        }
-    }
-}
-
-impl Default for ThemeConfig {
-    fn default() -> Self {
-        Self {
-            default_accent: None,
-            palette: ThemePaletteConfig::default(),
         }
     }
 }

--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -434,8 +434,11 @@ pub const IDLE_MESSAGES: &[&str] = &[
 
 /// Helper to mask an API key for display (shows first 4 and last 4 chars).
 pub fn mask_key(key: &str) -> String {
-    if key.len() > 8 {
-        format!("{}...{}", &key[..4], &key[key.len() - 4..])
+    let char_count = key.chars().count();
+    if char_count > 8 {
+        let prefix: String = key.chars().take(4).collect();
+        let suffix: String = key.chars().skip(char_count - 4).collect();
+        format!("{}...{}", prefix, suffix)
     } else {
         "(set, too short to mask)".to_string()
     }
@@ -579,6 +582,16 @@ mod tests {
         assert_eq!(mask_key("abcdefghij"), "abcd...ghij");
         assert_eq!(mask_key("short"), "(set, too short to mask)");
         assert_eq!(mask_key("123456789"), "1234...6789");
+    }
+
+    #[test]
+    fn mask_key_non_ascii() {
+        // Multi-byte UTF-8 characters must not panic
+        let key = "αβγδεζηθικ"; // 10 Greek letters, each 2 bytes
+        let result = mask_key(key);
+        assert_eq!(result, "αβγδ...ζηθι");
+        // Exactly 8 chars → too short to mask
+        assert_eq!(mask_key("αβγδεζηθ"), "(set, too short to mask)");
     }
 
     #[test]


### PR DESCRIPTION
Replace byte-index slicing (&key[..4], &key[key.len()-4..]) with
char-boundary-safe iteration using chars().take/skip so that keys
containing multi-byte UTF-8 characters no longer panic.

Also derive Default for ThemeConfig (pre-existing clippy::derivable_impls
warning) and add a non-ASCII test to cover the fix.

https://claude.ai/code/session_01VyZwc4M6o8pyC8JoprgRbU