### PR TITLE
fix: surface IPC failures to users via text log (#108, #113)

### DIFF
--- a/apps/ui/src/components/ChatPanel.svelte
+++ b/apps/ui/src/components/ChatPanel.svelte
@@ -133,7 +133,7 @@
 		{#if entryType(entry) === 'system'}
 			{@const isSplash = entry.content.includes('Copyright \u00A9')}
 			{@const lines = entry.content.split('\n')}
-			<div class="entry system" class:location={entry.subtype === 'location'}>
+			<div class="entry system" class:location={entry.subtype === 'location'} class:error={entry.subtype === 'error'}>
 				{#if isSplash}
 					<span class="content"><strong>{lines[0]}</strong>{'\n' + lines.slice(1).join('\n')}</span>
 				{:else}
@@ -237,6 +237,15 @@
 		border-left: 3px solid var(--color-location);
 		padding-left: 0.75rem;
 		color: var(--color-muted);
+	}
+
+	/* Error feedback: subtle red left border so failures are visible
+	   instead of silent — used by pushErrorLog for failed IPC calls. */
+	.entry.system.error {
+		border-left: 3px solid #c0554a;
+		padding-left: 0.75rem;
+		color: var(--color-muted);
+		font-size: 0.95rem;
 	}
 
 	/* Inline term highlighting */

--- a/apps/ui/src/components/InputField.svelte
+++ b/apps/ui/src/components/InputField.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { streamingActive, npcsHere, mapData } from '../stores/game';
+	import { streamingActive, npcsHere, mapData, pushErrorLog, formatIpcError } from '../stores/game';
 	import { submitInput } from '$lib/ipc';
 	import { filterCommands, type SlashCommand } from '$lib/slash-commands';
 	import { knownNouns, findMatches, type KnownNoun } from '../stores/nouns';
@@ -429,7 +429,9 @@
 		} else {
 			clearEditor();
 			dropdownMode = null;
-			submitInput(cmd.command);
+			submitInput(cmd.command).catch((err) => {
+				pushErrorLog(`Could not send "${cmd.command}": ${formatIpcError(err)}`);
+			});
 		}
 	}
 
@@ -466,7 +468,13 @@
 		if ($streamingActive) return;
 		selectedNpcRealNames = [];
 		clearEditor();
-		await submitInput(`go to ${locationName}`);
+		try {
+			await submitInput(`go to ${locationName}`);
+		} catch (err) {
+			pushErrorLog(
+				`Could not travel to ${locationName}: ${formatIpcError(err)}`
+			);
+		}
 	}
 
 	function toggleNpcSelection(realName: string) {
@@ -537,7 +545,11 @@
 
 		const addressedTo = [...selectedNpcRealNames];
 		selectedNpcRealNames = [];
-		await submitInput(trimmed, addressedTo);
+		try {
+			await submitInput(trimmed, addressedTo);
+		} catch (err) {
+			pushErrorLog(`Could not send input: ${formatIpcError(err)}`);
+		}
 	}
 
 	// ── Keyboard handling ───────────────────────────────────────────────────

--- a/apps/ui/src/components/InputField.test.ts
+++ b/apps/ui/src/components/InputField.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
-import { streamingActive, npcsHere, mapData } from '../stores/game';
+import { get } from 'svelte/store';
+import { streamingActive, npcsHere, mapData, textLog } from '../stores/game';
 import { findMatches, type KnownNoun } from '../stores/nouns';
 import InputField from './InputField.svelte';
 
@@ -31,7 +32,9 @@ describe('InputField', () => {
 		streamingActive.set(false);
 		npcsHere.set([]);
 		mapData.set(null);
-		mockSubmitInput.mockClear();
+		textLog.set([]);
+		mockSubmitInput.mockReset();
+		mockSubmitInput.mockImplementation(async () => {});
 		localStorage.clear?.();
 	});
 
@@ -743,6 +746,61 @@ describe('InputField', () => {
 			const chip = editor.querySelector('.mention-chip');
 			expect(chip).toBeTruthy();
 			expect(chip?.textContent).toBe('@Padraig Darcy');
+		});
+	});
+
+	// ── Submit error handling (#108) ────────────────────────────────────
+	describe('submit error handling', () => {
+		it('appends a system error entry when submitInput rejects', async () => {
+			mockSubmitInput.mockImplementationOnce(async () => {
+				throw new Error('network down');
+			});
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			editor.textContent = 'hello there';
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			// Let the rejected promise settle so the catch handler runs.
+			await Promise.resolve();
+			await Promise.resolve();
+
+			const log = get(textLog);
+			const last = log[log.length - 1];
+			expect(last.source).toBe('system');
+			expect(last.subtype).toBe('error');
+			expect(last.content).toContain('Could not send input');
+			expect(last.content).toContain('network down');
+		});
+
+		it('appends an error entry when a quick-travel chip click fails', async () => {
+			const testMap = {
+				locations: [
+					{ id: 'crossroads', name: 'The Crossroads', lat: 0, lon: 0, adjacent: true, hops: 0, visited: true },
+					{ id: 'pub', name: "Darcy's Pub", lat: 0.1, lon: 0.1, adjacent: true, hops: 1, visited: true }
+				],
+				edges: [['crossroads', 'pub']] as [string, string][],
+				player_location: 'crossroads',
+				player_lat: 0,
+				player_lon: 0
+			};
+			mapData.set(testMap);
+			mockSubmitInput.mockImplementationOnce(async () => {
+				throw new Error('server busy');
+			});
+
+			const { container } = render(InputField);
+			const chip = container.querySelector('.travel-chip') as HTMLButtonElement;
+			await fireEvent.click(chip);
+			await Promise.resolve();
+			await Promise.resolve();
+
+			const log = get(textLog);
+			const last = log[log.length - 1];
+			expect(last.subtype).toBe('error');
+			expect(last.content).toContain("Could not travel to Darcy's Pub");
+			expect(last.content).toContain('server busy');
 		});
 	});
 });

--- a/apps/ui/src/components/MapPanel.svelte
+++ b/apps/ui/src/components/MapPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { mapData, fullMapOpen } from '../stores/game';
+	import { mapData, fullMapOpen, pushErrorLog, formatIpcError } from '../stores/game';
 	import { travelState } from '../stores/travel';
 	import { submitInput } from '$lib/ipc';
 	import { MapController, type LocationHoverInfo } from '$lib/map/controller';
@@ -127,7 +127,13 @@
 
 		controller.onLocationClick(async (info) => {
 			if (!info.adjacent) return;
-			await submitInput(`go to ${info.name}`);
+			try {
+				await submitInput(`go to ${info.name}`);
+			} catch (err) {
+				pushErrorLog(
+					`Could not travel to ${info.name}: ${formatIpcError(err)}`
+				);
+			}
 		});
 
 		controller.onLocationHover(

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -10,7 +10,7 @@
 	import DebugPanel from '../components/DebugPanel.svelte';
 	import SavePicker from '../components/SavePicker.svelte';
 
-	import { worldState, mapData, npcsHere, textLog, streamingActive, loadingSpinner, loadingPhrase, loadingColor, languageHints, nameHints, uiConfig, fullMapOpen, focailOpen, addReaction, trimTextLog, messageHints } from '../stores/game';
+	import { worldState, mapData, npcsHere, textLog, streamingActive, loadingSpinner, loadingPhrase, loadingColor, languageHints, nameHints, uiConfig, fullMapOpen, focailOpen, addReaction, trimTextLog, messageHints, pushErrorLog, formatIpcError } from '../stores/game';
 
 	/** Which mobile-only panel is open (if any). Desktop ignores this. */
 	let mobilePanel = $state<'none' | 'map' | 'sidebar'>('none');
@@ -163,29 +163,44 @@
 		window.addEventListener('touchstart', onTrackerTouch);
 		window.addEventListener('mousemove', onTrackerMousemove);
 
-		// Initial data fetch (theme first to avoid color flash)
-		try {
-			const [snap, map, npcs, theme] = await Promise.all([
-				getWorldSnapshot(),
-				getMap(),
-				getNpcsHere(),
-				getTheme()
-			]);
+		// Initial data fetch (theme first to avoid color flash).
+		//
+		// Use `allSettled` so a single failed endpoint doesn't block the
+		// rest of the UI from loading. Any failure is surfaced via
+		// pushErrorLog so the user sees feedback instead of an indefinite
+		// "Loading..." state — see #113.
+		const [snapRes, mapRes, npcsRes, themeRes] = await Promise.allSettled([
+			getWorldSnapshot(),
+			getMap(),
+			getNpcsHere(),
+			getTheme()
+		]);
+		if (snapRes.status === 'fulfilled') {
+			const snap = snapRes.value;
 			worldState.set(snap);
-			mapData.set(map);
-			npcsHere.set(npcs);
-			palette.applyServerPalette(theme);
 			palette.applyGameHour(snap.hour);
 			if (snap.name_hints) nameHints.set(snap.name_hints);
-			// Show initial location description in the chat panel
 			if (snap.location_description) {
 				textLog.update((log) => [
 					...log,
 					{ source: 'system', content: snap.location_description }
 				]);
 			}
-		} catch (e) {
-			console.warn('Initial fetch failed (expected in browser dev):', e);
+		}
+		if (mapRes.status === 'fulfilled') mapData.set(mapRes.value);
+		if (npcsRes.status === 'fulfilled') npcsHere.set(npcsRes.value);
+		if (themeRes.status === 'fulfilled') palette.applyServerPalette(themeRes.value);
+
+		const failed: string[] = [];
+		if (snapRes.status === 'rejected') failed.push(`world (${formatIpcError(snapRes.reason)})`);
+		if (mapRes.status === 'rejected') failed.push(`map (${formatIpcError(mapRes.reason)})`);
+		if (npcsRes.status === 'rejected') failed.push(`NPCs (${formatIpcError(npcsRes.reason)})`);
+		if (themeRes.status === 'rejected') failed.push(`theme (${formatIpcError(themeRes.reason)})`);
+		if (failed.length > 0) {
+			pushErrorLog(`Failed to load initial game data: ${failed.join(', ')}.`);
+			for (const r of [snapRes, mapRes, npcsRes, themeRes]) {
+				if (r.status === 'rejected') console.warn('Initial fetch failed:', r.reason);
+			}
 		}
 
 		// Fetch UI config from mod and show splash text

--- a/apps/ui/src/stores/game.test.ts
+++ b/apps/ui/src/stores/game.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import { textLog, pushErrorLog, formatIpcError } from './game';
+
+describe('pushErrorLog', () => {
+	beforeEach(() => {
+		textLog.set([]);
+	});
+
+	it('appends a system entry with the error subtype', () => {
+		pushErrorLog('Something went wrong');
+		const log = get(textLog);
+		expect(log.length).toBe(1);
+		expect(log[0]).toMatchObject({
+			source: 'system',
+			subtype: 'error',
+			content: 'Something went wrong'
+		});
+	});
+
+	it('appends to existing log entries rather than replacing them', () => {
+		textLog.set([{ source: 'system', content: 'Welcome.' }]);
+		pushErrorLog('Network down');
+		const log = get(textLog);
+		expect(log.length).toBe(2);
+		expect(log[0].content).toBe('Welcome.');
+		expect(log[1].subtype).toBe('error');
+	});
+});
+
+describe('formatIpcError', () => {
+	it('returns the message from an Error instance', () => {
+		expect(formatIpcError(new Error('boom'))).toBe('boom');
+	});
+
+	it('returns a string error unchanged', () => {
+		expect(formatIpcError('already a string')).toBe('already a string');
+	});
+
+	it('falls back to a generic label for unknown shapes', () => {
+		expect(formatIpcError({ weird: true })).toBe('unknown error');
+		expect(formatIpcError(undefined)).toBe('unknown error');
+		expect(formatIpcError(null)).toBe('unknown error');
+	});
+});

--- a/apps/ui/src/stores/game.ts
+++ b/apps/ui/src/stores/game.ts
@@ -46,6 +46,26 @@ export const focailOpen = writable<boolean>(false);
 /** Maps message ID → Irish word hints for that completed NPC response. */
 export const messageHints = writable<Map<string, LanguageHint[]>>(new Map());
 
+/**
+ * Appends a user-visible error entry to the text log.
+ *
+ * Used to surface failures from IPC calls or initial data loads that would
+ * otherwise fail silently. The entry is a `system`-sourced message with the
+ * `error` subtype so it can be styled distinctly.
+ */
+export function pushErrorLog(content: string): void {
+	textLog.update((log) =>
+		trimTextLog([...log, { source: 'system', subtype: 'error', content }])
+	);
+}
+
+/** Extracts a concise user-facing string from a thrown IPC error. */
+export function formatIpcError(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	if (typeof err === 'string') return err;
+	return 'unknown error';
+}
+
 /** Adds a reaction to a message in the text log by message ID. */
 export function addReaction(messageId: string, emoji: string, source: string): void {
 	textLog.update((log) => {


### PR DESCRIPTION
## Summary

Two related frontend bugs caused IPC failures to disappear silently, leaving users staring at an unchanging UI with no feedback:

- **#108** — `submitInput` calls in `InputField.svelte` and `MapPanel.svelte` had no error handling. Failed sends cleared the input but surfaced no message.
- **#113** — The initial `Promise.all` fetch in `+page.svelte` wrapped every failure in an empty `.catch()`, so a single failing endpoint produced an indefinite "Loading..." with only a `console.warn`.

This PR replaces the silent catches with user-visible text-log entries, so players can tell when something failed and what.

## Changes

- **`stores/game.ts`** — new `pushErrorLog(content)` helper appends a `system` entry with `subtype: 'error'`, plus `formatIpcError(err)` for concise messages from thrown exceptions.
- **`ChatPanel.svelte`** — adds a `.entry.system.error` style (subtle red left border, muted text) so errors read as warnings rather than narrative prose.
- **`InputField.svelte`** — wraps `submitInput` in `handleSubmit`, `quickTravel`, and the no-arg `selectSlashCommand` path with try/catch; on failure a clear "Could not …" entry is appended.
- **`MapPanel.svelte`** — wraps the location-click `submitInput` with the same pattern.
- **`+page.svelte`** — swaps `Promise.all` for `Promise.allSettled` so a single failing endpoint no longer blocks the rest of the UI, and pushes a single aggregated error log if anything failed (while still logging details to the console for debugging).

## Tests

- `stores/game.test.ts` (new) — covers `pushErrorLog` (appends vs. replaces, subtype) and `formatIpcError` (Error, string, unknown shapes).
- `components/InputField.test.ts` — new error-handling describe block verifies that a rejected `submitInput` from `handleSubmit` and a failing quick-travel chip click both produce a system error entry in the text log.

Existing pre-existing vitest failures in the NPC-selection chip tests and pre-existing svelte-check errors are unchanged by this PR.

## Test plan

- [x] `npx vitest run src/stores/game.test.ts` — 5/5 pass
- [x] `npx vitest run src/components/InputField.test.ts` — new tests pass; 3 pre-existing failures unchanged
- [x] `npm run check` (svelte-check) — error count reduced from 10 → 9 (no new errors introduced)
- [ ] Manual: disconnect the server and submit input — verify a red-bordered "Could not send input" entry appears in the chat log
- [ ] Manual: quick-travel to an adjacent location while the server is unreachable — verify "Could not travel to …" entry appears
- [ ] Manual: start the client against an unreachable server — verify a single "Failed to load initial game data" entry appears instead of an indefinite Loading state

Fixes #108, #113

https://claude.ai/code/session_01S3W9XQLtnaLyNXT2JDSJos