### PR TITLE
Add advisory file locking to prevent concurrent save file access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,6 +2927,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "libc",
  "parish-npc",
  "parish-types",
  "parish-world",

--- a/apps/ui/src/components/SavePicker.svelte
+++ b/apps/ui/src/components/SavePicker.svelte
@@ -430,6 +430,8 @@
 							</span>
 							{#if isActive}
 								<span class="ledger-current">You are here</span>
+							{:else if file.locked}
+								<span class="ledger-locked">In Use</span>
 							{:else}
 								<button class="action-btn" on:click={() => handleSwitchLedger(file)} disabled={loading}>Open</button>
 							{/if}
@@ -870,6 +872,15 @@
 		font-style: italic;
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
+	}
+
+	.ledger-locked {
+		font-size: 0.6rem;
+		color: var(--color-muted);
+		font-style: italic;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		opacity: 0.6;
 	}
 
 	.new-ledger {

--- a/apps/ui/src/lib/types.ts
+++ b/apps/ui/src/lib/types.ts
@@ -456,6 +456,7 @@ export interface SaveFileInfo {
 	filename: string;
 	file_size: string;
 	branches: SaveBranchDisplay[];
+	locked: boolean;
 }
 
 export interface SaveState {

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
 	plugins: [sveltekit(), svelteTesting()],
 	clearScreen: false,
 	server: {
-		port: 5173,
+		port: parseInt(process.env.PARISH_DEV_PORT || '5173'),
 		strictPort: true,
 		fs: {
 			allow: ['.']

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -2,6 +2,10 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { svelteTesting } from '@testing-library/svelte/vite';
 import { defineConfig } from 'vitest/config';
 
+// Minimal local declaration so TypeScript accepts `process.env` in this Node-only
+// config file without pulling in `@types/node` as a project-wide dependency.
+declare const process: { env: Record<string, string | undefined> };
+
 export default defineConfig({
 	plugins: [sveltekit(), svelteTesting()],
 	clearScreen: false,

--- a/crates/parish-cli/src/app.rs
+++ b/crates/parish-cli/src/app.rs
@@ -183,6 +183,8 @@ pub struct App {
     pub flags: crate::config::FeatureFlags,
     /// Path to the flags persistence file (None disables persistence).
     pub flags_path: Option<PathBuf>,
+    /// Advisory file lock for the currently active save file.
+    pub save_lock: Option<crate::persistence::SaveFileLock>,
 }
 
 impl App {
@@ -240,6 +242,7 @@ impl App {
             game_mod: None,
             flags: crate::config::FeatureFlags::default(),
             flags_path: None,
+            save_lock: None,
         }
     }
 

--- a/crates/parish-cli/src/headless.rs
+++ b/crates/parish-cli/src/headless.rs
@@ -166,6 +166,9 @@ pub async fn run_headless(
     let db_path = crate::persistence::picker::run_picker(&saves_dir, &app.world.graph);
     app.save_file_path = Some(db_path.clone());
 
+    // Acquire advisory lock so other instances know this save is in use.
+    app.save_lock = crate::persistence::SaveFileLock::try_acquire(&db_path);
+
     match crate::persistence::Database::open(&db_path) {
         Ok(db) => {
             let async_db = Arc::new(crate::persistence::AsyncDatabase::new(db));
@@ -783,6 +786,9 @@ async fn handle_headless_load(app: &mut App, name: &str) {
                     app.npc_manager = mgr;
                 }
             }
+            // Release old lock and acquire lock on the new save file.
+            app.save_lock = crate::persistence::SaveFileLock::try_acquire(&new_path);
+
             match crate::persistence::Database::open(&new_path) {
                 Ok(new_db) => {
                     let async_db = Arc::new(crate::persistence::AsyncDatabase::new(new_db));

--- a/crates/parish-persistence/Cargo.toml
+++ b/crates/parish-persistence/Cargo.toml
@@ -16,5 +16,8 @@ tracing = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/parish-persistence/src/lib.rs
+++ b/crates/parish-persistence/src/lib.rs
@@ -7,11 +7,13 @@
 pub mod database;
 pub mod journal;
 pub mod journal_bridge;
+pub mod lock;
 pub mod picker;
 pub mod snapshot;
 
 pub use database::{AsyncDatabase, BranchInfo, Database, SnapshotInfo};
 pub use journal::{WorldEvent, replay_journal};
+pub use lock::SaveFileLock;
 pub use snapshot::{ClockSnapshot, GameSnapshot, NpcSnapshot};
 
 /// Formats an RFC 3339 timestamp into a short, human-readable local-time string.

--- a/crates/parish-persistence/src/lock.rs
+++ b/crates/parish-persistence/src/lock.rs
@@ -1,0 +1,240 @@
+//! Advisory file locking for save files.
+//!
+//! Prevents multiple app instances from writing to the same save file
+//! simultaneously. Each lock is a `<save_path>.lock` sidecar file
+//! containing the owning process's PID. Stale locks from crashed
+//! processes are detected and cleaned up automatically.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Advisory lock backed by a `.lock` sidecar file.
+///
+/// On creation, writes the current PID to `<save_path>.lock`.
+/// On drop, removes the lock file (best-effort).
+pub struct SaveFileLock {
+    lock_path: PathBuf,
+}
+
+impl SaveFileLock {
+    /// Attempts to acquire an advisory lock for the given save file.
+    ///
+    /// Returns `Some(lock)` on success, or `None` if the file is already
+    /// locked by another live process. Stale locks (dead PID) are cleaned
+    /// up and re-acquired automatically.
+    pub fn try_acquire(save_path: &Path) -> Option<Self> {
+        let lock_path = Self::lock_path_for(save_path);
+        let my_pid = std::process::id();
+
+        if lock_path.exists() {
+            match fs::read_to_string(&lock_path) {
+                Ok(contents) => {
+                    if let Ok(pid) = contents.trim().parse::<u32>() {
+                        if pid == my_pid {
+                            // We already hold this lock (re-entrant from same process).
+                            return None;
+                        }
+                        if is_process_alive(pid) {
+                            return None;
+                        }
+                        // Stale lock — remove it and proceed.
+                        tracing::info!(
+                            pid,
+                            path = %lock_path.display(),
+                            "Removing stale lock file (process no longer running)"
+                        );
+                        let _ = fs::remove_file(&lock_path);
+                    }
+                    // Unparseable content — treat as stale.
+                }
+                Err(_) => {
+                    // Unreadable lock file — treat as stale.
+                    let _ = fs::remove_file(&lock_path);
+                }
+            }
+        }
+
+        // Write PID atomically: write to .tmp then rename.
+        let tmp_path = lock_path.with_extension("lock.tmp");
+        let mut f = fs::File::create(&tmp_path).ok()?;
+        write!(f, "{}", my_pid).ok()?;
+        f.sync_all().ok()?;
+        drop(f);
+
+        if fs::rename(&tmp_path, &lock_path).is_err() {
+            let _ = fs::remove_file(&tmp_path);
+            return None;
+        }
+
+        // Verify we won the race: re-read and confirm our PID is there.
+        match fs::read_to_string(&lock_path) {
+            Ok(contents) if contents.trim() == my_pid.to_string() => {}
+            _ => return None,
+        }
+
+        Some(Self { lock_path })
+    }
+
+    /// Returns the lock file path for a given save file path.
+    pub fn lock_path_for(save_path: &Path) -> PathBuf {
+        let mut p = save_path.as_os_str().to_os_string();
+        p.push(".lock");
+        PathBuf::from(p)
+    }
+}
+
+impl Drop for SaveFileLock {
+    fn drop(&mut self) {
+        // Best-effort removal. If it fails (e.g. permission, already gone),
+        // the next instance will detect the stale lock via PID check.
+        if let Err(e) = fs::remove_file(&self.lock_path)
+            && e.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!(
+                path = %self.lock_path.display(),
+                error = %e,
+                "Failed to remove lock file on drop"
+            );
+        }
+    }
+}
+
+/// Checks whether a save file is currently locked by another live process.
+pub fn is_locked(save_path: &Path) -> bool {
+    let lock_path = SaveFileLock::lock_path_for(save_path);
+    if !lock_path.exists() {
+        return false;
+    }
+    match fs::read_to_string(&lock_path) {
+        Ok(contents) => match contents.trim().parse::<u32>() {
+            Ok(pid) => is_process_alive(pid),
+            Err(_) => false, // Unparseable — treat as stale (not locked).
+        },
+        Err(_) => false, // Unreadable — treat as stale.
+    }
+}
+
+/// Returns `true` if a process with the given PID is currently running.
+#[cfg(unix)]
+fn is_process_alive(pid: u32) -> bool {
+    // kill(pid, 0) checks process existence without sending a signal.
+    // Returns 0 if the process exists and we have permission to signal it.
+    // Returns -1 with ESRCH if the process does not exist.
+    // Returns -1 with EPERM if we lack permission — but the process exists.
+    let ret = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if ret == 0 {
+        return true;
+    }
+    // EPERM means the process exists but we can't signal it.
+    std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn is_process_alive(_pid: u32) -> bool {
+    // Conservative fallback for non-Unix: assume process is alive.
+    // This prevents accidental lock theft on unsupported platforms.
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lock_path_for() {
+        let save = Path::new("saves/parish_001.db");
+        let lock = SaveFileLock::lock_path_for(save);
+        assert_eq!(lock, PathBuf::from("saves/parish_001.db.lock"));
+    }
+
+    #[test]
+    fn test_acquire_and_release() {
+        let dir = tempfile::tempdir().unwrap();
+        let save = dir.path().join("test.db");
+        fs::write(&save, b"").unwrap();
+
+        let lock_path = SaveFileLock::lock_path_for(&save);
+
+        {
+            let lock = SaveFileLock::try_acquire(&save);
+            assert!(lock.is_some(), "should acquire lock");
+            assert!(lock_path.exists(), "lock file should exist");
+
+            let contents = fs::read_to_string(&lock_path).unwrap();
+            assert_eq!(
+                contents.trim(),
+                std::process::id().to_string(),
+                "lock should contain our PID"
+            );
+        }
+        // Lock dropped — file should be gone.
+        assert!(!lock_path.exists(), "lock file should be removed on drop");
+    }
+
+    #[test]
+    fn test_double_acquire_same_process() {
+        let dir = tempfile::tempdir().unwrap();
+        let save = dir.path().join("test.db");
+        fs::write(&save, b"").unwrap();
+
+        let lock1 = SaveFileLock::try_acquire(&save);
+        assert!(lock1.is_some());
+
+        // Second acquire from same process should fail (re-entrant guard).
+        let lock2 = SaveFileLock::try_acquire(&save);
+        assert!(lock2.is_none(), "same process should not double-acquire");
+    }
+
+    #[test]
+    fn test_stale_lock_cleanup() {
+        let dir = tempfile::tempdir().unwrap();
+        let save = dir.path().join("test.db");
+        fs::write(&save, b"").unwrap();
+
+        let lock_path = SaveFileLock::lock_path_for(&save);
+
+        // Write a lock file with a PID that almost certainly doesn't exist.
+        fs::write(&lock_path, "999999999").unwrap();
+
+        let lock = SaveFileLock::try_acquire(&save);
+        assert!(
+            lock.is_some(),
+            "should acquire lock after cleaning stale PID"
+        );
+    }
+
+    #[test]
+    fn test_is_locked_no_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let save = dir.path().join("test.db");
+        fs::write(&save, b"").unwrap();
+
+        assert!(!is_locked(&save));
+    }
+
+    #[test]
+    fn test_is_locked_with_active_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let save = dir.path().join("test.db");
+        fs::write(&save, b"").unwrap();
+
+        let _lock = SaveFileLock::try_acquire(&save);
+        assert!(is_locked(&save), "should report locked while lock is held");
+    }
+
+    #[test]
+    fn test_is_locked_stale() {
+        let dir = tempfile::tempdir().unwrap();
+        let save = dir.path().join("test.db");
+        fs::write(&save, b"").unwrap();
+
+        let lock_path = SaveFileLock::lock_path_for(&save);
+        fs::write(&lock_path, "999999999").unwrap();
+
+        assert!(
+            !is_locked(&save),
+            "stale lock with dead PID should not report locked"
+        );
+    }
+}

--- a/crates/parish-persistence/src/picker.rs
+++ b/crates/parish-persistence/src/picker.rs
@@ -70,6 +70,8 @@ pub struct SaveFileInfo {
     pub file_size: String,
     /// Branches within the save file.
     pub branches: Vec<SaveBranchDisplay>,
+    /// Whether this save file is currently locked by another running instance.
+    pub locked: bool,
 }
 
 /// Ensures the saves directory exists and returns its path.
@@ -129,11 +131,14 @@ pub fn discover_saves(saves_dir: &Path, graph: &WorldGraph) -> Vec<SaveFileInfo>
             .map(|m| format_file_size(m.len()))
             .unwrap_or_default();
 
+        let locked = crate::lock::is_locked(&path);
+
         saves.push(SaveFileInfo {
             path,
             filename,
             file_size,
             branches,
+            locked,
         });
     }
 

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -1716,6 +1716,8 @@ pub async fn load_branch(
     Extension(state): Extension<Arc<AppState>>,
     Json(body): Json<LoadBranchRequest>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    use parish_core::persistence::SaveFileLock;
+
     let path = std::path::PathBuf::from(&body.file_path);
     // Validate the path is within the saves directory to prevent path traversal.
     let canonical = path.canonicalize().map_err(|_| {
@@ -1738,6 +1740,20 @@ pub async fn load_branch(
     }
     let path = canonical;
     let branch_id = body.branch_id;
+
+    // If switching to a different save file, acquire a new lock first.
+    let current_path = state.save_path.lock().await.clone();
+    let switching_files = current_path.as_ref() != Some(&path);
+    if switching_files {
+        let lock = SaveFileLock::try_acquire(&path).ok_or_else(|| {
+            (
+                StatusCode::CONFLICT,
+                "This save file is in use by another instance.".to_string(),
+            )
+        })?;
+        *state.save_lock.lock().await = Some(lock);
+    }
+
     let path_clone = path.clone();
 
     let (snapshot, branch_name) =
@@ -1821,8 +1837,19 @@ pub async fn create_branch(
 pub async fn new_save_file(
     Extension(state): Extension<Arc<AppState>>,
 ) -> Result<StatusCode, (StatusCode, String)> {
+    use parish_core::persistence::SaveFileLock;
+
     let saves_dir = state.saves_dir.clone();
     let path = new_save_path(&saves_dir);
+
+    // Acquire lock on the new save file, releasing any previous lock.
+    let lock = SaveFileLock::try_acquire(&path).ok_or_else(|| {
+        (
+            StatusCode::CONFLICT,
+            "Could not lock the new save file.".to_string(),
+        )
+    })?;
+    *state.save_lock.lock().await = Some(lock);
 
     let snapshot = {
         let world = state.world.lock().await;

--- a/crates/parish-server/src/state.rs
+++ b/crates/parish-server/src/state.rs
@@ -167,6 +167,8 @@ pub struct AppState {
     /// email is rejected with 409 Conflict until the first socket closes.
     /// Uses a `tokio::sync::Mutex` so it can be held across await points.
     pub active_ws: tokio::sync::Mutex<HashSet<String>>,
+    /// Advisory file lock for the currently active save file.
+    pub save_lock: Mutex<Option<parish_core::persistence::SaveFileLock>>,
 }
 
 // GameConfig is now shared across all backends via parish-core.
@@ -280,6 +282,7 @@ pub fn build_app_state(
         worker_handle: Mutex::new(None),
         editor_sessions: tokio::sync::Mutex::new(std::collections::HashMap::new()),
         active_ws: tokio::sync::Mutex::new(HashSet::new()),
+        save_lock: Mutex::new(None),
     })
 }
 

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -1531,7 +1531,21 @@ pub async fn load_branch(
     state: tauri::State<'_, Arc<AppState>>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
+    use parish_core::persistence::SaveFileLock;
+
     let path = std::path::PathBuf::from(&file_path);
+
+    // If switching to a different save file, acquire a new lock first.
+    let current_path = state.save_path.lock().await.clone();
+    let switching_files = current_path.as_ref() != Some(&path);
+
+    if switching_files {
+        let lock = SaveFileLock::try_acquire(&path)
+            .ok_or_else(|| "This save file is in use by another instance.".to_string())?;
+        // Release old lock and store new one.
+        *state.save_lock.lock().await = Some(lock);
+    }
+
     let db = Database::open(&path).map_err(|e| e.to_string())?;
 
     let (_, snapshot) = db
@@ -1650,8 +1664,16 @@ async fn do_create_branch(
 /// Creates a new save file and saves the current state.
 #[tauri::command]
 pub async fn new_save_file(state: tauri::State<'_, Arc<AppState>>) -> Result<(), String> {
+    use parish_core::persistence::SaveFileLock;
+
     let sd = saves_dir();
     let path = new_save_path(&sd);
+
+    // Acquire lock on the new save file, releasing any previous lock.
+    let lock = SaveFileLock::try_acquire(&path)
+        .ok_or_else(|| "Could not lock the new save file.".to_string())?;
+    *state.save_lock.lock().await = Some(lock);
+
     let db = Database::open(&path).map_err(|e| e.to_string())?;
 
     let branch = db

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -266,6 +266,8 @@ pub struct AppState {
     pub worker_handle: Mutex<Option<JoinHandle<()>>>,
     /// Editor session — separate from gameplay state, may be empty.
     pub editor: std::sync::Mutex<parish_core::ipc::editor::EditorSession>,
+    /// Advisory file lock for the currently active save file.
+    pub save_lock: Mutex<Option<parish_core::persistence::SaveFileLock>>,
 }
 
 // ── Data path resolution ─────────────────────────────────────────────────────
@@ -598,6 +600,7 @@ pub fn run() {
         data_dir: data_dir.clone(),
         worker_handle: Mutex::new(None),
         editor: std::sync::Mutex::new(parish_core::ipc::editor::EditorSession::default()),
+        save_lock: Mutex::new(None),
         config: Mutex::new(GameConfig {
             provider_name,
             base_url,
@@ -757,6 +760,7 @@ pub fn run() {
                 // ── Persistence: auto-load or create save file ──────────────
                 {
                     use parish_core::persistence::Database;
+                    use parish_core::persistence::SaveFileLock;
                     use parish_core::persistence::picker::{
                         discover_saves, ensure_saves_dir, new_save_path,
                     };
@@ -785,8 +789,17 @@ pub fn run() {
                     let saves = discover_saves(&saves_dir, &world.graph);
                     drop(world);
 
-                    if let Some(save) = saves.last() {
-                        // Load the most recent save file
+                    // Find the most recent unlocked save (iterate in reverse).
+                    let unlocked_save = saves.iter().rev().find(|s| !s.locked);
+
+                    if let Some(save) = unlocked_save {
+                        // Acquire the advisory lock before loading.
+                        let lock = SaveFileLock::try_acquire(&save.path);
+                        if lock.is_some() {
+                            *state_setup.save_lock.lock().await = lock;
+                        }
+
+                        // Load the most recent unlocked save file
                         match Database::open(&save.path) {
                             Ok(db) => {
                                 // Find the "main" branch or first branch
@@ -838,9 +851,13 @@ pub fn run() {
                                 tracing::warn!("Failed to open save file {}: {}", save.filename, e);
                             }
                         }
-                    } else {
+                    } else if saves.is_empty() {
                         // No saves exist — create a new save file
                         let path = new_save_path(&saves_dir);
+                        let lock = SaveFileLock::try_acquire(&path);
+                        if lock.is_some() {
+                            *state_setup.save_lock.lock().await = lock;
+                        }
                         match Database::open(&path) {
                             Ok(db) => {
                                 if let Ok(Some(branch)) = db.find_branch("main") {
@@ -862,6 +879,14 @@ pub fn run() {
                                 tracing::warn!("Failed to create save file: {}", e);
                             }
                         }
+                    } else {
+                        // All saves are locked by other instances.
+                        // Show the save picker so the user can choose or create a new ledger.
+                        tracing::info!(
+                            "All {} save file(s) are locked by other instances — opening save picker",
+                            saves.len()
+                        );
+                        let _ = handle.emit(events::EVENT_SAVE_PICKER, ());
                     }
                 }
 

--- a/justfile
+++ b/justfile
@@ -89,10 +89,24 @@ clean:
 
 # ─── Run ─────────────────────────────────────────────────────────────────────
 
-# Run the game (Tauri desktop GUI) — installs frontend deps if missing
+# Run the game (Tauri desktop GUI) — installs frontend deps if missing.
+# Auto-detects a free dev port so multiple instances can run simultaneously.
 run:
-    @eval "$(fnm env)" && test -d apps/ui/node_modules || (echo "Installing frontend dependencies..." && cd apps/ui && npm install)
-    eval "$(fnm env)" && cargo tauri dev
+    #!/usr/bin/env bash
+    eval "$(fnm env)"
+    test -d apps/ui/node_modules || (echo "Installing frontend dependencies..." && cd apps/ui && npm install)
+    PORT=5173
+    while ss -tln 2>/dev/null | grep -q ":$PORT " || lsof -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1; do
+        PORT=$((PORT + 1))
+    done
+    export PARISH_DEV_PORT=$PORT
+    if [ "$PORT" -eq 5173 ]; then
+        echo "Dev server port: $PORT"
+        cargo tauri dev
+    else
+        echo "Dev server port: $PORT (default 5173 was in use)"
+        cargo tauri dev --config "{\"build\":{\"devUrl\":\"http://localhost:$PORT\"}}"
+    fi
 
 # Run the game in headless REPL mode (plain stdin/stdout)
 run-headless:
@@ -109,9 +123,9 @@ web PORT="3001": ui-build
 
 # ─── Tauri & Frontend ────────────────────────────────────────────────────────
 
-# Start the Tauri desktop app in dev mode (frontend + backend)
+# Start the Tauri desktop app in dev mode (same as `run`)
 tauri-dev:
-    eval "$(fnm env)" && cargo tauri dev
+    just run
 
 # Build the Tauri desktop app for production
 tauri-build:


### PR DESCRIPTION
## Summary
Implements advisory file locking for save files to prevent multiple app instances from writing to the same save file simultaneously. Each save file can now be locked by acquiring a `SaveFileLock`, which is backed by a `.lock` sidecar file containing the owning process's PID. Stale locks from crashed processes are automatically detected and cleaned up.

## Key Changes

- **New `lock` module** (`crates/parish-persistence/src/lock.rs`):
  - `SaveFileLock` struct that acquires/releases advisory locks via `.lock` sidecar files
  - Atomic lock acquisition using temp-file-then-rename pattern
  - Stale lock detection via PID validation (using `kill(pid, 0)` on Unix)
  - `is_locked()` function to check if a save file is currently locked
  - Comprehensive test coverage including re-entrancy guards and stale lock cleanup

- **Save file discovery integration** (`crates/parish-persistence/src/picker.rs`):
  - `SaveFileInfo` now includes a `locked` boolean field
  - `discover_saves()` checks lock status for each discovered save file

- **Tauri app state** (`crates/parish-tauri/src/lib.rs`):
  - Added `save_lock: Mutex<Option<SaveFileLock>>` to `AppState`
  - Lock acquisition during app startup (auto-load or new save creation)
  - Fallback to save picker if all existing saves are locked

- **Command handlers** (`crates/parish-tauri/src/commands.rs`):
  - `load_branch()` acquires lock when switching save files
  - `new_save_file()` acquires lock on newly created saves

- **Server routes** (`crates/parish-server/src/routes.rs`):
  - `load_branch()` and `new_save_file()` routes acquire locks before switching/creating saves
  - Returns HTTP 409 Conflict if a save file is already locked

- **CLI headless mode** (`crates/parish-cli/src/headless.rs`):
  - Acquires lock on selected save file to prevent concurrent access

- **UI updates** (`apps/ui/src/components/SavePicker.svelte`):
  - Displays "In Use" badge for locked save files
  - Disables "Open" button for locked saves

- **Dev tooling** (`justfile`, `apps/ui/vite.config.ts`):
  - Enhanced `run` command auto-detects free dev port via `PARISH_DEV_PORT` env var
  - Allows multiple dev instances to run simultaneously without port conflicts

## Implementation Details

- Lock files use atomic write-then-rename to prevent race conditions
- Re-entrancy guard prevents the same process from acquiring the same lock twice
- Conservative fallback on non-Unix platforms (assumes process is alive to prevent accidental lock theft)
- Best-effort lock cleanup on drop; stale locks are automatically detected and removed on next access
- Lock status is checked during save discovery and displayed in the UI

https://claude.ai/code/session_01Q2upsGpy1eNYLHpy7hHfMe