### PR TITLE
⚡ Bolt: single-pass home/work scan in known_roster

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2026-03-28 - Pre-existing test breakage in inference module
 **Learning:** The `max_tokens` parameter was added to `build_request()` and `InferenceQueue::send()` signatures but several tests weren't updated. This means test-only compilation failures can lurk undetected if `cargo test` isn't run regularly after API changes.
 **Action:** When modifying function signatures, always grep for all call sites including test modules.
+
+## 2026-04-14 - Recurring multi-pass HashMap scan anti-pattern in parish-npc
+**Learning:** `known_roster` in `manager.rs` repeated the double-scan anti-pattern — separate `for other in self.npcs.values()` loops for home and workplace co-residency. Same shape as the earlier fuzzy-search fix in `graph.rs`. When multiple optional filters apply to the same collection, consolidating into one pass with per-NPC conjunction checks is both faster and clearer.
+**Action:** When reviewing lookup/query methods against `NpcManager`/`WorldState` that iterate `.values()`, check whether nearby code iterates the same map again — if so, fold into a single pass.

--- a/crates/parish-npc/src/manager.rs
+++ b/crates/parish-npc/src/manager.rs
@@ -303,17 +303,26 @@ impl NpcManager {
             }
         }
 
-        // 4. NPCs at the same home or workplace location
-        if let Some(home) = npc.home {
+        // 4. NPCs at the same home or workplace location.
+        //
+        // Perf: single pass over `self.npcs` instead of two separate scans.
+        // Called once per NPC dialogue setup (see ipc/handlers.rs::build_enhanced_system_prompt),
+        // which is a hot path during conversations. For N NPCs this halves the
+        // HashMap traversals from 2N to N per call.
+        if npc.home.is_some() || npc.workplace.is_some() {
             for other in self.npcs.values() {
-                if other.id != npc.id && (other.home == Some(home) || other.location == home) {
-                    known_ids.insert(other.id);
+                if other.id == npc.id {
+                    continue;
                 }
-            }
-        }
-        if let Some(work) = npc.workplace {
-            for other in self.npcs.values() {
-                if other.id != npc.id && (other.workplace == Some(work) || other.location == work) {
+                let home_match = match npc.home {
+                    Some(home) => other.home == Some(home) || other.location == home,
+                    None => false,
+                };
+                let work_match = match npc.workplace {
+                    Some(work) => other.workplace == Some(work) || other.location == work,
+                    None => false,
+                };
+                if home_match || work_match {
                     known_ids.insert(other.id);
                 }
             }
@@ -1466,6 +1475,73 @@ mod tests {
         let found = mgr.find_by_name("an older man behind the bar", LocationId(2));
         assert!(found.is_some());
         assert_eq!(found.unwrap().id, NpcId(1));
+    }
+
+    #[test]
+    fn test_known_roster_unions_home_and_work_matches() {
+        // Regression test for the single-pass optimization in `known_roster`.
+        // Ensures NPCs sharing either home or workplace are included, dedup'd.
+        let mut mgr = NpcManager::new();
+
+        // Subject NPC: home=10, work=20.
+        let mut subject = make_test_npc(1, 10);
+        subject.home = Some(LocationId(10));
+        subject.workplace = Some(LocationId(20));
+        mgr.add_npc(subject.clone());
+
+        // NPC 2: shares home only (home=10, work=30).
+        let mut home_mate = make_test_npc(2, 30);
+        home_mate.home = Some(LocationId(10));
+        home_mate.workplace = Some(LocationId(30));
+        mgr.add_npc(home_mate);
+
+        // NPC 3: shares workplace only (home=40, work=20).
+        let mut work_mate = make_test_npc(3, 20);
+        work_mate.home = Some(LocationId(40));
+        work_mate.workplace = Some(LocationId(20));
+        mgr.add_npc(work_mate);
+
+        // NPC 4: currently located at subject's home (co-presence) but no home/work ties.
+        let mut visitor = make_test_npc(4, 10);
+        visitor.home = Some(LocationId(50));
+        visitor.workplace = None;
+        mgr.add_npc(visitor);
+
+        // NPC 5: shares both home and work (should appear once, not twice).
+        let mut both = make_test_npc(5, 10);
+        both.home = Some(LocationId(10));
+        both.workplace = Some(LocationId(20));
+        mgr.add_npc(both);
+
+        // NPC 6: unrelated — different home and work.
+        let mut stranger = make_test_npc(6, 99);
+        stranger.home = Some(LocationId(99));
+        stranger.workplace = Some(LocationId(98));
+        mgr.add_npc(stranger);
+
+        let roster = mgr.known_roster(&subject);
+        let ids: HashSet<NpcId> = roster.iter().map(|(id, _, _)| *id).collect();
+
+        assert!(ids.contains(&NpcId(2)), "home-mate should be in roster");
+        assert!(ids.contains(&NpcId(3)), "work-mate should be in roster");
+        assert!(
+            ids.contains(&NpcId(4)),
+            "NPC located at subject's home should be in roster"
+        );
+        assert!(
+            ids.contains(&NpcId(5)),
+            "NPC sharing both home and work should be in roster"
+        );
+        assert!(
+            !ids.contains(&NpcId(6)),
+            "unrelated NPC must not be in roster"
+        );
+        assert!(
+            !ids.contains(&NpcId(1)),
+            "subject must not be in its own roster"
+        );
+        // Dedup: each id appears exactly once.
+        assert_eq!(ids.len(), roster.len());
     }
 
     #[test]


### PR DESCRIPTION
## 💡 What

Consolidate the two independent `for other in self.npcs.values()` loops in `NpcManager::known_roster` (`crates/parish-npc/src/manager.rs`) into a single pass that checks both home and workplace co-residency per NPC.

## 🎯 Why

`known_roster` runs on every NPC dialogue setup — it's called from `ipc/handlers.rs:547` to build the "PEOPLE YOU KNOW" section of each NPC's system prompt. The previous implementation scanned the entire NPC HashMap **twice**:

```rust
if let Some(home) = npc.home {
    for other in self.npcs.values() { /* home check */ }
}
if let Some(work) = npc.workplace {
    for other in self.npcs.values() { /* work check */ }
}
```

This is the same multi-pass anti-pattern that was previously fixed in `graph.rs::find_by_name_with_config` (see PR #249).

## 📊 Impact

- **Halves HashMap traversals** in `known_roster` from `2N` to `N` per call, where `N = npc_count()`.
- With a typical parish of ~40 NPCs and an NPC dialogue on every conversational turn, this eliminates ~40 redundant NPC iterations per turn.
- Also short-circuits the scan entirely when both `npc.home` and `npc.workplace` are `None`.
- Zero allocation change — same `Vec<(NpcId, String, String)>` returned.

## 🔬 Measurement

- **Unit test:** Added `test_known_roster_unions_home_and_work_matches` in `manager.rs` covering:
  - home-only match
  - work-only match
  - co-location match (NPC present at subject's home)
  - NPC sharing both home and work (dedup check)
  - unrelated NPC (exclusion check)
  - subject excluded from own roster
- **Full suite:** `cargo test -p parish-npc --lib` → 308 passed
- **Dependents:** `cargo test -p parish-core --lib` → 122 passed
- **Build:** `cargo build --workspace --exclude parish-tauri` clean
- To confirm the win, profile an NPC-dense scene with many concurrent dialogues — the `known_roster` frame in a flamegraph should approximately halve.

## Risk

Very low. Behavior-equivalent refactor: produces the exact same `known_ids` set for all inputs, dedup semantics preserved via `HashSet`.
