### PR TITLE
fix: preserve multi-byte UTF-8 across SSE/NDJSON chunk boundaries (#223)

### DIFF
--- a/crates/parish-inference/src/client.rs
+++ b/crates/parish-inference/src/client.rs
@@ -146,12 +146,14 @@ impl OllamaClient {
 
         let mut accumulated = String::new();
         let mut line_buf = String::new();
+        let mut decoder = crate::utf8_stream::Utf8StreamDecoder::new();
 
         // Read chunks and split into NDJSON lines
         let mut response = resp;
         while let Some(chunk) = response.chunk().await? {
-            let text = String::from_utf8_lossy(&chunk);
-            line_buf.push_str(&text);
+            // Decode incrementally so multi-byte characters split across
+            // HTTP chunk boundaries aren't mangled into U+FFFD (#223).
+            line_buf.push_str(&decoder.push(&chunk));
 
             // Process complete lines
             while let Some(newline_pos) = line_buf.find('\n') {
@@ -174,7 +176,8 @@ impl OllamaClient {
             }
         }
 
-        // Process any remaining data in the buffer
+        // Flush any trailing incomplete bytes, then process any remaining line.
+        line_buf.push_str(&decoder.flush());
         let remaining = line_buf.trim();
         if !remaining.is_empty()
             && let Ok(gen_resp) = serde_json::from_str::<GenerateResponse>(remaining)

--- a/crates/parish-inference/src/lib.rs
+++ b/crates/parish-inference/src/lib.rs
@@ -9,6 +9,7 @@ pub mod openai_client;
 pub mod rate_limit;
 pub mod setup;
 pub mod simulator;
+pub(crate) mod utf8_stream;
 
 pub use rate_limit::InferenceRateLimiter;
 

--- a/crates/parish-inference/src/openai_client.rs
+++ b/crates/parish-inference/src/openai_client.rs
@@ -251,11 +251,13 @@ impl OpenAiClient {
 
         let mut accumulated = String::new();
         let mut line_buf = String::new();
+        let mut decoder = crate::utf8_stream::Utf8StreamDecoder::new();
 
         let mut response = resp;
         while let Some(chunk) = response.chunk().await? {
-            let text = String::from_utf8_lossy(&chunk);
-            line_buf.push_str(&text);
+            // Decode incrementally so multi-byte characters split across
+            // HTTP chunk boundaries aren't mangled into U+FFFD (#223).
+            line_buf.push_str(&decoder.push(&chunk));
 
             while let Some(newline_pos) = line_buf.find('\n') {
                 let line: String = line_buf.drain(..=newline_pos).collect();
@@ -266,7 +268,8 @@ impl OpenAiClient {
             }
         }
 
-        // Process any remaining data in the buffer
+        // Flush any trailing incomplete bytes, then process any remaining line.
+        line_buf.push_str(&decoder.flush());
         let remaining = line_buf.trim();
         if !remaining.is_empty() {
             process_sse_line(remaining, &token_tx, &mut accumulated);

--- a/crates/parish-inference/src/utf8_stream.rs
+++ b/crates/parish-inference/src/utf8_stream.rs
@@ -1,0 +1,185 @@
+//! Incremental UTF-8 decoder for byte streams from the network.
+//!
+//! HTTP chunk boundaries do not align with UTF-8 character boundaries, so
+//! converting each raw chunk with [`String::from_utf8_lossy`] mangles any
+//! multi-byte character that straddles two chunks (replacing it with
+//! `U+FFFD`). In this game that includes Irish-language accents (`é`, `ó`,
+//! `í`, `á`, `ú`), em dashes, smart quotes and NPC emoji reactions —
+//! visible garbage in dialogue and, worse, corrupt JSON in the metadata
+//! tail of an NPC stream response (issue #223).
+//!
+//! [`Utf8StreamDecoder`] accumulates bytes and emits only the longest
+//! valid UTF-8 prefix on each call to [`Utf8StreamDecoder::push`],
+//! retaining any incomplete trailing sequence for the next chunk. Bytes
+//! that are genuinely invalid (not just partial) are replaced with the
+//! Unicode replacement character `U+FFFD`, matching the conservative
+//! behaviour of `from_utf8_lossy` on unambiguous errors.
+
+/// Stateful decoder that converts a stream of raw byte chunks into
+/// well-formed UTF-8 strings without splitting multi-byte sequences.
+#[derive(Default)]
+pub(crate) struct Utf8StreamDecoder {
+    buf: Vec<u8>,
+}
+
+impl Utf8StreamDecoder {
+    /// Creates a new empty decoder.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends `bytes` to the internal buffer and returns every complete
+    /// UTF-8 sequence accumulated so far. Incomplete trailing bytes are
+    /// retained for the next call. Genuinely invalid bytes are replaced
+    /// with `U+FFFD`.
+    pub(crate) fn push(&mut self, bytes: &[u8]) -> String {
+        self.buf.extend_from_slice(bytes);
+        let mut out = String::new();
+        loop {
+            match std::str::from_utf8(&self.buf) {
+                Ok(valid) => {
+                    out.push_str(valid);
+                    self.buf.clear();
+                    return out;
+                }
+                Err(e) => {
+                    let valid_up_to = e.valid_up_to();
+                    // SAFETY: `valid_up_to()` is documented to return the
+                    // length of the longest valid UTF-8 prefix, so slicing
+                    // there yields definitely-valid UTF-8 bytes.
+                    out.push_str(unsafe {
+                        std::str::from_utf8_unchecked(&self.buf[..valid_up_to])
+                    });
+                    match e.error_len() {
+                        None => {
+                            // Incomplete trailing sequence — wait for more
+                            // bytes in the next chunk.
+                            self.buf.drain(..valid_up_to);
+                            return out;
+                        }
+                        Some(invalid_len) => {
+                            // Genuinely invalid bytes — emit a single
+                            // replacement char and skip past them.
+                            out.push('\u{FFFD}');
+                            self.buf.drain(..valid_up_to + invalid_len);
+                            // Loop to process any remaining bytes.
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Flushes any bytes still buffered after the stream has ended. An
+    /// incomplete trailing sequence is converted lossily (each invalid
+    /// byte becomes `U+FFFD`), matching `from_utf8_lossy`'s behaviour.
+    pub(crate) fn flush(&mut self) -> String {
+        if self.buf.is_empty() {
+            return String::new();
+        }
+        let s = String::from_utf8_lossy(&self.buf).into_owned();
+        self.buf.clear();
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ascii_passes_through_unchanged() {
+        let mut d = Utf8StreamDecoder::new();
+        assert_eq!(d.push(b"hello world"), "hello world");
+        assert_eq!(d.flush(), "");
+    }
+
+    #[test]
+    fn two_byte_char_split_across_chunks_is_reassembled() {
+        // 'é' is 0xC3 0xA9 in UTF-8.
+        let mut d = Utf8StreamDecoder::new();
+        assert_eq!(d.push(b"caf\xC3"), "caf"); // partial — no 'é' yet
+        assert_eq!(d.push(b"\xA9"), "é"); // completes the sequence
+        assert_eq!(d.flush(), "");
+    }
+
+    #[test]
+    fn three_byte_char_split_across_three_chunks() {
+        // '—' (em dash U+2014) is 0xE2 0x80 0x94 in UTF-8.
+        let mut d = Utf8StreamDecoder::new();
+        assert_eq!(d.push(b"oh \xE2"), "oh ");
+        assert_eq!(d.push(b"\x80"), "");
+        assert_eq!(d.push(b"\x94 yes"), "— yes");
+        assert_eq!(d.flush(), "");
+    }
+
+    #[test]
+    fn four_byte_emoji_split_across_chunks() {
+        // '🙂' (U+1F642) is 0xF0 0x9F 0x99 0x82 in UTF-8.
+        let mut d = Utf8StreamDecoder::new();
+        assert_eq!(d.push(b"smile \xF0\x9F"), "smile ");
+        assert_eq!(d.push(b"\x99\x82!"), "🙂!");
+        assert_eq!(d.flush(), "");
+    }
+
+    #[test]
+    fn multiple_multibyte_chars_in_single_chunk() {
+        let mut d = Utf8StreamDecoder::new();
+        assert_eq!(d.push("Siobhán — faith".as_bytes()), "Siobhán — faith");
+    }
+
+    #[test]
+    fn invalid_bytes_become_replacement_char() {
+        let mut d = Utf8StreamDecoder::new();
+        // 0xFF is never valid as the first byte of a UTF-8 sequence.
+        let out = d.push(b"a\xFFb");
+        assert_eq!(out, "a\u{FFFD}b");
+    }
+
+    #[test]
+    fn flush_reports_incomplete_trailing_as_replacement_char() {
+        let mut d = Utf8StreamDecoder::new();
+        // Feed only the first byte of a two-byte sequence, then end the stream.
+        assert_eq!(d.push(b"good \xC3"), "good ");
+        assert_eq!(d.flush(), "\u{FFFD}");
+        // Decoder is now clean.
+        assert_eq!(d.flush(), "");
+    }
+
+    #[test]
+    fn byte_by_byte_feed_reassembles_correctly() {
+        // Feed each byte of "café" individually.
+        let bytes: &[u8] = "café".as_bytes();
+        let mut d = Utf8StreamDecoder::new();
+        let mut combined = String::new();
+        for b in bytes {
+            combined.push_str(&d.push(&[*b]));
+        }
+        combined.push_str(&d.flush());
+        assert_eq!(combined, "café");
+    }
+
+    #[test]
+    fn json_with_accent_is_preserved_across_chunk_boundary() {
+        // Regression for #223: the metadata tail of an NPC response would
+        // fail JSON parsing if a multi-byte char inside it got mangled.
+        let payload = r#"{"speaker":"Siobh\u00e1n","line":"Dia dhuit — fáilte"}"#.as_bytes();
+        // Arbitrary split point chosen to land mid-sequence for the em dash
+        // (0xE2 0x80 0x94) inside the JSON string.
+        let dash_byte_idx = payload
+            .windows(3)
+            .position(|w| w == [0xE2, 0x80, 0x94])
+            .unwrap();
+        // Split between the first and second byte of the em dash.
+        let (a, b) = payload.split_at(dash_byte_idx + 1);
+        let mut d = Utf8StreamDecoder::new();
+        let mut combined = String::new();
+        combined.push_str(&d.push(a));
+        combined.push_str(&d.push(b));
+        combined.push_str(&d.flush());
+        assert_eq!(
+            combined,
+            r#"{"speaker":"Siobh\u00e1n","line":"Dia dhuit — fáilte"}"#
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #223 — both streaming clients (`OpenAiClient::generate_stream` for SSE and `OllamaClient::generate_stream` for NDJSON) convert each raw HTTP chunk with `String::from_utf8_lossy`, so any multi-byte character that straddles a chunk boundary is replaced with U+FFFD. That's reachable whenever the stream contains Irish accents (`é`, `ó`, `í`, `á`, `ú`), em dashes, smart quotes, or NPC emoji reactions — visible garbage in dialogue, and corrupt JSON in the `---\n{...}` metadata tail of an NPC stream response (which silently loses language hints, mood, etc. when JSON parsing fails).

## Changes

- **New `crates/parish-inference/src/utf8_stream.rs`** — small crate-local `Utf8StreamDecoder` that buffers bytes, emits the longest valid UTF-8 prefix on `push`, retains an incomplete trailing sequence for the next chunk, and only falls back to `U+FFFD` for genuinely invalid bytes (matching `from_utf8_lossy`'s behavior on unambiguous errors). `flush()` handles any leftover after the stream ends.
- **`crates/parish-inference/src/openai_client.rs`** (SSE `/v1/chat/completions`) — replaced the per-chunk `from_utf8_lossy` with the incremental decoder; flush on stream end.
- **`crates/parish-inference/src/client.rs`** (Ollama `/api/generate` NDJSON) — same fix for mode parity (same bug was also reachable on the Ollama-native path).
- **`crates/parish-inference/src/lib.rs`** — registered the new `utf8_stream` module.

## Tests

Eight new unit tests in `utf8_stream::tests` cover:

- ASCII passthrough
- 2-byte (`é`), 3-byte (em dash `—`), and 4-byte (emoji `🙂`) characters split across 1, 2, or 3 chunks
- Multiple multi-byte chars in a single chunk (`"Siobhán — faith"`)
- Byte-at-a-time feeds (one byte per `push` call)
- Genuinely invalid bytes becoming `U+FFFD`
- `flush()` reporting an incomplete trailing sequence as `U+FFFD`
- A JSON payload containing an em dash, split in the middle of the em dash's UTF-8 sequence, round-trips unchanged

All 133 `parish-inference` library tests + 23 `http_mock_tests.rs` integration tests pass.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --exclude parish-tauri --all-targets -- -D warnings` — clean
- [x] `cargo test -p parish-inference` — 133/133 lib + 23/23 mock HTTP tests passing, including all 8 new decoder tests
- [x] `cargo run -p parish -- --script testing/fixtures/test_aliases.txt` — harness run completes, JSON output looks correct
- [ ] Manual: exercise an NPC conversation with Irish names / em dashes / emoji in the response and verify no `` chars appear in the text log or the parsed metadata

Note: the pre-existing `parish_core::ipc::handlers::tests::mask_key_non_ascii` failure is unrelated (flagged in #317 / #318, reproduced on the parent commit before these changes).

https://claude.ai/code/session_01XnQf3AzaxyuqZJgnRWrkyN