### PR TITLE
fix: remove panic paths at system boundaries (#98, #82)

### DIFF
--- a/crates/parish-inference/src/client.rs
+++ b/crates/parish-inference/src/client.rs
@@ -60,19 +60,24 @@ impl OllamaClient {
     ///
     /// Uses `config.timeout_secs` for the default HTTP client and stores
     /// `config.streaming_timeout_secs` for streaming request clients.
+    ///
+    /// If the underlying `reqwest` builder fails (e.g. a TLS backend is
+    /// unavailable), this falls back to a default `reqwest::Client` with
+    /// no configured timeout rather than panicking, and emits a warning
+    /// via `tracing`. See issue #98.
     pub fn new_with_config(base_url: &str, config: &InferenceConfig) -> Self {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(config.timeout_secs))
-            .build()
-            .expect("failed to build reqwest client");
+        let client = crate::openai_client::build_client_or_fallback(
+            Duration::from_secs(config.timeout_secs),
+            "Ollama",
+        );
 
         // Pre-build the streaming client once so connection pooling is
         // preserved across streaming calls instead of creating a fresh
         // client (and fresh TCP connections) on every request.
-        let streaming_client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(config.streaming_timeout_secs))
-            .build()
-            .expect("failed to build streaming reqwest client");
+        let streaming_client = crate::openai_client::build_client_or_fallback(
+            Duration::from_secs(config.streaming_timeout_secs),
+            "Ollama streaming",
+        );
 
         Self {
             client,
@@ -311,10 +316,12 @@ impl OllamaProcess {
 
     /// Checks if the Ollama API is reachable by hitting the root endpoint.
     async fn is_reachable(base_url: &str) -> bool {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(2))
-            .build()
-            .unwrap();
+        // Use the shared builder helper so a failing reqwest build falls
+        // back to a default client instead of panicking (#98).
+        let client = crate::openai_client::build_client_or_fallback(
+            Duration::from_secs(2),
+            "Ollama reachability probe",
+        );
         client.get(base_url).send().await.is_ok()
     }
 

--- a/crates/parish-inference/src/openai_client.rs
+++ b/crates/parish-inference/src/openai_client.rs
@@ -12,6 +12,25 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
+/// Builds a `reqwest::Client` with the given timeout, falling back to a default
+/// client (no timeout) if the builder fails.
+///
+/// Historically this call used `.expect()` which would panic if the TLS
+/// backend failed to initialize (#98). We now log a warning and return a
+/// default client so the application can degrade gracefully rather than
+/// crashing at startup.
+pub(crate) fn build_client_or_fallback(timeout: Duration, label: &'static str) -> reqwest::Client {
+    match reqwest::Client::builder().timeout(timeout).build() {
+        Ok(client) => client,
+        Err(err) => {
+            tracing::warn!(
+                "failed to build {label} reqwest client ({err}); falling back to default client with no timeout",
+            );
+            reqwest::Client::new()
+        }
+    }
+}
+
 /// HTTP client for OpenAI-compatible chat completions endpoints.
 ///
 /// Works with Ollama, LM Studio, OpenRouter, and any provider that
@@ -125,23 +144,28 @@ impl OpenAiClient {
     ///
     /// Uses `config.timeout_secs` for the default HTTP client and stores
     /// `config.streaming_timeout_secs` for streaming request clients.
+    ///
+    /// If the underlying `reqwest` builder fails (e.g. a TLS backend is
+    /// unavailable), this falls back to a default `reqwest::Client` with
+    /// no configured timeout rather than panicking, and emits a warning
+    /// via `tracing`. See issue #98.
     pub fn new_with_config(
         base_url: &str,
         api_key: Option<&str>,
         config: &InferenceConfig,
     ) -> Self {
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(config.timeout_secs))
-            .build()
-            .expect("failed to build reqwest client");
+        let client = build_client_or_fallback(
+            Duration::from_secs(config.timeout_secs),
+            "OpenAI-compatible",
+        );
 
         // Pre-build the streaming client once so connection pooling is
         // preserved across streaming calls instead of creating a fresh
         // client (and fresh TCP connections) on every request.
-        let streaming_client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(config.streaming_timeout_secs))
-            .build()
-            .expect("failed to build streaming reqwest client");
+        let streaming_client = build_client_or_fallback(
+            Duration::from_secs(config.streaming_timeout_secs),
+            "OpenAI-compatible streaming",
+        );
 
         // Normalize the base URL: strip a trailing slash, and also strip a
         // trailing `/v1` (with or without slash) because the endpoint paths
@@ -475,6 +499,25 @@ fn extract_content(resp: &ChatCompletionResponse) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test for #98: the helper must never panic, even when
+    /// given an extreme timeout. The normal reqwest build path always
+    /// succeeds on a healthy system, so this mainly proves the function
+    /// is invokable and returns a usable client.
+    #[test]
+    fn test_build_client_or_fallback_returns_client() {
+        let client = build_client_or_fallback(Duration::from_secs(30), "test");
+        // Build a request builder to prove the returned client is usable.
+        let _ = client.get("http://127.0.0.1:1/ping");
+    }
+
+    /// Regression test for #98: constructors must not panic at a system
+    /// boundary. Previously `.expect()` would abort the whole process
+    /// if reqwest failed to build.
+    #[test]
+    fn test_openai_client_new_does_not_panic() {
+        let _ = OpenAiClient::new("http://localhost:11434", None);
+    }
 
     #[test]
     fn test_openai_client_new() {

--- a/crates/parish-persistence/src/database.rs
+++ b/crates/parish-persistence/src/database.rs
@@ -5,13 +5,32 @@
 //! concurrent read/write access.
 
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::journal::WorldEvent;
 use crate::snapshot::GameSnapshot;
 use parish_types::ParishError;
+
+/// Acquires a lock on `mutex`, recovering transparently from poisoning.
+///
+/// If a previous thread panicked while holding the database lock,
+/// `Mutex::lock()` will return a [`PoisonError`]. Without recovery, every
+/// subsequent call would cascade a single failure into a total application
+/// crash (issue #82). SQLite writes are transactional, so the connection
+/// itself remains in a consistent state after a panic; we simply log a
+/// warning and return the underlying guard so database access continues
+/// to work.
+fn lock_recovered<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            tracing::warn!("database lock was poisoned; recovering");
+            poisoned.into_inner()
+        }
+    }
+}
 
 /// Information about a save branch.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -357,7 +376,7 @@ impl AsyncDatabase {
         let db = self.inner.clone();
         let snapshot = snapshot.clone();
         tokio::task::spawn_blocking(move || {
-            let db = db.lock().expect("database lock poisoned");
+            let db = lock_recovered(&db);
             db.save_snapshot(branch_id, &snapshot)
         })
         .await
@@ -372,7 +391,7 @@ impl AsyncDatabase {
         let db = self.inner.clone();
         tokio::task::spawn_blocking(
             move || -> Result<Option<(i64, GameSnapshot)>, ParishError> {
-                let db = db.lock().expect("database lock poisoned");
+                let db = lock_recovered(&db);
                 db.load_latest_snapshot(branch_id)
             },
         )
@@ -389,7 +408,7 @@ impl AsyncDatabase {
         let db = self.inner.clone();
         let name = name.to_string();
         tokio::task::spawn_blocking(move || {
-            let db = db.lock().expect("database lock poisoned");
+            let db = lock_recovered(&db);
             db.create_branch(&name, parent_branch_id)
         })
         .await
@@ -401,7 +420,7 @@ impl AsyncDatabase {
         let db = self.inner.clone();
         let name = name.to_string();
         tokio::task::spawn_blocking(move || {
-            let db = db.lock().expect("database lock poisoned");
+            let db = lock_recovered(&db);
             db.find_branch(&name)
         })
         .await
@@ -412,7 +431,7 @@ impl AsyncDatabase {
     pub async fn list_branches(&self) -> Result<Vec<BranchInfo>, ParishError> {
         let db = self.inner.clone();
         tokio::task::spawn_blocking(move || {
-            let db = db.lock().expect("database lock poisoned");
+            let db = lock_recovered(&db);
             db.list_branches()
         })
         .await
@@ -431,7 +450,7 @@ impl AsyncDatabase {
         let event = event.clone();
         let game_time = game_time.to_string();
         tokio::task::spawn_blocking(move || {
-            let db = db.lock().expect("database lock poisoned");
+            let db = lock_recovered(&db);
             db.append_event(branch_id, snapshot_id, &event, &game_time)
         })
         .await
@@ -446,7 +465,7 @@ impl AsyncDatabase {
     ) -> Result<Vec<WorldEvent>, ParishError> {
         let db = self.inner.clone();
         tokio::task::spawn_blocking(move || {
-            let db = db.lock().expect("database lock poisoned");
+            let db = lock_recovered(&db);
             db.events_since_snapshot(branch_id, snapshot_id)
         })
         .await
@@ -461,7 +480,7 @@ impl AsyncDatabase {
     ) -> Result<usize, ParishError> {
         let db = self.inner.clone();
         tokio::task::spawn_blocking(move || {
-            let db = db.lock().expect("database lock poisoned");
+            let db = lock_recovered(&db);
             db.journal_count(branch_id, snapshot_id)
         })
         .await
@@ -472,7 +491,7 @@ impl AsyncDatabase {
     pub async fn branch_log(&self, branch_id: i64) -> Result<Vec<SnapshotInfo>, ParishError> {
         let db = self.inner.clone();
         tokio::task::spawn_blocking(move || {
-            let db = db.lock().expect("database lock poisoned");
+            let db = lock_recovered(&db);
             db.branch_log(branch_id)
         })
         .await
@@ -483,7 +502,7 @@ impl AsyncDatabase {
     pub async fn clear_journal(&self, branch_id: i64, snapshot_id: i64) -> Result<(), ParishError> {
         let db = self.inner.clone();
         tokio::task::spawn_blocking(move || {
-            let db = db.lock().expect("database lock poisoned");
+            let db = lock_recovered(&db);
             db.clear_journal(branch_id, snapshot_id)
         })
         .await
@@ -1049,5 +1068,55 @@ mod tests {
         // Both snapshots should have exactly one event each.
         assert_eq!(db.journal_count(branch.id, snap1).unwrap(), 1);
         assert_eq!(db.journal_count(branch.id, snap2).unwrap(), 1);
+    }
+
+    /// Regression test for #82: a previous panic while holding the mutex
+    /// must not cascade into every subsequent database call panicking.
+    /// `lock_recovered` should transparently recover from the poisoned
+    /// state.
+    #[test]
+    fn test_lock_recovered_handles_poisoned_mutex() {
+        let mutex: Arc<Mutex<u32>> = Arc::new(Mutex::new(42));
+
+        // Poison the mutex by panicking in another thread while holding it.
+        let mutex_clone = mutex.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = mutex_clone.lock().unwrap();
+            panic!("intentional panic to poison the mutex");
+        })
+        .join();
+
+        // The mutex is now poisoned; `.lock()` returns `Err(_)`.
+        assert!(mutex.lock().is_err(), "mutex should be poisoned");
+
+        // `lock_recovered` must still yield the inner value.
+        let guard = lock_recovered(&mutex);
+        assert_eq!(*guard, 42);
+    }
+
+    /// Regression test for #82: poison recovery also works on the
+    /// `Arc<Mutex<Database>>` used inside `AsyncDatabase`.
+    #[test]
+    fn test_lock_recovered_with_database_after_poison() {
+        let db = Database::open_memory().unwrap();
+        let branch = db.find_branch("main").unwrap().unwrap();
+        let inner: Arc<Mutex<Database>> = Arc::new(Mutex::new(db));
+
+        // Poison the inner mutex.
+        let inner_clone = inner.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = inner_clone.lock().unwrap();
+            panic!("intentional panic");
+        })
+        .join();
+
+        assert!(inner.lock().is_err(), "database mutex should be poisoned");
+
+        // Recover and verify the database is still usable.
+        let db = lock_recovered(&inner);
+        let loaded = db
+            .find_branch(&branch.name)
+            .expect("find_branch should still work after poison recovery");
+        assert!(loaded.is_some());
     }
 }


### PR DESCRIPTION
## Summary

Two related bugs where infallible operations panic at system boundaries, taking the whole process down for failure modes that should be recoverable.

- **#98** — `reqwest::Client::builder().build()` can fail (e.g. TLS backend unavailable) but was called via `.expect()` inside `OpenAiClient::new`, `OllamaClient::new`, and `OllamaProcess::is_reachable`. Any such failure panicked the inference pipeline during startup. A new helper `build_client_or_fallback` logs a warning and falls back to `reqwest::Client::new()` instead of aborting. Public API signatures are preserved so the ~40 existing call sites don't need to change.
- **#82** — `AsyncDatabase` methods called `.expect("database lock poisoned")` on every `Mutex::lock()`. A single panic while holding the lock would cascade into every subsequent database call panicking, permanently breaking save, load, autosave, branch ops, and journal writes. A new `lock_recovered` helper logs a warning and uses `PoisonError::into_inner()` to unwrap the guard so the connection stays usable — SQLite writes are transactional, so the DB itself remains consistent after a panic.

## Changes

- `crates/parish-inference/src/openai_client.rs` — new `build_client_or_fallback` helper; `OpenAiClient::new_with_config` routes both the default and streaming clients through it.
- `crates/parish-inference/src/client.rs` — `OllamaClient::new_with_config` and `OllamaProcess::is_reachable` use the same helper.
- `crates/parish-persistence/src/database.rs` — new `lock_recovered` helper; all 10 `.expect("database lock poisoned")` call sites inside `AsyncDatabase` replaced with it.

## Tests

New unit tests:

- `test_build_client_or_fallback_returns_client` — helper returns a working client on the happy path.
- `test_openai_client_new_does_not_panic` — constructor smoke test.
- `test_lock_recovered_handles_poisoned_mutex` — poison a mutex via a panicking thread, then verify the helper recovers the inner value.
- `test_lock_recovered_with_database_after_poison` — same, but against the real `Arc<Mutex<Database>>` used by `AsyncDatabase`, and asserts the database is still queryable after recovery.

## Test plan

- [x] `cargo fmt --check` clean for `parish-inference` and `parish-persistence`
- [x] `cargo clippy --workspace --all-targets --exclude parish-tauri -- -D warnings` clean
- [x] `cargo test -p parish-inference -p parish-persistence` — all pass (70 + 139 + 23)
- [x] `cargo test --workspace --exclude parish-tauri` — all pass
- [x] Game harness: `cargo run -- --script testing/fixtures/test_walkthrough.txt` — produces expected JSON output
- [x] No behavior change on the happy path (same client/lock semantics)

https://claude.ai/code/session_01WWpQE5hBqVsYtth6fPszJr