### PR TITLE
feat: add witness-style verification workflow

### DIFF
--- a/.agent/witness-log.md
+++ b/.agent/witness-log.md
@@ -1,0 +1,13 @@
+# Witness Log
+
+Append-only log for AI-task verification outcomes.
+
+## Template
+
+- Date (UTC): YYYY-MM-DD
+- Commit: <sha>
+- Oath: `.agent/oaths/<task-id>.md`
+- Result: PASS | FAIL
+- Checks run:
+  - `<command>`
+- Notes: <missing items or confidence notes>

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -9,6 +9,7 @@ Quick reference for AI agents (Claude Code, Codex, etc.) and human contributors 
 | Code style & dependencies | [code-style.md](code-style.md) |
 | Tokio / SQLite / Ollama gotchas | [gotchas.md](gotchas.md) |
 | Git workflow & engineering standards | [git-workflow.md](git-workflow.md) |
+| Witness-style completion gates | [witness.md](witness.md) |
 | Claude Code skills (`/check`, `/prove`, ...) | [skills.md](skills.md) |
 
 The root `CLAUDE.md` and `AGENTS.md` are slim indexes — start there if you're new, then come here for the details.

--- a/docs/agent/witness.md
+++ b/docs/agent/witness.md
@@ -1,0 +1,86 @@
+# Witness-style Completion Gates for Parish
+
+This document translates TEMM1E's "Oath / Witness / Ledger" model into a lightweight, repo-native workflow for Parish.
+
+## Why we need this
+
+Large AI-assisted refactors can report "done" while silently leaving placeholders, unwired code paths, or partial edits. In Parish, this risk is highest for umbrella tasks that touch multiple crates (`parish-core`, `parish-server`, UI, etc.).
+
+## Parish adaptation of the Five Laws
+
+### 1) Pre-commitment (`Oath`)
+
+Before running a coding agent, create a task contract in `.agent/oaths/<task-id>.md` with:
+
+- **Scope**: exact files/modules expected to change.
+- **Deterministic checks (Tier 0)**: commands that must pass.
+- **Semantic checks (Tier 1/Tier 2)**: human or LLM review prompts focused on behavior.
+- **Failure message template**: exact wording for partial completion.
+
+Use this template:
+
+```md
+# Oath: <task-id>
+
+## Scope
+- crates/parish-core/src/...
+- crates/parish-server/src/...
+
+## Postconditions (Tier 0)
+- [ ] `just witness-scan`
+- [ ] `cargo test -p parish-core <targeted-test>`
+- [ ] `rg -n "<new_symbol>" <expected_callsite_file>` returns >= 1 match
+
+## Postconditions (Tier 1)
+- [ ] Reviewer confirms new function is wired from caller -> callee.
+- [ ] Reviewer confirms no fallback/placeholder branch handles primary flow.
+
+## Honest failure text
+"Partial completion: <x>/<y> checks passed. Missing: <...>."
+```
+
+### 2) Independent verdict (`Witness`)
+
+The verifier must not rely on the agent summary. For now:
+
+- Run Tier 0 checks from shell (`just witness-scan` + targeted tests).
+- Review only changed files + test outputs.
+- If any check fails, report partial completion explicitly.
+
+### 3) Immutable-ish history (`Ledger`)
+
+Parish does not currently use a hash-chained DB ledger. Until then, use a commit-linked log:
+
+- Store Oaths in `.agent/oaths/`.
+- Append verification outcomes in `.agent/witness-log.md` with commit SHA.
+- Never edit old entries; add new entries only.
+
+(If needed later, we can implement a SQLite hash chain crate in `crates/parish-core` or a dedicated crate.)
+
+### 4) Loud failure
+
+Do not end an AI task with "done" unless every Tier 0 check passes.
+
+Use this format:
+
+- `PASS`: `Witness: 6/6 PASS` + command list.
+- `FAIL`: `Partial completion: 4/6 checks passed` + unmet checks.
+
+### 5) Narrative-only fail
+
+Verification should not auto-revert or auto-delete files. Keep verification read-only and report-only.
+
+## Minimum gate for every AI-generated refactor
+
+1. Draft Oath file.
+2. Implement changes.
+3. Run `just witness-scan`.
+4. Run targeted tests for touched crates.
+5. Record outcome in `.agent/witness-log.md`.
+6. Only then mark task complete.
+
+## Future hardening roadmap
+
+- Add a Rust CLI (`parish-witness`) for structured Oath JSON + deterministic predicates.
+- Add CI job that fails PRs if Oath is missing for large multi-file AI changes.
+- Add append-only signed attestations (Sigstore/Git note or SQLite hash-chain).

--- a/justfile
+++ b/justfile
@@ -203,6 +203,32 @@ check: fmt-check clippy test
 # Pre-push gate: check + game harness walkthrough
 verify: fmt-check clippy test game-test
 
+# Witness-style deterministic scan for common AI partial-completion markers
+witness-scan:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mapfile -t files < <(git status --porcelain | awk '{print $2}' | sed 's/^"//; s/"$//' | rg '^(crates|apps|docs|testing|mods)/')
+
+    if [ "${#files[@]}" -eq 0 ]; then
+      echo "No changed tracked files under crates/apps/docs/testing/mods; skipping scan."
+      exit 0
+    fi
+
+    echo "Scanning ${#files[@]} changed file(s) for placeholder markers..."
+    if rg -n \
+      -e '// unchanged' \
+      -e '// existing' \
+      -e '// ... rest of the function' \
+      -e 'pass\\s*#\\s*TODO' \
+      -e 'Not implemented' \
+      -e 'return nil\\s*//\\s*placeholder' \
+      "${files[@]}"; then
+      echo "Witness scan failed: placeholder-like markers found in changed files."
+      exit 1
+    fi
+
+    echo "Witness scan passed."
+
 # ─── Geo Tool ────────────────────────────────────────────────────────────────
 
 # Run the geo-tool to extract OSM data for an area


### PR DESCRIPTION
### Motivation
- Large AI-assisted refactors can silently leave TODOs, placeholders, or unwired code while the agent reports "done", so a lightweight independent-verification flow is needed. 
- Translate the TEMM1E "Oath / Witness / Ledger" Five Laws into a practical, repo-native workflow that enforces pre-committed postconditions and loud failure reporting. 
- Provide a fast, deterministic Tier-0 guardrail that is cheap to run and easy to adopt for multi-file AI changes.

### Description
- Add `docs/agent/witness.md` which documents the adapted Five Laws, an Oath template, minimum gate steps, and a future hardening roadmap. 
- Create repository artifacts for the workflow: `.agent/oaths/.gitkeep` (Oath placement) and `.agent/witness-log.md` (append-only verification log template). 
- Link the new guidance from `docs/agent/README.md` so contributors can find the witness playbook. 
- Add a `witness-scan` recipe to the `justfile` that scopes to changed files (via `git status`), runs `rg` against those files for common placeholder/partial-completion markers (e.g. `// unchanged`, `Not implemented`, `pass # TODO`, `return nil // placeholder`), and fails if any are found.

### Testing
- Attempted to run `just witness-scan` in this environment but `just` is not installed, so the recipe could not be executed here (failed). 
- Executed a manual equivalent script (`/tmp/witness_check.sh`) that implements the same `witness-scan` logic; it scanned the changed files and returned `Witness scan passed.` (success). 
- Full workspace verification (`just check` / `just verify`, `cargo test`, etc.) was not executed in this environment and should be run in CI or locally as a follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de79ea86208325b0c214ae855366af)