### PR TITLE
Document and enforce lock ordering in AppState background tick

### DIFF
--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -192,6 +192,28 @@ impl ConversationRuntimeState {
 ///
 /// Wrapped in `Arc` so background tasks can hold references without
 /// borrowing from `tauri::State<'_>` (which is not `'static`).
+///
+/// # Lock ordering contract
+///
+/// Several fields are wrapped in [`tokio::sync::Mutex`]. To avoid
+/// deadlocks, any code path that acquires more than one of them **must**
+/// do so in the following canonical order, from outermost to innermost:
+///
+/// 1. [`AppState::world`]
+/// 2. [`AppState::npc_manager`]
+/// 3. [`AppState::conversation`]
+/// 4. [`AppState::debug_events`] / [`AppState::game_events`]
+/// 5. [`AppState::config`]
+/// 6. [`AppState::save_path`] / [`AppState::current_branch_id`] /
+///    [`AppState::current_branch_name`]
+/// 7. [`AppState::client`] / [`AppState::cloud_client`]
+/// 8. [`AppState::inference_log`]
+/// 9. [`AppState::inference_queue`]
+///
+/// Never drop a lock only to re-acquire it in the same critical section —
+/// if two locks are needed, hold them both for the duration of the work.
+/// See `background tick` in [`run`] for the canonical example of holding
+/// `world` and `npc_manager` together through a full tick iteration.
 pub struct AppState {
     /// The game world (clock, player position, graph, weather).
     pub world: Mutex<WorldState>,
@@ -804,17 +826,26 @@ pub fn run() {
                     });
                 }
 
-                // Idle tick: emit world snapshot every 5 seconds.
+                // Idle tick: emit world snapshot and run world/NPC ticks every 5 seconds.
                 // The GameClock already flows via speed_factor — no manual advance needed.
+                //
+                // Lock ordering: `world` → `npc_manager` → `debug_events`. Both
+                // `world` and `npc_manager` are acquired once at the top of each
+                // iteration and held through the entire body to avoid any window
+                // where a command handler could sneak in between them and race
+                // the tick (see the AppState lock ordering contract).
                 let state_tick = Arc::clone(&state_setup);
                 let handle_tick = handle.clone();
                 tokio::spawn(async move {
                     loop {
                         tokio::time::sleep(Duration::from_secs(5)).await;
+
+                        let mut world = state_tick.world.lock().await;
+                        let mut npc_mgr = state_tick.npc_manager.lock().await;
+
+                        // Emit a fresh world snapshot to the frontend.
                         {
-                            let world = state_tick.world.lock().await;
                             let transport = state_tick.transport.default_mode();
-                            let npc_mgr = state_tick.npc_manager.lock().await;
                             let snapshot = crate::commands::get_world_snapshot_inner(
                                 &world,
                                 transport,
@@ -838,9 +869,6 @@ pub fn run() {
                             }
                         }
                         {
-                            let mut world = state_tick.world.lock().await;
-                            let mut npc_mgr = state_tick.npc_manager.lock().await;
-
                             // Tick weather engine
                             let season = world.clock.season();
                             let now = world.clock.now();


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation of the lock ordering contract for `AppState` and refactors the background tick loop to strictly adhere to it, eliminating potential deadlock windows and race conditions.

## Key Changes

- **Added lock ordering contract documentation** to `AppState` struct documenting the canonical order for acquiring multiple mutexes (world → npc_manager → conversation → debug_events → config → save_path/current_branch_id/current_branch_name → client/cloud_client → inference_log → inference_queue)

- **Refactored background tick loop** to acquire `world` and `npc_manager` locks once at the top of each iteration and hold them through the entire body, rather than acquiring and releasing them multiple times

- **Eliminated nested lock scopes** that previously created windows where command handlers could race between lock acquisitions

- **Updated tick comments** to clarify that the 5-second idle tick now runs world/NPC ticks in addition to emitting world snapshots

## Notable Implementation Details

The refactoring ensures that `world` and `npc_manager` are held together throughout:
- World snapshot emission
- Weather engine tick
- NPC schedule ticks and tier assignments
- Debug event logging
- Gossip propagation between co-located NPCs

This prevents any interleaving of command handlers between these operations, which could cause inconsistent state or race conditions. The code now serves as the canonical example of proper lock ordering as referenced in the `AppState` documentation.

https://claude.ai/code/session_019xznw1XHYe4JiSH5WVfDJj