### PR TITLE
fix: resolve #278, #288, #296, #297 — snapshot, debug, and SavePicker bugs

### DIFF
--- a/apps/ui/src/components/SavePicker.svelte
+++ b/apps/ui/src/components/SavePicker.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import { savePickerVisible, saveFiles, currentSaveState } from '../stores/save';
 	import { discoverSaveFiles, loadBranch, saveGame, newSaveFile, newGame, createBranch, getSaveState, getWorldSnapshot, getMap, getNpcsHere } from '$lib/ipc';
 	import { worldState, mapData, npcsHere } from '../stores/game';
@@ -7,6 +8,7 @@
 	let loading = false;
 	let forkingBranchId: number | null = null;
 	let forkName = '';
+	let forkError = '';
 	let showLedgers = false;
 
 	$: activeFile = files.find(f => f.filename === saveState?.filename) ?? files[0] ?? null;
@@ -262,7 +264,7 @@
 			});
 		} catch (e: any) {
 			console.error('Branch creation failed:', e);
-			forkName = String(e).substring(0, 60);
+			forkError = String(e).substring(0, 60);
 		}
 		loading = false;
 	}
@@ -293,6 +295,7 @@
 		if (!parent) return;
 		forkingBranchId = branchId;
 		forkName = generateBranchName(parent, activeFile.branches);
+		forkError = '';
 	}
 
 	function autofocus(node: HTMLInputElement) {
@@ -325,12 +328,14 @@
 	function cancelFork() {
 		forkingBranchId = null;
 		forkName = '';
+		forkError = '';
 	}
 
 	function close() {
 		savePickerVisible.set(false);
 		forkingBranchId = null;
 		forkName = '';
+		forkError = '';
 		showLedgers = false;
 	}
 
@@ -346,13 +351,12 @@
 		}
 	}
 
-	function scrollToCurrentNode() {
-		requestAnimationFrame(() => {
-			const current = document.querySelector('.dag-current');
-			if (current) {
-				current.scrollIntoView({ behavior: 'instant', block: 'center', inline: 'center' });
-			}
-		});
+	async function scrollToCurrentNode() {
+		await tick();
+		const current = document.querySelector('.dag-current');
+		if (current) {
+			current.scrollIntoView({ behavior: 'instant', block: 'center', inline: 'center' });
+		}
 	}
 
 	let prevVisible = false;
@@ -473,8 +477,13 @@
 												bind:value={forkName}
 												use:autofocus
 												on:keydown|stopPropagation={(e) => { if (e.key === 'Enter' && parent) { e.preventDefault(); handleFork(parent); } if (e.key === 'Escape') cancelFork(); }}
+												on:input={() => { forkError = ''; }}
 											/>
-											<span class="node-location">{node.branch.latest_location ?? 'New'}</span>
+											{#if forkError}
+												<span class="fork-error">{forkError}</span>
+											{:else}
+												<span class="node-location">{node.branch.latest_location ?? 'New'}</span>
+											{/if}
 											<div class="phantom-actions">
 												<button class="phantom-btn" on:click|stopPropagation={() => { if (parent) handleFork(parent); }} disabled={loading || !forkName.trim()}>Create</button>
 												<button class="phantom-btn" on:click|stopPropagation={cancelFork}>Cancel</button>
@@ -782,6 +791,15 @@
 	.phantom-name-input:focus {
 		border-color: var(--color-accent);
 		outline: none;
+	}
+
+	.fork-error {
+		font-size: 0.55rem;
+		color: #c44;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: 100%;
 	}
 
 	.phantom-actions {

--- a/crates/parish-persistence/src/snapshot.rs
+++ b/crates/parish-persistence/src/snapshot.rs
@@ -446,6 +446,30 @@ mod tests {
     }
 
     #[test]
+    fn test_game_snapshot_ludicrous_speed_roundtrip() {
+        use parish_types::GameSpeed;
+
+        let mut world = WorldState::new();
+        world.clock.set_speed(GameSpeed::Ludicrous);
+        let npc_manager = NpcManager::new();
+
+        let snapshot = GameSnapshot::capture(&world, &npc_manager);
+        assert!(
+            (snapshot.clock.speed_factor - GameSpeed::Ludicrous.factor()).abs() < 0.01,
+            "captured factor should match Ludicrous"
+        );
+
+        let mut new_world = WorldState::new();
+        let mut new_npcs = NpcManager::new();
+        snapshot.restore(&mut new_world, &mut new_npcs);
+
+        assert!(
+            (new_world.clock.speed_factor() - GameSpeed::Ludicrous.factor()).abs() < 0.01,
+            "restored speed factor should match Ludicrous"
+        );
+    }
+
+    #[test]
     fn test_game_snapshot_preserves_tier2_time() {
         let world = WorldState::new();
         let mut npc_manager = NpcManager::new();


### PR DESCRIPTION
- #278: Use GameSpeed::ALL instead of hardcoded array missing Ludicrous
  in snapshot restore, preventing speed preset loss on save/load.
  Added roundtrip test.
- #288: Fix inverted F12 debug toggle condition — snapshot was fetched
  on close instead of open.
- #296: Show branch creation errors in a separate UI element instead of
  overwriting the forkName input field with the error message.
- #297: Replace requestAnimationFrame with Svelte tick() in
  scrollToCurrentNode for reliable post-render DOM querying.

https://claude.ai/code/session_011aR3PpzonCqTD64YZBsDB1