### PR TITLE
fix: serialize env-mutating config tests via serial_test (#56)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2711,6 +2711,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serial_test",
  "strsim",
  "tempfile",
  "thiserror 2.0.18",
@@ -2730,6 +2731,7 @@ dependencies = [
  "parish-types",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",
@@ -3712,6 +3714,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3776,6 +3787,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -4009,6 +4026,32 @@ dependencies = [
  "ryu",
  "serde",
  "version_check",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/crates/parish-cli/Cargo.toml
+++ b/crates/parish-cli/Cargo.toml
@@ -37,3 +37,4 @@ rand = "0.8"
 tokio-test = "0.4"
 tempfile = "3"
 parish-types = { path = "../parish-types" }
+serial_test = "3"

--- a/crates/parish-cli/src/config.rs
+++ b/crates/parish-cli/src/config.rs
@@ -359,12 +359,20 @@ fn read_toml_config(path: &Path) -> Result<TomlConfig, ParishError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::io::Write;
 
     /// Clears all PARISH_ env vars so tests don't interfere with each other.
+    ///
+    /// Callers **must** annotate their test with `#[serial(parish_env)]` so
+    /// env-mutating tests never run concurrently — Rust 2024 marks
+    /// `std::env::remove_var` and `set_var` unsafe precisely because
+    /// concurrent access is UB.
     fn clear_parish_env() {
-        // SAFETY: Tests run single-threaded via `cargo test -- --test-threads=1`
-        // or are independent enough that concurrent env mutation is acceptable.
+        // SAFETY: All callers are annotated with `#[serial(parish_env)]`,
+        // which serialises every test that touches `PARISH_*` env vars
+        // across this module (and the sibling `parish-config` tests that
+        // share the same `parish_env` key).
         unsafe {
             std::env::remove_var("PARISH_PROVIDER");
             std::env::remove_var("PARISH_BASE_URL");
@@ -393,6 +401,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_category_configs_empty_when_no_overrides() {
         clear_parish_env();
         let base = ProviderConfig {
@@ -410,6 +419,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_category_configs_from_toml() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("parish.toml");
@@ -465,6 +475,7 @@ model = "qwen3:1.5b"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_category_configs_legacy_cloud_maps_to_dialogue() {
         clear_parish_env();
         let base = ProviderConfig {
@@ -491,6 +502,7 @@ model = "qwen3:1.5b"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_category_configs_toml_overrides_legacy_cloud() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("parish.toml");
@@ -535,6 +547,7 @@ model = "new-model"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_category_configs_cli_overrides() {
         clear_parish_env();
         let base = ProviderConfig {
@@ -567,6 +580,7 @@ model = "new-model"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_category_configs_validates_api_key() {
         clear_parish_env();
         let base = ProviderConfig {
@@ -596,6 +610,7 @@ model = "new-model"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_category_configs_inherits_base_url() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("parish.toml");

--- a/crates/parish-config/Cargo.toml
+++ b/crates/parish-config/Cargo.toml
@@ -14,3 +14,4 @@ thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = "3"

--- a/crates/parish-config/src/provider.rs
+++ b/crates/parish-config/src/provider.rs
@@ -526,12 +526,20 @@ fn read_toml_config(path: &Path) -> Result<TomlConfig, ParishError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::io::Write;
 
     /// Clears all PARISH_ env vars so tests don't interfere with each other.
+    ///
+    /// Callers **must** annotate their test with `#[serial(parish_env)]` so
+    /// env-mutating tests never run concurrently — Rust 2024 marks
+    /// `std::env::remove_var` and `set_var` unsafe precisely because
+    /// concurrent access is UB.
     fn clear_parish_env() {
-        // SAFETY: Tests run single-threaded via `cargo test -- --test-threads=1`
-        // or are independent enough that concurrent env mutation is acceptable.
+        // SAFETY: All callers are annotated with `#[serial(parish_env)]`,
+        // which serialises every test that touches `PARISH_*` env vars
+        // across this module (and the sibling `parish-cli` tests that
+        // share the same `parish_env` key).
         unsafe {
             std::env::remove_var("PARISH_PROVIDER");
             std::env::remove_var("PARISH_BASE_URL");
@@ -734,6 +742,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_config_vllm() {
         clear_parish_env();
 
@@ -751,6 +760,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_config_vllm_custom_base_url() {
         clear_parish_env();
 
@@ -766,6 +776,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_config_defaults() {
         clear_parish_env();
 
@@ -778,6 +789,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_config_from_toml() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("parish.toml");
@@ -803,6 +815,7 @@ model = "my-model"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_config_cli_overrides_toml() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("parish.toml");
@@ -831,6 +844,7 @@ model = "toml-model"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_config_openrouter_requires_api_key() {
         clear_parish_env();
 
@@ -847,6 +861,7 @@ model = "toml-model"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_config_openrouter_with_api_key() {
         clear_parish_env();
 
@@ -863,6 +878,7 @@ model = "toml-model"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_config_builtin_cloud_providers() {
         clear_parish_env();
 
@@ -899,6 +915,7 @@ model = "toml-model"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_config_cloud_provider_requires_api_key() {
         clear_parish_env();
 
@@ -923,6 +940,7 @@ model = "toml-model"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_config_custom_requires_base_url() {
         clear_parish_env();
 
@@ -939,6 +957,7 @@ model = "toml-model"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_config_empty_strings_filtered() {
         clear_parish_env();
 
@@ -989,6 +1008,7 @@ model = "toml-model"
     // --- Cloud config tests ---
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_cloud_config_none_when_not_configured() {
         clear_parish_env();
         let cli = CliCloudOverrides::default();
@@ -997,6 +1017,7 @@ model = "toml-model"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_cloud_config_from_toml() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("parish.toml");
@@ -1026,6 +1047,7 @@ model = "anthropic/claude-sonnet-4-20250514"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_cloud_config_from_cli() {
         clear_parish_env();
 
@@ -1044,6 +1066,7 @@ model = "anthropic/claude-sonnet-4-20250514"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_cloud_config_requires_model() {
         clear_parish_env();
 
@@ -1060,6 +1083,7 @@ model = "anthropic/claude-sonnet-4-20250514"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_cloud_config_openrouter_requires_api_key() {
         clear_parish_env();
 
@@ -1076,6 +1100,7 @@ model = "anthropic/claude-sonnet-4-20250514"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_cloud_config_defaults_to_openrouter() {
         clear_parish_env();
 
@@ -1094,6 +1119,7 @@ model = "anthropic/claude-sonnet-4-20250514"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_cloud_config_cli_overrides_toml() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("parish.toml");
@@ -1123,6 +1149,7 @@ model = "toml-model"
     }
 
     #[test]
+    #[serial(parish_env)]
     fn test_resolve_cloud_config_ollama_no_key_needed() {
         clear_parish_env();
 


### PR DESCRIPTION
## Summary

Fixes #56.

The `clear_parish_env` helpers in `parish-config::provider` and `parish-cli::config` wrapped `std::env::remove_var` in an `unsafe` block with a comment claiming tests were safe because they ran "single-threaded via `--test-threads=1`" — but that claim was never enforced. `cargo test` defaults to parallel thread count, and Rust 2024 marks `set_var`/`remove_var` unsafe precisely because concurrent env mutation is undefined behavior.

## Changes

- `crates/parish-config/Cargo.toml` + `crates/parish-cli/Cargo.toml` — add `serial_test = "3"` dev-dependency.
- `crates/parish-config/src/provider.rs` — 19 tests annotated with `#[serial(parish_env)]`; doc comment on `clear_parish_env` rewritten to describe the actual invariant.
- `crates/parish-cli/src/config.rs` — 7 tests annotated; doc comment rewritten.

The shared `parish_env` serial key serialises across both modules, so a `parish-config` provider test can't race a `parish-cli` category-config test for the same environment variables.

## Why `serial_test` over the alternatives

Option 1 from the issue (enforce `--test-threads=1`) is fragile — nothing stops a contributor or a fresh `cargo test` invocation from dropping the flag. Option 2 (restructure config resolution to take env vars as a parameter) is a much larger, more invasive refactor that changes the public surface of `resolve_config` / `resolve_cloud_config` / `resolve_category_configs` and bleeds into every caller. `serial_test` is the narrowest, most mechanical fix: opt-in at the test call site, no production-code change, and the `unsafe` stays correctly justified (now by an invariant the attribute actually enforces).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -p parish-config -p parish --all-targets -- -D warnings` clean
- [x] `cargo test -p parish-config --lib` — 58/58 pass (including under `--test-threads=4`)
- [x] `cargo test -p parish --lib` — 141/141 pass (including under `--test-threads=4`)
- [x] `cargo test --workspace --exclude parish-tauri --lib` — full suite green
- [x] Game harness: `cargo run -- --script testing/fixtures/test_walkthrough.txt` produces expected JSON output

https://claude.ai/code/session_016oRSZtitBK9nk1vNqZ5Yqw