### PR TITLE
fix: enforce real bounds on inference log and long-term memory (#340, #341)

### DIFF
--- a/crates/parish-core/src/game_session.rs
+++ b/crates/parish-core/src/game_session.rs
@@ -482,10 +482,7 @@ pub async fn stream_reaction_texts(
                 max_tokens: Some(100),
             };
             let mut log_guard = log.lock().await;
-            if log_guard.len() >= log_guard.capacity().max(1) {
-                log_guard.pop_front();
-            }
-            log_guard.push_back(entry);
+            log_guard.push(entry);
         }
     }
 }

--- a/crates/parish-inference/src/lib.rs
+++ b/crates/parish-inference/src/lib.rs
@@ -66,12 +66,65 @@ pub enum InferencePriority {
     Batch = 2,
 }
 
-/// Shared ring buffer of inference call log entries.
-pub type InferenceLog = Arc<Mutex<VecDeque<InferenceLogEntry>>>;
+/// Bounded ring buffer of inference call log entries.
+///
+/// Enforces a hard `max_entries` cap independent of `VecDeque::capacity()`.
+/// `VecDeque::with_capacity` rounds up to the next power of two and reallocates
+/// on overflow, so using `capacity()` as a bound leaks memory exponentially —
+/// see issue #340. This struct stores the configured cap explicitly and evicts
+/// the oldest entry whenever `push` would exceed it.
+#[derive(Debug)]
+pub struct BoundedInferenceLog {
+    entries: VecDeque<InferenceLogEntry>,
+    max_entries: usize,
+}
 
-/// Creates a new empty inference log with pre-allocated capacity from config.
+impl BoundedInferenceLog {
+    /// Creates an empty log bounded to `max_entries`. A value of 0 is treated
+    /// as 1 so that a `push` always leaves exactly one entry in the log.
+    pub fn new(max_entries: usize) -> Self {
+        let cap = max_entries.max(1);
+        Self {
+            entries: VecDeque::with_capacity(cap),
+            max_entries: cap,
+        }
+    }
+
+    /// Appends `entry`, evicting the oldest entries until `len <= max_entries`.
+    pub fn push(&mut self, entry: InferenceLogEntry) {
+        while self.entries.len() >= self.max_entries {
+            self.entries.pop_front();
+        }
+        self.entries.push_back(entry);
+    }
+
+    /// Iterates over stored entries, oldest first.
+    pub fn iter(&self) -> std::collections::vec_deque::Iter<'_, InferenceLogEntry> {
+        self.entries.iter()
+    }
+
+    /// Returns the current number of stored entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns true if the log is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Returns the configured maximum number of entries.
+    pub fn max_entries(&self) -> usize {
+        self.max_entries
+    }
+}
+
+/// Shared bounded ring buffer of inference call log entries.
+pub type InferenceLog = Arc<Mutex<BoundedInferenceLog>>;
+
+/// Creates a new empty inference log with capacity from config.
 pub fn new_inference_log_with_config(config: &InferenceConfig) -> InferenceLog {
-    Arc::new(Mutex::new(VecDeque::with_capacity(config.log_capacity)))
+    Arc::new(Mutex::new(BoundedInferenceLog::new(config.log_capacity)))
 }
 
 /// Creates a new empty inference log with default capacity.
@@ -541,10 +594,7 @@ pub fn spawn_inference_worker(
                     max_tokens,
                 };
                 let mut log = log.lock().await;
-                if log.len() >= log.capacity().max(1) {
-                    log.pop_front();
-                }
-                log.push_back(entry);
+                log.push(entry);
             }
 
             // Ignore send error — the caller may have dropped the receiver
@@ -556,6 +606,60 @@ pub fn spawn_inference_worker(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn log_entry(request_id: u64) -> InferenceLogEntry {
+        InferenceLogEntry {
+            request_id,
+            timestamp: "00:00:00".to_string(),
+            model: "test".to_string(),
+            streaming: false,
+            duration_ms: 0,
+            prompt_len: 0,
+            response_len: 0,
+            error: None,
+            system_prompt: None,
+            prompt_text: String::new(),
+            response_text: String::new(),
+            max_tokens: None,
+        }
+    }
+
+    /// Regression test for issue #340: the ring buffer must enforce its
+    /// configured cap regardless of `VecDeque::capacity()`'s rounded-up value.
+    #[test]
+    fn bounded_inference_log_enforces_configured_cap() {
+        let mut log = BoundedInferenceLog::new(50);
+        for i in 0..1000u64 {
+            log.push(log_entry(i));
+        }
+        assert_eq!(log.len(), 50, "log must never exceed its configured cap");
+        assert_eq!(log.max_entries(), 50);
+        // Oldest entry should have been evicted; we should see the last 50 IDs.
+        let ids: Vec<u64> = log.iter().map(|e| e.request_id).collect();
+        assert_eq!(ids.first().copied(), Some(950));
+        assert_eq!(ids.last().copied(), Some(999));
+    }
+
+    /// A zero cap is clamped to 1 so pushes always leave one entry.
+    #[test]
+    fn bounded_inference_log_zero_cap_is_clamped() {
+        let mut log = BoundedInferenceLog::new(0);
+        assert_eq!(log.max_entries(), 1);
+        log.push(log_entry(1));
+        log.push(log_entry(2));
+        assert_eq!(log.len(), 1);
+        assert_eq!(log.iter().next().unwrap().request_id, 2);
+    }
+
+    #[test]
+    fn bounded_inference_log_is_empty_and_len() {
+        let mut log = BoundedInferenceLog::new(4);
+        assert!(log.is_empty());
+        assert_eq!(log.len(), 0);
+        log.push(log_entry(1));
+        assert!(!log.is_empty());
+        assert_eq!(log.len(), 1);
+    }
 
     /// Helper to build a three-lane InferenceQueue and return the matching receivers.
     fn make_queue() -> (

--- a/crates/parish-npc/src/memory.rs
+++ b/crates/parish-npc/src/memory.rs
@@ -181,6 +181,13 @@ impl Default for ShortTermMemory {
 /// Minimum importance score for a memory to be stored long-term.
 const PROMOTION_THRESHOLD: f32 = 0.5;
 
+/// Default maximum number of entries held in a single NPC's long-term memory.
+///
+/// Matches the short-term cap and the designer's stated intent (issue #341).
+/// When this cap is reached, the lowest-scoring (importance, oldest-first)
+/// entry is evicted to make room.
+pub const LONG_TERM_CAPACITY: usize = 50;
+
 /// Words that signal emotionally significant events.
 const EMOTION_WORDS: &[&str] = &[
     "angry",
@@ -223,17 +230,50 @@ pub struct LongTermEntry {
 ///
 /// Stores important memories that survive short-term eviction. Retrieval
 /// scores entries by keyword overlap weighted by importance.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+///
+/// Bounded to [`LONG_TERM_CAPACITY`] entries per NPC (issue #341). When the
+/// cap is reached, [`Self::store`] evicts the lowest-importance entry
+/// (oldest first on ties) to keep the most salient memories.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LongTermMemory {
     entries: Vec<LongTermEntry>,
+    #[serde(default = "default_long_term_capacity")]
+    max_entries: usize,
+}
+
+/// Serde default for [`LongTermMemory::max_entries`]; matches the in-memory default
+/// and keeps pre-existing save files compatible.
+fn default_long_term_capacity() -> usize {
+    LONG_TERM_CAPACITY
+}
+
+impl Default for LongTermMemory {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl LongTermMemory {
-    /// Creates an empty long-term memory.
+    /// Creates an empty long-term memory with the default capacity.
     pub fn new() -> Self {
+        Self::with_capacity(LONG_TERM_CAPACITY)
+    }
+
+    /// Creates an empty long-term memory with the given capacity.
+    ///
+    /// A value of 0 is clamped to 1 so that `store` can always keep the
+    /// highest-importance entry seen so far.
+    pub fn with_capacity(max_entries: usize) -> Self {
+        let cap = max_entries.max(1);
         Self {
-            entries: Vec::new(),
+            entries: Vec::with_capacity(cap),
+            max_entries: cap,
         }
+    }
+
+    /// Returns the configured maximum number of stored entries.
+    pub fn max_entries(&self) -> usize {
+        self.max_entries
     }
 
     /// Returns all entries.
@@ -244,14 +284,44 @@ impl LongTermMemory {
     /// Stores an entry if it meets the importance threshold.
     ///
     /// Returns `true` if the entry was stored, `false` if it was below
-    /// the promotion threshold.
+    /// the promotion threshold or if every existing entry is more
+    /// important than the incoming one at capacity.
+    ///
+    /// When at capacity, the lowest-importance existing entry is evicted
+    /// to make room. Ties are broken by preferring to evict the oldest
+    /// entry. If the incoming entry's importance is strictly lower than
+    /// every stored entry's importance, it is rejected and the log is
+    /// unchanged.
     pub fn store(&mut self, entry: LongTermEntry) -> bool {
-        if entry.importance >= PROMOTION_THRESHOLD {
-            self.entries.push(entry);
-            true
-        } else {
-            false
+        if entry.importance < PROMOTION_THRESHOLD {
+            return false;
         }
+
+        if self.entries.len() >= self.max_entries {
+            // Find the least-important, oldest entry. `position` returns the
+            // first index, so ties naturally favour eviction of the oldest.
+            let (evict_idx, evict_importance) = self
+                .entries
+                .iter()
+                .enumerate()
+                .min_by(|a, b| {
+                    a.1.importance
+                        .partial_cmp(&b.1.importance)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                        .then_with(|| a.1.timestamp.cmp(&b.1.timestamp))
+                })
+                .map(|(i, e)| (i, e.importance))
+                .expect("entries is non-empty when at capacity");
+
+            // Refuse to evict a more-important entry for a less-important one.
+            if entry.importance < evict_importance {
+                return false;
+            }
+            self.entries.remove(evict_idx);
+        }
+
+        self.entries.push(entry);
+        true
     }
 
     /// Retrieves the top `limit` entries matching the query by keyword overlap.
@@ -782,6 +852,100 @@ mod tests {
 
         let empty = ltm.recall_context_string(&["nobody"], 3);
         assert!(empty.is_empty());
+    }
+
+    // ── Long-term memory capacity (issue #341) ──────────────────────
+
+    fn make_lt_entry_at(ts_hour: u32, importance: f32) -> LongTermEntry {
+        LongTermEntry {
+            timestamp: Utc.with_ymd_and_hms(1820, 3, 20, ts_hour, 0, 0).unwrap(),
+            content: format!("event at hour {ts_hour} (score {importance})"),
+            importance,
+            keywords: vec!["test".to_string()],
+        }
+    }
+
+    #[test]
+    fn long_term_memory_default_capacity_matches_const() {
+        let ltm = LongTermMemory::new();
+        assert_eq!(ltm.max_entries(), LONG_TERM_CAPACITY);
+    }
+
+    #[test]
+    fn long_term_memory_is_bounded_by_cap() {
+        let mut ltm = LongTermMemory::with_capacity(3);
+        for h in 0..10 {
+            ltm.store(make_lt_entry_at(h, 0.7));
+        }
+        assert_eq!(ltm.len(), 3, "must not grow past configured cap");
+    }
+
+    #[test]
+    fn long_term_memory_evicts_lowest_importance_first() {
+        let mut ltm = LongTermMemory::with_capacity(3);
+        assert!(ltm.store(make_lt_entry_at(0, 0.6))); // idx 0
+        assert!(ltm.store(make_lt_entry_at(1, 0.9))); // idx 1
+        assert!(ltm.store(make_lt_entry_at(2, 0.7))); // idx 2
+        // Pushing a new 0.8 at capacity: the 0.6 entry (hour 0) is the
+        // lowest-importance entry and must be evicted to make room.
+        assert!(ltm.store(make_lt_entry_at(3, 0.8)));
+        let remaining_importance: Vec<f32> = ltm.entries().iter().map(|e| e.importance).collect();
+        assert!(!remaining_importance.iter().any(|i| (*i - 0.6).abs() < 1e-6));
+        assert_eq!(ltm.len(), 3);
+    }
+
+    #[test]
+    fn long_term_memory_evicts_oldest_on_importance_tie() {
+        let mut ltm = LongTermMemory::with_capacity(2);
+        assert!(ltm.store(make_lt_entry_at(0, 0.6)));
+        assert!(ltm.store(make_lt_entry_at(1, 0.6)));
+        // New 0.6 entry at capacity: a tie on importance — the oldest
+        // (hour 0) should be evicted.
+        assert!(ltm.store(make_lt_entry_at(2, 0.6)));
+        let kept_hours: Vec<u32> = ltm
+            .entries()
+            .iter()
+            .map(|e| e.timestamp.format("%H").to_string().parse().unwrap())
+            .collect();
+        assert!(!kept_hours.contains(&0));
+        assert!(kept_hours.contains(&1));
+        assert!(kept_hours.contains(&2));
+    }
+
+    #[test]
+    fn long_term_memory_rejects_lower_importance_when_full() {
+        let mut ltm = LongTermMemory::with_capacity(2);
+        assert!(ltm.store(make_lt_entry_at(0, 0.9)));
+        assert!(ltm.store(make_lt_entry_at(1, 0.8)));
+        // Incoming 0.6 is strictly below every stored importance — reject.
+        assert!(!ltm.store(make_lt_entry_at(2, 0.6)));
+        assert_eq!(ltm.len(), 2);
+    }
+
+    #[test]
+    fn long_term_memory_preserves_importance_threshold_even_when_empty_room() {
+        let mut ltm = LongTermMemory::with_capacity(2);
+        assert!(!ltm.store(make_lt_entry_at(0, 0.49)));
+        assert!(ltm.is_empty());
+    }
+
+    #[test]
+    fn long_term_memory_deserialises_legacy_format_without_max_entries() {
+        // Legacy save files only have `entries`. Verify #[serde(default)]
+        // fills in the capacity so autosave round-trips don't regress.
+        let legacy = serde_json::json!({
+            "entries": [
+                {
+                    "timestamp": "1820-03-20T10:00:00Z",
+                    "content": "legacy",
+                    "importance": 0.8,
+                    "keywords": ["legacy"]
+                }
+            ]
+        });
+        let ltm: LongTermMemory = serde_json::from_value(legacy).unwrap();
+        assert_eq!(ltm.len(), 1);
+        assert_eq!(ltm.max_entries(), LONG_TERM_CAPACITY);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two related unbounded-memory bugs, same underlying pattern: *"looks capped, isn't."*

- **#340** — `InferenceLog` used `VecDeque::capacity()` as its eviction guard. But `VecDeque::with_capacity(50)` rounds up to 64, and each `push_back` at full length reallocates to the next power of two — so the log doubled indefinitely (64 → 128 → 256 → …) while `/api/debug-snapshot` cloned the whole Vec on every poll.
- **#341** — `LongTermMemory::entries` had no eviction at all. Every promoted memory from every NPC dialogue accumulated forever and was serialised into every autosave/snapshot.

## Changes

- `crates/parish-inference/src/lib.rs` — new `BoundedInferenceLog` struct that stores the configured cap in a dedicated field and evicts via `while len >= max_entries` before pushing. `InferenceLog = Arc<Mutex<BoundedInferenceLog>>`. Both log-writing sites now call `log.push(entry)` instead of the buggy `len() >= capacity()` guard.
- `crates/parish-core/src/game_session.rs` — streaming-path log site updated to use `push()`.
- `crates/parish-npc/src/memory.rs` — `LongTermMemory` now has a `max_entries: usize` field (default `LONG_TERM_CAPACITY = 50`) with `#[serde(default)]` for legacy-save compatibility. `store()` evicts the lowest-importance entry (ties broken by oldest timestamp) at capacity, and refuses strictly less-important incoming entries when full.

No behaviour change for read sites — `.iter().cloned().collect()` still works, and `LongTermMemory::entries()`/`len()`/`is_empty()`/`recall()` are unchanged.

## Why these choices

- **Explicit max field (not `capacity()`).** Re-reading `VecDeque`'s docs confirms `capacity()` is the *allocation* capacity and changes under `push_back`. Any fix that leaves `capacity()` in the guard stays wrong, even with `shrink_to_fit`. The minimum-viable fix is to store the cap the caller asked for.
- **Importance-weighted eviction.** The issue suggested `importance * recency`, but the pragmatic version — evict the least-important, oldest-on-tie — is O(N) per overflow and avoids time-decay bookkeeping in the serialised struct. `try_promote`'s threshold still gates admission, so capacity pressure only affects already-important memories.
- **`#[serde(default)]` on `max_entries`.** Pre-existing save files round-trip cleanly (covered by a test) and populate the cap from the default.

## Tests

All new tests live alongside the code they cover:

- `BoundedInferenceLog`: pushes 1000 entries with cap 50, asserts `len == 50` and that the retained IDs are the last 50 (regression for the exponential-growth bug). Plus `max_entries(0)` clamped-to-1 edge case and empty-state invariants.
- `LongTermMemory`:
  - default capacity matches `LONG_TERM_CAPACITY`
  - bounded across repeated stores past the cap
  - evicts lowest-importance first
  - ties broken by oldest timestamp
  - rejects entries strictly less important than every stored entry at capacity
  - still enforces the 0.5 promotion threshold even when capacity is available
  - legacy save files (no `max_entries` field) deserialise correctly

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p parish-inference -p parish-core -p parish-npc -p parish-server -p parish --tests -- -D warnings`
- [x] `cargo test -p parish-inference -p parish-core -p parish-npc -p parish-persistence -p parish-server -p parish`
- [x] `cargo run -- --script testing/fixtures/test_walkthrough.txt` — clean JSON output through the walkthrough

Fixes #340.
Fixes #341.

https://claude.ai/code/session_01RGvyjSBfEkhQ1Hr6Y8de42
