### PR TITLE
fix: resolve #279 and #281 — text_log cap and new_game conversation reset

### DIFF
--- a/crates/parish-cli/src/testing.rs
+++ b/crates/parish-cli/src/testing.rs
@@ -1376,6 +1376,22 @@ mod tests {
     }
 
     #[test]
+    fn test_text_log_capped() {
+        let mut h = GameTestHarness::new();
+        // Push well over the 500-entry backend cap.
+        for i in 0..600 {
+            h.app.world.log(format!("entry {i}"));
+        }
+        assert!(
+            h.text_log().len() <= 500,
+            "text_log should be capped at 500 but was {}",
+            h.text_log().len()
+        );
+        // The most recent entry should still be present.
+        assert!(h.text_log().last().unwrap().contains("entry 599"));
+    }
+
+    #[test]
     fn test_exits_not_empty() {
         let h = GameTestHarness::new();
         let exits = h.exits();

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -33,7 +33,7 @@ use parish_core::persistence::Database;
 use parish_core::persistence::picker::{SaveFileInfo, discover_saves, new_save_path};
 use parish_core::persistence::snapshot::GameSnapshot;
 
-use crate::state::{AppState, SaveState};
+use crate::state::{AppState, ConversationRuntimeState, SaveState};
 
 /// Monotonically increasing request ID counter for inference requests.
 static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
@@ -1456,14 +1456,20 @@ async fn do_new_game_inner(state: &Arc<AppState>) -> Result<(), String> {
     });
     npc_manager.assign_tiers(&world, &[]);
 
-    // Replace state
+    // Replace state atomically (both locks held together to prevent a window
+    // where a command handler sees the new world with the old NPC manager).
     {
         let mut w = state.world.lock().await;
-        *w = world;
-    }
-    {
         let mut nm = state.npc_manager.lock().await;
+        *w = world;
         *nm = npc_manager;
+    }
+
+    // Reset conversation transcript so stale dialogue from the previous game
+    // does not bleed into NPC conversations in the new game (#281).
+    {
+        let mut conv = state.conversation.lock().await;
+        *conv = ConversationRuntimeState::new();
     }
 
     // Create a new save file

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -29,7 +29,10 @@ use crate::events::{
     EVENT_TRAVEL_START, EVENT_WORLD_UPDATE, NpcReactionPayload, StreamEndPayload,
     StreamTokenPayload, StreamTurnEndPayload, TextLogPayload, spawn_loading_animation,
 };
-use crate::{AppState, MapData, MapLocation, NpcInfo, SaveState, ThemePalette, WorldSnapshot};
+use crate::{
+    AppState, ConversationRuntimeState, MapData, MapLocation, NpcInfo, SaveState, ThemePalette,
+    WorldSnapshot,
+};
 
 /// Monotonically increasing request ID counter for inference requests.
 static REQUEST_ID: AtomicU64 = AtomicU64::new(1);
@@ -1605,6 +1608,13 @@ async fn do_new_game(state: &Arc<AppState>, app: &tauri::AppHandle) -> Result<()
     let mut npc_manager = state.npc_manager.lock().await;
     *world = fresh_world;
     *npc_manager = fresh_npcs;
+
+    // Reset conversation transcript so stale dialogue from the previous game
+    // does not bleed into NPC conversations in the new game (#281).
+    {
+        let mut conv = state.conversation.lock().await;
+        *conv = ConversationRuntimeState::new();
+    }
 
     // Create a new save file with the fresh state
     let sd = saves_dir();

--- a/crates/parish-world/src/lib.rs
+++ b/crates/parish-world/src/lib.rs
@@ -29,6 +29,10 @@ use parish_types::{ConversationLog, EventBus, GameClock, GossipNetwork, ParishEr
 use graph::{LocationData, WorldGraph};
 use weather::WeatherEngine;
 
+/// Maximum number of entries kept in the backend text log, matching the
+/// frontend cap (`MAX_TEXT_LOG_SIZE` in `apps/ui/src/stores/game.ts`).
+const MAX_TEXT_LOG: usize = 500;
+
 /// Central game state container.
 ///
 /// Holds the game clock, player position, the world graph, weather,
@@ -256,9 +260,14 @@ impl WorldState {
         self.graph.get(self.player_location)
     }
 
-    /// Appends a line to the text log.
+    /// Appends a line to the text log, evicting the oldest entries when the
+    /// log exceeds [`MAX_TEXT_LOG`].
     pub fn log(&mut self, text: String) {
         self.text_log.push(text);
+        if self.text_log.len() > MAX_TEXT_LOG {
+            let excess = self.text_log.len() - MAX_TEXT_LOG;
+            self.text_log.drain(..excess);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes two related game state correctness bugs:

- **#279**: `WorldState::text_log` grew without bound — every movement narration, NPC reaction, and system message was appended with no cap. The entire log was serialized into every `GameSnapshot`, making saves progressively larger over long sessions. Now capped at 500 entries (matching the frontend `MAX_TEXT_LOG_SIZE`), evicting oldest entries on overflow.

- **#281**: `do_new_game_inner` (server) and `do_new_game` (Tauri) replaced `world` and `npc_manager` but never reset `ConversationRuntimeState`. Stale dialogue context from the previous game bled into NPC conversations in the new game. Both entry points now reset conversation state. The server version also merges the world/npc_manager lock scopes to eliminate a brief inconsistency window.

## Changes

| File | Change |
|------|--------|
| `crates/parish-world/src/lib.rs` | Add `MAX_TEXT_LOG` constant (500); update `log()` to evict oldest entries at cap |
| `crates/parish-server/src/routes.rs` | Merge lock scopes in `do_new_game_inner`; reset `ConversationRuntimeState` |
| `crates/parish-tauri/src/commands.rs` | Reset `ConversationRuntimeState` in `do_new_game` (mode parity) |
| `crates/parish-cli/src/testing.rs` | Add `test_text_log_capped` regression test |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — no new warnings (Tauri crate skipped due to missing GTK libs in CI)
- [x] `cargo test --workspace --exclude parish-tauri` — all tests pass (1 pre-existing failure in `handle_npc_conversation_preserves_order_and_follow_up_context` unrelated to this PR)
- [x] New `test_text_log_capped` verifies the 500-entry cap and that the most recent entry is retained

https://claude.ai/code/session_01AKchJTM7CZFj64nzL5Ju41