### PR TITLE
fix: exempt health-check endpoint from Cloudflare Access auth

### DIFF
--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -44,6 +44,10 @@ async fn cf_access_guard(
     if addr.ip().is_loopback() {
         return Ok(next.run(req).await);
     }
+    // Allow the health-check endpoint without auth so Railway can probe it.
+    if req.uri().path() == "/api/ui-config" {
+        return Ok(next.run(req).await);
+    }
     if req
         .headers()
         .contains_key("CF-Access-Authenticated-User-Email")


### PR DESCRIPTION
Railway's health check probes /api/ui-config from an internal IP that
doesn't pass through Cloudflare, so it lacks the required
CF-Access-Authenticated-User-Email header. The middleware was returning
401, causing Railway to consider the deployment unhealthy.

The endpoint only returns non-sensitive UI config (splash text, accent
colour, hints label), so it's safe to serve without authentication.

https://claude.ai/code/session_01AnK4QHUP9d5KG8Xz7A5xHX