### PR TITLE
fix: modernise paste handler and clean up WebSocket on unmount (#289, #290)

### DIFF
--- a/apps/ui/src/components/InputField.svelte
+++ b/apps/ui/src/components/InputField.svelte
@@ -742,11 +742,42 @@
 		syncEditorText();
 	}
 
-	// Prevent pasting rich content — only plain text
+	// Prevent pasting rich content — only plain text.
+	// `document.execCommand('insertText')` is deprecated and doesn't
+	// always fire the `input` event, which would leave `editorText` stale.
+	// We insert a text node at the current selection manually and then
+	// sync the reactive state ourselves.
 	function handlePaste(e: ClipboardEvent) {
 		e.preventDefault();
 		const text = e.clipboardData?.getData('text/plain') ?? '';
-		document.execCommand('insertText', false, text);
+		if (!text || !editorEl) return;
+
+		const sel = window.getSelection();
+		if (!sel || sel.rangeCount === 0) {
+			// No selection (e.g. editor never focused) — append to end.
+			editorEl.appendChild(document.createTextNode(text));
+		} else {
+			const range = sel.getRangeAt(0);
+			// Only insert if the cursor is inside the editor.
+			if (!editorEl.contains(range.startContainer)) return;
+			range.deleteContents();
+			const node = document.createTextNode(text);
+			range.insertNode(node);
+			// Move cursor to the end of the inserted text.
+			range.setStartAfter(node);
+			range.collapse(true);
+			sel.removeAllRanges();
+			sel.addRange(range);
+		}
+
+		// execCommand used to fire 'input'; insertNode does not, so keep
+		// editorText in sync and re-run input-driven logic (mention/slash
+		// detection, history/completion resets) explicitly.
+		if (historyIndex >= 0) historyIndex = -1;
+		if (completion.active) resetCompletion();
+		detectMention();
+		if (dropdownMode !== 'mention') detectSlash();
+		syncEditorText();
 	}
 </script>
 

--- a/apps/ui/src/components/InputField.test.ts
+++ b/apps/ui/src/components/InputField.test.ts
@@ -507,6 +507,77 @@ describe('InputField', () => {
 		});
 	});
 
+	// ── Paste handling ──────────────────────────────────────────────────
+
+	describe('paste handling', () => {
+		function placeCursorAtEnd(editor: HTMLElement) {
+			const range = document.createRange();
+			const sel = window.getSelection();
+			range.selectNodeContents(editor);
+			range.collapse(false);
+			sel?.removeAllRanges();
+			sel?.addRange(range);
+		}
+
+		function makePasteEvent(text: string): ClipboardEvent {
+			// jsdom doesn't expose `DataTransfer`, so build a minimal stand-in
+			// that only supports the `getData('text/plain')` call the paste
+			// handler makes, and attach it via a non-enumerable property.
+			const evt = new Event('paste', {
+				bubbles: true,
+				cancelable: true
+			}) as ClipboardEvent;
+			Object.defineProperty(evt, 'clipboardData', {
+				value: {
+					getData: (type: string) => (type === 'text/plain' ? text : '')
+				}
+			});
+			return evt;
+		}
+
+		it('inserts pasted plain text into an empty editor', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox') as HTMLElement;
+			editor.focus();
+			placeCursorAtEnd(editor);
+
+			const evt = makePasteEvent('hello world');
+			editor.dispatchEvent(evt);
+
+			expect(evt.defaultPrevented).toBe(true);
+			expect(editor.textContent).toBe('hello world');
+		});
+
+		it('inserts pasted text at the cursor and keeps editorText state in sync (send enabled)', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox') as HTMLElement;
+			const sendBtn = getByRole('button', { name: 'Send' }) as HTMLButtonElement;
+			expect(sendBtn.disabled).toBe(true);
+
+			editor.focus();
+			placeCursorAtEnd(editor);
+			editor.dispatchEvent(makePasteEvent('pasted'));
+
+			// Wait a microtask for Svelte reactivity to settle.
+			await Promise.resolve();
+			expect(editor.textContent).toBe('pasted');
+			expect(sendBtn.disabled).toBe(false);
+		});
+
+		it('pasting submits via Enter with the pasted content', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox') as HTMLElement;
+			editor.focus();
+			placeCursorAtEnd(editor);
+
+			editor.dispatchEvent(makePasteEvent('typed via paste'));
+			await Promise.resolve();
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			expect(mockSubmitInput).toHaveBeenCalledWith('typed via paste', []);
+		});
+	});
+
 	// ── findMatches utility ─────────────────────────────────────────────
 
 	describe('findMatches', () => {

--- a/apps/ui/src/lib/ipc.test.ts
+++ b/apps/ui/src/lib/ipc.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// ── Minimal fake WebSocket ───────────────────────────────────────────────
+//
+// `ipc.ts` creates a real `WebSocket` at module load when any listener is
+// registered. We substitute a fake before importing the module so no real
+// network traffic is attempted and so we can observe/close behaviour.
+
+interface FakeWs {
+	url: string;
+	closeCalls: number;
+	onopen: ((e: Event) => void) | null;
+	onmessage: ((e: MessageEvent) => void) | null;
+	onclose: ((e: CloseEvent) => void) | null;
+	onerror: ((e: Event) => void) | null;
+	simulateOpen: () => void;
+	simulateClose: () => void;
+}
+
+const openSockets: FakeWs[] = [];
+
+class MockWebSocket implements FakeWs {
+	static CONNECTING = 0;
+	static OPEN = 1;
+	static CLOSING = 2;
+	static CLOSED = 3;
+
+	url: string;
+	closeCalls = 0;
+	onopen: ((e: Event) => void) | null = null;
+	onmessage: ((e: MessageEvent) => void) | null = null;
+	onclose: ((e: CloseEvent) => void) | null = null;
+	onerror: ((e: Event) => void) | null = null;
+
+	constructor(url: string) {
+		this.url = url;
+		openSockets.push(this);
+	}
+
+	close() {
+		this.closeCalls += 1;
+	}
+
+	simulateOpen() {
+		this.onopen?.(new Event('open'));
+	}
+
+	simulateClose() {
+		// Browsers null handlers before dispatch — mimic by firing whatever
+		// the module currently has attached, since the module may null it
+		// during `disposeTransport()`.
+		const handler = this.onclose;
+		if (handler) handler(new CloseEvent('close'));
+	}
+}
+
+// Stub window.location so ensureWebSocket can build a URL.
+beforeEach(() => {
+	Object.defineProperty(globalThis, 'WebSocket', {
+		configurable: true,
+		writable: true,
+		value: MockWebSocket
+	});
+	openSockets.length = 0;
+});
+
+afterEach(() => {
+	vi.resetModules();
+	vi.useRealTimers();
+});
+
+async function loadIpc() {
+	// Import fresh so module-level state is isolated per test.
+	const mod = await import('./ipc');
+	return mod;
+}
+
+describe('ipc WebSocket transport lifecycle', () => {
+	it('opens a single WebSocket when the first event listener registers', async () => {
+		const ipc = await loadIpc();
+		await ipc.onTextLog(() => {});
+		expect(openSockets.length).toBe(1);
+		expect(openSockets[0].url).toContain('/api/ws');
+	});
+
+	it('disposeTransport closes the WebSocket and detaches handlers', async () => {
+		const ipc = await loadIpc();
+		const unlisten = await ipc.onTextLog(() => {});
+		expect(openSockets.length).toBe(1);
+		const sock = openSockets[0];
+		expect(sock.closeCalls).toBe(0);
+
+		ipc.disposeTransport();
+
+		expect(sock.closeCalls).toBe(1);
+		expect(sock.onclose).toBeNull();
+		expect(sock.onerror).toBeNull();
+		expect(sock.onmessage).toBeNull();
+
+		// Dropping the unlisten after disposal must not re-open the socket.
+		unlisten();
+		expect(openSockets.length).toBe(1);
+	});
+
+	it('disposeTransport cancels a pending reconnect timer', async () => {
+		vi.useFakeTimers();
+		const ipc = await loadIpc();
+		await ipc.onTextLog(() => {});
+		const sock = openSockets[0];
+
+		// Trigger the reconnect path (mirrors a real socket closing).
+		sock.simulateClose();
+
+		// Tear down before the reconnect timer fires.
+		ipc.disposeTransport();
+
+		vi.advanceTimersByTime(5_000);
+		// The timer must have been cleared — no second socket opened.
+		expect(openSockets.length).toBe(1);
+	});
+
+	it('is safe to call disposeTransport with no connection', async () => {
+		const ipc = await loadIpc();
+		expect(() => ipc.disposeTransport()).not.toThrow();
+		expect(openSockets.length).toBe(0);
+	});
+
+	it('cancels a pending reconnect when the last listener unlistens', async () => {
+		vi.useFakeTimers();
+		const ipc = await loadIpc();
+		const unlisten = await ipc.onTextLog(() => {});
+		const sock = openSockets[0];
+
+		// Simulate a drop — module queues a 2s reconnect timer.
+		sock.simulateClose();
+
+		// Remove the only listener before the reconnect fires.
+		unlisten();
+
+		vi.advanceTimersByTime(5_000);
+		expect(openSockets.length).toBe(1); // no zombie second socket
+	});
+
+	it('still reconnects if listeners remain when the socket drops', async () => {
+		vi.useFakeTimers();
+		const ipc = await loadIpc();
+		await ipc.onTextLog(() => {});
+		const sock = openSockets[0];
+		sock.simulateClose();
+
+		// Listener still active, so the 2s timer should reconnect.
+		vi.advanceTimersByTime(2_000);
+		expect(openSockets.length).toBe(2);
+	});
+});

--- a/apps/ui/src/lib/ipc.ts
+++ b/apps/ui/src/lib/ipc.ts
@@ -100,6 +100,13 @@ let ws: WebSocket | null = null;
 let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 const wsListeners = new Map<string, Set<EventCallback<unknown>>>();
 
+function clearReconnectTimer(): void {
+	if (wsReconnectTimer !== null) {
+		clearTimeout(wsReconnectTimer);
+		wsReconnectTimer = null;
+	}
+}
+
 function ensureWebSocket(): void {
 	if (IS_TAURI || ws) return;
 
@@ -124,8 +131,10 @@ function ensureWebSocket(): void {
 
 	ws.onclose = () => {
 		ws = null;
-		// Auto-reconnect after 2 seconds
-		if (!wsReconnectTimer) {
+		// Auto-reconnect after 2 seconds, but only if we still have
+		// listeners expecting events. If the page already tore down its
+		// listeners, bail out instead of reconnecting to nothing.
+		if (wsReconnectTimer === null && wsListeners.size > 0) {
 			wsReconnectTimer = setTimeout(() => {
 				wsReconnectTimer = null;
 				if (wsListeners.size > 0) {
@@ -138,6 +147,31 @@ function ensureWebSocket(): void {
 	ws.onerror = () => {
 		// onclose will fire after onerror
 	};
+}
+
+/**
+ * Tear down the browser-mode WebSocket transport.
+ *
+ * Clears the pending reconnect timer (if any) and closes the socket.
+ * Safe to call multiple times and in Tauri mode (no-op). The page
+ * should call this from `onDestroy` to prevent orphaned connections
+ * and reconnect timers after navigation.
+ */
+export function disposeTransport(): void {
+	if (IS_TAURI) return;
+	clearReconnectTimer();
+	if (ws) {
+		// Detach handlers so the `onclose` reconnect path doesn't fire.
+		ws.onclose = null;
+		ws.onerror = null;
+		ws.onmessage = null;
+		try {
+			ws.close();
+		} catch {
+			// Ignore — already closing/closed.
+		}
+		ws = null;
+	}
 }
 
 async function onEvent<T>(event: string, cb: EventCallback<T>): Promise<UnlistenFn> {
@@ -160,6 +194,11 @@ async function onEvent<T>(event: string, cb: EventCallback<T>): Promise<Unlisten
 			if (set.size === 0) {
 				wsListeners.delete(event);
 			}
+		}
+		// When no listeners remain, cancel any pending reconnect so we
+		// don't open a zombie socket after the page has torn down.
+		if (wsListeners.size === 0) {
+			clearReconnectTimer();
 		}
 	};
 }

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -38,7 +38,8 @@
 		onToggleFullMap,
 		onNpcReaction,
 		onTravelStart,
-		submitInput
+		submitInput,
+		disposeTransport
 	} from '$lib/ipc';
 	import { createAutoPauseTracker } from '$lib/auto-pause';
 	import { getStreamChunkDelayMs, takeNextStreamChunk } from '$lib/stream-pacing';
@@ -151,6 +152,10 @@
 	});
 	onDestroy(() => {
 		mountCleanup?.();
+		// In browser mode, also tear down the shared WebSocket and any
+		// pending reconnect timer so navigation away doesn't leave an
+		// orphan socket or a zombie reconnect queued.
+		disposeTransport();
 	});
 
 	async function setupMount(): Promise<() => void> {


### PR DESCRIPTION
## Summary

Two related frontend-hygiene bugs in `apps/ui/`:

- **#289** — `InputField.handlePaste` used `document.execCommand('insertText')`, which is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand), inconsistent across browsers, and doesn't reliably fire the `input` event — leaving `editorText` desynced from the DOM. Replaced with a `Range`-based text-node insertion and an explicit sync / detect pass so mention autocomplete, slash autocomplete, completion reset, history reset, and the Send button all stay consistent after a paste.
- **#290** — The module-level WebSocket in `lib/ipc.ts` was never torn down on navigation. The `onclose` reconnect timer could fire after the last listener was removed and spin up orphan sockets. Added a `disposeTransport()` export that clears any pending reconnect timer, detaches the socket's handlers (so `onclose` can't re-arm a timer), and closes the socket. Wired it into `+page.svelte`'s `onDestroy`. Also cancel the reconnect timer in the per-listener unlisten when `wsListeners.size === 0`, and guard `onclose` from arming a timer when there are no listeners.

## Changes

- `apps/ui/src/components/InputField.svelte` — modern `Range.insertNode` paste handler with guard clauses for no-selection / cursor-outside-editor, plus an explicit `syncEditorText()` + mention/slash detection pass (mirrors `handleInput`).
- `apps/ui/src/lib/ipc.ts` — new `clearReconnectTimer()` helper, `ws.onclose` only arms a timer if listeners remain, per-listener unlisten cancels the timer when it drops the last listener, new exported `disposeTransport()` that closes the socket and clears the timer (no-op in Tauri mode).
- `apps/ui/src/routes/+page.svelte` — imports `disposeTransport` and calls it from `onDestroy` alongside the existing mount cleanup.

## Tests

- **New `apps/ui/src/lib/ipc.test.ts`** (6 tests) — covers the full transport lifecycle: single socket on first listener registration, `disposeTransport()` closes the socket and nulls handlers, reconnect timer cancelled by both `disposeTransport()` and the last-listener unlisten, idempotency of disposal, and that the reconnect path still runs while listeners remain.
- **Extended `InputField.test.ts`** with a `paste handling` describe block (3 tests) — plain-text insertion into an empty editor, Send button enablement via reactive `editorText` after paste, and Enter-submit flow delivering the pasted content to `submitInput`.

## Test plan

- [x] `npx vitest run` — **130/130 pass** (including 9 new tests)
- [x] `npm run check` — 0 errors, 3 pre-existing warnings (unchanged)
- [ ] Manual (web mode): paste plain text into the input field with cursor mid-word; confirm text lands at cursor, Send enables immediately, and Enter submits the combined text
- [ ] Manual (web mode): paste rich/HTML content; confirm only the plain-text portion is inserted
- [ ] Manual (web mode): navigate between pages (or reload SPA) repeatedly; confirm no WebSocket accumulation in DevTools → Network → WS and no `onclose` reconnect loops in the console

Fixes #289, #290

https://claude.ai/code/session_01P2y5jtXuNxGuATF8CJ9eBG