### PR TITLE
feat: runtime feature flag system with /flag slash commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Detailed guides live in [docs/agent/](docs/agent/README.md):
 3. **Tests on every change.** Coverage must stay above 90% (`cargo tarpaulin`). Run `/check` before any commit and `/verify` before any push.
 4. **Prove gameplay features.** After implementing any gameplay change, run `/prove <feature>` — unit tests passing is not enough.
 5. **No `#[allow]`** without a justifying comment.
+6. **Feature flags for new engine features.** Every new gameplay or engine feature must be gated behind a feature flag (enabled by default). Add the flag check via `config.flags.is_enabled("my-feature-name")` and document the flag name in the PR. Use `/flag disable <name>` to turn it off if issues arise in production.
 
 ## Quick start
 

--- a/crates/parish-config/src/flags.rs
+++ b/crates/parish-config/src/flags.rs
@@ -39,6 +39,21 @@ impl FeatureFlags {
         self.flags.insert(name.to_string(), false);
     }
 
+    /// Returns `true` only when the flag has been **explicitly** disabled.
+    ///
+    /// Unknown flags return `false` — features are considered on by default.
+    /// Use this (instead of `is_enabled`) for features that should ship
+    /// enabled and be kill-switched off in production:
+    ///
+    /// ```ignore
+    /// if !config.flags.is_disabled("new-npc-schedules") {
+    ///     // feature code
+    /// }
+    /// ```
+    pub fn is_disabled(&self, name: &str) -> bool {
+        self.flags.get(name).copied() == Some(false)
+    }
+
     /// Returns all flags in alphabetical order as `(name, enabled)` pairs.
     pub fn list(&self) -> Vec<(&str, bool)> {
         self.flags.iter().map(|(k, v)| (k.as_str(), *v)).collect()
@@ -165,6 +180,27 @@ mod tests {
         let flags = FeatureFlags::default();
         flags.save_to_file(&path).unwrap();
         assert!(path.exists());
+    }
+
+    #[test]
+    fn test_is_disabled_unknown_flag_returns_false() {
+        // Unknown flags are NOT disabled — features ship enabled by default.
+        let flags = FeatureFlags::default();
+        assert!(!flags.is_disabled("never-set"));
+    }
+
+    #[test]
+    fn test_is_disabled_after_disable() {
+        let mut flags = FeatureFlags::default();
+        flags.disable("kill-switch");
+        assert!(flags.is_disabled("kill-switch"));
+    }
+
+    #[test]
+    fn test_is_disabled_after_enable() {
+        let mut flags = FeatureFlags::default();
+        flags.enable("re-enabled");
+        assert!(!flags.is_disabled("re-enabled"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds a `FeatureFlags` type (`parish-config`) backed by a `BTreeMap<String, bool>` with JSON persistence to `parish-flags.json` in the data directory
- Wires flag loading and saving into all three backends (headless CLI, axum web server, Tauri)
- Adds `/flag enable <name>`, `/flag disable <name>`, `/flag list`, and `/flags` slash commands with autocomplete in the UI
- Adds `is_disabled()` helper for features that ship enabled by default — unknown flags return `false` (not disabled), so features run until explicitly kill-switched

## Usage

```
/flag enable my-feature    # enable a flag (persists across restarts)
/flag disable my-feature   # disable / kill-switch a flag
/flag list                 # show all flags with [on]/[off] status
```

Gate new engine features with:
```rust
if !config.flags.is_disabled("my-feature") {
    // feature code
}
```

## Test plan

- [ ] `cargo clippy --workspace --exclude parish-tauri -- -D warnings` passes clean
- [ ] `cargo test --workspace --exclude parish-tauri` — all tests pass (1,180+)
- [ ] `cargo run -- --script testing/fixtures/test_flags.txt` — fixture runs cleanly with correct enable/disable/list output
- [ ] `cargo run -- --script testing/fixtures/test_walkthrough.txt` — no regressions; `/help` lists `/flag` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)