### PR TITLE
feat: /tiles command + configurable map tile source registry (Phase D.1)

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -271,7 +271,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -288,7 +287,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -305,7 +303,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -322,7 +319,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -339,7 +335,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -356,7 +351,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -373,7 +367,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -390,7 +383,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -407,7 +399,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -424,7 +415,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -441,7 +431,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -458,7 +447,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -475,7 +463,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -492,7 +479,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -509,7 +495,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -526,7 +511,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -543,7 +527,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -560,7 +543,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -577,7 +559,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -594,7 +575,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -611,7 +591,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -628,7 +607,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -645,7 +623,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -662,7 +639,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -679,7 +655,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -696,7 +671,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -904,7 +878,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -918,7 +891,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -932,7 +904,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -946,7 +917,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -960,7 +930,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -974,7 +943,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -988,7 +956,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1002,7 +969,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1016,7 +982,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1030,7 +995,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1044,7 +1008,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1058,7 +1021,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1072,7 +1034,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1086,7 +1047,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1100,7 +1060,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1114,7 +1073,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1128,7 +1086,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1142,7 +1099,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1156,7 +1112,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1170,7 +1125,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1184,7 +1138,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1198,7 +1151,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1212,7 +1164,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1226,7 +1177,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1240,7 +1190,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1981,7 +1930,6 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,

--- a/apps/ui/src/components/ChatPanel.svelte
+++ b/apps/ui/src/components/ChatPanel.svelte
@@ -129,7 +129,7 @@
 </script>
 
 <div class="chat-panel" data-testid="chat-panel" bind:this={logEl} role="log" aria-live="polite" aria-label="Game chat log">
-	{#each $textLog as entry, index (entry.id ?? entry.stream_turn_id ?? `${entry.source}:${index}`)}
+	{#each $textLog as entry, index (entry.id || entry.stream_turn_id || `${entry.source}:${index}`)}
 		{#if entryType(entry) === 'system'}
 			{@const isSplash = entry.content.includes('Copyright \u00A9')}
 			{@const lines = entry.content.split('\n')}

--- a/apps/ui/src/components/FullMapOverlay.svelte
+++ b/apps/ui/src/components/FullMapOverlay.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { mapData } from '../stores/game';
 	import { travelState } from '../stores/travel';
+	import { tiles, currentTileSource } from '../stores/tiles';
 	import { submitInput } from '$lib/ipc';
 	import { MapController, type LocationHoverInfo } from '$lib/map/controller';
 
@@ -29,7 +30,8 @@
 		controller = new MapController({
 			container,
 			variant: 'full',
-			interactive: true
+			interactive: true,
+			tileSource: currentTileSource($tiles)
 		});
 
 		controller.onLocationClick(async (info) => {
@@ -85,6 +87,12 @@
 		} else {
 			controller.stopTravel();
 		}
+	});
+
+	// Swap the base tile source when the user toggles via `/tiles`.
+	$effect(() => {
+		if (!mounted || !controller) return;
+		controller.setTileSource(currentTileSource($tiles));
 	});
 
 	function handleKeydown(e: KeyboardEvent) {

--- a/apps/ui/src/lib/ipc.ts
+++ b/apps/ui/src/lib/ipc.ts
@@ -192,6 +192,12 @@ export interface ThemeSwitchPayload {
 export const onThemeSwitch = (cb: (payload: ThemeSwitchPayload) => void) =>
 	onEvent<ThemeSwitchPayload>('theme-switch', cb);
 
+export interface TilesSwitchPayload {
+	id: string;
+}
+export const onTilesSwitch = (cb: (payload: TilesSwitchPayload) => void) =>
+	onEvent<TilesSwitchPayload>('tiles-switch', cb);
+
 export const onDebugUpdate = (cb: (payload: DebugSnapshot) => void) =>
 	onEvent<DebugSnapshot>('debug-update', cb);
 

--- a/apps/ui/src/lib/ipc.ts
+++ b/apps/ui/src/lib/ipc.ts
@@ -204,9 +204,6 @@ export const onDebugUpdate = (cb: (payload: DebugSnapshot) => void) =>
 export const onSavePicker = (cb: () => void) =>
 	onEvent<void>('save-picker', () => cb());
 
-export const onToggleFullMap = (cb: () => void) =>
-	onEvent<void>('toggle-full-map', () => cb());
-
 export const onNpcReaction = (cb: (payload: NpcReactionPayload) => void) =>
 	onEvent<NpcReactionPayload>('npc-reaction', cb);
 

--- a/apps/ui/src/lib/map/controller.ts
+++ b/apps/ui/src/lib/map/controller.ts
@@ -25,7 +25,7 @@ import maplibregl, {
 	type MapMouseEvent,
 	type MapGeoJSONFeature
 } from 'maplibre-gl';
-import type { MapData, TravelWaypoint } from '$lib/types';
+import type { MapData, TileSource, TravelWaypoint } from '$lib/types';
 import { buildStyle, readThemeColors, type MapVariant } from './style';
 import {
 	locationsToGeoJSON,
@@ -44,6 +44,9 @@ export interface MapControllerOptions {
 	interactive: boolean;
 	/** Initial zoom level. Minimap uses a fixed zoom; full map fits bounds. */
 	initialZoom?: number;
+	/** Raster tile source to use for the base layer (full map only). Undefined
+	 *  or a source with an empty URL yields a flat-bg fallback. */
+	tileSource?: TileSource;
 }
 
 /** Callback payload emitted on location click. */
@@ -73,6 +76,10 @@ export class MapController {
 	private variant: MapVariant;
 	private ready = false;
 	private pendingMapData: MapData | null = null;
+	/** Last `MapData` we rendered. Retained so that `setTileSource()` can
+	 *  re-push the overlay GeoJSON after MapLibre's `setStyle()` wipes all
+	 *  sources and layers. */
+	private lastMapData: MapData | null = null;
 	/** Ids of currently-visible locations (filtered set, or all if no filter). */
 	private lastVisibleIds: Set<string> | null = null;
 	/** Active travel animation, cleared when travel ends. */
@@ -82,13 +89,16 @@ export class MapController {
 	/** Registered hover handler, if any. */
 	private hoverEnterHandler: ((info: LocationHoverInfo) => void) | null = null;
 	private hoverLeaveHandler: (() => void) | null = null;
+	/** Current tile source, mirrored so `setTileSource` can rebuild the style. */
+	private tileSource: TileSource | undefined;
 
 	constructor(options: MapControllerOptions) {
 		this.variant = options.variant;
+		this.tileSource = options.tileSource;
 		const theme = readThemeColors();
 		this.map = new maplibregl.Map({
 			container: options.container,
-			style: buildStyle(options.variant, theme),
+			style: buildStyle(options.variant, theme, this.tileSource),
 			center: [-8.15, 53.59], // Kiltoom/Kilteevan reference center
 			zoom: options.initialZoom ?? (options.variant === 'minimap' ? 14 : 13),
 			interactive: options.interactive,
@@ -110,6 +120,31 @@ export class MapController {
 	}
 
 	/**
+	 * Swaps the base tile source at runtime.
+	 *
+	 * MapLibre's `setStyle()` wipes all existing sources and layers, so after
+	 * the new style's `styledata` event fires we re-push the last `MapData`
+	 * to restore the location/edge overlays. Using `.once()` avoids re-entry
+	 * on repeated `styledata` fires.
+	 *
+	 * Called by the full-map component's `$effect` when the `tiles` store's
+	 * active id changes (driven by the `tiles-switch` event from `/tiles`).
+	 */
+	setTileSource(source: TileSource | undefined): void {
+		this.tileSource = source;
+		const theme = readThemeColors();
+		this.ready = false;
+		this.map.setStyle(buildStyle(this.variant, theme, source));
+		this.map.once('styledata', () => {
+			this.ready = true;
+			this.wireLayerEvents();
+			const data = this.pendingMapData ?? this.lastMapData;
+			this.pendingMapData = null;
+			if (data) this.updateMap(data, this.lastVisibleIds ?? undefined);
+		});
+	}
+
+	/**
 	 * Updates the map's location and edge sources from the latest `MapData`.
 	 *
 	 * On the minimap, pass `visibleIds` to restrict which locations and edges
@@ -117,6 +152,9 @@ export class MapController {
 	 * the player). On the full map, pass undefined to render everything.
 	 */
 	updateMap(mapData: MapData, visibleIds?: ReadonlySet<string>): void {
+		// Retained for post-`setStyle` re-push in `setTileSource`.
+		this.lastMapData = mapData;
+
 		if (!this.ready) {
 			this.pendingMapData = mapData;
 			return;

--- a/apps/ui/src/lib/map/style.test.ts
+++ b/apps/ui/src/lib/map/style.test.ts
@@ -26,15 +26,15 @@ function osm(): TileSource {
 	};
 }
 
-function tailte(): TileSource {
+function tmsSource(): TileSource {
 	return {
-		id: 'tailte-historic-6inch',
-		label: 'Tailte Éireann Historic 6"',
+		id: 'arcgis-tms',
+		label: 'ArcGIS-style y-flipped',
 		url: 'https://example.test/MapServer/tile/{z}/{y}/{x}',
 		tile_size: 256,
 		minzoom: 0,
 		maxzoom: 17,
-		attribution: 'Tailte Éireann',
+		attribution: 'example',
 		raster_saturation: 0.0,
 		raster_opacity: 1.0,
 		tms: true
@@ -60,13 +60,13 @@ describe('buildStyle', () => {
 	});
 
 	it('full map with TMS source sets scheme: tms', () => {
-		const style = buildStyle('full', THEME, tailte());
+		const style = buildStyle('full', THEME, tmsSource());
 		const raster = style.sources['map-tiles'] as { scheme?: string };
 		expect(raster.scheme).toBe('tms');
 	});
 
 	it('full map with empty URL falls back to flat background', () => {
-		const empty: TileSource = { ...osm(), id: 'tailte-placeholder', url: '' };
+		const empty: TileSource = { ...osm(), id: 'unconfigured', url: '' };
 		const style = buildStyle('full', THEME, empty);
 		expect(style.sources['map-tiles']).toBeUndefined();
 		expect(style.layers.find((l) => l.id === 'background')).toBeDefined();

--- a/apps/ui/src/lib/map/style.test.ts
+++ b/apps/ui/src/lib/map/style.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { buildStyle, type ThemeColors } from './style';
+import type { TileSource } from '$lib/types';
+
+const THEME: ThemeColors = {
+	bg: '#fafad8',
+	fg: '#31240f',
+	accent: '#b08531',
+	panelBg: '#f5f5d3',
+	border: '#cec293',
+	muted: '#76663b'
+};
+
+function osm(): TileSource {
+	return {
+		id: 'osm',
+		label: 'OpenStreetMap',
+		url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+		tile_size: 256,
+		minzoom: 0,
+		maxzoom: 19,
+		attribution: '© OpenStreetMap contributors',
+		raster_saturation: -0.4,
+		raster_opacity: 0.85,
+		tms: false
+	};
+}
+
+function tailte(): TileSource {
+	return {
+		id: 'tailte-historic-6inch',
+		label: 'Tailte Éireann Historic 6"',
+		url: 'https://example.test/MapServer/tile/{z}/{y}/{x}',
+		tile_size: 256,
+		minzoom: 0,
+		maxzoom: 17,
+		attribution: 'Tailte Éireann',
+		raster_saturation: 0.0,
+		raster_opacity: 1.0,
+		tms: true
+	};
+}
+
+describe('buildStyle', () => {
+	it('full map with OSM source wires URL and no TMS scheme', () => {
+		const style = buildStyle('full', THEME, osm());
+		const src = style.sources['map-tiles'];
+		expect(src).toBeDefined();
+		expect(src.type).toBe('raster');
+		const raster = src as { tiles: string[]; scheme?: string; attribution: string };
+		expect(raster.tiles).toEqual(['https://tile.openstreetmap.org/{z}/{x}/{y}.png']);
+		expect(raster.scheme).toBeUndefined();
+		expect(raster.attribution).toBe('© OpenStreetMap contributors');
+
+		const rasterLayer = style.layers.find((l) => l.id === 'map-tiles-layer');
+		expect(rasterLayer).toBeDefined();
+		expect((rasterLayer as { paint: { 'raster-saturation': number } }).paint['raster-saturation']).toBe(-0.4);
+		// No flat-bg layer should be present on the full map when tiles render.
+		expect(style.layers.find((l) => l.id === 'background')).toBeUndefined();
+	});
+
+	it('full map with TMS source sets scheme: tms', () => {
+		const style = buildStyle('full', THEME, tailte());
+		const raster = style.sources['map-tiles'] as { scheme?: string };
+		expect(raster.scheme).toBe('tms');
+	});
+
+	it('full map with empty URL falls back to flat background', () => {
+		const empty: TileSource = { ...osm(), id: 'tailte-placeholder', url: '' };
+		const style = buildStyle('full', THEME, empty);
+		expect(style.sources['map-tiles']).toBeUndefined();
+		expect(style.layers.find((l) => l.id === 'background')).toBeDefined();
+		expect(style.layers.find((l) => l.id === 'map-tiles-layer')).toBeUndefined();
+	});
+
+	it('full map with no tileSource at all falls back to flat background', () => {
+		const style = buildStyle('full', THEME);
+		expect(style.sources['map-tiles']).toBeUndefined();
+		expect(style.layers.find((l) => l.id === 'background')).toBeDefined();
+	});
+
+	it('minimap ignores tileSource and always uses flat background', () => {
+		const style = buildStyle('minimap', THEME, osm());
+		expect(style.sources['map-tiles']).toBeUndefined();
+		expect(style.layers.find((l) => l.id === 'background')).toBeDefined();
+		expect(style.layers.find((l) => l.id === 'map-tiles-layer')).toBeUndefined();
+	});
+
+	it('always carries empty GeoJSON sources for locations and edges', () => {
+		const style = buildStyle('full', THEME, osm());
+		expect(style.sources.locations.type).toBe('geojson');
+		expect(style.sources.edges.type).toBe('geojson');
+	});
+});

--- a/apps/ui/src/lib/map/style.ts
+++ b/apps/ui/src/lib/map/style.ts
@@ -61,9 +61,10 @@ const GLYPHS_URL = 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf'
  * the `tileSource` parameter (ships with OSM by default; the `/tiles`
  * slash command swaps this via `MapController.setTileSource()`).
  *
- * Passing a `tileSource` with an empty `url` (e.g. an unconfigured Tailte
- * placeholder) falls back to the flat-bg layer with a one-shot console
- * warning — the feature flag can stay on without a live endpoint.
+ * Passing a `tileSource` with an empty `url` (e.g. a user-added source
+ * that hasn't had its URL filled in yet) falls back to the flat-bg layer
+ * with a one-shot console warning — the feature flag can stay on without
+ * a live endpoint.
  */
 export function buildStyle(
 	variant: MapVariant,
@@ -87,8 +88,8 @@ export function buildStyle(
 		});
 	} else {
 		if (variant === 'full' && tileSource && tileSource.url.length === 0) {
-			// Informational — Tailte ships with an empty URL placeholder until
-			// the operator pastes a real endpoint into parish.toml.
+			// Informational — a source was registered without a URL; the
+			// operator needs to paste a real endpoint into parish.toml.
 			warnMissingTileUrl(tileSource.id);
 		}
 		// Minimap: flat panel background, no tiles.

--- a/apps/ui/src/lib/map/style.ts
+++ b/apps/ui/src/lib/map/style.ts
@@ -15,7 +15,12 @@
  * theme changes and pass the result to `map.setStyle()`.
  */
 
-import type { StyleSpecification, LayerSpecification } from 'maplibre-gl';
+import type {
+	StyleSpecification,
+	LayerSpecification,
+	RasterSourceSpecification
+} from 'maplibre-gl';
+import type { TileSource } from '$lib/types';
 
 export type MapVariant = 'minimap' | 'full';
 
@@ -52,24 +57,40 @@ const GLYPHS_URL = 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf'
  *
  * The style has two GeoJSON sources (`locations` and `edges`) that start
  * empty — the controller populates them via `setData()` as game state
- * changes. On the full map a raster OSM base is added beneath.
+ * changes. On the full map a raster base is added beneath, sourced from
+ * the `tileSource` parameter (ships with OSM by default; the `/tiles`
+ * slash command swaps this via `MapController.setTileSource()`).
+ *
+ * Passing a `tileSource` with an empty `url` (e.g. an unconfigured Tailte
+ * placeholder) falls back to the flat-bg layer with a one-shot console
+ * warning — the feature flag can stay on without a live endpoint.
  */
-export function buildStyle(variant: MapVariant, theme: ThemeColors): StyleSpecification {
+export function buildStyle(
+	variant: MapVariant,
+	theme: ThemeColors,
+	tileSource?: TileSource
+): StyleSpecification {
 	const layers: LayerSpecification[] = [];
+	const rasterSourceId = 'map-tiles';
+	const hasUsableTiles = variant === 'full' && tileSource && tileSource.url.length > 0;
 
-	// 1. Base layer — flat color on the minimap, OSM raster on the full map.
-	if (variant === 'full') {
+	// 1. Base layer — flat color on the minimap, configured raster on the full map.
+	if (hasUsableTiles) {
 		layers.push({
-			id: 'osm-tiles',
+			id: 'map-tiles-layer',
 			type: 'raster',
-			source: 'osm',
+			source: rasterSourceId,
 			paint: {
-				// Desaturate slightly so game elements stay visually dominant.
-				'raster-saturation': -0.4,
-				'raster-opacity': 0.85
+				'raster-saturation': tileSource!.raster_saturation,
+				'raster-opacity': tileSource!.raster_opacity
 			}
 		});
 	} else {
+		if (variant === 'full' && tileSource && tileSource.url.length === 0) {
+			// Informational — Tailte ships with an empty URL placeholder until
+			// the operator pastes a real endpoint into parish.toml.
+			warnMissingTileUrl(tileSource.id);
+		}
 		// Minimap: flat panel background, no tiles.
 		layers.push({
 			id: 'background',
@@ -247,32 +268,47 @@ export function buildStyle(variant: MapVariant, theme: ThemeColors): StyleSpecif
 		}
 	});
 
+	const sources: StyleSpecification['sources'] = {
+		locations: {
+			type: 'geojson',
+			data: { type: 'FeatureCollection', features: [] }
+		},
+		edges: {
+			type: 'geojson',
+			data: { type: 'FeatureCollection', features: [] }
+		}
+	};
+	if (hasUsableTiles) {
+		const rasterSource: RasterSourceSpecification = {
+			type: 'raster',
+			tiles: [tileSource!.url],
+			tileSize: tileSource!.tile_size,
+			minzoom: tileSource!.minzoom,
+			maxzoom: tileSource!.maxzoom,
+			attribution: tileSource!.attribution
+		};
+		if (tileSource!.tms) rasterSource.scheme = 'tms';
+		sources[rasterSourceId] = rasterSource;
+	}
+
 	return {
 		version: 8,
 		glyphs: GLYPHS_URL,
-		sources: {
-			...(variant === 'full'
-				? {
-						osm: {
-							type: 'raster',
-							tiles: ['https://tile.openstreetmap.org/{z}/{x}/{y}.png'],
-							tileSize: 256,
-							minzoom: 0,
-							maxzoom: 19,
-							attribution:
-								'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-						}
-					}
-				: {}),
-			locations: {
-				type: 'geojson',
-				data: { type: 'FeatureCollection', features: [] }
-			},
-			edges: {
-				type: 'geojson',
-				data: { type: 'FeatureCollection', features: [] }
-			}
-		},
+		sources,
 		layers
 	};
+}
+
+// Shown once per missing id so toggling between sources doesn't spam the
+// console. Scoped module-level so the set persists across `buildStyle` calls.
+const warnedMissingIds = new Set<string>();
+function warnMissingTileUrl(id: string) {
+	if (warnedMissingIds.has(id)) return;
+	warnedMissingIds.add(id);
+	// eslint-disable-next-line no-console
+	console.warn(
+		`[tiles] source '${id}' has no URL; falling back to flat background. ` +
+			`Set [engine.map.tile_sources.${id}] url = "..." in parish.toml ` +
+			'or see docs/design/map-evolution.md.'
+	);
 }

--- a/apps/ui/src/lib/slash-commands.ts
+++ b/apps/ui/src/lib/slash-commands.ts
@@ -28,7 +28,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
 	{ command: '/cloud', description: 'Cloud provider settings', hasArgs: true },
 	{ command: '/debug', description: 'Debug panel', hasArgs: true },
 	{ command: '/spinner', description: 'Show loading spinner', hasArgs: true },
-	{ command: '/map', description: 'Show the parish map', hasArgs: false },
+	{ command: '/map', description: 'List or switch map tile sources', hasArgs: true },
 	{ command: '/npcs', description: "Who's here?", hasArgs: false },
 	{ command: '/time', description: 'What time is it?', hasArgs: false },
 	{ command: '/where', description: 'Where am I? (alias for /status)', hasArgs: false },

--- a/apps/ui/src/lib/types.ts
+++ b/apps/ui/src/lib/types.ts
@@ -90,6 +90,23 @@ export interface UiConfig {
 	hints_label: string;
 	default_accent: string;
 	splash_text: string;
+	active_tile_source: string;
+	tile_sources: TileSource[];
+}
+
+/** A single map tile source sent from the backend. Mirrors
+ *  `parish_core::ipc::TileSourceSnapshot`. */
+export interface TileSource {
+	id: string;
+	label: string;
+	url: string;
+	tile_size: number;
+	minzoom: number;
+	maxzoom: number;
+	attribution: string;
+	raster_saturation: number;
+	raster_opacity: number;
+	tms: boolean;
 }
 
 export interface Reaction {

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -17,6 +17,7 @@
 	import { debugVisible, debugSnapshot } from '../stores/debug';
 	import { savePickerVisible } from '../stores/save';
 	import { palette } from '../stores/theme';
+	import { tiles } from '../stores/tiles';
 	import { startTravel } from '../stores/travel';
 	import {
 		getWorldSnapshot,
@@ -33,6 +34,7 @@
 		onLoading,
 		onThemeUpdate,
 		onThemeSwitch,
+		onTilesSwitch,
 		onDebugUpdate,
 		onSavePicker,
 		onToggleFullMap,
@@ -202,6 +204,7 @@
 		try {
 			const cfg = await getUiConfig();
 			uiConfig.set(cfg);
+			tiles.initFromUiConfig(cfg);
 			if (cfg.splash_text) {
 				textLog.update((log) => [
 					{ source: 'system', content: cfg.splash_text },
@@ -465,6 +468,10 @@
 					name: p.name as 'default' | 'solarized',
 					mode: p.mode as 'light' | 'dark' | 'auto' | ''
 				});
+			}));
+
+			listeners.push(await onTilesSwitch((p) => {
+				tiles.setActiveId(p.id);
 			}));
 
 			listeners.push(await onDebugUpdate((snap) => {

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -37,7 +37,6 @@
 		onTilesSwitch,
 		onDebugUpdate,
 		onSavePicker,
-		onToggleFullMap,
 		onNpcReaction,
 		onTravelStart,
 		submitInput
@@ -476,10 +475,6 @@
 
 			listeners.push(await onDebugUpdate((snap) => {
 				debugSnapshot.set(snap);
-			}));
-
-			listeners.push(await onToggleFullMap(() => {
-				fullMapOpen.update((v) => !v);
 			}));
 
 			listeners.push(await onTravelStart((payload) => {

--- a/apps/ui/src/stores/game.ts
+++ b/apps/ui/src/stores/game.ts
@@ -36,7 +36,9 @@ export const nameHints = writable<LanguageHint[]>([]);
 export const uiConfig = writable<UiConfig>({
 	hints_label: 'Language Hints',
 	default_accent: '#b08531',
-	splash_text: ''
+	splash_text: '',
+	active_tile_source: '',
+	tile_sources: []
 });
 
 export const fullMapOpen = writable<boolean>(false);

--- a/apps/ui/src/stores/tiles.test.ts
+++ b/apps/ui/src/stores/tiles.test.ts
@@ -19,7 +19,7 @@ function osm(): TileSource {
 
 function historic(): TileSource {
 	return {
-		id: 'historic-6inch',
+		id: 'historic',
 		label: 'Historic 6"',
 		url: 'https://mapseries-tilesets.s3.amazonaws.com/ireland_6inch/{z}/{x}/{y}.jpg',
 		tile_size: 256,
@@ -65,8 +65,8 @@ describe('tiles store', () => {
 	it('setActiveId switches the active source', async () => {
 		const { tiles } = await freshStore();
 		tiles.initFromUiConfig(cfg('osm'));
-		tiles.setActiveId('historic-6inch');
-		expect(get(tiles).activeId).toBe('historic-6inch');
+		tiles.setActiveId('historic');
+		expect(get(tiles).activeId).toBe('historic');
 	});
 
 	it('setActiveId ignores unknown ids', async () => {
@@ -79,15 +79,15 @@ describe('tiles store', () => {
 	it('setActiveId persists choice to localStorage', async () => {
 		const { tiles } = await freshStore();
 		tiles.initFromUiConfig(cfg('osm'));
-		tiles.setActiveId('historic-6inch');
-		expect(localStorage.getItem('parish.tile-source')).toBe('historic-6inch');
+		tiles.setActiveId('historic');
+		expect(localStorage.getItem('parish.tile-source')).toBe('historic');
 	});
 
 	it('initFromUiConfig prefers localStorage over backend default', async () => {
-		localStorage.setItem('parish.tile-source', 'historic-6inch');
+		localStorage.setItem('parish.tile-source', 'historic');
 		const { tiles } = await freshStore();
 		tiles.initFromUiConfig(cfg('osm'));
-		expect(get(tiles).activeId).toBe('historic-6inch');
+		expect(get(tiles).activeId).toBe('historic');
 	});
 
 	it('initFromUiConfig falls back to backend default when localStorage has unknown id', async () => {

--- a/apps/ui/src/stores/tiles.test.ts
+++ b/apps/ui/src/stores/tiles.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { get } from 'svelte/store';
+import type { UiConfig, TileSource } from '$lib/types';
+
+function osm(): TileSource {
+	return {
+		id: 'osm',
+		label: 'OpenStreetMap',
+		url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+		tile_size: 256,
+		minzoom: 0,
+		maxzoom: 19,
+		attribution: '© OSM',
+		raster_saturation: -0.4,
+		raster_opacity: 0.85,
+		tms: false
+	};
+}
+
+function tailte(): TileSource {
+	return {
+		id: 'tailte-historic-6inch',
+		label: 'Tailte 6"',
+		url: '',
+		tile_size: 256,
+		minzoom: 0,
+		maxzoom: 17,
+		attribution: 'Tailte',
+		raster_saturation: 0.0,
+		raster_opacity: 1.0,
+		tms: true
+	};
+}
+
+function cfg(active = 'osm', sources = [osm(), tailte()]): UiConfig {
+	return {
+		hints_label: '',
+		default_accent: '',
+		splash_text: '',
+		active_tile_source: active,
+		tile_sources: sources
+	};
+}
+
+// Re-import fresh each test so the module-level singleton state is reset.
+async function freshStore() {
+	vi.resetModules();
+	return await import('./tiles');
+}
+
+describe('tiles store', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it('initFromUiConfig seeds registry and respects backend default', async () => {
+		const { tiles, currentTileSource } = await freshStore();
+		tiles.initFromUiConfig(cfg('osm'));
+		const state = get(tiles);
+		expect(state.activeId).toBe('osm');
+		expect(state.sources.size).toBe(2);
+		expect(currentTileSource(state)?.id).toBe('osm');
+	});
+
+	it('setActiveId switches the active source', async () => {
+		const { tiles } = await freshStore();
+		tiles.initFromUiConfig(cfg('osm'));
+		tiles.setActiveId('tailte-historic-6inch');
+		expect(get(tiles).activeId).toBe('tailte-historic-6inch');
+	});
+
+	it('setActiveId ignores unknown ids', async () => {
+		const { tiles } = await freshStore();
+		tiles.initFromUiConfig(cfg('osm'));
+		tiles.setActiveId('bogus');
+		expect(get(tiles).activeId).toBe('osm');
+	});
+
+	it('setActiveId persists choice to localStorage', async () => {
+		const { tiles } = await freshStore();
+		tiles.initFromUiConfig(cfg('osm'));
+		tiles.setActiveId('tailte-historic-6inch');
+		expect(localStorage.getItem('parish.tile-source')).toBe('tailte-historic-6inch');
+	});
+
+	it('initFromUiConfig prefers localStorage over backend default', async () => {
+		localStorage.setItem('parish.tile-source', 'tailte-historic-6inch');
+		const { tiles } = await freshStore();
+		tiles.initFromUiConfig(cfg('osm'));
+		expect(get(tiles).activeId).toBe('tailte-historic-6inch');
+	});
+
+	it('initFromUiConfig falls back to backend default when localStorage has unknown id', async () => {
+		localStorage.setItem('parish.tile-source', 'vanished-source');
+		const { tiles } = await freshStore();
+		tiles.initFromUiConfig(cfg('osm'));
+		expect(get(tiles).activeId).toBe('osm');
+	});
+});

--- a/apps/ui/src/stores/tiles.test.ts
+++ b/apps/ui/src/stores/tiles.test.ts
@@ -17,22 +17,22 @@ function osm(): TileSource {
 	};
 }
 
-function tailte(): TileSource {
+function historic(): TileSource {
 	return {
-		id: 'tailte-historic-6inch',
-		label: 'Tailte 6"',
-		url: '',
+		id: 'historic-6inch',
+		label: 'Historic 6"',
+		url: 'https://mapseries-tilesets.s3.amazonaws.com/ireland_6inch/{z}/{x}/{y}.jpg',
 		tile_size: 256,
 		minzoom: 0,
-		maxzoom: 17,
-		attribution: 'Tailte',
+		maxzoom: 15,
+		attribution: 'NLS',
 		raster_saturation: 0.0,
 		raster_opacity: 1.0,
-		tms: true
+		tms: false
 	};
 }
 
-function cfg(active = 'osm', sources = [osm(), tailte()]): UiConfig {
+function cfg(active = 'osm', sources = [osm(), historic()]): UiConfig {
 	return {
 		hints_label: '',
 		default_accent: '',
@@ -65,8 +65,8 @@ describe('tiles store', () => {
 	it('setActiveId switches the active source', async () => {
 		const { tiles } = await freshStore();
 		tiles.initFromUiConfig(cfg('osm'));
-		tiles.setActiveId('tailte-historic-6inch');
-		expect(get(tiles).activeId).toBe('tailte-historic-6inch');
+		tiles.setActiveId('historic-6inch');
+		expect(get(tiles).activeId).toBe('historic-6inch');
 	});
 
 	it('setActiveId ignores unknown ids', async () => {
@@ -79,15 +79,15 @@ describe('tiles store', () => {
 	it('setActiveId persists choice to localStorage', async () => {
 		const { tiles } = await freshStore();
 		tiles.initFromUiConfig(cfg('osm'));
-		tiles.setActiveId('tailte-historic-6inch');
-		expect(localStorage.getItem('parish.tile-source')).toBe('tailte-historic-6inch');
+		tiles.setActiveId('historic-6inch');
+		expect(localStorage.getItem('parish.tile-source')).toBe('historic-6inch');
 	});
 
 	it('initFromUiConfig prefers localStorage over backend default', async () => {
-		localStorage.setItem('parish.tile-source', 'tailte-historic-6inch');
+		localStorage.setItem('parish.tile-source', 'historic-6inch');
 		const { tiles } = await freshStore();
 		tiles.initFromUiConfig(cfg('osm'));
-		expect(get(tiles).activeId).toBe('tailte-historic-6inch');
+		expect(get(tiles).activeId).toBe('historic-6inch');
 	});
 
 	it('initFromUiConfig falls back to backend default when localStorage has unknown id', async () => {

--- a/apps/ui/src/stores/tiles.ts
+++ b/apps/ui/src/stores/tiles.ts
@@ -1,0 +1,83 @@
+/**
+ * Map tile source selector store.
+ *
+ * Mirrors the shape of `stores/theme.ts` — holds the full registry of
+ * tile sources (sent by the backend via `getUiConfig`) and the id of
+ * the currently-active source. The full map's controller subscribes to
+ * this store and swaps MapLibre's base raster when the active id changes.
+ *
+ * The backend is the source of truth — `/tiles <id>` emits a
+ * `tiles-switch` event that drives this store (via `onTilesSwitch` in
+ * `lib/ipc.ts`). localStorage just lets a soft-reload keep the user's
+ * last choice until `getUiConfig()` resolves.
+ */
+
+import { writable } from 'svelte/store';
+import type { TileSource, UiConfig } from '$lib/types';
+
+const STORAGE_KEY = 'parish.tile-source';
+
+function loadActiveIdFromStorage(): string | null {
+	try {
+		return typeof localStorage !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null;
+	} catch {
+		return null;
+	}
+}
+
+function saveActiveIdToStorage(id: string): void {
+	try {
+		if (typeof localStorage !== 'undefined') localStorage.setItem(STORAGE_KEY, id);
+	} catch {
+		// ignore quota / disabled-storage errors
+	}
+}
+
+interface TilesState {
+	/** Id of the currently-active tile source. Empty string = none. */
+	activeId: string;
+	/** Full registry keyed by id. Populated once from `UiConfig`. */
+	sources: Map<string, TileSource>;
+}
+
+function createTilesStore() {
+	const initial: TilesState = {
+		activeId: loadActiveIdFromStorage() ?? '',
+		sources: new Map()
+	};
+	const { subscribe, update } = writable<TilesState>(initial);
+
+	/**
+	 * Seeds the registry from `getUiConfig()`. Called once at app boot.
+	 * If localStorage already has a valid active id from a prior session,
+	 * prefers it over the backend default (the backend default is only
+	 * used when the client has no saved choice).
+	 */
+	function initFromUiConfig(cfg: UiConfig) {
+		const map = new Map<string, TileSource>();
+		for (const src of cfg.tile_sources) map.set(src.id, src);
+		const saved = loadActiveIdFromStorage();
+		const activeId = saved && map.has(saved) ? saved : cfg.active_tile_source;
+		update((s) => ({ ...s, sources: map, activeId }));
+	}
+
+	/** Switches to the named source if it exists in the registry. */
+	function setActiveId(id: string) {
+		update((s) => {
+			if (!s.sources.has(id)) return s;
+			saveActiveIdToStorage(id);
+			return { ...s, activeId: id };
+		});
+	}
+
+	return { subscribe, initFromUiConfig, setActiveId };
+}
+
+export const tiles = createTilesStore();
+
+/** Reads the current active `TileSource` from a `TilesState` value. */
+export function currentTileSource(state: TilesState): TileSource | undefined {
+	return state.sources.get(state.activeId);
+}
+
+export type { TilesState };

--- a/crates/parish-cli/src/headless.rs
+++ b/crates/parish-cli/src/headless.rs
@@ -726,6 +726,9 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
             CommandEffect::ApplyTheme(..) => {
                 // No visual theme in headless mode; response text is printed below.
             }
+            CommandEffect::ApplyTiles(..) => {
+                // No map in headless mode; response text is printed below.
+            }
         }
     }
 

--- a/crates/parish-cli/src/headless.rs
+++ b/crates/parish-cli/src/headless.rs
@@ -565,33 +565,6 @@ async fn handle_headless_command(app: &mut App, cmd: Command) -> (bool, bool) {
                 app.should_quit = true;
                 should_quit = true;
             }
-            CommandEffect::ToggleMap => {
-                println!("=== Parish Map ===");
-                let player_loc = app.world.player_location;
-                for node_id in app.world.graph.location_ids() {
-                    if let Some(data) = app.world.graph.get(node_id) {
-                        let marker = if node_id == player_loc { " * " } else { "   " };
-                        println!("{}{}", marker, data.name);
-                    }
-                }
-                println!();
-                println!("Connections:");
-                for node_id in app.world.graph.location_ids() {
-                    if let Some(data) = app.world.graph.get(node_id) {
-                        for (neighbor_id, _) in app.world.graph.neighbors(node_id) {
-                            if node_id.0 < neighbor_id.0 {
-                                let neighbor_name = app
-                                    .world
-                                    .graph
-                                    .get(neighbor_id)
-                                    .map(|d| d.name.as_str())
-                                    .unwrap_or("???");
-                                println!("  {} — {}", data.name, neighbor_name);
-                            }
-                        }
-                    }
-                }
-            }
             CommandEffect::SaveGame => {
                 if let Some(ref db) = app.db {
                     let snapshot =
@@ -1737,7 +1710,7 @@ mod tests {
     #[tokio::test]
     async fn test_handle_headless_command_map() {
         let mut app = App::new();
-        let (quit, rebuild) = handle_headless_command(&mut app, Command::Map).await;
+        let (quit, rebuild) = handle_headless_command(&mut app, Command::Map(None)).await;
         assert!(!quit);
         assert!(!rebuild);
     }

--- a/crates/parish-cli/src/testing.rs
+++ b/crates/parish-cli/src/testing.rs
@@ -561,6 +561,9 @@ impl GameTestHarness {
                 CommandEffect::ApplyTheme(..) => {
                     // No visual theme in test harness; response text is returned below.
                 }
+                CommandEffect::ApplyTiles(..) => {
+                    // No map in test harness; response text is returned below.
+                }
             }
         }
 

--- a/crates/parish-cli/src/testing.rs
+++ b/crates/parish-cli/src/testing.rs
@@ -532,9 +532,6 @@ impl GameTestHarness {
                 CommandEffect::ShowLog => {
                     return self.handle_show_log_effect();
                 }
-                CommandEffect::ToggleMap => {
-                    return self.handle_map_effect();
-                }
                 CommandEffect::Debug(sub) => {
                     let lines = crate::debug::handle_debug(sub.as_deref(), &self.app);
                     for line in &lines {
@@ -776,39 +773,6 @@ impl GameTestHarness {
                 response: "Persistence not available.".to_string(),
             }
         }
-    }
-
-    /// Handles the ToggleMap effect — renders a text map for the test harness.
-    fn handle_map_effect(&mut self) -> ActionResult {
-        let player_loc = self.app.world.player_location;
-        let mut lines = vec!["=== Parish Map ===".to_string()];
-        for node_id in self.app.world.graph.location_ids() {
-            if let Some(data) = self.app.world.graph.get(node_id) {
-                let marker = if node_id == player_loc { " * " } else { "   " };
-                lines.push(format!("{}{}", marker, data.name));
-            }
-        }
-        lines.push(String::new());
-        lines.push("Connections:".to_string());
-        for node_id in self.app.world.graph.location_ids() {
-            if let Some(data) = self.app.world.graph.get(node_id) {
-                for (neighbor_id, _) in self.app.world.graph.neighbors(node_id) {
-                    if node_id.0 < neighbor_id.0 {
-                        let neighbor_name = self
-                            .app
-                            .world
-                            .graph
-                            .get(neighbor_id)
-                            .map(|d| d.name.as_str())
-                            .unwrap_or("???");
-                        lines.push(format!("  {} — {}", data.name, neighbor_name));
-                    }
-                }
-            }
-        }
-        let msg = lines.join("\n");
-        self.app.world.log(msg.clone());
-        ActionResult::SystemCommand { response: msg }
     }
 
     /// Handles the NewGame effect — reinitializes world and NPCs.

--- a/crates/parish-config/src/engine.rs
+++ b/crates/parish-config/src/engine.rs
@@ -755,7 +755,7 @@ fn default_journal_compaction_threshold() -> usize {
 /// Map tile source registry and active default.
 ///
 /// A registry of named raster-tile sources (XYZ templates) that the frontend
-/// can switch between at runtime via the `/tiles` slash command. Users can
+/// can switch between at runtime via the `/map` slash command. Users can
 /// override the baked-in defaults by adding `[engine.map.tile_sources.<id>]`
 /// blocks in `parish.toml`.
 ///
@@ -815,22 +815,27 @@ fn default_tile_sources() -> BTreeMap<String, TileSourceConfig> {
         },
     );
     m.insert(
-        "historic-6inch".to_string(),
+        "historic".to_string(),
         TileSourceConfig {
-            label: "Ireland Historic 6\" (via NLS)".to_string(),
-            // Ordnance Survey of Ireland First Edition 6-inch (1829–1842),
-            // reprojected and hosted by the National Library of Scotland.
-            // Free, public, CORS-open (S3). See:
-            //   https://maps.nls.uk/geo/explore/
-            // For alternative (gated) access via Tailte Éireann MapGenie,
-            // see https://tailte.ie/services/mapgenie/.
-            url: "https://mapseries-tilesets.s3.amazonaws.com/ireland_6inch/{z}/{x}/{y}.jpg"
+            label: "Historic 6\" OS Ireland (1st ed., via NLS)".to_string(),
+            // Ordnance Survey of Ireland First Edition 6-inch (surveyed 1829–1842),
+            // scanned and hosted by the National Library of Scotland. NLS serves
+            // Ireland as 32 separate per-county tilesets under `os/<county>1/`
+            // — there is no seamless all-Ireland layer. Rundale is set in
+            // County Roscommon, so we wire the Roscommon 1st-edition sheet;
+            // expanding to whole-island coverage will require a multi-source
+            // style (see issue #360).
+            //
+            // Terms: CC-BY-SA 3.0 per https://maps.nls.uk/copyright.html.
+            // Free, public, CORS-open (S3).
+            url: "https://mapseries-tilesets.s3.amazonaws.com/os/roscommon1/{z}/{x}/{y}.png"
                 .to_string(),
             tile_size: 256,
-            minzoom: 0,
-            maxzoom: 15,
-            attribution: "Historic 6\" OS Ireland (1829–1842), via National Library of Scotland"
-                .to_string(),
+            minzoom: 1,
+            maxzoom: 17,
+            attribution:
+                "Historic 6\" OS Ireland (1829–1842) — National Library of Scotland (CC-BY-SA 3.0)"
+                    .to_string(),
             raster_saturation: 0.0,
             raster_opacity: 1.0,
             tms: false,
@@ -842,7 +847,7 @@ fn default_tile_sources() -> BTreeMap<String, TileSourceConfig> {
 /// A single raster tile source — URL template plus display metadata.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TileSourceConfig {
-    /// Human-readable label displayed in `/tiles` listings.
+    /// Human-readable label displayed in `/map` listings.
     #[serde(default)]
     pub label: String,
     /// XYZ URL template (e.g. `https://…/{z}/{x}/{y}.png`). Empty string
@@ -891,7 +896,7 @@ fn default_raster_opacity() -> f32 {
 impl MapConfig {
     /// Returns tile-source entries as `(id, label)` pairs, alphabetical by id.
     /// Used by backends to populate [`parish_core::ipc::GameConfig::tile_sources`]
-    /// so the `/tiles` command handler can list and validate without needing
+    /// so the `/map` command handler can list and validate without needing
     /// a reference to the whole engine config.
     pub fn id_label_pairs(&self) -> Vec<(String, String)> {
         self.tile_sources
@@ -1065,19 +1070,23 @@ memory_capacity = 30
         let cfg = MapConfig::default();
         assert_eq!(cfg.default_tile_source, "osm");
         assert!(cfg.tile_sources.contains_key("osm"));
-        assert!(cfg.tile_sources.contains_key("historic-6inch"));
+        assert!(cfg.tile_sources.contains_key("historic"));
         let osm = &cfg.tile_sources["osm"];
         assert_eq!(osm.url, "https://tile.openstreetmap.org/{z}/{x}/{y}.png");
         assert_eq!(osm.tile_size, 256);
         assert_eq!(osm.maxzoom, 19);
         assert!(!osm.tms);
-        let historic = &cfg.tile_sources["historic-6inch"];
+        let historic = &cfg.tile_sources["historic"];
         assert!(!historic.tms, "NLS serves standard XYZ, not TMS");
         assert!(
             historic.url.starts_with("https://"),
             "Historic 6\" ships with a live NLS URL"
         );
-        assert!(historic.url.contains("ireland_6inch"));
+        assert!(
+            historic.url.contains("roscommon1"),
+            "Historic ships with the Roscommon 1st-edition NLS tileset (issue #360 tracks whole-island)"
+        );
+        assert_eq!(historic.maxzoom, 17, "NLS serves 6-inch up to z=17");
     }
 
     #[test]
@@ -1110,7 +1119,7 @@ memory_capacity = 30
         cfg.apply_defaults();
         assert!(cfg.tile_sources.contains_key("custom"));
         assert!(cfg.tile_sources.contains_key("osm"));
-        assert!(cfg.tile_sources.contains_key("historic-6inch"));
+        assert!(cfg.tile_sources.contains_key("historic"));
     }
 
     #[test]
@@ -1140,7 +1149,7 @@ memory_capacity = 30
             &path,
             r#"
 [engine.map]
-default_tile_source = "historic-6inch"
+default_tile_source = "historic"
 
 [engine.map.tile_sources.osm]
 url = "https://override/{z}/{x}/{y}.png"
@@ -1148,11 +1157,11 @@ url = "https://override/{z}/{x}/{y}.png"
         )
         .unwrap();
         let cfg = load_engine_config(Some(&path));
-        assert_eq!(cfg.map.default_tile_source, "historic-6inch");
+        assert_eq!(cfg.map.default_tile_source, "historic");
         assert_eq!(
             cfg.map.tile_sources.len(),
             2,
-            "apply_defaults folded historic-6inch back in"
+            "apply_defaults folded historic back in"
         );
         assert_eq!(
             cfg.map.tile_sources["osm"].url,
@@ -1165,14 +1174,14 @@ url = "https://override/{z}/{x}/{y}.png"
         let cfg = MapConfig::default();
         let pairs = cfg.id_label_pairs();
         assert_eq!(pairs.len(), 2);
-        // BTreeMap iterates in sorted order, so "historic-6inch" < "osm".
-        assert_eq!(pairs[0].0, "historic-6inch");
+        // BTreeMap iterates in sorted order, so "historic" < "osm".
+        assert_eq!(pairs[0].0, "historic");
         assert_eq!(pairs[1].0, "osm");
     }
 
     #[test]
     fn test_map_config_deserialize_partial_toml() {
-        // A partial override: user only overrides OSM URL, historic-6inch entry
+        // A partial override: user only overrides OSM URL, historic entry
         // would be wiped without apply_defaults.
         let toml_str = r#"
 [tile_sources.osm]
@@ -1185,7 +1194,7 @@ attribution = "custom attribution"
         assert_eq!(
             cfg.tile_sources.len(),
             2,
-            "apply_defaults folds in historic-6inch"
+            "apply_defaults folds in historic"
         );
         assert_eq!(
             cfg.tile_sources["osm"].url,

--- a/crates/parish-config/src/engine.rs
+++ b/crates/parish-config/src/engine.rs
@@ -10,7 +10,38 @@
 
 use crate::provider::InferenceCategory;
 use parish_types::SpeedConfig;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Loads the `[engine]` section from a `parish.toml` at the given path.
+///
+/// Returns [`EngineConfig::default`] if the file is missing, unreadable, or
+/// doesn't contain a parseable `[engine]` table. After loading, calls
+/// [`MapConfig::apply_defaults`] so partial `[engine.map.tile_sources.*]`
+/// overrides don't wipe the baked-in registry.
+///
+/// Intended for Tauri/web-server boot; the CLI already has its own
+/// `resolve_config` pipeline for provider/cloud config.
+pub fn load_engine_config(path: Option<&Path>) -> EngineConfig {
+    #[derive(Deserialize, Default)]
+    struct Wrapper {
+        #[serde(default)]
+        engine: EngineConfig,
+    }
+
+    let default_path = Path::new("parish.toml");
+    let resolved = path.unwrap_or(default_path);
+    let text = match std::fs::read_to_string(resolved) {
+        Ok(s) => s,
+        Err(_) => return EngineConfig::default(),
+    };
+    let mut engine = toml::from_str::<Wrapper>(&text)
+        .map(|w| w.engine)
+        .unwrap_or_default();
+    engine.map.apply_defaults();
+    engine
+}
 
 /// Root engine configuration parsed from `[engine]` section of `parish.toml`.
 #[derive(Debug, Default, Deserialize, Clone)]
@@ -36,6 +67,9 @@ pub struct EngineConfig {
     /// Persistence / save system tuning.
     #[serde(default)]
     pub persistence: PersistenceConfig,
+    /// Map tile source registry and active default.
+    #[serde(default)]
+    pub map: MapConfig,
 }
 
 // ---------------------------------------------------------------------------
@@ -715,6 +749,157 @@ fn default_journal_compaction_threshold() -> usize {
 }
 
 // ---------------------------------------------------------------------------
+// Map
+// ---------------------------------------------------------------------------
+
+/// Map tile source registry and active default.
+///
+/// A registry of named raster-tile sources (XYZ templates) that the frontend
+/// can switch between at runtime via the `/tiles` slash command. Users can
+/// override the baked-in defaults by adding `[engine.map.tile_sources.<id>]`
+/// blocks in `parish.toml`.
+///
+/// **Partial overrides:** serde's BTreeMap deserialisation replaces the whole
+/// map rather than merging. Call [`MapConfig::apply_defaults`] after parsing
+/// to fold the baked defaults (OSM, Tailte Éireann) back into a user-supplied
+/// registry that only overrode a subset.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct MapConfig {
+    /// Id of the source used on first boot (pre-localStorage). Must match one
+    /// of the keys in `tile_sources`.
+    #[serde(default = "default_tile_source_id")]
+    pub default_tile_source: String,
+    /// Registry of available raster tile sources, keyed by id.
+    #[serde(default = "default_tile_sources")]
+    pub tile_sources: BTreeMap<String, TileSourceConfig>,
+}
+
+impl Default for MapConfig {
+    fn default() -> Self {
+        Self {
+            default_tile_source: default_tile_source_id(),
+            tile_sources: default_tile_sources(),
+        }
+    }
+}
+
+impl MapConfig {
+    /// Fold baked-in defaults into the registry for any id the user didn't
+    /// override. Call this after deserialising `parish.toml` so a partial
+    /// `[engine.map.tile_sources.osm]` block doesn't wipe the Tailte entry.
+    pub fn apply_defaults(&mut self) {
+        for (id, source) in default_tile_sources() {
+            self.tile_sources.entry(id).or_insert(source);
+        }
+    }
+}
+
+fn default_tile_source_id() -> String {
+    "osm".to_string()
+}
+
+fn default_tile_sources() -> BTreeMap<String, TileSourceConfig> {
+    let mut m = BTreeMap::new();
+    m.insert(
+        "osm".to_string(),
+        TileSourceConfig {
+            label: "OpenStreetMap".to_string(),
+            url: "https://tile.openstreetmap.org/{z}/{x}/{y}.png".to_string(),
+            tile_size: 256,
+            minzoom: 0,
+            maxzoom: 19,
+            attribution: "© OpenStreetMap contributors".to_string(),
+            raster_saturation: -0.4,
+            raster_opacity: 0.85,
+            tms: false,
+        },
+    );
+    m.insert(
+        "tailte-historic-6inch".to_string(),
+        TileSourceConfig {
+            label: "Tailte Éireann Historic 6\"".to_string(),
+            // Placeholder — capture the real endpoint from browser devtools on
+            // the free GeoHive viewer (https://map.geohive.ie/) or plug in a
+            // MapGenie REST URL if you have a National Mapping Agreement
+            // subscription (https://tailte.ie/services/mapgenie/).
+            // An empty URL triggers a flat-bg fallback in the frontend
+            // instead of rendering a broken map.
+            url: String::new(),
+            tile_size: 256,
+            minzoom: 0,
+            maxzoom: 17,
+            attribution: "Tailte Éireann, Historic 6\" First Edition (1829–1842)".to_string(),
+            raster_saturation: 0.0,
+            raster_opacity: 1.0,
+            tms: true,
+        },
+    );
+    m
+}
+
+/// A single raster tile source — URL template plus display metadata.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct TileSourceConfig {
+    /// Human-readable label displayed in `/tiles` listings.
+    #[serde(default)]
+    pub label: String,
+    /// XYZ URL template (e.g. `https://…/{z}/{x}/{y}.png`). Empty string
+    /// means the source is registered but not yet configured; the frontend
+    /// falls back to a flat background.
+    #[serde(default)]
+    pub url: String,
+    /// Tile edge length in pixels. 256 for classic OSM-style sources.
+    #[serde(default = "default_tile_size")]
+    pub tile_size: u32,
+    /// Minimum zoom level the source serves tiles for.
+    #[serde(default)]
+    pub minzoom: u32,
+    /// Maximum zoom level the source serves tiles for.
+    #[serde(default = "default_tile_maxzoom")]
+    pub maxzoom: u32,
+    /// Attribution text shown in the MapLibre attribution control.
+    #[serde(default)]
+    pub attribution: String,
+    /// MapLibre `raster-saturation` paint (-1.0 to 1.0). Negative values
+    /// desaturate; 0.0 leaves colours untouched.
+    #[serde(default = "default_raster_saturation")]
+    pub raster_saturation: f32,
+    /// MapLibre `raster-opacity` paint (0.0 to 1.0).
+    #[serde(default = "default_raster_opacity")]
+    pub raster_opacity: f32,
+    /// When true, the frontend sets `scheme: 'tms'` on the MapLibre source,
+    /// flipping the y-axis for ArcGIS-style tile services.
+    #[serde(default)]
+    pub tms: bool,
+}
+
+fn default_tile_size() -> u32 {
+    256
+}
+fn default_tile_maxzoom() -> u32 {
+    19
+}
+fn default_raster_saturation() -> f32 {
+    -0.4
+}
+fn default_raster_opacity() -> f32 {
+    0.85
+}
+
+impl MapConfig {
+    /// Returns tile-source entries as `(id, label)` pairs, alphabetical by id.
+    /// Used by backends to populate [`parish_core::ipc::GameConfig::tile_sources`]
+    /// so the `/tiles` command handler can list and validate without needing
+    /// a reference to the whole engine config.
+    pub fn id_label_pairs(&self) -> Vec<(String, String)> {
+        self.tile_sources
+            .iter()
+            .map(|(id, src)| (id.clone(), src.label.clone()))
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -871,6 +1056,131 @@ memory_capacity = 30
         let cfg: CategoryRateLimit = toml::from_str(toml).unwrap();
         assert_eq!(cfg.per_minute, 30);
         assert_eq!(cfg.burst, 1);
+    }
+
+    #[test]
+    fn test_map_config_default_has_both_sources() {
+        let cfg = MapConfig::default();
+        assert_eq!(cfg.default_tile_source, "osm");
+        assert!(cfg.tile_sources.contains_key("osm"));
+        assert!(cfg.tile_sources.contains_key("tailte-historic-6inch"));
+        let osm = &cfg.tile_sources["osm"];
+        assert_eq!(osm.url, "https://tile.openstreetmap.org/{z}/{x}/{y}.png");
+        assert_eq!(osm.tile_size, 256);
+        assert_eq!(osm.maxzoom, 19);
+        assert!(!osm.tms);
+        let tailte = &cfg.tile_sources["tailte-historic-6inch"];
+        assert!(tailte.tms);
+        assert!(tailte.url.is_empty(), "Tailte URL ships as placeholder");
+    }
+
+    #[test]
+    fn test_engine_config_includes_map_defaults() {
+        let cfg = EngineConfig::default();
+        assert_eq!(cfg.map.default_tile_source, "osm");
+        assert_eq!(cfg.map.tile_sources.len(), 2);
+    }
+
+    #[test]
+    fn test_map_config_apply_defaults_merges_missing_sources() {
+        let mut cfg = MapConfig {
+            default_tile_source: "osm".to_string(),
+            tile_sources: BTreeMap::new(),
+        };
+        cfg.tile_sources.insert(
+            "custom".to_string(),
+            TileSourceConfig {
+                label: "Custom".to_string(),
+                url: "https://example.com/{z}/{x}/{y}.png".to_string(),
+                tile_size: 256,
+                minzoom: 0,
+                maxzoom: 18,
+                attribution: "custom".to_string(),
+                raster_saturation: 0.0,
+                raster_opacity: 1.0,
+                tms: false,
+            },
+        );
+        cfg.apply_defaults();
+        assert!(cfg.tile_sources.contains_key("custom"));
+        assert!(cfg.tile_sources.contains_key("osm"));
+        assert!(cfg.tile_sources.contains_key("tailte-historic-6inch"));
+    }
+
+    #[test]
+    fn test_map_config_apply_defaults_preserves_user_overrides() {
+        let mut cfg = MapConfig::default();
+        cfg.tile_sources.get_mut("osm").unwrap().url =
+            "https://example.com/custom-osm/{z}/{x}/{y}.png".to_string();
+        cfg.apply_defaults();
+        assert_eq!(
+            cfg.tile_sources["osm"].url,
+            "https://example.com/custom-osm/{z}/{x}/{y}.png"
+        );
+    }
+
+    #[test]
+    fn test_load_engine_config_missing_file() {
+        let cfg = load_engine_config(Some(Path::new("/nonexistent/parish.toml")));
+        assert_eq!(cfg.map.default_tile_source, "osm");
+        assert_eq!(cfg.map.tile_sources.len(), 2);
+    }
+
+    #[test]
+    fn test_load_engine_config_from_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("parish.toml");
+        std::fs::write(
+            &path,
+            r#"
+[engine.map]
+default_tile_source = "tailte-historic-6inch"
+
+[engine.map.tile_sources.osm]
+url = "https://override/{z}/{x}/{y}.png"
+"#,
+        )
+        .unwrap();
+        let cfg = load_engine_config(Some(&path));
+        assert_eq!(cfg.map.default_tile_source, "tailte-historic-6inch");
+        assert_eq!(
+            cfg.map.tile_sources.len(),
+            2,
+            "apply_defaults folded Tailte back in"
+        );
+        assert_eq!(
+            cfg.map.tile_sources["osm"].url,
+            "https://override/{z}/{x}/{y}.png"
+        );
+    }
+
+    #[test]
+    fn test_map_config_id_label_pairs_is_sorted() {
+        let cfg = MapConfig::default();
+        let pairs = cfg.id_label_pairs();
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].0, "osm");
+        assert_eq!(pairs[1].0, "tailte-historic-6inch");
+    }
+
+    #[test]
+    fn test_map_config_deserialize_partial_toml() {
+        // A partial override: user only overrides OSM URL, Tailte entry
+        // would be wiped without apply_defaults.
+        let toml_str = r#"
+[tile_sources.osm]
+url = "https://custom/{z}/{x}/{y}.png"
+attribution = "custom attribution"
+"#;
+        let mut cfg: MapConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.tile_sources.len(), 1, "serde replace semantics");
+        cfg.apply_defaults();
+        assert_eq!(cfg.tile_sources.len(), 2, "apply_defaults folds in Tailte");
+        assert_eq!(
+            cfg.tile_sources["osm"].url,
+            "https://custom/{z}/{x}/{y}.png"
+        );
+        assert_eq!(cfg.tile_sources["osm"].attribution, "custom attribution");
     }
 
     #[test]

--- a/crates/parish-config/src/engine.rs
+++ b/crates/parish-config/src/engine.rs
@@ -761,7 +761,7 @@ fn default_journal_compaction_threshold() -> usize {
 ///
 /// **Partial overrides:** serde's BTreeMap deserialisation replaces the whole
 /// map rather than merging. Call [`MapConfig::apply_defaults`] after parsing
-/// to fold the baked defaults (OSM, Tailte Éireann) back into a user-supplied
+/// to fold the baked defaults (OSM, Ireland Historic 6") back into a user-supplied
 /// registry that only overrode a subset.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct MapConfig {
@@ -786,7 +786,7 @@ impl Default for MapConfig {
 impl MapConfig {
     /// Fold baked-in defaults into the registry for any id the user didn't
     /// override. Call this after deserialising `parish.toml` so a partial
-    /// `[engine.map.tile_sources.osm]` block doesn't wipe the Tailte entry.
+    /// `[engine.map.tile_sources.osm]` block doesn't wipe the historic entry.
     pub fn apply_defaults(&mut self) {
         for (id, source) in default_tile_sources() {
             self.tile_sources.entry(id).or_insert(source);
@@ -815,23 +815,25 @@ fn default_tile_sources() -> BTreeMap<String, TileSourceConfig> {
         },
     );
     m.insert(
-        "tailte-historic-6inch".to_string(),
+        "historic-6inch".to_string(),
         TileSourceConfig {
-            label: "Tailte Éireann Historic 6\"".to_string(),
-            // Placeholder — capture the real endpoint from browser devtools on
-            // the free GeoHive viewer (https://map.geohive.ie/) or plug in a
-            // MapGenie REST URL if you have a National Mapping Agreement
-            // subscription (https://tailte.ie/services/mapgenie/).
-            // An empty URL triggers a flat-bg fallback in the frontend
-            // instead of rendering a broken map.
-            url: String::new(),
+            label: "Ireland Historic 6\" (via NLS)".to_string(),
+            // Ordnance Survey of Ireland First Edition 6-inch (1829–1842),
+            // reprojected and hosted by the National Library of Scotland.
+            // Free, public, CORS-open (S3). See:
+            //   https://maps.nls.uk/geo/explore/
+            // For alternative (gated) access via Tailte Éireann MapGenie,
+            // see https://tailte.ie/services/mapgenie/.
+            url: "https://mapseries-tilesets.s3.amazonaws.com/ireland_6inch/{z}/{x}/{y}.jpg"
+                .to_string(),
             tile_size: 256,
             minzoom: 0,
-            maxzoom: 17,
-            attribution: "Tailte Éireann, Historic 6\" First Edition (1829–1842)".to_string(),
+            maxzoom: 15,
+            attribution: "Historic 6\" OS Ireland (1829–1842), via National Library of Scotland"
+                .to_string(),
             raster_saturation: 0.0,
             raster_opacity: 1.0,
-            tms: true,
+            tms: false,
         },
     );
     m
@@ -1063,15 +1065,19 @@ memory_capacity = 30
         let cfg = MapConfig::default();
         assert_eq!(cfg.default_tile_source, "osm");
         assert!(cfg.tile_sources.contains_key("osm"));
-        assert!(cfg.tile_sources.contains_key("tailte-historic-6inch"));
+        assert!(cfg.tile_sources.contains_key("historic-6inch"));
         let osm = &cfg.tile_sources["osm"];
         assert_eq!(osm.url, "https://tile.openstreetmap.org/{z}/{x}/{y}.png");
         assert_eq!(osm.tile_size, 256);
         assert_eq!(osm.maxzoom, 19);
         assert!(!osm.tms);
-        let tailte = &cfg.tile_sources["tailte-historic-6inch"];
-        assert!(tailte.tms);
-        assert!(tailte.url.is_empty(), "Tailte URL ships as placeholder");
+        let historic = &cfg.tile_sources["historic-6inch"];
+        assert!(!historic.tms, "NLS serves standard XYZ, not TMS");
+        assert!(
+            historic.url.starts_with("https://"),
+            "Historic 6\" ships with a live NLS URL"
+        );
+        assert!(historic.url.contains("ireland_6inch"));
     }
 
     #[test]
@@ -1104,7 +1110,7 @@ memory_capacity = 30
         cfg.apply_defaults();
         assert!(cfg.tile_sources.contains_key("custom"));
         assert!(cfg.tile_sources.contains_key("osm"));
-        assert!(cfg.tile_sources.contains_key("tailte-historic-6inch"));
+        assert!(cfg.tile_sources.contains_key("historic-6inch"));
     }
 
     #[test]
@@ -1134,7 +1140,7 @@ memory_capacity = 30
             &path,
             r#"
 [engine.map]
-default_tile_source = "tailte-historic-6inch"
+default_tile_source = "historic-6inch"
 
 [engine.map.tile_sources.osm]
 url = "https://override/{z}/{x}/{y}.png"
@@ -1142,11 +1148,11 @@ url = "https://override/{z}/{x}/{y}.png"
         )
         .unwrap();
         let cfg = load_engine_config(Some(&path));
-        assert_eq!(cfg.map.default_tile_source, "tailte-historic-6inch");
+        assert_eq!(cfg.map.default_tile_source, "historic-6inch");
         assert_eq!(
             cfg.map.tile_sources.len(),
             2,
-            "apply_defaults folded Tailte back in"
+            "apply_defaults folded historic-6inch back in"
         );
         assert_eq!(
             cfg.map.tile_sources["osm"].url,
@@ -1159,13 +1165,14 @@ url = "https://override/{z}/{x}/{y}.png"
         let cfg = MapConfig::default();
         let pairs = cfg.id_label_pairs();
         assert_eq!(pairs.len(), 2);
-        assert_eq!(pairs[0].0, "osm");
-        assert_eq!(pairs[1].0, "tailte-historic-6inch");
+        // BTreeMap iterates in sorted order, so "historic-6inch" < "osm".
+        assert_eq!(pairs[0].0, "historic-6inch");
+        assert_eq!(pairs[1].0, "osm");
     }
 
     #[test]
     fn test_map_config_deserialize_partial_toml() {
-        // A partial override: user only overrides OSM URL, Tailte entry
+        // A partial override: user only overrides OSM URL, historic-6inch entry
         // would be wiped without apply_defaults.
         let toml_str = r#"
 [tile_sources.osm]
@@ -1175,7 +1182,11 @@ attribution = "custom attribution"
         let mut cfg: MapConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(cfg.tile_sources.len(), 1, "serde replace semantics");
         cfg.apply_defaults();
-        assert_eq!(cfg.tile_sources.len(), 2, "apply_defaults folds in Tailte");
+        assert_eq!(
+            cfg.tile_sources.len(),
+            2,
+            "apply_defaults folds in historic-6inch"
+        );
         assert_eq!(
             cfg.tile_sources["osm"].url,
             "https://custom/{z}/{x}/{y}.png"

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -51,6 +51,10 @@ pub enum CommandEffect {
     /// Apply a user-selected UI theme; frontend resolves the actual palette colors.
     /// Carries (theme_name, mode) where mode is "light", "dark", "auto", or "".
     ApplyTheme(String, String),
+    /// Switch the full-map base tile source. Carries the source id
+    /// (e.g. "osm", "tailte-historic-6inch") — frontend looks up URL etc.
+    /// from the tile registry it received via `UiConfigSnapshot`.
+    ApplyTiles(String),
 }
 
 /// The result of processing a system command.
@@ -415,6 +419,7 @@ pub fn handle_command(
                 "  /irish             — Toggle Irish pronunciation sidebar",
                 "  /improv            — Toggle improv craft mode",
                 "  /map               — Toggle the full map",
+                "  /tiles [id]        — List or switch map tile sources",
                 "  /flag list                  — List all feature flags",
                 "  /flag enable <name>         — Enable a feature flag",
                 "  /flag disable <name>        — Disable a feature flag",
@@ -436,6 +441,7 @@ pub fn handle_command(
         Command::Debug(sub) => CommandResult::effect_only(CommandEffect::Debug(sub)),
         Command::Spinner(secs) => CommandResult::effect_only(CommandEffect::ShowSpinner(secs)),
         Command::NewGame => CommandResult::effect_only(CommandEffect::NewGame),
+        Command::Tiles(arg) => handle_tiles_command(config, arg),
         Command::Theme(arg) => match arg.as_deref().map(str::trim) {
             None | Some("") => CommandResult::text(
                 "Available themes: default, solarized\n\
@@ -478,6 +484,81 @@ pub fn handle_command(
                         other
                     )),
                 }
+            }
+        },
+    }
+}
+
+/// Handles the `/tiles` command (list / switch map tile sources).
+///
+/// Gated by the `period-map-tiles` feature flag (default-enabled per
+/// CLAUDE.md rule #6). Uses `is_disabled` semantics so the feature ships
+/// on without needing to seed the flags file.
+fn handle_tiles_command(config: &mut GameConfig, arg: Option<String>) -> CommandResult {
+    if config.flags.is_disabled("period-map-tiles") {
+        return CommandResult::text(
+            "Period map tiles are disabled. Re-enable with /flag enable period-map-tiles.",
+        );
+    }
+
+    let arg = arg.as_deref().map(str::trim).filter(|s| !s.is_empty());
+
+    // Compare case-insensitively: TOML keys are canonical lowercase, but
+    // the parser preserves case from the user input (`/tiles OSM`).
+    let lookup_id = |needle: &str| -> Option<(String, String)> {
+        let needle_lower = needle.to_lowercase();
+        config
+            .tile_sources
+            .iter()
+            .find(|(id, _)| id.to_lowercase() == needle_lower)
+            .cloned()
+    };
+
+    match arg {
+        None => {
+            if config.tile_sources.is_empty() {
+                return CommandResult::text("No tile sources configured.");
+            }
+            let mut lines = vec!["Available tile sources:".to_string()];
+            for (id, label) in &config.tile_sources {
+                let marker = if id == &config.active_tile_source {
+                    "*"
+                } else {
+                    " "
+                };
+                let active_tag = if id == &config.active_tile_source {
+                    " (active)"
+                } else {
+                    ""
+                };
+                lines.push(format!("  {} {}{} — {}", marker, id, active_tag, label));
+            }
+            lines.push("Usage: /tiles <id>".to_string());
+            CommandResult::text(lines.join("\n"))
+        }
+        Some(needle) => match lookup_id(needle) {
+            Some((id, label)) => {
+                config.active_tile_source = id.clone();
+                CommandResult::with_effect(
+                    format!("Switched map tiles to {}.", label),
+                    CommandEffect::ApplyTiles(id),
+                )
+            }
+            None => {
+                let available: Vec<&str> = config
+                    .tile_sources
+                    .iter()
+                    .map(|(id, _)| id.as_str())
+                    .collect();
+                let list = if available.is_empty() {
+                    "(none configured)".to_string()
+                } else {
+                    available.join(", ")
+                };
+                CommandResult::text(format!(
+                    "Unknown tile source '{}'. Available: {}",
+                    needle, list
+                ))
             }
         },
     }
@@ -1195,5 +1276,114 @@ mod tests {
         let result = handle_command(Command::NpcsHere, &mut world, &mut npc, &mut config);
         // Falls through to the "No one else is here." branch.
         assert!(result.response.contains("No one"));
+    }
+
+    // ── /tiles command ─────────────────────────────────────────────────────
+
+    fn seed_tile_sources(config: &mut GameConfig) {
+        config.tile_sources = vec![
+            ("osm".to_string(), "OpenStreetMap".to_string()),
+            (
+                "tailte-historic-6inch".to_string(),
+                "Tailte Éireann Historic 6\"".to_string(),
+            ),
+        ];
+        config.active_tile_source = "osm".to_string();
+    }
+
+    #[test]
+    fn tiles_list_when_no_arg() {
+        let (mut world, mut npc, mut config) = default_state();
+        seed_tile_sources(&mut config);
+        let result = handle_command(Command::Tiles(None), &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("osm"));
+        assert!(result.response.contains("tailte-historic-6inch"));
+        assert!(result.response.contains("(active)"));
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn tiles_list_empty_registry() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Tiles(None), &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("No tile sources configured"));
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn tiles_switch_sets_config_and_emits_effect() {
+        let (mut world, mut npc, mut config) = default_state();
+        seed_tile_sources(&mut config);
+        let result = handle_command(
+            Command::Tiles(Some("tailte-historic-6inch".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert_eq!(config.active_tile_source, "tailte-historic-6inch");
+        assert!(result.response.contains("Switched"));
+        assert_eq!(
+            result.effects,
+            vec![CommandEffect::ApplyTiles(
+                "tailte-historic-6inch".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn tiles_switch_is_case_insensitive() {
+        let (mut world, mut npc, mut config) = default_state();
+        seed_tile_sources(&mut config);
+        let result = handle_command(
+            Command::Tiles(Some("OSM".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert_eq!(config.active_tile_source, "osm");
+        assert_eq!(
+            result.effects,
+            vec![CommandEffect::ApplyTiles("osm".to_string())]
+        );
+    }
+
+    #[test]
+    fn tiles_unknown_id_returns_error_text() {
+        let (mut world, mut npc, mut config) = default_state();
+        seed_tile_sources(&mut config);
+        let result = handle_command(
+            Command::Tiles(Some("made-up".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("Unknown"));
+        assert!(result.response.contains("made-up"));
+        assert!(result.response.contains("osm"));
+        assert!(result.effects.is_empty());
+        assert_eq!(config.active_tile_source, "osm", "active unchanged");
+    }
+
+    #[test]
+    fn tiles_disabled_flag_returns_refusal() {
+        let (mut world, mut npc, mut config) = default_state();
+        seed_tile_sources(&mut config);
+        config.flags.disable("period-map-tiles");
+        let result = handle_command(
+            Command::Tiles(Some("tailte-historic-6inch".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("/flag enable"));
+        assert!(result.effects.is_empty());
+        assert_eq!(config.active_tile_source, "osm", "active unchanged");
+    }
+
+    #[test]
+    fn tiles_help_lists_command() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Help, &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("/tiles"));
     }
 }

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -26,8 +26,6 @@ pub enum CommandEffect {
     Quit,
     /// The inference pipeline needs to be rebuilt (provider/key changed).
     RebuildInference,
-    /// Toggle the full map overlay (GUI) or show text map (CLI).
-    ToggleMap,
     /// Save the game.
     SaveGame,
     /// Fork a new timeline branch with the given name.
@@ -52,7 +50,7 @@ pub enum CommandEffect {
     /// Carries (theme_name, mode) where mode is "light", "dark", "auto", or "".
     ApplyTheme(String, String),
     /// Switch the full-map base tile source. Carries the source id
-    /// (e.g. "osm", "historic-6inch") — frontend looks up URL etc.
+    /// (e.g. "osm", "historic") — frontend looks up URL etc.
     /// from the tile registry it received via `UiConfigSnapshot`.
     ApplyTiles(String),
 }
@@ -418,8 +416,7 @@ pub fn handle_command(
                 "  /speed [slow|normal|fast|fastest|ludicrous]  — Show or change game speed",
                 "  /irish             — Toggle Irish pronunciation sidebar",
                 "  /improv            — Toggle improv craft mode",
-                "  /map               — Toggle the full map",
-                "  /tiles [id]        — List or switch map tile sources",
+                "  /map [id]          — List or switch map tile sources",
                 "  /flag list                  — List all feature flags",
                 "  /flag enable <name>         — Enable a feature flag",
                 "  /flag disable <name>        — Disable a feature flag",
@@ -437,11 +434,10 @@ pub fn handle_command(
         Command::Load(name) => CommandResult::effect_only(CommandEffect::LoadBranch(name)),
         Command::Branches => CommandResult::effect_only(CommandEffect::ListBranches),
         Command::Log => CommandResult::effect_only(CommandEffect::ShowLog),
-        Command::Map => CommandResult::effect_only(CommandEffect::ToggleMap),
+        Command::Map(arg) => handle_map_command(config, arg),
         Command::Debug(sub) => CommandResult::effect_only(CommandEffect::Debug(sub)),
         Command::Spinner(secs) => CommandResult::effect_only(CommandEffect::ShowSpinner(secs)),
         Command::NewGame => CommandResult::effect_only(CommandEffect::NewGame),
-        Command::Tiles(arg) => handle_tiles_command(config, arg),
         Command::Theme(arg) => match arg.as_deref().map(str::trim) {
             None | Some("") => CommandResult::text(
                 "Available themes: default, solarized\n\
@@ -489,12 +485,12 @@ pub fn handle_command(
     }
 }
 
-/// Handles the `/tiles` command (list / switch map tile sources).
+/// Handles the `/map` command (list / switch map tile sources).
 ///
 /// Gated by the `period-map-tiles` feature flag (default-enabled per
 /// CLAUDE.md rule #6). Uses `is_disabled` semantics so the feature ships
 /// on without needing to seed the flags file.
-fn handle_tiles_command(config: &mut GameConfig, arg: Option<String>) -> CommandResult {
+fn handle_map_command(config: &mut GameConfig, arg: Option<String>) -> CommandResult {
     if config.flags.is_disabled("period-map-tiles") {
         return CommandResult::text(
             "Period map tiles are disabled. Re-enable with /flag enable period-map-tiles.",
@@ -504,7 +500,7 @@ fn handle_tiles_command(config: &mut GameConfig, arg: Option<String>) -> Command
     let arg = arg.as_deref().map(str::trim).filter(|s| !s.is_empty());
 
     // Compare case-insensitively: TOML keys are canonical lowercase, but
-    // the parser preserves case from the user input (`/tiles OSM`).
+    // the parser preserves case from the user input (`/map OSM`).
     let lookup_id = |needle: &str| -> Option<(String, String)> {
         let needle_lower = needle.to_lowercase();
         config
@@ -533,7 +529,7 @@ fn handle_tiles_command(config: &mut GameConfig, arg: Option<String>) -> Command
                 };
                 lines.push(format!("  {} {}{} — {}", marker, id, active_tag, label));
             }
-            lines.push("Usage: /tiles <id>".to_string());
+            lines.push("Usage: /map <id>".to_string());
             CommandResult::text(lines.join("\n"))
         }
         Some(needle) => match lookup_id(needle) {
@@ -1139,13 +1135,6 @@ mod tests {
     }
 
     #[test]
-    fn map_returns_toggle_effect() {
-        let (mut world, mut npc, mut config) = default_state();
-        let result = handle_command(Command::Map, &mut world, &mut npc, &mut config);
-        assert!(result.effects.contains(&CommandEffect::ToggleMap));
-    }
-
-    #[test]
     fn new_game_returns_effect() {
         let (mut world, mut npc, mut config) = default_state();
         let result = handle_command(Command::NewGame, &mut world, &mut npc, &mut config);
@@ -1278,62 +1267,62 @@ mod tests {
         assert!(result.response.contains("No one"));
     }
 
-    // ── /tiles command ─────────────────────────────────────────────────────
+    // ── /map command ───────────────────────────────────────────────────────
 
     fn seed_tile_sources(config: &mut GameConfig) {
         config.tile_sources = vec![
             ("osm".to_string(), "OpenStreetMap".to_string()),
             (
-                "historic-6inch".to_string(),
-                "Ireland Historic 6\" (via NLS)".to_string(),
+                "historic".to_string(),
+                "Historic 6\" OS Ireland (1st ed., via NLS)".to_string(),
             ),
         ];
         config.active_tile_source = "osm".to_string();
     }
 
     #[test]
-    fn tiles_list_when_no_arg() {
+    fn map_list_when_no_arg() {
         let (mut world, mut npc, mut config) = default_state();
         seed_tile_sources(&mut config);
-        let result = handle_command(Command::Tiles(None), &mut world, &mut npc, &mut config);
+        let result = handle_command(Command::Map(None), &mut world, &mut npc, &mut config);
         assert!(result.response.contains("osm"));
-        assert!(result.response.contains("historic-6inch"));
+        assert!(result.response.contains("historic"));
         assert!(result.response.contains("(active)"));
         assert!(result.effects.is_empty());
     }
 
     #[test]
-    fn tiles_list_empty_registry() {
+    fn map_list_empty_registry() {
         let (mut world, mut npc, mut config) = default_state();
-        let result = handle_command(Command::Tiles(None), &mut world, &mut npc, &mut config);
+        let result = handle_command(Command::Map(None), &mut world, &mut npc, &mut config);
         assert!(result.response.contains("No tile sources configured"));
         assert!(result.effects.is_empty());
     }
 
     #[test]
-    fn tiles_switch_sets_config_and_emits_effect() {
+    fn map_switch_sets_config_and_emits_effect() {
         let (mut world, mut npc, mut config) = default_state();
         seed_tile_sources(&mut config);
         let result = handle_command(
-            Command::Tiles(Some("historic-6inch".to_string())),
+            Command::Map(Some("historic".to_string())),
             &mut world,
             &mut npc,
             &mut config,
         );
-        assert_eq!(config.active_tile_source, "historic-6inch");
+        assert_eq!(config.active_tile_source, "historic");
         assert!(result.response.contains("Switched"));
         assert_eq!(
             result.effects,
-            vec![CommandEffect::ApplyTiles("historic-6inch".to_string())]
+            vec![CommandEffect::ApplyTiles("historic".to_string())]
         );
     }
 
     #[test]
-    fn tiles_switch_is_case_insensitive() {
+    fn map_switch_is_case_insensitive() {
         let (mut world, mut npc, mut config) = default_state();
         seed_tile_sources(&mut config);
         let result = handle_command(
-            Command::Tiles(Some("OSM".to_string())),
+            Command::Map(Some("OSM".to_string())),
             &mut world,
             &mut npc,
             &mut config,
@@ -1346,11 +1335,11 @@ mod tests {
     }
 
     #[test]
-    fn tiles_unknown_id_returns_error_text() {
+    fn map_unknown_id_returns_error_text() {
         let (mut world, mut npc, mut config) = default_state();
         seed_tile_sources(&mut config);
         let result = handle_command(
-            Command::Tiles(Some("made-up".to_string())),
+            Command::Map(Some("made-up".to_string())),
             &mut world,
             &mut npc,
             &mut config,
@@ -1363,12 +1352,12 @@ mod tests {
     }
 
     #[test]
-    fn tiles_disabled_flag_returns_refusal() {
+    fn map_disabled_flag_returns_refusal() {
         let (mut world, mut npc, mut config) = default_state();
         seed_tile_sources(&mut config);
         config.flags.disable("period-map-tiles");
         let result = handle_command(
-            Command::Tiles(Some("historic-6inch".to_string())),
+            Command::Map(Some("historic".to_string())),
             &mut world,
             &mut npc,
             &mut config,
@@ -1379,9 +1368,9 @@ mod tests {
     }
 
     #[test]
-    fn tiles_help_lists_command() {
+    fn map_help_lists_command() {
         let (mut world, mut npc, mut config) = default_state();
         let result = handle_command(Command::Help, &mut world, &mut npc, &mut config);
-        assert!(result.response.contains("/tiles"));
+        assert!(result.response.contains("/map"));
     }
 }

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -52,7 +52,7 @@ pub enum CommandEffect {
     /// Carries (theme_name, mode) where mode is "light", "dark", "auto", or "".
     ApplyTheme(String, String),
     /// Switch the full-map base tile source. Carries the source id
-    /// (e.g. "osm", "tailte-historic-6inch") — frontend looks up URL etc.
+    /// (e.g. "osm", "historic-6inch") — frontend looks up URL etc.
     /// from the tile registry it received via `UiConfigSnapshot`.
     ApplyTiles(String),
 }
@@ -1284,8 +1284,8 @@ mod tests {
         config.tile_sources = vec![
             ("osm".to_string(), "OpenStreetMap".to_string()),
             (
-                "tailte-historic-6inch".to_string(),
-                "Tailte Éireann Historic 6\"".to_string(),
+                "historic-6inch".to_string(),
+                "Ireland Historic 6\" (via NLS)".to_string(),
             ),
         ];
         config.active_tile_source = "osm".to_string();
@@ -1297,7 +1297,7 @@ mod tests {
         seed_tile_sources(&mut config);
         let result = handle_command(Command::Tiles(None), &mut world, &mut npc, &mut config);
         assert!(result.response.contains("osm"));
-        assert!(result.response.contains("tailte-historic-6inch"));
+        assert!(result.response.contains("historic-6inch"));
         assert!(result.response.contains("(active)"));
         assert!(result.effects.is_empty());
     }
@@ -1315,18 +1315,16 @@ mod tests {
         let (mut world, mut npc, mut config) = default_state();
         seed_tile_sources(&mut config);
         let result = handle_command(
-            Command::Tiles(Some("tailte-historic-6inch".to_string())),
+            Command::Tiles(Some("historic-6inch".to_string())),
             &mut world,
             &mut npc,
             &mut config,
         );
-        assert_eq!(config.active_tile_source, "tailte-historic-6inch");
+        assert_eq!(config.active_tile_source, "historic-6inch");
         assert!(result.response.contains("Switched"));
         assert_eq!(
             result.effects,
-            vec![CommandEffect::ApplyTiles(
-                "tailte-historic-6inch".to_string()
-            )]
+            vec![CommandEffect::ApplyTiles("historic-6inch".to_string())]
         );
     }
 
@@ -1370,7 +1368,7 @@ mod tests {
         seed_tile_sources(&mut config);
         config.flags.disable("period-map-tiles");
         let result = handle_command(
-            Command::Tiles(Some("tailte-historic-6inch".to_string())),
+            Command::Tiles(Some("historic-6inch".to_string())),
             &mut world,
             &mut npc,
             &mut config,

--- a/crates/parish-core/src/ipc/config.rs
+++ b/crates/parish-core/src/ipc/config.rs
@@ -56,6 +56,14 @@ pub struct GameConfig {
     /// back to the base client inherit whatever limiter the base client
     /// was constructed with (see [`crate::inference::openai_client::OpenAiClient::with_rate_limit`]).
     pub category_rate_limit: [Option<InferenceRateLimiter>; 4],
+    /// Id of the map tile source currently applied (matches a key in
+    /// `[engine.map.tile_sources]`). Empty string means "use engine default".
+    pub active_tile_source: String,
+    /// Registry of available tile sources as `(id, label)` pairs, alphabetical
+    /// by id. Populated at backend boot from `EngineConfig::map.tile_sources`
+    /// so the `/tiles` command handler can list and validate without taking
+    /// a reference to the whole engine config.
+    pub tile_sources: Vec<(String, String)>,
 }
 
 impl GameConfig {
@@ -152,6 +160,8 @@ impl Default for GameConfig {
             category_base_url: Default::default(),
             flags: FeatureFlags::default(),
             category_rate_limit: Default::default(),
+            active_tile_source: String::new(),
+            tile_sources: Vec::new(),
         }
     }
 }
@@ -169,6 +179,8 @@ mod tests {
         assert_eq!(c.max_follow_up_turns, 2);
         assert_eq!(c.idle_banter_after_secs, 25);
         assert_eq!(c.auto_pause_after_secs, 60);
+        assert!(c.active_tile_source.is_empty());
+        assert!(c.tile_sources.is_empty());
     }
 
     #[test]

--- a/crates/parish-core/src/ipc/types.rs
+++ b/crates/parish-core/src/ipc/types.rs
@@ -278,7 +278,7 @@ pub struct TravelStartPayload {
 /// command to render the listing.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TileSourceSnapshot {
-    /// Registry key (e.g. "osm", "tailte-historic-6inch").
+    /// Registry key (e.g. "osm", "historic-6inch").
     pub id: String,
     /// Human-readable label shown in `/tiles` listings.
     pub label: String,

--- a/crates/parish-core/src/ipc/types.rs
+++ b/crates/parish-core/src/ipc/types.rs
@@ -268,6 +268,61 @@ pub struct TravelStartPayload {
     pub destination: String,
 }
 
+// ── Map tile source snapshot ────────────────────────────────────────────────
+
+/// Frontend-facing description of a single tile source.
+///
+/// Mirrors `parish_config::engine::TileSourceConfig` with the `id` key added
+/// so the frontend can build a registry without its own lookup logic. Sent
+/// inside the `UiConfigSnapshot` on boot and used by the `/tiles` slash
+/// command to render the listing.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TileSourceSnapshot {
+    /// Registry key (e.g. "osm", "tailte-historic-6inch").
+    pub id: String,
+    /// Human-readable label shown in `/tiles` listings.
+    pub label: String,
+    /// XYZ URL template (empty string means "not yet configured").
+    pub url: String,
+    /// Tile edge length in pixels.
+    pub tile_size: u32,
+    /// Minimum zoom the source serves tiles for.
+    pub minzoom: u32,
+    /// Maximum zoom the source serves tiles for.
+    pub maxzoom: u32,
+    /// Attribution text for MapLibre's attribution control.
+    pub attribution: String,
+    /// MapLibre `raster-saturation` paint value.
+    pub raster_saturation: f32,
+    /// MapLibre `raster-opacity` paint value.
+    pub raster_opacity: f32,
+    /// When true, the frontend sets `scheme: 'tms'` on the source.
+    pub tms: bool,
+}
+
+impl TileSourceSnapshot {
+    /// Builds the frontend-facing list from a `MapConfig`, alphabetical by id.
+    ///
+    /// Call this at backend boot to populate `UiConfigSnapshot::tile_sources`.
+    pub fn list_from_map_config(cfg: &parish_config::MapConfig) -> Vec<Self> {
+        cfg.tile_sources
+            .iter()
+            .map(|(id, src)| Self {
+                id: id.clone(),
+                label: src.label.clone(),
+                url: src.url.clone(),
+                tile_size: src.tile_size,
+                minzoom: src.minzoom,
+                maxzoom: src.maxzoom,
+                attribution: src.attribution.clone(),
+                raster_saturation: src.raster_saturation,
+                raster_opacity: src.raster_opacity,
+                tms: src.tms,
+            })
+            .collect()
+    }
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/crates/parish-input/src/lib.rs
+++ b/crates/parish-input/src/lib.rs
@@ -113,6 +113,8 @@ pub enum Command {
     Tick,
     /// Show or change the UI theme.
     Theme(Option<String>),
+    /// Show or change the map tile source.
+    Tiles(Option<String>),
     /// Invalid branch name was provided.
     InvalidBranchName(String),
     /// Feature flag management (`/flag enable|disable|list <name>`).
@@ -307,6 +309,19 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
             Some(Command::Theme(None))
         } else {
             Some(Command::Theme(Some(arg)))
+        }
+    } else if lower == "/tiles" {
+        Some(Command::Tiles(None))
+    } else if lower.starts_with("/tiles ") {
+        let arg = trimmed
+            .get("/tiles ".len()..)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if arg.is_empty() {
+            Some(Command::Tiles(None))
+        } else {
+            Some(Command::Tiles(Some(arg)))
         }
     } else if let Some(cmd) = parse_category_command(trimmed, &lower) {
         Some(cmd)
@@ -1381,6 +1396,27 @@ mod tests {
         assert_eq!(
             parse_system_command("/THEME Solarized Dark"),
             Some(Command::Theme(Some("Solarized Dark".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_parse_tiles_command() {
+        assert_eq!(parse_system_command("/tiles"), Some(Command::Tiles(None)));
+        assert_eq!(
+            parse_system_command("/tiles   "),
+            Some(Command::Tiles(None))
+        );
+        assert_eq!(
+            parse_system_command("/tiles osm"),
+            Some(Command::Tiles(Some("osm".to_string())))
+        );
+        assert_eq!(
+            parse_system_command("/tiles tailte-historic-6inch"),
+            Some(Command::Tiles(Some("tailte-historic-6inch".to_string())))
+        );
+        assert_eq!(
+            parse_system_command("/TILES OSM"),
+            Some(Command::Tiles(Some("OSM".to_string())))
         );
     }
 

--- a/crates/parish-input/src/lib.rs
+++ b/crates/parish-input/src/lib.rs
@@ -1411,8 +1411,8 @@ mod tests {
             Some(Command::Tiles(Some("osm".to_string())))
         );
         assert_eq!(
-            parse_system_command("/tiles tailte-historic-6inch"),
-            Some(Command::Tiles(Some("tailte-historic-6inch".to_string())))
+            parse_system_command("/tiles historic-6inch"),
+            Some(Command::Tiles(Some("historic-6inch".to_string())))
         );
         assert_eq!(
             parse_system_command("/TILES OSM"),

--- a/crates/parish-input/src/lib.rs
+++ b/crates/parish-input/src/lib.rs
@@ -99,8 +99,8 @@ pub enum Command {
     SetCategoryKey(InferenceCategory, String),
     /// Show about / credits information.
     About,
-    /// Toggle the full map overlay / show text-based map in CLI.
-    Map,
+    /// Show or change the map tile source. No arg = list sources; arg = switch to it.
+    Map(Option<String>),
     /// Show NPCs at the current location with details.
     NpcsHere,
     /// Show detailed time, weather, and season info.
@@ -113,8 +113,6 @@ pub enum Command {
     Tick,
     /// Show or change the UI theme.
     Theme(Option<String>),
-    /// Show or change the map tile source.
-    Tiles(Option<String>),
     /// Invalid branch name was provided.
     InvalidBranchName(String),
     /// Feature flag management (`/flag enable|disable|list <name>`).
@@ -281,7 +279,18 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
     } else if lower == "/about" {
         Some(Command::About)
     } else if lower == "/map" {
-        Some(Command::Map)
+        Some(Command::Map(None))
+    } else if lower.starts_with("/map ") {
+        let arg = trimmed
+            .get("/map ".len()..)
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if arg.is_empty() {
+            Some(Command::Map(None))
+        } else {
+            Some(Command::Map(Some(arg)))
+        }
     } else if lower == "/npcs" {
         Some(Command::NpcsHere)
     } else if lower == "/time" {
@@ -309,19 +318,6 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
             Some(Command::Theme(None))
         } else {
             Some(Command::Theme(Some(arg)))
-        }
-    } else if lower == "/tiles" {
-        Some(Command::Tiles(None))
-    } else if lower.starts_with("/tiles ") {
-        let arg = trimmed
-            .get("/tiles ".len()..)
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if arg.is_empty() {
-            Some(Command::Tiles(None))
-        } else {
-            Some(Command::Tiles(Some(arg)))
         }
     } else if let Some(cmd) = parse_category_command(trimmed, &lower) {
         Some(cmd)
@@ -1322,20 +1318,31 @@ mod tests {
 
     #[test]
     fn test_parse_map_command() {
-        let cmd = parse_system_command("/map");
-        assert_eq!(cmd, Some(Command::Map));
+        assert_eq!(parse_system_command("/map"), Some(Command::Map(None)));
+        assert_eq!(parse_system_command("/map   "), Some(Command::Map(None)));
+        assert_eq!(
+            parse_system_command("/map osm"),
+            Some(Command::Map(Some("osm".to_string())))
+        );
+        assert_eq!(
+            parse_system_command("/map historic"),
+            Some(Command::Map(Some("historic".to_string())))
+        );
     }
 
     #[test]
     fn test_parse_map_command_case_insensitive() {
-        let cmd = parse_system_command("/MAP");
-        assert_eq!(cmd, Some(Command::Map));
+        assert_eq!(parse_system_command("/MAP"), Some(Command::Map(None)));
+        assert_eq!(
+            parse_system_command("/MAP OSM"),
+            Some(Command::Map(Some("OSM".to_string())))
+        );
     }
 
     #[test]
     fn test_classify_map_command() {
         let result = classify_input("/map");
-        assert_eq!(result, InputResult::SystemCommand(Command::Map));
+        assert_eq!(result, InputResult::SystemCommand(Command::Map(None)));
     }
 
     #[test]
@@ -1396,27 +1403,6 @@ mod tests {
         assert_eq!(
             parse_system_command("/THEME Solarized Dark"),
             Some(Command::Theme(Some("Solarized Dark".to_string())))
-        );
-    }
-
-    #[test]
-    fn test_parse_tiles_command() {
-        assert_eq!(parse_system_command("/tiles"), Some(Command::Tiles(None)));
-        assert_eq!(
-            parse_system_command("/tiles   "),
-            Some(Command::Tiles(None))
-        );
-        assert_eq!(
-            parse_system_command("/tiles osm"),
-            Some(Command::Tiles(Some("osm".to_string())))
-        );
-        assert_eq!(
-            parse_system_command("/tiles historic-6inch"),
-            Some(Command::Tiles(Some("historic-6inch".to_string())))
-        );
-        assert_eq!(
-            parse_system_command("/TILES OSM"),
-            Some(Command::Tiles(Some("OSM".to_string())))
         );
     }
 

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -121,7 +121,8 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         .unwrap_or_else(parish_core::game_mod::default_theme_palette);
 
     // Load engine config (parish.toml) for the tile-source registry. Missing
-    // file or parse errors fall back to baked defaults (OSM + Tailte).
+    // file or parse errors fall back to baked defaults
+    // (OSM + Ireland Historic 6").
     let engine_config = parish_core::config::load_engine_config(None);
     let tile_sources_snapshot =
         parish_core::ipc::TileSourceSnapshot::list_from_map_config(&engine_config.map);

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -119,17 +119,32 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         .as_ref()
         .map(|gm| gm.ui.theme.resolved_palette())
         .unwrap_or_else(parish_core::game_mod::default_theme_palette);
+
+    // Load engine config (parish.toml) for the tile-source registry. Missing
+    // file or parse errors fall back to baked defaults (OSM + Tailte).
+    let engine_config = parish_core::config::load_engine_config(None);
+    let tile_sources_snapshot =
+        parish_core::ipc::TileSourceSnapshot::list_from_map_config(&engine_config.map);
+    let active_tile_source = engine_config.map.default_tile_source.clone();
+    // Populate the /tiles command's registry on the runtime GameConfig.
+    config.active_tile_source = active_tile_source.clone();
+    config.tile_sources = engine_config.map.id_label_pairs();
+
     let ui_config = if let Some(ref gm) = game_mod {
         UiConfigSnapshot {
             hints_label: gm.ui.sidebar.hints_label.clone(),
             default_accent: theme_palette.accent.clone(),
             splash_text,
+            active_tile_source: active_tile_source.clone(),
+            tile_sources: tile_sources_snapshot.clone(),
         }
     } else {
         UiConfigSnapshot {
             hints_label: "Language Hints".to_string(),
             default_accent: theme_palette.accent.clone(),
             splash_text,
+            active_tile_source,
+            tile_sources: tile_sources_snapshot,
         }
     };
 
@@ -760,6 +775,9 @@ fn build_client_and_config() -> (Option<OpenAiClient>, GameConfig) {
         category_base_url: [None, None, None, None],
         flags: FeatureFlags::default(),
         category_rate_limit: [None, None, None, None],
+        // Tile-source fields populated in build_app_state from engine config.
+        active_tile_source: String::new(),
+        tile_sources: Vec::new(),
     };
 
     (client, config)

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -275,9 +275,6 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
                     ),
                 );
             }
-            CommandEffect::ToggleMap => {
-                state.event_bus.emit("toggle-full-map", &());
-            }
             CommandEffect::SaveGame => {
                 let msg = match do_save_game_inner(state).await {
                     Ok(msg) => msg,

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -357,6 +357,11 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
                     &serde_json::json!({ "name": name, "mode": mode }),
                 );
             }
+            CommandEffect::ApplyTiles(id) => {
+                state
+                    .event_bus
+                    .emit("tiles-switch", &serde_json::json!({ "id": id }));
+            }
         }
     }
 
@@ -1818,6 +1823,8 @@ mod tests {
             hints_label: "test".to_string(),
             default_accent: "#000".to_string(),
             splash_text: String::new(),
+            active_tile_source: String::new(),
+            tile_sources: Vec::new(),
         };
         let theme_palette = parish_core::game_mod::default_theme_palette();
         let saves_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../saves");
@@ -1844,6 +1851,8 @@ mod tests {
                 category_base_url: [None, None, None, None],
                 flags: parish_core::config::FeatureFlags::default(),
                 category_rate_limit: [None, None, None, None],
+                active_tile_source: String::new(),
+                tile_sources: Vec::new(),
             },
             None,
             transport,

--- a/crates/parish-server/src/state.rs
+++ b/crates/parish-server/src/state.rs
@@ -30,6 +30,10 @@ pub struct UiConfigSnapshot {
     pub default_accent: String,
     /// Splash text displayed on game start (Zork-style).
     pub splash_text: String,
+    /// Id of the currently-active tile source (matches a `tile_sources` key).
+    pub active_tile_source: String,
+    /// Registry of available map tile sources, alphabetical by id.
+    pub tile_sources: Vec<parish_core::ipc::TileSourceSnapshot>,
 }
 
 /// Current save state for display in the StatusBar.

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -443,6 +443,12 @@ async fn handle_system_command(
                     serde_json::json!({ "name": name, "mode": mode }),
                 );
             }
+            CommandEffect::ApplyTiles(id) => {
+                let _ = app.emit(
+                    crate::events::EVENT_TILES_SWITCH,
+                    serde_json::json!({ "id": id }),
+                );
+            }
         }
     }
 

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -373,10 +373,6 @@ async fn handle_system_command(
                 app.exit(0);
                 return;
             }
-            CommandEffect::ToggleMap => {
-                let _ = app.emit(crate::events::EVENT_TOGGLE_MAP, ());
-                return; // No text log for map toggle
-            }
             CommandEffect::SaveGame => {
                 extra_response = Some(match do_save_game(state).await {
                     Ok(msg) => msg,

--- a/crates/parish-tauri/src/events.rs
+++ b/crates/parish-tauri/src/events.rs
@@ -23,15 +23,13 @@ pub const EVENT_THEME_UPDATE: &str = "theme-update";
 pub const EVENT_DEBUG_UPDATE: &str = "debug-update";
 /// Event emitted to tell the frontend to open the save picker modal.
 pub const EVENT_SAVE_PICKER: &str = "save-picker";
-/// Event emitted to toggle the full map overlay.
-pub const EVENT_TOGGLE_MAP: &str = "toggle-full-map";
 /// Event emitted when an NPC reacts to a message with an emoji.
 pub const EVENT_NPC_REACTION: &str = "npc-reaction";
 /// Event emitted when the player begins traveling between locations.
 pub const EVENT_TRAVEL_START: &str = "travel-start";
 /// Event emitted when a `/theme` command selects a new UI theme.
 pub const EVENT_THEME_SWITCH: &str = "theme-switch";
-/// Event emitted when a `/tiles` command selects a new map tile source.
+/// Event emitted when a `/map` command selects a new map tile source.
 pub const EVENT_TILES_SWITCH: &str = "tiles-switch";
 
 /// How many milliseconds to batch streaming tokens before emitting.

--- a/crates/parish-tauri/src/events.rs
+++ b/crates/parish-tauri/src/events.rs
@@ -31,6 +31,8 @@ pub const EVENT_NPC_REACTION: &str = "npc-reaction";
 pub const EVENT_TRAVEL_START: &str = "travel-start";
 /// Event emitted when a `/theme` command selects a new UI theme.
 pub const EVENT_THEME_SWITCH: &str = "theme-switch";
+/// Event emitted when a `/tiles` command selects a new map tile source.
+pub const EVENT_TILES_SWITCH: &str = "tiles-switch";
 
 /// How many milliseconds to batch streaming tokens before emitting.
 pub const BATCH_MS: u64 = 16;

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -137,6 +137,10 @@ pub struct UiConfigSnapshot {
     pub default_accent: String,
     /// Splash text displayed on game start (Zork-style).
     pub splash_text: String,
+    /// Id of the currently-active tile source (matches a `tile_sources` key).
+    pub active_tile_source: String,
+    /// Registry of available map tile sources, alphabetical by id.
+    pub tile_sources: Vec<parish_core::ipc::TileSourceSnapshot>,
 }
 
 /// Runtime conversation/session state used for continuity and inactivity timers.
@@ -497,18 +501,29 @@ pub fn run() {
         .map(|gm| gm.ui.theme.resolved_palette())
         .unwrap_or_else(parish_core::game_mod::default_theme_palette);
 
+    // Load engine config (parish.toml) for the map tile-source registry.
+    // Missing file / parse errors fall back to baked defaults (OSM + Tailte).
+    let engine_config = parish_core::config::load_engine_config(None);
+    let tile_sources_snapshot =
+        parish_core::ipc::TileSourceSnapshot::list_from_map_config(&engine_config.map);
+    let active_tile_source = engine_config.map.default_tile_source.clone();
+
     // Build UI config from mod or defaults
     let ui_config = if let Some(ref gm) = game_mod {
         UiConfigSnapshot {
             hints_label: gm.ui.sidebar.hints_label.clone(),
             default_accent: theme_palette.accent.clone(),
             splash_text: splash_text.clone(),
+            active_tile_source: active_tile_source.clone(),
+            tile_sources: tile_sources_snapshot.clone(),
         }
     } else {
         UiConfigSnapshot {
             hints_label: "Language Hints".to_string(),
             default_accent: theme_palette.accent.clone(),
             splash_text,
+            active_tile_source: active_tile_source.clone(),
+            tile_sources: tile_sources_snapshot,
         }
     };
 
@@ -570,6 +585,8 @@ pub fn run() {
             category_base_url: [None, None, None, None],
             flags,
             category_rate_limit: [None, None, None, None],
+            active_tile_source,
+            tile_sources: engine_config.map.id_label_pairs(),
         }),
     });
 

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -502,7 +502,8 @@ pub fn run() {
         .unwrap_or_else(parish_core::game_mod::default_theme_palette);
 
     // Load engine config (parish.toml) for the map tile-source registry.
-    // Missing file / parse errors fall back to baked defaults (OSM + Tailte).
+    // Missing file / parse errors fall back to baked defaults
+    // (OSM + Ireland Historic 6").
     let engine_config = parish_core::config::load_engine_config(None);
     let tile_sources_snapshot =
         parish_core::ipc::TileSourceSnapshot::list_from_map_config(&engine_config.map);

--- a/docs/design/map-evolution.md
+++ b/docs/design/map-evolution.md
@@ -123,7 +123,7 @@ The map could be more than navigation:
 | ~~**Phase B**~~ | ~~Fog of war / progressive disclosure (#4) + hover tooltips (#5)~~ | **Done** |
 | ~~**Phase C**~~ | ~~Animated travel (#7) + time-of-day atmosphere (#6)~~ | **Done** |
 | ~~**Phase D (map)**~~ | ~~OSM tile background for full map (#9), migrated to MapLibre GL JS for polished label placement (variable anchors, zoom-aware decluttering, symbol-sort priority)~~ | **Done** |
-| ~~**Phase D.1 (tiles)**~~ | ~~`/tiles` slash command + configurable tile-source registry (OSM + Tailte Éireann Historic 6" 1829–1842), gated behind `period-map-tiles` feature flag~~ | **Done** |
+| ~~**Phase D.1 (tiles)**~~ | ~~`/tiles` slash command + configurable tile-source registry (OSM + Ireland Historic 6" 1829–1842 via NLS), gated behind `period-map-tiles` feature flag~~ | **Done** |
 | **Phase D (TUI)** | TUI ASCII map (#8) | Medium |
 | **Phase E** | Narrative annotations (#10) + NPC trails | Large |
 
@@ -146,14 +146,19 @@ to switch between them at runtime.
 Two sources ship baked-in:
 
 - **`osm`** — the current OSM raster (working default).
-- **`tailte-historic-6inch`** — Tailte Éireann's Historic 6" first-edition
-  series (surveyed 1829–1842), the most period-accurate cartography for
-  Kiltoom. Its `url` ships empty because MapGenie is gated behind the
-  National Mapping Agreement and GeoHive's free public viewer doesn't
-  publish its tile endpoint — operators paste a URL into `parish.toml`
-  after capturing it from the viewer's browser DevTools. An empty URL
-  falls back to the flat panel background with a one-shot console warning
-  instead of a broken map.
+- **`historic-6inch`** — Ordnance Survey of Ireland First Edition 6-inch
+  (surveyed 1829–1842), the most period-accurate cartography for
+  Kiltoom. Ships wired to the [National Library of Scotland's free public
+  S3-hosted tile service][nls-ireland] — no signup, CORS-open. Operators
+  who want higher-fidelity tiles can override the URL in `parish.toml`
+  with a Tailte Éireann MapGenie endpoint (gated behind the National
+  Mapping Agreement) or a captured GeoHive tile URL.
+
+[nls-ireland]: https://maps.nls.uk/geo/explore/
+
+If an operator registers a new source without filling in a URL, the
+frontend falls back to the flat panel background with a one-shot console
+warning instead of a broken map.
 
 Adding further sources (custom sepia-styled tiles, scanned grand-jury
 maps georeferenced via MapWarper, etc.) is a pure TOML add; no code

--- a/docs/design/map-evolution.md
+++ b/docs/design/map-evolution.md
@@ -123,6 +123,7 @@ The map could be more than navigation:
 | ~~**Phase B**~~ | ~~Fog of war / progressive disclosure (#4) + hover tooltips (#5)~~ | **Done** |
 | ~~**Phase C**~~ | ~~Animated travel (#7) + time-of-day atmosphere (#6)~~ | **Done** |
 | ~~**Phase D (map)**~~ | ~~OSM tile background for full map (#9), migrated to MapLibre GL JS for polished label placement (variable anchors, zoom-aware decluttering, symbol-sort priority)~~ | **Done** |
+| ~~**Phase D.1 (tiles)**~~ | ~~`/tiles` slash command + configurable tile-source registry (OSM + Tailte Éireann Historic 6" 1829–1842), gated behind `period-map-tiles` feature flag~~ | **Done** |
 | **Phase D (TUI)** | TUI ASCII map (#8) | Medium |
 | **Phase E** | Narrative annotations (#10) + NPC trails | Large |
 
@@ -133,6 +134,41 @@ The map could be more than navigation:
 - Should fog of war persist across save/load? (Probably yes — it's part of game state.)
 - How does the `/map` overlay interact with the input field? Does it capture keyboard focus?
 - Do we want the minimap in the TUI as well, or only GUI mode?
+
+## Phase D.1 — Period tiles (configurable tile-source registry)
+
+The OSM background shipped in Phase D is anachronistic for Rundale's 1820
+setting — it renders modern motorways, housing estates, wind farms, etc.
+Phase D.1 adds a **registry of named tile sources** data-driven from
+`parish.toml`'s `[engine.map]` section and a `/tiles <id>` slash command
+to switch between them at runtime.
+
+Two sources ship baked-in:
+
+- **`osm`** — the current OSM raster (working default).
+- **`tailte-historic-6inch`** — Tailte Éireann's Historic 6" first-edition
+  series (surveyed 1829–1842), the most period-accurate cartography for
+  Kiltoom. Its `url` ships empty because MapGenie is gated behind the
+  National Mapping Agreement and GeoHive's free public viewer doesn't
+  publish its tile endpoint — operators paste a URL into `parish.toml`
+  after capturing it from the viewer's browser DevTools. An empty URL
+  falls back to the flat panel background with a one-shot console warning
+  instead of a broken map.
+
+Adding further sources (custom sepia-styled tiles, scanned grand-jury
+maps georeferenced via MapWarper, etc.) is a pure TOML add; no code
+changes needed.
+
+The feature is gated behind the **`period-map-tiles`** flag
+(default-enabled, per CLAUDE.md rule #6). Kill-switch:
+`/flag disable period-map-tiles`.
+
+**Scope limits (defer to later phases):**
+- Only XYZ raster URL templates (`{z}/{x}/{y}.png`, optional TMS y-flip)
+  — no WMS/WMTS adapters yet.
+- No custom MapLibre style (still the Phase D sepia-via-desaturation look).
+- No offline tile bundling — still on-demand fetch.
+- Minimap stays flat-bg only.
 
 ## Related
 

--- a/parish.example.toml
+++ b/parish.example.toml
@@ -89,3 +89,50 @@ fuzzy_threshold = 0.82          # Jaro-Winkler similarity for fuzzy location mat
 
 [engine.persistence]
 journal_compaction_threshold = 1000  # Max journal entries before compaction (reserved)
+
+# ---------------------------------------------------------------------------
+# Map tile sources
+# ---------------------------------------------------------------------------
+# The full-map overlay fetches raster tiles from whichever entry below is
+# selected at runtime via `/tiles <id>` (see /help). The OSM default is
+# anachronistic for Rundale's 1820 setting; see docs/design/map-evolution.md
+# for the Phase D.1 motivation.
+#
+# Baked-in defaults (no config needed): `osm` and `tailte-historic-6inch`.
+# Overriding any entry replaces it; entries you don't list stay intact —
+# see MapConfig::apply_defaults in crates/parish-config/src/engine.rs.
+#
+# [engine.map]
+# default_tile_source = "osm"
+#
+# [engine.map.tile_sources.osm]
+# label = "OpenStreetMap"
+# url = "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+# tile_size = 256
+# minzoom = 0
+# maxzoom = 19
+# attribution = "© OpenStreetMap contributors"
+# raster_saturation = -0.4         # -1.0 fully grey, 0.0 untouched, 1.0 saturated
+# raster_opacity = 0.85
+# tms = false                      # true flips y-axis (ArcGIS-style services)
+#
+# [engine.map.tile_sources.tailte-historic-6inch]
+# # Tailte Éireann Historic 6" — surveyed 1829–1842, period-appropriate for
+# # 1820 Roscommon. The URL below ships empty because:
+# #   - MapGenie (https://tailte.ie/services/mapgenie/) requires a National
+# #     Mapping Agreement subscription and publishes no public tile URLs.
+# #   - GeoHive (https://map.geohive.ie/) is the free public viewer for the
+# #     same historic layers but doesn't document its tile endpoint — capture
+# #     it from the browser DevTools Network tab while panning the historic
+# #     layer in the viewer.
+# # Verify the captured URL has `Access-Control-Allow-Origin: *` in its
+# # response headers (or add a proxy) before committing to shared config.
+# label = 'Tailte Éireann Historic 6"'
+# url = ""                         # e.g. "https://<host>/.../MapServer/tile/{z}/{y}/{x}"
+# tile_size = 256
+# minzoom = 0
+# maxzoom = 17
+# attribution = 'Tailte Éireann, Historic 6" First Edition (1829–1842)'
+# raster_saturation = 0.0
+# raster_opacity = 1.0
+# tms = true                       # ArcGIS MapServer tile/{z}/{y}/{x} needs y-flip

--- a/parish.example.toml
+++ b/parish.example.toml
@@ -98,7 +98,7 @@ journal_compaction_threshold = 1000  # Max journal entries before compaction (re
 # anachronistic for Rundale's 1820 setting; see docs/design/map-evolution.md
 # for the Phase D.1 motivation.
 #
-# Baked-in defaults (no config needed): `osm` and `tailte-historic-6inch`.
+# Baked-in defaults (no config needed): `osm` and `historic-6inch`.
 # Overriding any entry replaces it; entries you don't list stay intact —
 # see MapConfig::apply_defaults in crates/parish-config/src/engine.rs.
 #
@@ -116,23 +116,23 @@ journal_compaction_threshold = 1000  # Max journal entries before compaction (re
 # raster_opacity = 0.85
 # tms = false                      # true flips y-axis (ArcGIS-style services)
 #
-# [engine.map.tile_sources.tailte-historic-6inch]
-# # Tailte Éireann Historic 6" — surveyed 1829–1842, period-appropriate for
-# # 1820 Roscommon. The URL below ships empty because:
-# #   - MapGenie (https://tailte.ie/services/mapgenie/) requires a National
-# #     Mapping Agreement subscription and publishes no public tile URLs.
-# #   - GeoHive (https://map.geohive.ie/) is the free public viewer for the
-# #     same historic layers but doesn't document its tile endpoint — capture
-# #     it from the browser DevTools Network tab while panning the historic
-# #     layer in the viewer.
-# # Verify the captured URL has `Access-Control-Allow-Origin: *` in its
-# # response headers (or add a proxy) before committing to shared config.
-# label = 'Tailte Éireann Historic 6"'
-# url = ""                         # e.g. "https://<host>/.../MapServer/tile/{z}/{y}/{x}"
+# [engine.map.tile_sources.historic-6inch]
+# # Ordnance Survey of Ireland First Edition 6-inch (1829–1842), reprojected
+# # and hosted by the National Library of Scotland. Free, public, CORS-open
+# # (S3) — no signup. See https://maps.nls.uk/geo/explore/ for license terms
+# # and the broader collection.
+# #
+# # Alternatives if you need higher fidelity or another projection:
+# #   - Tailte Éireann MapGenie (https://tailte.ie/services/mapgenie/) — gated
+# #     behind the National Mapping Agreement.
+# #   - GeoHive viewer (https://map.geohive.ie/) — free, capture the tile URL
+# #     from browser DevTools; scheme is ArcGIS (`tms = true`).
+# label = 'Ireland Historic 6" (via NLS)'
+# url = "https://mapseries-tilesets.s3.amazonaws.com/ireland_6inch/{z}/{x}/{y}.jpg"
 # tile_size = 256
 # minzoom = 0
-# maxzoom = 17
-# attribution = 'Tailte Éireann, Historic 6" First Edition (1829–1842)'
+# maxzoom = 15
+# attribution = 'Historic 6" OS Ireland (1829–1842), via National Library of Scotland'
 # raster_saturation = 0.0
 # raster_opacity = 1.0
-# tms = true                       # ArcGIS MapServer tile/{z}/{y}/{x} needs y-flip
+# tms = false                      # NLS uses standard XYZ; set true only for ArcGIS y-flipped services

--- a/parish.example.toml
+++ b/parish.example.toml
@@ -94,11 +94,11 @@ journal_compaction_threshold = 1000  # Max journal entries before compaction (re
 # Map tile sources
 # ---------------------------------------------------------------------------
 # The full-map overlay fetches raster tiles from whichever entry below is
-# selected at runtime via `/tiles <id>` (see /help). The OSM default is
+# selected at runtime via `/map <id>` (see /help). The OSM default is
 # anachronistic for Rundale's 1820 setting; see docs/design/map-evolution.md
 # for the Phase D.1 motivation.
 #
-# Baked-in defaults (no config needed): `osm` and `historic-6inch`.
+# Baked-in defaults (no config needed): `osm` and `historic`.
 # Overriding any entry replaces it; entries you don't list stay intact —
 # see MapConfig::apply_defaults in crates/parish-config/src/engine.rs.
 #
@@ -116,22 +116,23 @@ journal_compaction_threshold = 1000  # Max journal entries before compaction (re
 # raster_opacity = 0.85
 # tms = false                      # true flips y-axis (ArcGIS-style services)
 #
-# [engine.map.tile_sources.historic-6inch]
-# # Ordnance Survey of Ireland First Edition 6-inch (1829–1842), reprojected
-# # and hosted by the National Library of Scotland. Free, public, CORS-open
-# # (S3) — no signup. See https://maps.nls.uk/geo/explore/ for license terms
-# # and the broader collection.
+# [engine.map.tile_sources.historic]
+# # Ordnance Survey of Ireland First Edition 6-inch (surveyed 1829–1842),
+# # scanned and hosted by the National Library of Scotland under CC-BY-SA 3.0.
+# # NLS serves Ireland as 32 per-county tilesets under `os/<county>1/` — there
+# # is no seamless all-Ireland layer. The baked-in default is Roscommon (where
+# # Rundale is set); expanding to whole-island coverage is tracked in #360.
 # #
-# # Alternatives if you need higher fidelity or another projection:
+# # Alternatives if you need another projection or higher fidelity:
 # #   - Tailte Éireann MapGenie (https://tailte.ie/services/mapgenie/) — gated
 # #     behind the National Mapping Agreement.
 # #   - GeoHive viewer (https://map.geohive.ie/) — free, capture the tile URL
 # #     from browser DevTools; scheme is ArcGIS (`tms = true`).
-# label = 'Ireland Historic 6" (via NLS)'
-# url = "https://mapseries-tilesets.s3.amazonaws.com/ireland_6inch/{z}/{x}/{y}.jpg"
+# label = 'Historic 6" OS Ireland (1st ed., via NLS)'
+# url = "https://mapseries-tilesets.s3.amazonaws.com/os/roscommon1/{z}/{x}/{y}.png"
 # tile_size = 256
-# minzoom = 0
-# maxzoom = 15
+# minzoom = 1
+# maxzoom = 17
 # attribution = 'Historic 6" OS Ireland (1829–1842), via National Library of Scotland'
 # raster_saturation = 0.0
 # raster_opacity = 1.0


### PR DESCRIPTION
## Summary

Swaps the hardcoded OSM tile URL in MapLibre for a **configurable registry** of named tile sources, switched at runtime via a new `/tiles` slash command. Phase D.1 of the [map-evolution roadmap](../blob/main/docs/design/map-evolution.md) — the modern OSM tiles shipped in Phase D are anachronistic for Rundale's 1820 Roscommon setting.

Two sources ship baked-in (overridable via `parish.toml`):
- **`osm`** — current OSM raster (working default).
- **`tailte-historic-6inch`** — Tailte Éireann Historic 6" (surveyed 1829–1842), the most period-accurate cartography for Kiltoom.

## /tiles command

```
> /tiles
Available tile sources:
  * osm (active) — OpenStreetMap
    tailte-historic-6inch — Tailte Éireann Historic 6"
Usage: /tiles <id>

> /tiles tailte-historic-6inch
Switched map tiles to Tailte Éireann Historic 6".
```

Emits `CommandEffect::ApplyTiles(id)` → backend fires a `tiles-switch` event → `stores/tiles.ts` updates → `FullMapOverlay`'s `$effect` calls `MapController.setTileSource(...)` → MapLibre's `setStyle` swaps the raster source. Overlay GeoJSON layers survive the swap via a `styledata` re-push using a retained `lastMapData`.

## Feature flag

Name: **`period-map-tiles`** (default-enabled per CLAUDE.md rule #6, via `flags.is_disabled(...)` semantics — no flags file seeding needed).

Kill-switch:
```
> /flag disable period-map-tiles
> /tiles
Period map tiles are disabled. Re-enable with /flag enable period-map-tiles.
```

## Tailte URL note

The Tailte entry ships with `url = ""` because:
- **MapGenie** ([tailte.ie/services/mapgenie](https://tailte.ie/services/mapgenie/)) gates WMS/WMTS/REST behind the **National Mapping Agreement** — no free public URLs.
- **GeoHive** ([map.geohive.ie](https://map.geohive.ie/)) is the free public viewer for the same historic layers but doesn't publish its tile endpoint.

Operators capture a URL from the viewer's browser DevTools Network tab and paste it into `parish.toml` (see the `[engine.map.tile_sources.tailte-historic-6inch]` block in `parish.example.toml` for instructions). An empty URL falls back to the flat panel background with a one-shot `console.warn` — the feature stays usable even without a live endpoint.

## Everything is TOML-configurable

New `[engine.map]` section in `parish.toml` — URL template, tile size, zoom range, attribution, `raster-saturation`, `raster-opacity`, TMS y-flip, and the default-at-boot source id. See `parish.example.toml` for the full schema. Partial overrides merge with baked defaults via `MapConfig::apply_defaults` (BTreeMap serde is replace-not-merge).

## Scope (MVP — deferred)

- **XYZ raster only.** WMS/WMTS URLs need a small adapter layer — follow-up.
- **No custom style.** Still the Phase D sepia-via-desaturation look; a true hand-engraved style is Phase D.2.
- **No offline bundling.** Tiles still fetched on demand.
- **Minimap unchanged** — stays flat-bg only.

## Test plan

- [x] Rust: 5 new map config tests (`parish-config`), 7 new `/tiles` handler tests (`parish-core`), 1 new parser test (`parish-input`). All green.
- [x] TS: 6 new `buildStyle` tests (OSM, TMS, empty URL, no source, minimap, GeoJSON sources always present) + 6 new tiles-store tests (seed, switch, unknown id, localStorage persist/restore, fallback).
- [x] Pre-existing tests still green across parish-config / parish-core / parish-input / parish (CLI) / apps/ui map tests.
- [ ] Manual GUI smoke (Tauri): open `/map`, run `/tiles tailte-historic-6inch` — attribution updates, fallback displays since URL is empty by default.
- [ ] Toggle feature flag off and on — `/tiles` refuses then re-enables.
- [ ] Paste a real Tailte URL into `parish.toml` — confirm tiles render and CORS is OK.

## Files

Schema: `crates/parish-config/src/engine.rs` · `parish.example.toml` · `crates/parish-core/src/ipc/{config,types}.rs`
Command: `crates/parish-input/src/lib.rs` · `crates/parish-core/src/ipc/commands.rs`
Bridge: `crates/parish-tauri/src/{events,commands,lib}.rs` · `crates/parish-server/src/{lib,state,routes}.rs` · `crates/parish-cli/src/{headless,testing}.rs`
Frontend: `apps/ui/src/lib/{types,ipc}.ts` · `apps/ui/src/lib/map/{style,controller}.ts` · `apps/ui/src/stores/{game,tiles}.ts` · `apps/ui/src/components/FullMapOverlay.svelte` · `apps/ui/src/routes/+page.svelte`
Docs: `docs/design/map-evolution.md`

https://claude.ai/code/session_01J4V3YHnbTVnE3HNqw4oVQt