### PR TITLE
fix: resolve 4 open bugs (#278, #288, #291, #292)

### DIFF
--- a/apps/ui/src/components/ChatPanel.svelte
+++ b/apps/ui/src/components/ChatPanel.svelte
@@ -10,10 +10,12 @@
 	let hoveredMessageId: string | null = $state(null);
 
 	$effect(() => {
-		// Scroll to bottom when log changes
 		const _ = $textLog;
+		const nearBottom = logEl
+			? logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 50
+			: true;
 		tick().then(() => {
-			if (logEl) {
+			if (logEl && nearBottom) {
 				logEl.scrollTop = logEl.scrollHeight;
 			}
 		});

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -66,9 +66,10 @@
 		}
 		if (e.key === 'F12') {
 			e.preventDefault();
-			debugVisible.update((v) => !v);
+			const nowVisible = !get(debugVisible);
+			debugVisible.set(nowVisible);
 			// Fetch initial snapshot when opening
-			if (!$debugVisible) {
+			if (nowVisible) {
 				getDebugSnapshot()
 					.then((s) => debugSnapshot.set(s))
 					.catch(() => {});

--- a/apps/ui/src/stores/game.ts
+++ b/apps/ui/src/stores/game.ts
@@ -49,22 +49,20 @@ export const messageHints = writable<Map<string, LanguageHint[]>>(new Map());
 /** Adds a reaction to a message in the text log by message ID. */
 export function addReaction(messageId: string, emoji: string, source: string): void {
 	textLog.update((log) => {
-		const entry = log.find((e) => e.id === messageId);
-		if (!entry) return log;
-
-		const reactions = entry.reactions ?? [];
-		// Player: one reaction per message (replace existing)
-		if (source === 'player') {
-			const existing = reactions.findIndex((r) => r.source === 'player');
-			if (existing >= 0) {
-				reactions[existing] = { emoji, source };
+		return log.map((entry) => {
+			if (entry.id !== messageId) return entry;
+			const reactions = [...(entry.reactions ?? [])];
+			if (source === 'player') {
+				const existing = reactions.findIndex((r) => r.source === 'player');
+				if (existing >= 0) {
+					reactions[existing] = { emoji, source };
+				} else {
+					reactions.push({ emoji, source });
+				}
 			} else {
 				reactions.push({ emoji, source });
 			}
-		} else {
-			reactions.push({ emoji, source });
-		}
-		entry.reactions = reactions;
-		return [...log];
+			return { ...entry, reactions };
+		});
 	});
 }

--- a/crates/parish-persistence/src/snapshot.rs
+++ b/crates/parish-persistence/src/snapshot.rs
@@ -273,14 +273,10 @@ impl GameSnapshot {
         // Set speed by finding the matching preset, or use custom factor
         let factor = self.clock.speed_factor;
         use parish_types::GameSpeed;
-        let speed = [
-            GameSpeed::Slow,
-            GameSpeed::Normal,
-            GameSpeed::Fast,
-            GameSpeed::Fastest,
-        ]
-        .into_iter()
-        .find(|s| (s.factor() - factor).abs() < 0.01);
+        let speed = GameSpeed::ALL
+            .iter()
+            .copied()
+            .find(|s| (s.factor() - factor).abs() < 0.01);
         if let Some(s) = speed {
             clock.set_speed(s);
         }


### PR DESCRIPTION
- #288: F12 debug toggle fetched snapshot when closing instead of
  opening due to checking $debugVisible after the toggle (inverted
  condition). Use get() to capture pre-toggle value explicitly.

- #292: ChatPanel forced scroll-to-bottom on every text log update,
  making it impossible to read earlier messages during NPC streaming.
  Only auto-scroll when user is already near the bottom (<50px).

- #291: addReaction mutated entry objects in-place, bypassing Svelte
  reactivity in keyed {#each} blocks. Use map() with spread to produce
  new entry references for modified messages.

- #278: GameSpeed::Ludicrous was omitted from the hardcoded preset
  array in snapshot restore, causing the named speed to be lost on
  save/load. Use GameSpeed::ALL instead of a handwritten array.

https://claude.ai/code/session_01G7Afwk38T5JnMnEEpH8Nyc