### PR TITLE
⚡ Bolt: avoid redundant lowercasing in long-term memory recall

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -11,3 +11,7 @@
 ## 2026-04-14 - Recurring multi-pass HashMap scan anti-pattern in parish-npc
 **Learning:** `known_roster` in `manager.rs` repeated the double-scan anti-pattern — separate `for other in self.npcs.values()` loops for home and workplace co-residency. Same shape as the earlier fuzzy-search fix in `graph.rs`. When multiple optional filters apply to the same collection, consolidating into one pass with per-NPC conjunction checks is both faster and clearer.
 **Action:** When reviewing lookup/query methods against `NpcManager`/`WorldState` that iterate `.values()`, check whether nearby code iterates the same map again — if so, fold into a single pass.
+
+## 2026-04-15 - Pre-lowercased storage invariant defeated by per-lookup re-lowercasing
+**Learning:** `LongTermMemory::recall` in `parish-npc/memory.rs` re-lowercased both query and stored keywords inside an O(entries × query × entry_keywords) nested loop — yet `extract_keywords` (the only production producer) already stores everything lowercased. The `ek.to_lowercase()` inside `.any()` was pure waste; the `qk.to_lowercase()` should be hoisted above the entries loop. Called per NPC per dialogue turn via `build_enhanced_context_with_config`.
+**Action:** When a "lowercase on read" pattern sits inside a loop, trace every write site of the compared field. If producers already normalise, document the invariant on the struct field and compare directly — don't re-normalise defensively inside hot loops.

--- a/crates/parish-npc/src/memory.rs
+++ b/crates/parish-npc/src/memory.rs
@@ -216,6 +216,10 @@ pub struct LongTermEntry {
     /// Importance score from 0.0 (trivial) to 1.0 (life-changing).
     pub importance: f32,
     /// Keywords for retrieval (NPC names, locations, event types).
+    ///
+    /// Invariant: keywords are stored pre-lowercased (see [`extract_keywords`]).
+    /// [`LongTermMemory::recall`] relies on this to avoid per-lookup
+    /// allocations.
     pub keywords: Vec<String>,
 }
 
@@ -264,19 +268,25 @@ impl LongTermMemory {
             return Vec::new();
         }
 
+        // Perf: lowercase each query keyword exactly once, up-front. The previous
+        // implementation re-lowercased every query keyword AND every entry
+        // keyword inside the per-entry loop, producing
+        // O(entries × query × (1 + entry_keywords)) transient String
+        // allocations. Entry keywords are guaranteed pre-lowercased (see
+        // `extract_keywords` and the `LongTermEntry::keywords` invariant), so
+        // comparison reduces to a cheap `Vec::contains` against the already-
+        // lowered query. This is on the NPC dialogue hot path
+        // (`ticks::build_enhanced_context_with_config` → `recall_context_string`,
+        // invoked per conversation turn per NPC via `ipc::handlers`).
+        let query_lower: Vec<String> = query_keywords.iter().map(|qk| qk.to_lowercase()).collect();
+
         let mut scored: Vec<(f32, &LongTermEntry)> = self
             .entries
             .iter()
             .filter_map(|entry| {
-                let keyword_matches = query_keywords
+                let keyword_matches = query_lower
                     .iter()
-                    .filter(|qk| {
-                        let qk_lower = qk.to_lowercase();
-                        entry
-                            .keywords
-                            .iter()
-                            .any(|ek| ek.to_lowercase() == qk_lower)
-                    })
+                    .filter(|qk| entry.keywords.contains(*qk))
                     .count();
 
                 if keyword_matches > 0 {
@@ -768,6 +778,21 @@ mod tests {
         ltm.store(make_lt_entry("something happened", 0.7, &["padraig"]));
         let results = ltm.recall(&["nonexistent"], 5);
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_long_term_recall_mixed_case_query() {
+        // Query keywords may arrive mixed-case from player input
+        // (see `ticks::build_enhanced_context_with_config`). The recall
+        // path must lower-case them to match the lowercased stored keywords.
+        let mut ltm = LongTermMemory::new();
+        ltm.store(make_lt_entry("Saw the landlord", 0.8, &["landlord"]));
+
+        let upper = ltm.recall(&["LANDLORD"], 5);
+        assert_eq!(upper.len(), 1, "uppercase query should match");
+
+        let mixed = ltm.recall(&["LandLord"], 5);
+        assert_eq!(mixed.len(), 1, "mixed-case query should match");
     }
 
     #[test]


### PR DESCRIPTION
## 💡 What
Hoist the per-entry `to_lowercase()` calls out of `LongTermMemory::recall()` in `crates/parish-npc/src/memory.rs`. Query keywords are now lowercased once up-front, and stored keywords — which `extract_keywords` already lowercases at write time — are compared directly via `Vec::contains`.

The invariant is now documented on `LongTermEntry::keywords` so future writers don't defeat it.

## 🎯 Why
The previous implementation looked like this inside a nested loop over every stored memory entry:

```rust
.filter(|qk| {
    let qk_lower = qk.to_lowercase();            // re-allocated per entry
    entry.keywords.iter().any(|ek| ek.to_lowercase() == qk_lower)  // re-allocated per stored keyword
})
```

That's **O(entries × query × (1 + entry_keywords))** transient `String` allocations per call. And `recall()` sits on the NPC dialogue hot path:

`ipc::handlers::build_enhanced_system_prompt` → `ticks::build_enhanced_context_with_config` → `recall_context_string` → `recall()`

It runs once per NPC per conversation turn. For a typical session (3 query words × 20 stored entries × ~5 keywords per entry) the old path burned **~360 throwaway `String` allocations per recall**; the new one burns **3**.

## 📊 Impact
- **~99% fewer allocations per `recall()` call** (e.g. 360 → 3 for a typical 3-word query over 20 entries).
- Scales linearly with stored-entry count instead of entries×keywords.
- On the NPC conversation path, so every dialogue turn benefits.
- No behaviour change — mixed-case queries still match (covered by new `test_long_term_recall_mixed_case_query`).

## 🔬 Measurement
The allocation reduction is directly visible in the diff: the `ek.to_lowercase()` call is gone, and `qk.to_lowercase()` moved outside the `self.entries.iter()` loop.

To verify locally:
```sh
cargo test -p parish-npc --lib memory::          # 32 passed (31 existing + 1 new)
cargo clippy --workspace --exclude parish-tauri --all-targets -- -D warnings  # clean
cargo fmt --check                                  # clean
```

Full workspace `cargo test` (excluding `parish-tauri`, which needs GTK system libs unavailable in this sandbox) passes: 141 + 58 + 198 + 137 + 114 + 309 + 68 + 21 + 72 + 129 = 1,247 tests green.

For a micro-benchmark: wrap a `recall()` call with `Instant::now()` and a tight 10k-iteration loop against a `LongTermMemory` holding ~20 entries with 5 keywords each, querying 3 keywords. Expect the new version to be materially faster because it's spending nearly none of its time in the allocator.

## Files touched
- `crates/parish-npc/src/memory.rs` — the optimization + doc-invariant + new test
- `.jules/bolt.md` — Bolt's journal entry about the pre-normalisation-defeated-by-loop-re-normalisation anti-pattern

https://claude.ai/code/session_017BvjWdRDkdSiaTtrGGqsm2