### PR TITLE
claude/throttle-npc-dialogue-AorhP

### DIFF
--- a/crates/parish-config/src/engine.rs
+++ b/crates/parish-config/src/engine.rs
@@ -482,6 +482,9 @@ pub struct ReactionConfig {
     /// LLM timeout for reaction greeting calls (seconds).
     #[serde(default = "default_reaction_llm_timeout_secs")]
     pub llm_timeout_secs: u64,
+    /// Maximum number of NPCs that react on a single arrival (0 = no cap).
+    #[serde(default = "default_reaction_max_reactions")]
+    pub max_reactions: usize,
 }
 
 impl Default for ReactionConfig {
@@ -494,6 +497,7 @@ impl Default for ReactionConfig {
             negative_mood_penalty: 0.20,
             night_penalty: 0.15,
             llm_timeout_secs: 5,
+            max_reactions: 2,
         }
     }
 }
@@ -518,6 +522,9 @@ fn default_reaction_night_penalty() -> f64 {
 }
 fn default_reaction_llm_timeout_secs() -> u64 {
     5
+}
+fn default_reaction_max_reactions() -> usize {
+    2
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/parish-core/src/game_session.rs
+++ b/crates/parish-core/src/game_session.rs
@@ -664,8 +664,10 @@ mod tests {
 
         // Force base_chance = 1.0 so every present NPC reacts regardless of
         // dice rolls; the test is about the pipeline, not the probability model.
-        let mut config = ReactionConfig::default();
-        config.base_chance = 1.0;
+        let config = ReactionConfig {
+            base_chance: 1.0,
+            ..Default::default()
+        };
         let reactions = apply_arrival_reactions(&mut world, &mut mgr, &templates, &config);
 
         assert!(

--- a/crates/parish-core/src/game_session.rs
+++ b/crates/parish-core/src/game_session.rs
@@ -662,7 +662,10 @@ mod tests {
         world.player_location = loc_with_npc;
         let log_len_before = world.text_log.len();
 
-        let config = ReactionConfig::default();
+        // Force base_chance = 1.0 so every present NPC reacts regardless of
+        // dice rolls; the test is about the pipeline, not the probability model.
+        let mut config = ReactionConfig::default();
+        config.base_chance = 1.0;
         let reactions = apply_arrival_reactions(&mut world, &mut mgr, &templates, &config);
 
         assert!(

--- a/crates/parish-npc/src/reactions.rs
+++ b/crates/parish-npc/src/reactions.rs
@@ -446,6 +446,19 @@ pub fn generate_arrival_reactions(
         });
     }
 
+    // Cap the number of simultaneous reactions, prioritising the most
+    // socially significant kinds first so the publican always greets you
+    // before a random patron does.
+    if config.max_reactions > 0 && reactions.len() > config.max_reactions {
+        reactions.sort_by_key(|r| match r.kind {
+            ReactionKind::Introduction => 0u8,
+            ReactionKind::Welcome => 1,
+            ReactionKind::Greeting => 2,
+            ReactionKind::Gesture => 3,
+        });
+        reactions.truncate(config.max_reactions);
+    }
+
     reactions
 }
 
@@ -1364,6 +1377,72 @@ mod tests {
         assert!(reactions[0].use_llm);
         // Introduction uses real name
         assert_eq!(reactions[0].npc_display_name, "Siobhan Murphy");
+    }
+
+    #[test]
+    fn test_max_reactions_cap() {
+        // Four introduced non-workplace NPCs all roll to react.
+        // With max_reactions = 2 only two should come through.
+        let npc1 = test_npc(1, "Aoife", "Farmer", None);
+        let npc2 = test_npc(2, "Brigid", "Farmer", None);
+        let npc3 = test_npc(3, "Cormac", "Farmer", None);
+        let npc4 = test_npc(4, "Donal", "Farmer", None);
+        let loc = test_location(1, false);
+        let mut introduced = HashSet::new();
+        for id in [1u32, 2, 3, 4] {
+            introduced.insert(NpcId(id));
+        }
+        let templates = ReactionTemplates::default();
+        let mut config = ReactionConfig::default();
+        config.max_reactions = 2;
+        // All chance rolls = 0.0 (pass), type rolls = 0.3 → Greeting for each
+        let dice = fixed_n(&[0.0, 0.3, 0.0, 0.3, 0.0, 0.3, 0.0, 0.3]);
+
+        let reactions = generate_arrival_reactions(
+            &[&npc1, &npc2, &npc3, &npc4],
+            &introduced,
+            &loc,
+            TimeOfDay::Morning,
+            "clear",
+            &templates,
+            &config,
+            &dice,
+        );
+
+        assert_eq!(reactions.len(), 2);
+    }
+
+    #[test]
+    fn test_max_reactions_priority_keeps_introduction() {
+        // NPC1 is introduced → Gesture (type_roll 0.6 ≥ 0.5).
+        // NPC2 is not introduced → Introduction (type_roll 0.1 < 0.25).
+        // With cap = 1 the Introduction beats the Gesture.
+        let npc1 = test_npc(1, "Eoin", "Farmer", None);
+        let npc2 = test_npc(2, "Fiona Murphy", "Farmer", None);
+        let loc = test_location(1, false);
+        let mut introduced = HashSet::new();
+        introduced.insert(NpcId(1)); // npc1 introduced; npc2 is not
+        let templates = ReactionTemplates::default();
+        let mut config = ReactionConfig::default();
+        config.max_reactions = 1;
+        // npc1: chance 0.0 (pass), type 0.6 → Gesture
+        // npc2: chance 0.0 (pass), type 0.1 → Introduction
+        let dice = fixed_n(&[0.0, 0.6, 0.0, 0.1]);
+
+        let reactions = generate_arrival_reactions(
+            &[&npc1, &npc2],
+            &introduced,
+            &loc,
+            TimeOfDay::Morning,
+            "clear",
+            &templates,
+            &config,
+            &dice,
+        );
+
+        assert_eq!(reactions.len(), 1);
+        assert_eq!(reactions[0].kind, ReactionKind::Introduction);
+        assert_eq!(reactions[0].npc_id, NpcId(2));
     }
 
     #[test]

--- a/crates/parish-npc/src/reactions.rs
+++ b/crates/parish-npc/src/reactions.rs
@@ -1393,8 +1393,10 @@ mod tests {
             introduced.insert(NpcId(id));
         }
         let templates = ReactionTemplates::default();
-        let mut config = ReactionConfig::default();
-        config.max_reactions = 2;
+        let config = ReactionConfig {
+            max_reactions: 2,
+            ..Default::default()
+        };
         // All chance rolls = 0.0 (pass), type rolls = 0.3 → Greeting for each
         let dice = fixed_n(&[0.0, 0.3, 0.0, 0.3, 0.0, 0.3, 0.0, 0.3]);
 
@@ -1423,8 +1425,10 @@ mod tests {
         let mut introduced = HashSet::new();
         introduced.insert(NpcId(1)); // npc1 introduced; npc2 is not
         let templates = ReactionTemplates::default();
-        let mut config = ReactionConfig::default();
-        config.max_reactions = 1;
+        let config = ReactionConfig {
+            max_reactions: 1,
+            ..Default::default()
+        };
         // npc1: chance 0.0 (pass), type 0.6 → Gesture
         // npc2: chance 0.0 (pass), type 0.1 → Introduction
         let dice = fixed_n(&[0.0, 0.6, 0.0, 0.1]);


### PR DESCRIPTION
When the player enters a busy location, all NPCs independently rolled
against their reaction threshold (base 55%, boosted indoors/at workplace),
which could fire 3-5 greetings at once and feel overwhelming.

Adds `max_reactions: usize` to `ReactionConfig` (default 2, 0 = no cap).
After dice rolls produce candidates, the list is sorted by social priority
— Introduction > Welcome > Greeting > Gesture — then truncated, so the
publican always gets through before random patrons.

https://claude.ai/code/session_01UaEPaaoQKuPuTtfVYrzxRk