### PR TITLE
🎨 Palette: aria-labels for icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+# Palette's Journal
+
+Critical UX/accessibility learnings only.

--- a/apps/ui/src/components/ChatPanel.svelte
+++ b/apps/ui/src/components/ChatPanel.svelte
@@ -160,11 +160,13 @@
 							<div class="reaction-picker" role="toolbar" aria-label="React to message" data-testid="reaction-picker">
 								{#each REACTION_PALETTE as reaction}
 									<button
+										type="button"
 										class="reaction-btn"
 										title={reaction.description}
+										aria-label={`React with ${reaction.description}`}
 										onclick={() => handleReaction(entry, reaction.emoji)}
 									>
-										{reaction.emoji}
+										<span aria-hidden="true">{reaction.emoji}</span>
 									</button>
 								{/each}
 							</div>

--- a/apps/ui/src/components/MapPanel.svelte
+++ b/apps/ui/src/components/MapPanel.svelte
@@ -209,8 +209,8 @@
 <div class="map-panel" data-testid="map-panel">
 	<div class="map-header">
 		<span class="map-title">Map</span>
-		<button class="expand-btn" onclick={openFullMap} title="Open full map (M)">
-			<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+		<button type="button" class="expand-btn" onclick={openFullMap} title="Open full map (M)" aria-label="Open full map">
+			<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true" focusable="false">
 				<path d="M1 1h5v2H3v3H1V1zm9 0h5v5h-2V3h-3V1zM1 10h2v3h3v2H1v-5zm12 3h-3v2h5v-5h-2v3z" />
 			</svg>
 		</button>

--- a/apps/ui/src/components/Sidebar.svelte
+++ b/apps/ui/src/components/Sidebar.svelte
@@ -8,7 +8,7 @@
 	<div class="focail-panel">
 		<div class="panel-header">
 			<span class="panel-title"><span class="panel-title-word">Focail Gaeilge</span> <span class="panel-title-label">(Irish Words)</span></span>
-			<button class="close-btn" onclick={onclose}>&times;</button>
+			<button type="button" class="close-btn" aria-label="Close Irish words panel" title="Close" onclick={onclose}><span aria-hidden="true">&times;</span></button>
 		</div>
 		<div class="panel-content">
 			{#if $nameHints.length > 0 || $languageHints.length > 0}
@@ -120,8 +120,15 @@
 		line-height: 1;
 	}
 
-	.close-btn:hover {
+	.close-btn:hover,
+	.close-btn:focus-visible {
 		color: var(--color-fg);
+	}
+
+	.close-btn:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
+		border-radius: 2px;
 	}
 
 	.panel-content {


### PR DESCRIPTION
## 💡 What
Makes three icon-only buttons accessible to keyboard and screen reader users:

- **Sidebar close button** (`×`) — previously had no label at all. Now labeled `"Close Irish words panel"`, with a visible `:focus-visible` outline for keyboard users.
- **ChatPanel reaction picker buttons** (emoji) — now carry `aria-label="React with <description>"` so screen readers announce intent instead of raw emoji.
- **MapPanel expand button** (SVG icon) — gains an `aria-label="Open full map"` and the inner SVG is marked `aria-hidden` / `focusable="false"`.

All three buttons also get an explicit `type="button"` so they never accidentally submit an ancestor form, and decorative glyphs (`×`, emoji, svg) are wrapped with `aria-hidden="true"` to avoid double-announcement.

## 🎯 Why
Screen readers previously announced the sidebar close control as *"multiplication sign, button"* — confusing even to sighted testers. The reaction buttons relied on `title` alone, which isn't consistently read aloud. And the map expand button announced nothing meaningful at all.

These are small, high-frequency controls; this is a pure a11y win with zero visual change for sighted mouse users.

## ♿ Accessibility
- Icon-only buttons now have intent-describing `aria-label`s.
- Purely decorative glyphs/svgs are `aria-hidden` so screen readers don't repeat them.
- Explicit `type="button"` prevents unintended form submission.
- Sidebar close button gains a visible keyboard focus ring (`:focus-visible` with `--color-accent`).

## ✅ Verification
- `npm run check` — 0 errors, no new warnings
- `npx vitest run` — **121 / 121 passing**
- `npm run build` — production build succeeds

## Scope
3 files, +14 / −5 lines.

https://claude.ai/code/session_01LB56ADYqPx9HfiTQJzJz2m