### PR TITLE
fix: store inference worker JoinHandle in web AppState (#224, #231)

### DIFF
--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -165,7 +165,10 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         let (interactive_tx, interactive_rx) = tokio::sync::mpsc::channel(16);
         let (background_tx, background_rx) = tokio::sync::mpsc::channel(32);
         let (batch_tx, batch_rx) = tokio::sync::mpsc::channel(64);
-        let _worker = spawn_inference_worker(
+        // Store the worker JoinHandle on AppState so a later rebuild_inference
+        // call can abort this initial worker — otherwise it leaks for the
+        // lifetime of the process (bug #231).
+        let worker = spawn_inference_worker(
             ac,
             interactive_rx,
             background_rx,
@@ -175,6 +178,9 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         let queue = InferenceQueue::new(interactive_tx, background_tx, batch_tx);
         let mut iq = state.inference_queue.lock().await;
         *iq = Some(queue);
+        drop(iq);
+        let mut wh = state.worker_handle.lock().await;
+        *wh = Some(worker);
     }
 
     // Spawn background ticks

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -189,10 +189,20 @@ async fn rebuild_inference(state: &Arc<AppState>) {
         AnyClient::open_ai(oai)
     };
 
+    // Abort the old inference worker before spawning a replacement to prevent
+    // orphaned tasks from accumulating (each holds an HTTP client and channel).
+    // Without this, repeated provider/key/model changes leak workers (bug #224).
+    {
+        let mut wh = state.worker_handle.lock().await;
+        if let Some(old) = wh.take() {
+            old.abort();
+        }
+    }
+
     let (interactive_tx, interactive_rx) = tokio::sync::mpsc::channel(16);
     let (background_tx, background_rx) = tokio::sync::mpsc::channel(32);
     let (batch_tx, batch_rx) = tokio::sync::mpsc::channel(64);
-    let _worker = spawn_inference_worker(
+    let worker = spawn_inference_worker(
         any_client,
         interactive_rx,
         background_rx,
@@ -202,6 +212,9 @@ async fn rebuild_inference(state: &Arc<AppState>) {
     let queue = InferenceQueue::new(interactive_tx, background_tx, batch_tx);
     let mut iq = state.inference_queue.lock().await;
     *iq = Some(queue);
+    drop(iq);
+    let mut wh = state.worker_handle.lock().await;
+    *wh = Some(worker);
 }
 
 async fn touch_player_activity(state: &Arc<AppState>) {
@@ -2254,5 +2267,79 @@ mod tests {
         assert!(result.is_err());
         let (status, _msg) = result.unwrap_err();
         assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    /// Regression test for #224 / #231: rebuild_inference must abort the
+    /// previously-stored inference worker, otherwise each provider/key/model
+    /// change leaks a worker holding an HTTP client and channel state.
+    #[tokio::test]
+    async fn rebuild_inference_aborts_previous_worker() {
+        let state = test_app_state();
+        // Use the simulator so rebuild_inference doesn't try to talk to a real
+        // LLM endpoint.
+        {
+            let mut config = state.config.lock().await;
+            config.provider_name = "simulator".to_string();
+        }
+
+        // Spawn a sentinel "worker" that runs forever; mirror the real worker
+        // by just sleeping in a loop. Stash an AbortHandle so we can verify
+        // from outside whether rebuild_inference cancelled it.
+        let sentinel = tokio::spawn(async {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        });
+        let abort_handle = sentinel.abort_handle();
+        *state.worker_handle.lock().await = Some(sentinel);
+        assert!(
+            !abort_handle.is_finished(),
+            "sentinel should be running before rebuild"
+        );
+
+        rebuild_inference(&state).await;
+
+        // Yield + brief sleep so the runtime processes the abort.
+        for _ in 0..10 {
+            if abort_handle.is_finished() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            abort_handle.is_finished(),
+            "rebuild_inference must abort the previous worker (#224, #231)"
+        );
+
+        // And a fresh worker handle must be stored.
+        let wh = state.worker_handle.lock().await;
+        assert!(
+            wh.is_some(),
+            "rebuild_inference must install a new worker handle"
+        );
+    }
+
+    /// Regression test for #224 / #231: rebuild_inference must work (and
+    /// install a worker) even when no previous worker was stored — that
+    /// matches the case where startup failed to spawn one.
+    #[tokio::test]
+    async fn rebuild_inference_installs_worker_when_none_stored() {
+        let state = test_app_state();
+        {
+            let mut config = state.config.lock().await;
+            config.provider_name = "simulator".to_string();
+        }
+        assert!(state.worker_handle.lock().await.is_none());
+
+        rebuild_inference(&state).await;
+
+        assert!(
+            state.worker_handle.lock().await.is_some(),
+            "rebuild_inference must install a worker even if none was stored"
+        );
+        assert!(
+            state.inference_queue.lock().await.is_some(),
+            "rebuild_inference must install an inference queue"
+        );
     }
 }

--- a/crates/parish-server/src/state.rs
+++ b/crates/parish-server/src/state.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use tokio::sync::{Mutex, broadcast};
+use tokio::task::JoinHandle;
 
 use parish_core::debug_snapshot::DebugEvent;
 use parish_core::game_mod::PronunciationEntry;
@@ -142,6 +143,10 @@ pub struct AppState {
     pub pronunciations: Vec<PronunciationEntry>,
     /// Path to the feature flags persistence file.
     pub flags_path: PathBuf,
+    /// Handle for the active inference worker task; used to abort it on rebuild
+    /// or shutdown so orphaned workers (each holding an HTTP client and channel)
+    /// don't accumulate.  See bugs #224 and #231.
+    pub worker_handle: Mutex<Option<JoinHandle<()>>>,
 }
 
 // GameConfig is now shared across all backends via parish-core.
@@ -252,6 +257,7 @@ pub fn build_app_state(
         game_mod,
         pronunciations,
         flags_path,
+        worker_handle: Mutex::new(None),
     })
 }
 


### PR DESCRIPTION
## Summary

Fixes #224 and #231 — closely-related bugs in the `parish-server` web backend where the `JoinHandle<()>` returned by `spawn_inference_worker` was bound to `_worker` and immediately dropped, both at startup (#231) and on `rebuild_inference` (#224).

Without a stored handle, every provider/key/model change leaks a worker holding an HTTP client and an mpsc receiver, and the boot-time worker can't be aborted for the lifetime of the process. The Tauri backend already mirrors the correct pattern via `AppState.worker_handle` — this PR brings the web server into parity (per the CLAUDE.md "Mode parity" rule).

## Changes

- `crates/parish-server/src/state.rs`: added `worker_handle: Mutex<Option<JoinHandle<()>>>` to `AppState`, initialized to `None` in `build_app_state`.
- `crates/parish-server/src/lib.rs` (`run_server`): store the boot-time worker handle in `state.worker_handle` instead of dropping it (#231).
- `crates/parish-server/src/routes.rs` (`rebuild_inference`): take + `.abort()` the previously-stored worker before spawning the replacement, then store the new handle (#224).

## Tests

Two new regression tests in `routes.rs`:

- `rebuild_inference_aborts_previous_worker` — installs a sentinel task into `worker_handle`, captures its `AbortHandle`, calls `rebuild_inference`, and asserts the sentinel is reported finished (i.e. aborted).
- `rebuild_inference_installs_worker_when_none_stored` — verifies the function still installs a fresh worker + queue when no previous handle was stored.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --exclude parish-tauri --all-targets -- -D warnings` — clean (parish-tauri excluded due to missing GTK system libs in the test env, unrelated)
- [x] `cargo test -p parish-server` — 21/21 passing, including both new regression tests
- [ ] Manual: change provider via `/provider` endpoint twice; confirm via `top` / `ps` that no detached inference workers accumulate
- [ ] Manual: shutdown the server and confirm no orphaned tasks linger

Note: pre-existing failing test `parish_core::ipc::handlers::tests::mask_key_non_ascii` is unrelated (verified failing on the parent commit before these changes were applied).

https://claude.ai/code/session_01C7GptJ3rpqEct4HZfbCmYf