### PR TITLE
feat: enforce Cloudflare Access auth on web server

### DIFF
--- a/crates/parish-cli/tests/world_graph_integration.rs
+++ b/crates/parish-cli/tests/world_graph_integration.rs
@@ -16,8 +16,7 @@ use parish::world::transport::TransportMode;
 
 fn load_parish_graph() -> WorldGraph {
     let path = Path::new("../../mods/rundale/world.json");
-    WorldGraph::load_from_file(path)
-        .expect("mods/rundale/world.json should load and validate")
+    WorldGraph::load_from_file(path).expect("mods/rundale/world.json should load and validate")
 }
 
 fn walking() -> TransportMode {

--- a/crates/parish-core/src/game_mod.rs
+++ b/crates/parish-core/src/game_mod.rs
@@ -236,7 +236,7 @@ impl Default for ThemePaletteConfig {
 }
 
 /// Theme section of the UI configuration.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct ThemeConfig {
     /// Legacy accent override for older mods.
     #[serde(default)]
@@ -298,15 +298,6 @@ impl Default for SidebarConfig {
     fn default() -> Self {
         Self {
             hints_label: default_hints_label(),
-        }
-    }
-}
-
-impl Default for ThemeConfig {
-    fn default() -> Self {
-        Self {
-            default_accent: None,
-            palette: ThemePaletteConfig::default(),
         }
     }
 }

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -8,11 +8,16 @@ pub mod routes;
 pub mod state;
 pub mod ws;
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use axum::Router;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::Response;
 use axum::routing::{get, post};
 use tower_http::services::ServeDir;
 
@@ -24,6 +29,29 @@ use parish_core::world::transport::TransportConfig;
 use parish_core::world::{LocationId, WorldState};
 
 use state::{AppState, GameConfig, UiConfigSnapshot, build_app_state};
+
+/// Middleware that enforces Cloudflare Access authentication on non-localhost traffic.
+///
+/// Requests from loopback addresses (127.0.0.1 / ::1) are always allowed so local
+/// development works without a Cloudflare tunnel.  All other requests must carry the
+/// `CF-Access-Authenticated-User-Email` header that Cloudflare Access injects after a
+/// successful login.  Requests that lack the header are rejected with 401.
+async fn cf_access_guard(
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    req: Request<axum::body::Body>,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    if addr.ip().is_loopback() {
+        return Ok(next.run(req).await);
+    }
+    if req
+        .headers()
+        .contains_key("CF-Access-Authenticated-User-Email")
+    {
+        return Ok(next.run(req).await);
+    }
+    Err(StatusCode::UNAUTHORIZED)
+}
 
 /// Starts the Parish web server on the given port.
 ///
@@ -145,6 +173,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         .route("/api/save-state", get(routes::get_save_state))
         .route("/api/ws", get(ws::ws_handler))
         .fallback_service(ServeDir::new(&static_dir).append_index_html_on_directories(true))
+        .layer(middleware::from_fn(cf_access_guard))
         .with_state(state);
 
     let addr = format!("0.0.0.0:{}", port);
@@ -152,7 +181,11 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     tracing::info!("Serving static files from {}", static_dir.display());
 
     let listener = tokio::net::TcpListener::bind(&addr).await?;
-    axum::serve(listener, app).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await?;
 
     Ok(())
 }

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -18,9 +18,8 @@ use parish_core::inference::{InferenceQueue, spawn_inference_worker};
 use parish_core::input::{InputResult, classify_input, parse_intent};
 use parish_core::ipc::{
     ConversationLine, IDLE_MESSAGES, INFERENCE_FAILURE_MESSAGES, LoadingPayload, MapData, NpcInfo,
-    NpcReactionPayload, ReactRequest, StreamEndPayload, StreamTokenPayload,
-    StreamTurnEndPayload, ThemePalette, WorldSnapshot, capitalize_first, text_log,
-    text_log_for_stream_turn,
+    NpcReactionPayload, ReactRequest, StreamEndPayload, StreamTokenPayload, StreamTurnEndPayload,
+    ThemePalette, WorldSnapshot, capitalize_first, text_log, text_log_for_stream_turn,
 };
 use parish_core::npc::NpcId;
 use parish_core::npc::manager::NpcManager;
@@ -584,12 +583,10 @@ async fn run_npc_turn(
     let (token_tx, token_rx) = mpsc::unbounded_channel::<String>();
     let display_label = capitalize_first(&setup.display_name);
     let req_id = REQUEST_ID.fetch_add(1, Ordering::SeqCst);
-    state
-        .event_bus
-        .emit(
-            "text-log",
-            &text_log_for_stream_turn(display_label.clone(), String::new(), req_id),
-        );
+    state.event_bus.emit(
+        "text-log",
+        &text_log_for_stream_turn(display_label.clone(), String::new(), req_id),
+    );
     let send_result = queue
         .send(
             req_id,
@@ -605,10 +602,9 @@ async fn run_npc_turn(
         Ok(rx) => rx,
         Err(e) => {
             tracing::error!("Failed to submit inference request: {}", e);
-            state.event_bus.emit(
-                "stream-turn-end",
-                &StreamTurnEndPayload { turn_id: req_id },
-            );
+            state
+                .event_bus
+                .emit("stream-turn-end", &StreamTurnEndPayload { turn_id: req_id });
             state.event_bus.emit(
                 "text-log",
                 &text_log(
@@ -643,10 +639,9 @@ async fn run_npc_turn(
 
     let response = response_rx.await.ok();
     let _ = stream_handle.await;
-    state.event_bus.emit(
-        "stream-turn-end",
-        &StreamTurnEndPayload { turn_id: req_id },
-    );
+    state
+        .event_bus
+        .emit("stream-turn-end", &StreamTurnEndPayload { turn_id: req_id });
     loading_cancel.cancel();
 
     let Some(response) = response else {

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -25,9 +25,9 @@ use parish_core::npc::ticks::apply_tier1_response;
 use parish_core::world::transport::TransportMode;
 
 use crate::events::{
-    EVENT_SAVE_PICKER, EVENT_STREAM_END, EVENT_STREAM_TURN_END, EVENT_TEXT_LOG,
-    EVENT_TRAVEL_START, EVENT_WORLD_UPDATE, NpcReactionPayload, StreamEndPayload,
-    StreamTokenPayload, StreamTurnEndPayload, TextLogPayload, spawn_loading_animation,
+    EVENT_SAVE_PICKER, EVENT_STREAM_END, EVENT_STREAM_TURN_END, EVENT_TEXT_LOG, EVENT_TRAVEL_START,
+    EVENT_WORLD_UPDATE, NpcReactionPayload, StreamEndPayload, StreamTokenPayload,
+    StreamTurnEndPayload, TextLogPayload, spawn_loading_animation,
 };
 use crate::{AppState, MapData, MapLocation, NpcInfo, SaveState, ThemePalette, WorldSnapshot};
 


### PR DESCRIPTION
## Summary

- Adds `cf_access_guard` middleware to `parish-server` that checks for the `CF-Access-Authenticated-User-Email` header injected by Cloudflare Access after successful login
- Requests from loopback addresses (127.0.0.1 / ::1) are always allowed so local dev works without a tunnel
- All other requests missing the header are rejected with 401
- Fixes a pre-existing clippy warning (`ThemeConfig` manual `Default` impl replaced with `#[derive(Default)]`) that was failing quality gates

## Test plan

- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] Local dev (`just run-headless`) still works without any auth header
- [ ] Deployed on Railway behind Cloudflare Access: unauthenticated direct requests return 401, authenticated requests pass through

🤖 Generated with [Claude Code](https://claude.com/claude-code)