### PR TITLE
⚡ Bolt: iterate fog-of-war sets directly in build_map_data

### DIFF
--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -95,12 +95,15 @@ pub fn build_map_data(world: &WorldState, transport: &TransportMode) -> MapData 
         }
     }
 
-    // Build visited locations (fully enriched)
-    let mut locations: Vec<MapLocation> = world
-        .graph
-        .location_ids()
-        .into_iter()
-        .filter(|id| visited.contains(id))
+    // Build visited locations (fully enriched).
+    //
+    // Perf: iterate `visited` directly instead of fetching every id in the
+    // graph and filtering. Under fog-of-war the visited set is usually far
+    // smaller than the full graph, so this skips a `Vec<LocationId>`
+    // allocation and |graph| - |visited| filter rejections per call.
+    let mut locations: Vec<MapLocation> = visited
+        .iter()
+        .copied()
         .filter_map(|id| world.graph.get(id).map(|data| (id, data)))
         .map(|(id, data)| {
             let travel_minutes = if id == player_loc {
@@ -143,13 +146,15 @@ pub fn build_map_data(world: &WorldState, transport: &TransportMode) -> MapData 
         }
     }
 
-    // Edges: between any two locations that are both visible (visited or frontier)
+    // Edges: between any two locations that are both visible (visited or frontier).
+    //
+    // Perf: iterate `visible` directly rather than scanning every location in
+    // the graph. This avoids an extra `Vec<LocationId>` allocation and drops
+    // the per-iteration `visible.contains(&loc_id)` rejection check — only
+    // the inner `visible.contains(&neighbor_id)` guard is still required.
     let visible: HashSet<LocationId> = visited.union(&frontier).copied().collect();
     let mut edges: Vec<(String, String)> = Vec::new();
-    for loc_id in world.graph.location_ids() {
-        if !visible.contains(&loc_id) {
-            continue;
-        }
+    for &loc_id in &visible {
         for (neighbor_id, _conn) in world.graph.neighbors(loc_id) {
             if loc_id.0 < neighbor_id.0 && visible.contains(&neighbor_id) {
                 edges.push((loc_id.0.to_string(), neighbor_id.0.to_string()));


### PR DESCRIPTION
## 💡 What
Rewrote the two "scan full graph, filter by set" loops in `build_map_data` (`crates/parish-core/src/ipc/handlers.rs`) to iterate the already-small fog-of-war sets directly.

```diff
- let mut locations: Vec<MapLocation> = world
-     .graph
-     .location_ids()
-     .into_iter()
-     .filter(|id| visited.contains(id))
+ let mut locations: Vec<MapLocation> = visited
+     .iter()
+     .copied()
      .filter_map(|id| world.graph.get(id).map(|data| (id, data)))

- for loc_id in world.graph.location_ids() {
-     if !visible.contains(&loc_id) {
-         continue;
-     }
+ for &loc_id in &visible {
      for (neighbor_id, _conn) in world.graph.neighbors(loc_id) {
```

## 🎯 Why
`world.graph.location_ids()` allocates a fresh `Vec<LocationId>` of **every** location in the graph on each call. `build_map_data` called it twice per map refresh, then immediately filtered the result down to the (usually much smaller) visited/visible subset. That full-graph pass is pure overhead under fog-of-war — by definition the rendered map is a subset of everything.

## 📊 Impact
Per map refresh (runs on every snapshot/IPC update during gameplay):

- **Eliminates 2 `Vec<LocationId>` allocations** sized `|graph|`.
- **Visited loop:** iteration shrinks from `O(|graph|)` to `O(|visited|)` and drops `|graph| - |visited|` filter rejections.
- **Edge loop:** iteration shrinks from `O(|graph|)` to `O(|visible|)` and drops the per-iteration `visible.contains(&loc_id)` check.

Rundale currently ships 22 locations; most of a session only a handful are visible, so the outer loops do roughly **4–8× less work** per refresh. Savings scale linearly with world size — larger mods (and the frequently-called web/Tauri map-polling path) benefit most.

Neither set change affects determinism: graph storage is already a `HashMap` (nondeterministic iteration order), and edge dedup is handled by the `loc_id.0 < neighbor_id.0` guard.

## 🔬 Measurement
- `cargo test -p parish-core --lib` → **122 passed**
- `cargo test -p parish --test game_harness_integration` → **29 passed**, including `test_fog_of_war_frontier_at_pub` which directly exercises `build_map_data`
- `cargo clippy -p parish-core --lib -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean

(Pre-existing clippy warnings in `parish-types` tests and a pre-existing failure in `parish-server::routes::tests::handle_npc_conversation_preserves_order_and_follow_up_context` are unrelated — both reproduce on `main` at the same SHA.)

To benchmark in isolation: the `test_fog_of_war_frontier_at_pub` harness or a criterion benchmark stepping through several movements and calling `build_map_data` would show reduced allocation count (measure via `cargo run --release --bin ... -- --profile` or `valgrind --tool=dhat`).

https://claude.ai/code/session_017h2TkQveip117QqLQ8XtCe