### PR TITLE
fix: add safety timeout to inference response receiver (#100, #227)

### DIFF
--- a/crates/parish-inference/src/lib.rs
+++ b/crates/parish-inference/src/lib.rs
@@ -182,6 +182,55 @@ impl InferenceQueue {
     }
 }
 
+/// Outcome of awaiting an inference response with a safety timeout.
+#[derive(Debug)]
+pub enum InferenceAwaitOutcome {
+    /// The worker sent a response.
+    Response(InferenceResponse),
+    /// The worker dropped the sender without producing a response.
+    Closed,
+    /// The safety timeout fired before the worker responded. The `secs` field
+    /// records the timeout duration so callers can surface it in diagnostics.
+    TimedOut { secs: u64 },
+}
+
+/// Default safety timeout for awaiting an inference response.
+///
+/// Slightly above `InferenceConfig::streaming_timeout_secs` (300s) so that the
+/// underlying HTTP client's timeout has a chance to fire first and produce a
+/// proper error response. Only kicks in if the worker task is wedged or the
+/// HTTP timeout fails to trigger.
+pub const INFERENCE_RESPONSE_TIMEOUT_SECS: u64 = 360;
+
+/// Await an inference response with a safety timeout.
+///
+/// Wraps `response_rx.await` in [`tokio::time::timeout`] so a stuck worker or
+/// a dropped sender never hangs the caller indefinitely. Returns a distinct
+/// outcome for each failure mode so callers can log timeouts separately from
+/// closed channels.
+///
+/// Pass `None` for `timeout` to disable the safety cap (falls back to the
+/// previous unbounded `.await` behaviour, used when the
+/// `inference-response-timeout` feature flag is explicitly disabled).
+pub async fn await_inference_response(
+    response_rx: oneshot::Receiver<InferenceResponse>,
+    timeout: Option<std::time::Duration>,
+) -> InferenceAwaitOutcome {
+    match timeout {
+        Some(dur) => match tokio::time::timeout(dur, response_rx).await {
+            Ok(Ok(resp)) => InferenceAwaitOutcome::Response(resp),
+            Ok(Err(_)) => InferenceAwaitOutcome::Closed,
+            Err(_) => InferenceAwaitOutcome::TimedOut {
+                secs: dur.as_secs(),
+            },
+        },
+        None => match response_rx.await {
+            Ok(resp) => InferenceAwaitOutcome::Response(resp),
+            Err(_) => InferenceAwaitOutcome::Closed,
+        },
+    }
+}
+
 /// Monotonically increasing request ID counter for queue-submitted JSON requests.
 static QUEUE_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -618,6 +667,68 @@ mod tests {
         };
         let debug = format!("{:?}", response);
         assert!(debug.contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn test_await_inference_response_returns_response() {
+        let (tx, rx) = oneshot::channel();
+        tx.send(InferenceResponse {
+            id: 42,
+            text: "ok".to_string(),
+            error: None,
+        })
+        .unwrap();
+        let outcome = await_inference_response(rx, Some(std::time::Duration::from_secs(1))).await;
+        match outcome {
+            InferenceAwaitOutcome::Response(r) => {
+                assert_eq!(r.id, 42);
+                assert_eq!(r.text, "ok");
+            }
+            other => panic!("expected Response, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_await_inference_response_detects_closed_channel() {
+        let (tx, rx) = oneshot::channel::<InferenceResponse>();
+        drop(tx);
+        let outcome = await_inference_response(rx, Some(std::time::Duration::from_secs(1))).await;
+        assert!(matches!(outcome, InferenceAwaitOutcome::Closed));
+    }
+
+    #[tokio::test]
+    async fn test_await_inference_response_times_out() {
+        // Keep the sender alive so the channel isn't closed; only the timeout
+        // arm can fire. Use a tiny real duration so the test runs fast.
+        let (_tx, rx) = oneshot::channel::<InferenceResponse>();
+        let outcome =
+            await_inference_response(rx, Some(std::time::Duration::from_millis(20))).await;
+        // `Duration::from_millis(20).as_secs()` rounds down to 0.
+        match outcome {
+            InferenceAwaitOutcome::TimedOut { secs } => assert_eq!(secs, 0),
+            other => panic!("expected TimedOut, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_await_inference_response_without_timeout_awaits_forever() {
+        // With `None`, the helper should await the channel without a cap.
+        // We simulate this by sending a response on a background task and
+        // asserting the helper receives it.
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            let _ = tx.send(InferenceResponse {
+                id: 7,
+                text: "late".to_string(),
+                error: None,
+            });
+        });
+        let outcome = await_inference_response(rx, None).await;
+        match outcome {
+            InferenceAwaitOutcome::Response(r) => assert_eq!(r.id, 7),
+            other => panic!("expected Response, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -14,7 +14,10 @@ use tokio::sync::mpsc;
 
 use parish_core::config::InferenceCategory;
 use parish_core::inference::openai_client::OpenAiClient;
-use parish_core::inference::{AnyClient, InferenceQueue, spawn_inference_worker};
+use parish_core::inference::{
+    AnyClient, INFERENCE_RESPONSE_TIMEOUT_SECS, InferenceAwaitOutcome, InferenceQueue,
+    await_inference_response, spawn_inference_worker,
+};
 use parish_core::input::{InputResult, classify_input, parse_intent};
 use parish_core::ipc::{
     ConversationLine, IDLE_MESSAGES, INFERENCE_FAILURE_MESSAGES, LoadingPayload, MapData, NpcInfo,
@@ -707,19 +710,46 @@ async fn run_npc_turn(
         }
     });
 
-    let response = response_rx.await.ok();
+    let timeout_secs = {
+        let config = state.config.lock().await;
+        if config.flags.is_disabled("inference-response-timeout") {
+            None
+        } else {
+            Some(INFERENCE_RESPONSE_TIMEOUT_SECS)
+        }
+    };
+    let outcome = await_inference_response(
+        response_rx,
+        timeout_secs.map(std::time::Duration::from_secs),
+    )
+    .await;
     let _ = stream_handle.await;
     state
         .event_bus
         .emit("stream-turn-end", &StreamTurnEndPayload { turn_id: req_id });
     loading_cancel.cancel();
 
-    let Some(response) = response else {
-        state.event_bus.emit(
-            "text-log",
-            &text_log("system", "The storyteller has wandered off mid-tale."),
-        );
-        return None;
+    let response = match outcome {
+        InferenceAwaitOutcome::Response(r) => r,
+        InferenceAwaitOutcome::Closed => {
+            tracing::warn!(
+                req_id,
+                "NPC inference response channel closed without a reply",
+            );
+            state.event_bus.emit(
+                "text-log",
+                &text_log("system", "The storyteller has wandered off mid-tale."),
+            );
+            return None;
+        }
+        InferenceAwaitOutcome::TimedOut { secs } => {
+            tracing::warn!(req_id, secs, "NPC inference response timed out",);
+            state.event_bus.emit(
+                "text-log",
+                &text_log("system", "The storyteller is lost in thought. Try again."),
+            );
+            return None;
+        }
     };
 
     if response.error.is_some() {

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -12,7 +12,10 @@ use tokio::sync::mpsc;
 use parish_core::config::InferenceCategory;
 use parish_core::debug_snapshot::{self, DebugEvent, DebugSnapshot, InferenceDebug};
 use parish_core::inference::openai_client::OpenAiClient;
-use parish_core::inference::{AnyClient, InferenceQueue, spawn_inference_worker};
+use parish_core::inference::{
+    AnyClient, INFERENCE_RESPONSE_TIMEOUT_SECS, InferenceAwaitOutcome, InferenceQueue,
+    await_inference_response, spawn_inference_worker,
+};
 use parish_core::input::{InputResult, classify_input, parse_intent};
 use parish_core::ipc::{
     ConversationLine, IDLE_MESSAGES, INFERENCE_FAILURE_MESSAGES, capitalize_first,
@@ -864,7 +867,19 @@ async fn run_npc_turn(
         }
     });
 
-    let response = response_rx.await.ok();
+    let timeout_secs = {
+        let config = state.config.lock().await;
+        if config.flags.is_disabled("inference-response-timeout") {
+            None
+        } else {
+            Some(INFERENCE_RESPONSE_TIMEOUT_SECS)
+        }
+    };
+    let outcome = await_inference_response(
+        response_rx,
+        timeout_secs.map(std::time::Duration::from_secs),
+    )
+    .await;
     let _ = stream_handle.await;
     let _ = app.emit(
         EVENT_STREAM_TURN_END,
@@ -872,17 +887,48 @@ async fn run_npc_turn(
     );
     loading_cancel.cancel();
 
-    let Some(response) = response else {
-        let _ = app.emit(
-            EVENT_TEXT_LOG,
-            TextLogPayload {
-                id: String::new(),
-                stream_turn_id: None,
-                source: "system".to_string(),
-                content: "The storyteller has wandered off mid-tale.".to_string(),
-            },
-        );
-        return None;
+    let response = match outcome {
+        InferenceAwaitOutcome::Response(r) => r,
+        InferenceAwaitOutcome::Closed => {
+            tracing::warn!(
+                req_id,
+                "NPC inference response channel closed without a reply",
+            );
+            let _ = app.emit(
+                EVENT_TEXT_LOG,
+                TextLogPayload {
+                    id: String::new(),
+                    stream_turn_id: None,
+                    source: "system".to_string(),
+                    content: "The storyteller has wandered off mid-tale.".to_string(),
+                },
+            );
+            return None;
+        }
+        InferenceAwaitOutcome::TimedOut { secs } => {
+            tracing::warn!(req_id, secs, "NPC inference response timed out");
+            let ts = debug_event_timestamp(state).await;
+            let mut events = state.debug_events.lock().await;
+            if events.len() >= crate::DEBUG_EVENT_CAPACITY {
+                events.pop_front();
+            }
+            events.push_back(DebugEvent {
+                timestamp: ts,
+                category: "inference".to_string(),
+                message: format!("Response timed out after {secs}s"),
+            });
+            drop(events);
+            let _ = app.emit(
+                EVENT_TEXT_LOG,
+                TextLogPayload {
+                    id: String::new(),
+                    stream_turn_id: None,
+                    source: "system".to_string(),
+                    content: "The storyteller is lost in thought. Try again.".to_string(),
+                },
+            );
+            return None;
+        }
     };
 
     if let Some(ref err) = response.error {


### PR DESCRIPTION
## Summary

Adds a safety timeout around the `oneshot::Receiver<InferenceResponse>`
`.await` in both the Tauri backend (`run_npc_turn` in
`crates/parish-tauri/src/commands.rs`) and the web server (`run_npc_turn`
in `crates/parish-server/src/routes.rs`). Previously a wedged worker
(stuck HTTP call, panic that somehow leaked the sender, etc.) would hang
the receiver forever and leave the player staring at a loading state.

Fixes dmooney/parish#100 and dmooney/parish#227.

## Changes

- **`parish-inference`**: new shared `await_inference_response` helper
  that wraps the receiver await in `tokio::time::timeout` and returns a
  three-way outcome (`Response` / `Closed` / `TimedOut { secs }`), plus
  4 unit tests covering each outcome.
- **`parish-server::routes::run_npc_turn`**: use the helper; distinct
  `tracing::warn!` lines and user-visible text-log messages for closed
  vs. timed-out.
- **`parish-tauri::commands::run_npc_turn`**: same, plus a debug event
  entry on timeout so it surfaces in the debug panel.

## Feature flag

Gated behind `inference-response-timeout` (enabled by default). If the
safety cap causes any regression, turn it off with:

```
/flag disable inference-response-timeout
```

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p parish-inference -p parish-server --all-targets -- -D warnings`
- [x] `cargo test -p parish-inference -p parish-server` — 170 tests pass
- [x] New tests cover the `Response`, `Closed`, `TimedOut`, and no-timeout
      (`None`) paths of the helper.
- [ ] Manual play-test: kick off an NPC conversation, confirm normal
      responses stream end-to-end; simulate a hung worker (stop the LLM
      provider mid-stream) and confirm the user sees "The storyteller is
      lost in thought. Try again." after 360s rather than a perpetual
      loading state.

Note: the `parish-tauri` crate could not be compiled in this
environment (missing system GTK/WebKit libs). All code paths there
mirror the `parish-server` pattern byte-for-byte.
