### PR TITLE
test: expand unit test coverage across parish-core, parish-types, parish-world

### DIFF
--- a/crates/parish-core/src/game_session.rs
+++ b/crates/parish-core/src/game_session.rs
@@ -764,4 +764,134 @@ mod tests {
             "NPC at the player's location must be promoted to Tier 1"
         );
     }
+
+    // ── Additional coverage ──────────────────────────────────────────────────
+
+    #[test]
+    fn reaction_req_id_monotonic() {
+        let first = reaction_req_id_peek();
+        // The counter starts at 100_000 and only grows; any subsequent read
+        // must be >= the first read.
+        let second = reaction_req_id_peek();
+        assert!(second >= first);
+        assert!(first >= 100_000);
+    }
+
+    #[test]
+    fn apply_movement_not_found_log_contains_exits() {
+        let Some((mut world, mut mgr, templates, transport)) = setup() else {
+            return;
+        };
+        let effects = apply_movement(
+            &mut world,
+            &mut mgr,
+            &templates,
+            "definitely-not-a-place-0xdeadbeef",
+            &transport,
+        );
+        // The not-found message should also have been logged to world.log.
+        assert!(
+            world
+                .text_log
+                .iter()
+                .any(|line| line.contains("faintest notion")),
+            "not-found message must be appended to text_log"
+        );
+        // Effects carry the same message.
+        assert_eq!(effects.messages.len(), 1);
+        assert!(!effects.world_changed);
+    }
+
+    #[test]
+    fn apply_movement_records_edge_traversal_and_visit() {
+        let Some((mut world, mut mgr, templates, transport)) = setup() else {
+            return;
+        };
+        let start = world.player_location;
+        let neighbor = world.graph.neighbors(start).into_iter().next();
+        let Some((neighbor_id, _)) = neighbor else {
+            return;
+        };
+        let neighbor_name = world
+            .graph
+            .get(neighbor_id)
+            .map(|d| d.name.clone())
+            .unwrap_or_default();
+
+        assert!(!world.visited_locations.contains(&neighbor_id));
+        let clock_before = world.clock.now();
+
+        let effects = apply_movement(&mut world, &mut mgr, &templates, &neighbor_name, &transport);
+
+        // World mutations: visited, clock advanced, edge traversal recorded.
+        assert!(effects.world_changed);
+        assert!(world.visited_locations.contains(&neighbor_id));
+        assert!(world.clock.now() > clock_before);
+
+        // Edge traversal is canonical (min, max).
+        let key = if start < neighbor_id {
+            (start, neighbor_id)
+        } else {
+            (neighbor_id, start)
+        };
+        assert_eq!(world.edge_traversals.get(&key).copied(), Some(1));
+    }
+
+    #[test]
+    fn apply_movement_already_here_explicit() {
+        let Some((mut world, mut mgr, templates, transport)) = setup() else {
+            return;
+        };
+        let exact_name = world.current_location().name.clone();
+        let start = world.player_location;
+        let text_log_before = world.text_log.len();
+
+        let effects = apply_movement(&mut world, &mut mgr, &templates, &exact_name, &transport);
+
+        // Player location should not change, but the harness currently resolves the
+        // *same* name via fuzzy match to the same location — accept either the
+        // `AlreadyHere` short-circuit or the `Arrived`-to-self pipeline.
+        assert_eq!(world.player_location, start);
+        // Either way, at least one line is appended to the log.
+        assert!(world.text_log.len() > text_log_before);
+        // And at least one user-visible message is emitted.
+        assert!(!effects.messages.is_empty());
+    }
+
+    #[test]
+    fn apply_arrival_reactions_returns_empty_when_no_location_data() {
+        // WorldState::new() has a legacy `locations` map but no graph data for
+        // the current location — the fast-path should return an empty vec.
+        let mut world = WorldState::new();
+        let mut mgr = NpcManager::new();
+        let templates = ReactionTemplates::default();
+        let config = ReactionConfig::default();
+        let reactions = apply_arrival_reactions(&mut world, &mut mgr, &templates, &config);
+        assert!(reactions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn stream_reaction_texts_empty_list_emits_nothing() {
+        let mut log_sources: Vec<String> = Vec::new();
+        let mut token_chunks: Vec<String> = Vec::new();
+
+        stream_reaction_texts(
+            &[],
+            &[],
+            LocationId(0),
+            "Galway",
+            crate::world::time::TimeOfDay::Morning,
+            "clear",
+            &std::collections::HashSet::new(),
+            None,
+            "",
+            None,
+            |_turn_id, name| log_sources.push(name.to_string()),
+            |_turn_id, _source, tok| token_chunks.push(tok.to_string()),
+        )
+        .await;
+
+        assert!(log_sources.is_empty());
+        assert!(token_chunks.is_empty());
+    }
 }

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -641,4 +641,559 @@ mod tests {
         let text = render_look_text(&world, &npc, 1.25, "on foot", true);
         assert!(!text.is_empty());
     }
+
+    // ── Additional coverage for previously untested Command variants ─────────
+
+    #[test]
+    fn about_command_returns_game_blurb() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::About, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("Parish"));
+        assert!(result.response.contains("/help"));
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn help_command_lists_commands() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Help, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("/help"));
+        assert!(result.response.contains("/save"));
+        assert!(result.response.contains("/pause"));
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn wait_command_advances_clock() {
+        let (mut world, mut npc, mut config) = default_state();
+        let start = world.clock.now();
+        let result = handle_command(Command::Wait(30), &mut world, &mut npc, &mut config);
+        let end = world.clock.now();
+        let delta = (end - start).num_minutes();
+        assert_eq!(delta, 30);
+        assert!(result.response.contains("30 minutes"));
+    }
+
+    #[test]
+    fn tick_command_with_empty_roster() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Tick, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("No NPC activity"));
+    }
+
+    #[test]
+    fn show_speed_reports_current_speed() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::ShowSpeed, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("Speed:"));
+    }
+
+    #[test]
+    fn set_speed_updates_clock() {
+        use parish_types::time::GameSpeed;
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::SetSpeed(GameSpeed::Fast),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        // Activation message should be non-empty; speed should be Fast.
+        assert!(!result.response.is_empty());
+        assert_eq!(world.clock.current_speed(), Some(GameSpeed::Fast));
+    }
+
+    #[test]
+    fn invalid_speed_reports_hint() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::InvalidSpeed("warp".to_string()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("warp"));
+        assert!(result.response.contains("slow"));
+    }
+
+    #[test]
+    fn invalid_branch_name_returns_msg() {
+        let (mut world, mut npc, mut config) = default_state();
+        let msg = "Branch name too long.".to_string();
+        let result = handle_command(
+            Command::InvalidBranchName(msg.clone()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert_eq!(result.response, msg);
+    }
+
+    #[test]
+    fn invalid_flag_name_returns_msg() {
+        let (mut world, mut npc, mut config) = default_state();
+        let msg = "Flag name cannot be empty.".to_string();
+        let result = handle_command(
+            Command::InvalidFlagName(msg.clone()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert_eq!(result.response, msg);
+    }
+
+    #[test]
+    fn toggle_sidebar_returns_message() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::ToggleSidebar, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("sidebar"));
+    }
+
+    #[test]
+    fn set_model_updates_config() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::SetModel("qwen3:14b".to_string()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert_eq!(config.model_name, "qwen3:14b");
+        assert!(result.response.contains("qwen3:14b"));
+    }
+
+    #[test]
+    fn show_key_not_set() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::ShowKey, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("not set"));
+    }
+
+    #[test]
+    fn show_key_masks_when_set() {
+        let (mut world, mut npc, mut config) = default_state();
+        config.api_key = Some("sk-abcdefghijklmnop".to_string());
+        let result = handle_command(Command::ShowKey, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("API key"));
+        // Full key must not leak.
+        assert!(!result.response.contains("abcdefghijklmnop"));
+    }
+
+    #[test]
+    fn show_provider_reflects_config() {
+        let (mut world, mut npc, mut config) = default_state();
+        config.provider_name = "lmstudio".to_string();
+        let result = handle_command(Command::ShowProvider, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("lmstudio"));
+    }
+
+    #[test]
+    fn set_provider_invalid_returns_error() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::SetProvider("bogus".to_string()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        // Invalid provider should not trigger a rebuild.
+        assert!(!result.effects.contains(&CommandEffect::RebuildInference));
+    }
+
+    // ── Cloud provider commands ──────────────────────────────────────────────
+
+    #[test]
+    fn show_cloud_not_configured() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::ShowCloud, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("No cloud provider"));
+    }
+
+    #[test]
+    fn show_cloud_configured() {
+        let (mut world, mut npc, mut config) = default_state();
+        config.cloud_provider_name = Some("openrouter".to_string());
+        config.cloud_model_name = Some("anthropic/claude-3-haiku".to_string());
+        let result = handle_command(Command::ShowCloud, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("openrouter"));
+        assert!(result.response.contains("claude-3-haiku"));
+    }
+
+    #[test]
+    fn set_cloud_provider_triggers_rebuild() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::SetCloudProvider("openrouter".to_string()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("openrouter"));
+        assert!(result.effects.contains(&CommandEffect::RebuildCloudClient));
+        assert_eq!(config.cloud_provider_name.as_deref(), Some("openrouter"));
+    }
+
+    #[test]
+    fn set_cloud_model_updates_config() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::SetCloudModel("gpt-4o".to_string()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert_eq!(config.cloud_model_name.as_deref(), Some("gpt-4o"));
+        assert!(result.response.contains("gpt-4o"));
+    }
+
+    #[test]
+    fn set_cloud_key_triggers_cloud_rebuild() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::SetCloudKey("sk-cloud-secret".to_string()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.contains(&CommandEffect::RebuildCloudClient));
+        assert_eq!(config.cloud_api_key.as_deref(), Some("sk-cloud-secret"));
+    }
+
+    #[test]
+    fn show_cloud_model_not_set() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::ShowCloudModel, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("not set"));
+    }
+
+    #[test]
+    fn show_cloud_key_masks_when_set() {
+        let (mut world, mut npc, mut config) = default_state();
+        config.cloud_api_key = Some("sk-cloudabcd1234".to_string());
+        let result = handle_command(Command::ShowCloudKey, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("Cloud API key"));
+        assert!(!result.response.contains("cloudabcd1234"));
+    }
+
+    // ── Category-specific commands ───────────────────────────────────────────
+
+    #[test]
+    fn set_category_provider_stores_and_triggers_rebuild() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::SetCategoryProvider(InferenceCategory::Dialogue, "openrouter".to_string()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.contains(&CommandEffect::RebuildInference));
+        let idx = GameConfig::cat_idx(InferenceCategory::Dialogue);
+        assert_eq!(config.category_provider[idx].as_deref(), Some("openrouter"));
+    }
+
+    #[test]
+    fn set_category_model_stores_override() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::SetCategoryModel(InferenceCategory::Simulation, "mini-model".to_string()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        let idx = GameConfig::cat_idx(InferenceCategory::Simulation);
+        assert_eq!(config.category_model[idx].as_deref(), Some("mini-model"));
+        assert!(result.response.contains("mini-model"));
+    }
+
+    #[test]
+    fn show_category_model_inherits_base() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::ShowCategoryModel(InferenceCategory::Intent),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("inherits base"));
+    }
+
+    #[test]
+    fn show_category_key_not_set() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::ShowCategoryKey(InferenceCategory::Reaction),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("not set"));
+    }
+
+    #[test]
+    fn set_category_key_triggers_rebuild() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::SetCategoryKey(InferenceCategory::Dialogue, "sk-cat-key".to_string()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.contains(&CommandEffect::RebuildInference));
+        let idx = GameConfig::cat_idx(InferenceCategory::Dialogue);
+        assert_eq!(config.category_api_key[idx].as_deref(), Some("sk-cat-key"));
+    }
+
+    // ── Feature flags ────────────────────────────────────────────────────────
+
+    #[test]
+    fn flag_list_empty() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Flag(FlagSubcommand::List),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        // Either empty-state message or flag header — depends on default flags.
+        assert!(
+            result.response.contains("No feature flags")
+                || result.response.contains("Feature flags")
+        );
+    }
+
+    #[test]
+    fn flag_enable_triggers_save() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Flag(FlagSubcommand::Enable("my-feature".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.contains(&CommandEffect::SaveFlags));
+        assert!(result.response.contains("my-feature"));
+        assert!(result.response.contains("enabled"));
+    }
+
+    #[test]
+    fn flag_disable_triggers_save() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Flag(FlagSubcommand::Disable("my-feature".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.contains(&CommandEffect::SaveFlags));
+        assert!(result.response.contains("disabled"));
+    }
+
+    #[test]
+    fn flags_alias_matches_list() {
+        let (mut world, mut npc, mut config) = default_state();
+        let flags_result = handle_command(Command::Flags, &mut world, &mut npc, &mut config);
+        let list_result = handle_command(
+            Command::Flag(FlagSubcommand::List),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert_eq!(flags_result.response, list_result.response);
+    }
+
+    // ── Effect-only commands ─────────────────────────────────────────────────
+
+    #[test]
+    fn save_returns_save_effect() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Save, &mut world, &mut npc, &mut config);
+        assert!(result.response.is_empty());
+        assert!(result.effects.contains(&CommandEffect::SaveGame));
+    }
+
+    #[test]
+    fn fork_returns_fork_effect() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Fork("experiment".to_string()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(
+            result
+                .effects
+                .contains(&CommandEffect::ForkBranch("experiment".to_string()))
+        );
+    }
+
+    #[test]
+    fn load_returns_load_effect() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Load("main".to_string()),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(
+            result
+                .effects
+                .contains(&CommandEffect::LoadBranch("main".to_string()))
+        );
+    }
+
+    #[test]
+    fn branches_returns_list_effect() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Branches, &mut world, &mut npc, &mut config);
+        assert!(result.effects.contains(&CommandEffect::ListBranches));
+    }
+
+    #[test]
+    fn log_returns_show_log_effect() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Log, &mut world, &mut npc, &mut config);
+        assert!(result.effects.contains(&CommandEffect::ShowLog));
+    }
+
+    #[test]
+    fn map_returns_toggle_effect() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Map, &mut world, &mut npc, &mut config);
+        assert!(result.effects.contains(&CommandEffect::ToggleMap));
+    }
+
+    #[test]
+    fn new_game_returns_effect() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::NewGame, &mut world, &mut npc, &mut config);
+        assert!(result.effects.contains(&CommandEffect::NewGame));
+    }
+
+    #[test]
+    fn spinner_returns_effect_with_seconds() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Spinner(5), &mut world, &mut npc, &mut config);
+        assert!(result.effects.contains(&CommandEffect::ShowSpinner(5)));
+    }
+
+    #[test]
+    fn debug_returns_effect_with_subcommand() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Debug(Some("schedule".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(
+            result
+                .effects
+                .contains(&CommandEffect::Debug(Some("schedule".to_string())))
+        );
+    }
+
+    #[test]
+    fn debug_no_subcommand() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Debug(None), &mut world, &mut npc, &mut config);
+        assert!(result.effects.contains(&CommandEffect::Debug(None)));
+    }
+
+    // ── Theme ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn theme_no_arg_lists_available() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Theme(None), &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("default"));
+        assert!(result.response.contains("solarized"));
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn theme_default_applies_default() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Theme(Some("default".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.iter().any(|e| matches!(
+            e,
+            CommandEffect::ApplyTheme(name, _) if name == "default"
+        )));
+    }
+
+    #[test]
+    fn theme_solarized_defaults_to_auto() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Theme(Some("solarized".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.iter().any(|e| matches!(
+            e,
+            CommandEffect::ApplyTheme(name, mode) if name == "solarized" && mode == "auto"
+        )));
+    }
+
+    #[test]
+    fn theme_solarized_with_explicit_mode() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Theme(Some("solarized dark".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.iter().any(|e| matches!(
+            e,
+            CommandEffect::ApplyTheme(name, mode) if name == "solarized" && mode == "dark"
+        )));
+    }
+
+    #[test]
+    fn theme_unknown_name_returns_error() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Theme(Some("neon".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("neon"));
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn theme_solarized_invalid_mode() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Theme(Some("solarized taupe".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("taupe"));
+        assert!(result.effects.is_empty());
+    }
+
+    // ── NpcsHere with population ─────────────────────────────────────────────
+
+    #[test]
+    fn npcs_here_lists_present_npcs() {
+        // Use the full GameTestHarness via the default state + direct roster inspection.
+        // We can't cheaply populate an NpcManager from scratch here, so we only assert
+        // the branch is reachable via the empty path; the populated path is covered by
+        // integration tests in crates/parish-cli/tests/.
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::NpcsHere, &mut world, &mut npc, &mut config);
+        // Falls through to the "No one else is here." branch.
+        assert!(result.response.contains("No one"));
+    }
 }

--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -996,4 +996,169 @@ mod tests {
             }
         }
     }
+
+    // ── Additional coverage for text_log helpers and supporting functions ───
+
+    #[test]
+    fn capitalize_first_handles_unicode() {
+        // Irish — initial letter has an acute accent.
+        assert_eq!(capitalize_first("éire"), "Éire");
+        // Leading whitespace is preserved.
+        assert_eq!(capitalize_first(" hello"), " hello");
+    }
+
+    #[test]
+    fn mask_key_boundary_conditions() {
+        // Exactly 8 chars still falls into the short branch.
+        assert_eq!(mask_key("12345678"), "(set, too short to mask)");
+        // 9 chars reveals first 4 and last 4.
+        assert_eq!(mask_key("123456789"), "1234...6789");
+        // Empty.
+        assert_eq!(mask_key(""), "(set, too short to mask)");
+    }
+
+    #[test]
+    fn text_log_assigns_unique_monotonic_ids() {
+        let a = text_log("system", "first");
+        let b = text_log("system", "second");
+        assert!(a.id.starts_with("msg-"));
+        assert!(b.id.starts_with("msg-"));
+        assert_ne!(a.id, b.id);
+        assert_eq!(a.source, "system");
+        assert_eq!(a.content, "first");
+        assert!(a.subtype.is_none());
+        assert!(a.stream_turn_id.is_none());
+    }
+
+    #[test]
+    fn text_log_for_stream_turn_carries_turn_id() {
+        let payload = text_log_for_stream_turn("npc", "hello", 42);
+        assert_eq!(payload.stream_turn_id, Some(42));
+        assert_eq!(payload.source, "npc");
+        assert_eq!(payload.content, "hello");
+        assert!(payload.subtype.is_none());
+    }
+
+    #[test]
+    fn text_log_typed_sets_subtype() {
+        let payload = text_log_typed("system", "A wren hops by.", "ambient");
+        assert_eq!(payload.subtype.as_deref(), Some("ambient"));
+        assert_eq!(payload.content, "A wren hops by.");
+        assert!(payload.stream_turn_id.is_none());
+    }
+
+    // ── detect_and_record_player_name ───────────────────────────────────────
+
+    #[test]
+    fn detect_player_name_records_first_introduction() {
+        let mut world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+        let mut npc = Npc::new_test_npc();
+        npc.location = world.player_location;
+        let speaker = npc.id;
+        npc_mgr.add_npc(npc);
+
+        assert!(world.player_name.is_none());
+        detect_and_record_player_name(&mut world, &mut npc_mgr, "My name is Ciaran.", speaker);
+        assert_eq!(world.player_name.as_deref(), Some("Ciaran"));
+        assert!(npc_mgr.knows_player_name(speaker));
+    }
+
+    #[test]
+    fn detect_player_name_does_not_overwrite() {
+        let mut world = WorldState::new();
+        world.player_name = Some("Aoife".to_string());
+        let mut npc_mgr = NpcManager::new();
+        let mut npc = Npc::new_test_npc();
+        npc.location = world.player_location;
+        let speaker = npc.id;
+        npc_mgr.add_npc(npc);
+
+        detect_and_record_player_name(&mut world, &mut npc_mgr, "My name is Ciaran.", speaker);
+        assert_eq!(world.player_name.as_deref(), Some("Aoife"));
+        // The speaker still gets taught the name because detection fired.
+        assert!(npc_mgr.knows_player_name(speaker));
+    }
+
+    #[test]
+    fn detect_player_name_skips_non_introductions() {
+        let mut world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+        let mut npc = Npc::new_test_npc();
+        npc.location = world.player_location;
+        let speaker = npc.id;
+        npc_mgr.add_npc(npc);
+
+        detect_and_record_player_name(&mut world, &mut npc_mgr, "Tell me the news.", speaker);
+        assert!(world.player_name.is_none());
+        assert!(!npc_mgr.knows_player_name(speaker));
+    }
+
+    // ── compute_name_hints ───────────────────────────────────────────────────
+
+    #[test]
+    fn compute_name_hints_empty_when_no_pronunciations() {
+        let world = WorldState::new();
+        let npc_mgr = NpcManager::new();
+        let hints = compute_name_hints(&world, &npc_mgr, &[]);
+        assert!(hints.is_empty());
+    }
+
+    #[test]
+    fn compute_name_hints_matches_location_name() {
+        use crate::game_mod::PronunciationEntry;
+        let world = WorldState::new();
+        let npc_mgr = NpcManager::new();
+        // Match the default crossroads location.
+        let entries = vec![PronunciationEntry {
+            word: "Crossroads".to_string(),
+            pronunciation: "KROSS-rohds".to_string(),
+            meaning: Some("meeting of ways".to_string()),
+            matches: vec!["crossroads".to_string()],
+        }];
+        let hints = compute_name_hints(&world, &npc_mgr, &entries);
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].word, "Crossroads");
+    }
+
+    #[test]
+    fn compute_name_hints_ignores_unintroduced_npcs() {
+        use crate::game_mod::PronunciationEntry;
+        let world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+        let mut npc = Npc::new_test_npc();
+        npc.location = world.player_location;
+        npc.name = "Siobhan".to_string();
+        let npc_id = npc.id;
+        npc_mgr.add_npc(npc);
+        // Do NOT mark introduced.
+
+        let entries = vec![PronunciationEntry {
+            word: "Siobhan".to_string(),
+            pronunciation: "shi-VAWN".to_string(),
+            meaning: None,
+            matches: vec!["siobhan".to_string()],
+        }];
+        let hints = compute_name_hints(&world, &npc_mgr, &entries);
+        assert!(hints.is_empty(), "unintroduced NPC names must not leak");
+
+        // After introduction, the hint appears.
+        npc_mgr.mark_introduced(npc_id);
+        let hints = compute_name_hints(&world, &npc_mgr, &entries);
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].word, "Siobhan");
+    }
+
+    // ── check_for_hallucinated_names ─────────────────────────────────────────
+
+    #[test]
+    fn check_hallucinated_returns_none_when_metadata_absent() {
+        let response = crate::npc::NpcStreamResponse {
+            dialogue: "Hello.".to_string(),
+            metadata: None,
+        };
+        let roster: Vec<(NpcId, String, String)> = vec![];
+        let result = check_for_hallucinated_names(&response, &roster, None);
+        assert!(result.is_none());
+    }
 }

--- a/crates/parish-core/src/ipc/streaming.rs
+++ b/crates/parish-core/src/ipc/streaming.rs
@@ -217,4 +217,109 @@ mod tests {
         // even if batching delays some.
         assert_eq!(collected.chars().count(), 3);
     }
+
+    // ── Additional coverage for stream_npc_tokens edge cases ────────────────
+
+    #[tokio::test]
+    async fn stream_empty_channel_returns_empty_string() {
+        let (tx, token_rx) = mpsc::unbounded_channel::<String>();
+        drop(tx); // Close immediately without sending.
+
+        let mut collected = String::new();
+        let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
+        assert_eq!(full, "");
+        assert_eq!(collected, "");
+    }
+
+    #[tokio::test]
+    async fn stream_separator_split_across_tokens() {
+        // Receiver must stitch the separator together even when it arrives in pieces.
+        let (tx, token_rx) = mpsc::unbounded_channel();
+        tx.send("Dialogue text\n".to_string()).unwrap();
+        tx.send("--".to_string()).unwrap();
+        tx.send("-\n".to_string()).unwrap();
+        tx.send("{\"hints\":[]}".to_string()).unwrap();
+        drop(tx);
+
+        let mut collected = String::new();
+        let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
+        assert_eq!(full, "Dialogue text\n---\n{\"hints\":[]}");
+        // No JSON metadata should have leaked into the collected output.
+        assert!(!collected.contains("hints"));
+        assert!(collected.contains("Dialogue text"));
+    }
+
+    #[tokio::test]
+    async fn stream_handles_multibyte_utf8_at_holdback_boundary() {
+        // The holdback window must never land inside a multi-byte char.
+        // Build a long dialogue so the sliding window actually engages, with
+        // Irish accented characters (é, á) around the boundary.
+        let (tx, token_rx) = mpsc::unbounded_channel();
+        let line = "Is fíor-álainn an lá é inniu — gealltanach agus éadrom, caithfidh mé a rá.";
+        tx.send(line.to_string()).unwrap();
+        drop(tx);
+
+        let mut collected = String::new();
+        let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
+        assert_eq!(full, line);
+        // Output must be valid UTF-8 and contain the full phrase.
+        assert!(collected.contains("fíor-álainn"));
+    }
+
+    #[tokio::test]
+    async fn stream_without_separator_strips_trailing_json() {
+        // Weak models sometimes omit the --- separator and emit metadata inline.
+        let (tx, token_rx) = mpsc::unbounded_channel();
+        tx.send("A fine morning it is. ".to_string()).unwrap();
+        tx.send("{\"action\":\"speaks\"}".to_string()).unwrap();
+        drop(tx);
+
+        let mut collected = String::new();
+        let _ = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
+        // The trailing JSON must be stripped from the emitted text.
+        assert!(collected.contains("fine morning"));
+        assert!(!collected.contains("action"));
+    }
+
+    #[tokio::test]
+    async fn stream_short_text_under_holdback_window_still_emits() {
+        // Text shorter than SEPARATOR_HOLDBACK should flush through the
+        // "no separator found" tail path.
+        let (tx, token_rx) = mpsc::unbounded_channel();
+        tx.send("Hi.".to_string()).unwrap();
+        drop(tx);
+
+        let mut collected = String::new();
+        let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
+        assert_eq!(full, "Hi.");
+        assert_eq!(collected, "Hi.");
+    }
+
+    // ── strip_trailing_json edge cases ──────────────────────────────────────
+
+    #[test]
+    fn strip_trailing_json_ignores_unmatched_close_brace() {
+        // A lone '}' with no matching '{' should not crash; text is returned.
+        let text = "punctuation is weird}";
+        assert_eq!(strip_trailing_json(text), text);
+    }
+
+    #[test]
+    fn strip_trailing_json_rejects_invalid_json() {
+        // The candidate block looks like JSON but isn't valid — keep the text.
+        let text = "the deal is {not, a: valid}";
+        assert_eq!(strip_trailing_json(text), text);
+    }
+
+    #[test]
+    fn strip_trailing_json_handles_whitespace_before_json() {
+        let text = "Good evening to ye.   {\"a\":1}";
+        assert_eq!(strip_trailing_json(text), "Good evening to ye.");
+    }
+
+    #[test]
+    fn strip_trailing_json_handles_nested_objects() {
+        let text = r#"(smiles) Welcome home. {"action":"speaks","meta":{"mood":"warm"}}"#;
+        assert_eq!(strip_trailing_json(text), "(smiles) Welcome home.");
+    }
 }

--- a/crates/parish-types/src/ids.rs
+++ b/crates/parish-types/src/ids.rs
@@ -164,3 +164,227 @@ pub fn find_response_separator(text: &str) -> Option<(usize, usize)> {
 
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Weather FromStr ──────────────────────────────────────────────────────
+
+    #[test]
+    fn weather_from_str_canonical_forms() {
+        assert_eq!("Clear".parse::<Weather>().unwrap(), Weather::Clear);
+        assert_eq!(
+            "Partly Cloudy".parse::<Weather>().unwrap(),
+            Weather::PartlyCloudy
+        );
+        assert_eq!("Overcast".parse::<Weather>().unwrap(), Weather::Overcast);
+        assert_eq!("Light Rain".parse::<Weather>().unwrap(), Weather::LightRain);
+        assert_eq!("Heavy Rain".parse::<Weather>().unwrap(), Weather::HeavyRain);
+        assert_eq!("Fog".parse::<Weather>().unwrap(), Weather::Fog);
+        assert_eq!("Storm".parse::<Weather>().unwrap(), Weather::Storm);
+    }
+
+    #[test]
+    fn weather_from_str_alternate_spellings() {
+        assert_eq!(
+            "PartlyCloudy".parse::<Weather>().unwrap(),
+            Weather::PartlyCloudy
+        );
+        assert_eq!("LightRain".parse::<Weather>().unwrap(), Weather::LightRain);
+        assert_eq!("Rain".parse::<Weather>().unwrap(), Weather::LightRain);
+        assert_eq!("HeavyRain".parse::<Weather>().unwrap(), Weather::HeavyRain);
+    }
+
+    #[test]
+    fn weather_from_str_unknown_returns_error() {
+        let err = "Blizzard".parse::<Weather>().unwrap_err();
+        match err {
+            ParishError::Config(msg) => {
+                assert!(msg.contains("Blizzard"));
+                assert!(msg.contains("unknown weather"));
+            }
+            other => panic!("expected ParishError::Config, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn weather_from_str_empty_errors() {
+        assert!("".parse::<Weather>().is_err());
+    }
+
+    #[test]
+    fn weather_from_str_is_case_sensitive() {
+        // Lowercase is not accepted — documents current behaviour.
+        assert!("clear".parse::<Weather>().is_err());
+        assert!("STORM".parse::<Weather>().is_err());
+    }
+
+    // ── Weather Display ──────────────────────────────────────────────────────
+
+    #[test]
+    fn weather_display_matches_canonical_form() {
+        assert_eq!(Weather::Clear.to_string(), "Clear");
+        assert_eq!(Weather::PartlyCloudy.to_string(), "Partly Cloudy");
+        assert_eq!(Weather::Overcast.to_string(), "Overcast");
+        assert_eq!(Weather::LightRain.to_string(), "Light Rain");
+        assert_eq!(Weather::HeavyRain.to_string(), "Heavy Rain");
+        assert_eq!(Weather::Fog.to_string(), "Fog");
+        assert_eq!(Weather::Storm.to_string(), "Storm");
+    }
+
+    #[test]
+    fn weather_display_then_parse_is_identity() {
+        for w in [
+            Weather::Clear,
+            Weather::PartlyCloudy,
+            Weather::Overcast,
+            Weather::LightRain,
+            Weather::HeavyRain,
+            Weather::Fog,
+            Weather::Storm,
+        ] {
+            let s = w.to_string();
+            let parsed: Weather = s.parse().unwrap();
+            assert_eq!(parsed, w, "round-trip failed for {:?}", w);
+        }
+    }
+
+    // ── LocationId / NpcId ───────────────────────────────────────────────────
+
+    #[test]
+    fn location_id_serde_round_trip() {
+        let id = LocationId(42);
+        let json = serde_json::to_string(&id).unwrap();
+        // Transparent newtype: serialises to bare number.
+        assert_eq!(json, "42");
+        let back: LocationId = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, id);
+    }
+
+    #[test]
+    fn npc_id_serde_round_trip() {
+        let id = NpcId(7);
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, "7");
+        let back: NpcId = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, id);
+    }
+
+    #[test]
+    fn location_id_ordering() {
+        let mut ids = vec![LocationId(3), LocationId(1), LocationId(2)];
+        ids.sort();
+        assert_eq!(ids, vec![LocationId(1), LocationId(2), LocationId(3)]);
+    }
+
+    #[test]
+    fn npc_id_usable_in_hashmap() {
+        use std::collections::HashMap;
+        let mut m: HashMap<NpcId, &'static str> = HashMap::new();
+        m.insert(NpcId(1), "Siobhan");
+        m.insert(NpcId(2), "Padraig");
+        assert_eq!(m.get(&NpcId(1)), Some(&"Siobhan"));
+        assert_eq!(m.get(&NpcId(3)), None);
+    }
+
+    // ── floor_char_boundary ──────────────────────────────────────────────────
+
+    #[test]
+    fn floor_char_boundary_ascii_stays_put() {
+        let s = "hello world";
+        assert_eq!(floor_char_boundary(s, 5), 5);
+        assert_eq!(floor_char_boundary(s, 0), 0);
+    }
+
+    #[test]
+    fn floor_char_boundary_clamps_beyond_end() {
+        let s = "hi";
+        assert_eq!(floor_char_boundary(s, 100), s.len());
+    }
+
+    #[test]
+    fn floor_char_boundary_moves_off_multibyte() {
+        // "é" is two bytes (0xC3 0xA9) in UTF-8.
+        let s = "café";
+        // Position 4 is inside the "é" code unit sequence — should fall back to 3.
+        assert_eq!(floor_char_boundary(s, 4), 3);
+        // Position 3 is the start of "é" — a valid boundary.
+        assert_eq!(floor_char_boundary(s, 3), 3);
+        // Position 5 is the end of the string — valid boundary.
+        assert_eq!(floor_char_boundary(s, 5), 5);
+    }
+
+    #[test]
+    fn floor_char_boundary_empty_string() {
+        assert_eq!(floor_char_boundary("", 0), 0);
+        assert_eq!(floor_char_boundary("", 10), 0);
+    }
+
+    // ── find_response_separator ──────────────────────────────────────────────
+
+    #[test]
+    fn separator_found_on_own_line() {
+        let text = "Hello there.\n---\n{\"action\":\"speaks\"}";
+        let (d, m) = find_response_separator(text).unwrap();
+        // dialogue_end sits just past the newline that ends the dialogue —
+        // callers trim trailing whitespace themselves.
+        assert_eq!(&text[..d], "Hello there.\n");
+        assert_eq!(&text[m..], "{\"action\":\"speaks\"}");
+    }
+
+    #[test]
+    fn separator_found_inline() {
+        let text = "Quick line --- {\"action\":\"speaks\"}";
+        let (d, m) = find_response_separator(text).unwrap();
+        assert_eq!(&text[..d], "Quick line");
+        assert_eq!(&text[m..], "{\"action\":\"speaks\"}");
+    }
+
+    #[test]
+    fn separator_inline_with_newline_suffix() {
+        let text = "Short ---\n{\"a\":1}";
+        let (d, m) = find_response_separator(text).unwrap();
+        assert_eq!(&text[..d], "Short");
+        assert_eq!(&text[m..], "{\"a\":1}");
+    }
+
+    #[test]
+    fn separator_absent_returns_none() {
+        assert!(find_response_separator("no separator here").is_none());
+        assert!(find_response_separator("").is_none());
+    }
+
+    #[test]
+    fn separator_own_line_takes_precedence() {
+        // When both patterns are present, the own-line one wins because
+        // it's checked first.
+        let text = "Intro\n---\ntail --- more";
+        let (d, m) = find_response_separator(text).unwrap();
+        assert_eq!(&text[..d], "Intro\n");
+        // After the own-line separator, the rest includes "tail --- more".
+        assert!(text[m..].starts_with("tail"));
+    }
+
+    // ── LanguageHint serde ───────────────────────────────────────────────────
+
+    #[test]
+    fn language_hint_round_trip_with_meaning() {
+        let hint = LanguageHint {
+            word: "dúlra".to_string(),
+            pronunciation: "DOOL-rah".to_string(),
+            meaning: Some("nature".to_string()),
+        };
+        let json = serde_json::to_string(&hint).unwrap();
+        let back: LanguageHint = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, hint);
+    }
+
+    #[test]
+    fn language_hint_defaults_meaning_when_missing() {
+        let json = r#"{"word":"fáilte","pronunciation":"FAWL-cheh"}"#;
+        let hint: LanguageHint = serde_json::from_str(json).unwrap();
+        assert_eq!(hint.word, "fáilte");
+        assert!(hint.meaning.is_none());
+    }
+}

--- a/crates/parish-world/src/lib.rs
+++ b/crates/parish-world/src/lib.rs
@@ -276,3 +276,128 @@ impl Default for WorldState {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_starts_at_crossroads() {
+        let world = WorldState::new();
+        assert_eq!(world.player_location, LocationId(1));
+        assert_eq!(world.current_location().name, "The Crossroads");
+    }
+
+    #[test]
+    fn new_initial_collections_are_fresh() {
+        let world = WorldState::new();
+        assert!(world.text_log.is_empty());
+        assert!(world.edge_traversals.is_empty());
+        // Starting location is pre-marked as visited.
+        assert!(world.visited_locations.contains(&LocationId(1)));
+        assert_eq!(world.visited_locations.len(), 1);
+        assert!(world.player_name.is_none());
+    }
+
+    #[test]
+    fn new_default_weather_is_clear() {
+        let world = WorldState::new();
+        assert_eq!(world.weather, Weather::Clear);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let a = WorldState::default();
+        let b = WorldState::new();
+        assert_eq!(a.player_location, b.player_location);
+        assert_eq!(a.weather, b.weather);
+        assert_eq!(a.text_log.len(), b.text_log.len());
+    }
+
+    #[test]
+    fn log_appends_to_text_log() {
+        let mut world = WorldState::new();
+        world.log("hello".to_string());
+        world.log("world".to_string());
+        assert_eq!(world.text_log, vec!["hello", "world"]);
+    }
+
+    #[test]
+    fn mark_visited_adds_location() {
+        let mut world = WorldState::new();
+        world.mark_visited(LocationId(42));
+        assert!(world.visited_locations.contains(&LocationId(42)));
+    }
+
+    #[test]
+    fn mark_visited_is_idempotent() {
+        let mut world = WorldState::new();
+        world.mark_visited(LocationId(5));
+        world.mark_visited(LocationId(5));
+        assert_eq!(
+            world
+                .visited_locations
+                .iter()
+                .filter(|&&id| id == LocationId(5))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn record_path_traversal_canonicalises_edge_order() {
+        let mut world = WorldState::new();
+        // Walk 2 → 1 then 1 → 2 — both should land on the same canonical edge.
+        world.record_path_traversal(&[LocationId(2), LocationId(1)]);
+        world.record_path_traversal(&[LocationId(1), LocationId(2)]);
+        assert_eq!(world.edge_traversals.len(), 1);
+        assert_eq!(
+            world.edge_traversals.get(&(LocationId(1), LocationId(2))),
+            Some(&2)
+        );
+        // The reversed key should never appear.
+        assert!(
+            !world
+                .edge_traversals
+                .contains_key(&(LocationId(2), LocationId(1)))
+        );
+    }
+
+    #[test]
+    fn record_path_traversal_handles_multi_hop_paths() {
+        let mut world = WorldState::new();
+        // Path A→B→C should register two edges.
+        world.record_path_traversal(&[LocationId(1), LocationId(2), LocationId(3)]);
+        assert_eq!(
+            world.edge_traversals.get(&(LocationId(1), LocationId(2))),
+            Some(&1)
+        );
+        assert_eq!(
+            world.edge_traversals.get(&(LocationId(2), LocationId(3))),
+            Some(&1)
+        );
+    }
+
+    #[test]
+    fn record_path_traversal_ignores_empty_and_single() {
+        let mut world = WorldState::new();
+        world.record_path_traversal(&[]);
+        world.record_path_traversal(&[LocationId(1)]);
+        assert!(world.edge_traversals.is_empty());
+    }
+
+    #[test]
+    fn current_location_data_none_for_empty_graph() {
+        // new() sets up a legacy `locations` map but an empty `graph`.
+        let world = WorldState::new();
+        assert!(world.current_location_data().is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "player location must exist")]
+    fn current_location_panics_when_player_location_missing() {
+        let mut world = WorldState::new();
+        world.player_location = LocationId(999);
+        let _ = world.current_location();
+    }
+}


### PR DESCRIPTION
Adds ~86 new unit tests across six files targeting previously untested
pure functions and core game state helpers. Follows a coverage gap
analysis that identified these modules as high-impact, low-effort wins:

- parish-core/ipc/commands.rs: cover the remaining Command variants
  (Wait, Tick, Speed, Cloud/Category provider+key, Flag*, Theme,
  effect-only Save/Fork/Load/Branches/Log/Map/NewGame/Spinner/Debug,
  Invalid* sentinels, About, Help, ToggleSidebar).
- parish-types/ids.rs: first tests for this file — Weather FromStr and
  Display round-trips, LocationId/NpcId serde and Ord/Hash, UTF-8
  boundary helpers, response separator edge cases, LanguageHint serde.
- parish-world/lib.rs: first tests for WorldState — constructor state,
  log append, mark_visited idempotency, record_path_traversal edge
  canonicalisation, current_location panic on missing player location.
- parish-core/ipc/handlers.rs: text_log / text_log_typed /
  text_log_for_stream_turn ID uniqueness, detect_and_record_player_name
  introduction paths, compute_name_hints location/NPC matching,
  check_for_hallucinated_names empty-metadata guard, mask_key and
  capitalize_first boundary cases.
- parish-core/game_session.rs: reaction_req_id monotonicity, edge
  traversal + visited-set recording on movement, NotFound log append,
  stream_reaction_texts empty-list behaviour.
- parish-core/ipc/streaming.rs: separator split across tokens, UTF-8
  multi-byte at holdback boundary, empty channel, trailing-JSON strip
  when no separator, strip_trailing_json nested objects and whitespace
  handling.

All new tests pass under cargo test and cargo clippy -D warnings.