### PR TITLE
fix: skip theme-update emits when palette unchanged (#63, #229)

### DIFF
--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -247,6 +247,7 @@ fn spawn_background_ticks(state: Arc<AppState>) {
     let state_tick = Arc::clone(&state);
     tokio::spawn(async move {
         tracing::debug!("World tick task started");
+        let mut last_palette: Option<parish_core::world::palette::RawPalette> = None;
         loop {
             tokio::time::sleep(Duration::from_secs(5)).await;
             {
@@ -272,9 +273,12 @@ fn spawn_background_ticks(state: Arc<AppState>) {
                         world.clock.season(),
                         world.weather,
                     );
-                    state_tick
-                        .event_bus
-                        .emit("theme-update", &ThemePalette::from(raw));
+                    if last_palette != Some(raw) {
+                        state_tick
+                            .event_bus
+                            .emit("theme-update", &ThemePalette::from(raw));
+                        last_palette = Some(raw);
+                    }
                 }
             }
             {

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -844,6 +844,7 @@ pub fn run() {
                 let state_tick = Arc::clone(&state_setup);
                 let handle_tick = handle.clone();
                 tokio::spawn(async move {
+                    let mut last_palette: Option<parish_core::world::palette::RawPalette> = None;
                     loop {
                         tokio::time::sleep(Duration::from_secs(5)).await;
 
@@ -871,8 +872,13 @@ pub fn run() {
                                     world.clock.season(),
                                     world.weather,
                                 );
-                                let _ = handle_tick
-                                    .emit(events::EVENT_THEME_UPDATE, ThemePalette::from(raw));
+                                if last_palette != Some(raw) {
+                                    let _ = handle_tick.emit(
+                                        events::EVENT_THEME_UPDATE,
+                                        ThemePalette::from(raw),
+                                    );
+                                    last_palette = Some(raw);
+                                }
                             }
                         }
                         {


### PR DESCRIPTION
## Summary

- Closes #63 (Tauri) and #229 (web server) — the same bug in two backends, fixed in parallel per CLAUDE.md's Mode Parity rule.
- Both 5 s world ticks previously emitted a `theme-update` event every iteration regardless of whether the palette had changed, wasting IPC / WebSocket frames and causing constant Svelte `:root` CSS re-applies.
- Caches the last emitted `RawPalette` in each tick's local state and only emits when the new value differs. `RawPalette` already derives `Copy + PartialEq + Eq` (`crates/parish-world/src/palette.rs:32`), so no derives or public types needed to change.

## Changes

- `crates/parish-tauri/src/lib.rs` — cache + skip in the tokio task spawned at line 846 (commit 63b5737).
- `crates/parish-server/src/lib.rs` — identical cache + skip in the tokio task spawned at line 248 (commit 7d36325).

No new abstraction introduced — the duplicated delta is ~3 lines per site and both loops live in backend-specific setup code around local mutable state that does not cleanly hoist into `parish-core`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p parish-server --all-targets -- -D warnings` clean
- [x] `cargo test -p parish-server` — 19/19 passing
- [ ] `cargo clippy -p parish-tauri -- -D warnings` + `cargo test -p parish-tauri` — not runnable in sandbox (Tauri's build requires `libgtk-3-dev` / `libwebkit2gtk-4.1-dev`, unavailable here); CI will exercise the full matrix.
- [ ] Manual: connect a client, advance the clock, confirm `theme-update` only fires on palette boundary crossings (hour/minute/season/weather change) rather than every 5 s.

https://claude.ai/code/session_01EcLjJ4QzUr3k2Da21gVi5R