### PR TITLE
🎨 Palette: Add global focus-visible ring for keyboard navigation

### DIFF
--- a/apps/ui/src/app.css
+++ b/apps/ui/src/app.css
@@ -77,6 +77,12 @@ body::before {
 	flex: 0 0 auto !important;
 }
 
+/* Keyboard focus ring — visible only during keyboard navigation */
+:focus-visible {
+	outline: 2px solid var(--color-accent);
+	outline-offset: 2px;
+}
+
 ::-webkit-scrollbar {
 	width: 4px;
 }


### PR DESCRIPTION
## 💡 What
Adds a global `:focus-visible` outline style to `app.css` — a 2px accent-colored ring that appears on any interactive element during keyboard navigation.

## 🎯 Why
The UI had **zero** `:focus-visible` styles. Keyboard users tabbing through buttons (Ledger, Dbg, Close, Open, Branch From Here, mobile toolbar toggles, footer buttons, etc.) received no consistent visual focus indicator. The only two `:focus` rules in the entire app were on text inputs (`InputField`, `SavePicker` phantom input`), leaving all buttons invisible to keyboard navigation.

## ♿ Accessibility
- **WCAG 2.4.7 (Focus Visible):** All interactive elements now show a clear focus ring during keyboard navigation
- Uses `:focus-visible` (not `:focus`) so mouse users see no change — the ring only appears when navigating via Tab/Shift+Tab
- Uses the existing `--color-accent` design token to stay consistent with the parchment theme
- `outline-offset: 2px` provides breathing room so the ring doesn't overlap element borders

## 📐 Scope
- **1 file changed**, 6 lines added
- Pure CSS, no component logic touched
- All 130 passing tests remain passing (3 pre-existing failures in `InputField.test.ts` are unrelated)

https://claude.ai/code/session_01FQdYf2iMwyxvj2yfRW8eH3