### PR TITLE
fix: harden journal replay against corruption and divergence (#344, #345)

### DIFF
--- a/crates/parish-persistence/src/database.rs
+++ b/crates/parish-persistence/src/database.rs
@@ -587,6 +587,7 @@ mod tests {
         let event1 = WorldEvent::PlayerMoved {
             from: parish_types::LocationId(1),
             to: parish_types::LocationId(2),
+            minutes: None,
         };
         let event2 = WorldEvent::WeatherChanged {
             new_weather: "Rain".to_string(),

--- a/crates/parish-persistence/src/journal.rs
+++ b/crates/parish-persistence/src/journal.rs
@@ -22,6 +22,12 @@ pub enum WorldEvent {
         from: LocationId,
         /// Destination location.
         to: LocationId,
+        /// Travel time in minutes (used on replay to advance the clock).
+        ///
+        /// Optional and `#[serde(default)]` for backwards compatibility with
+        /// legacy journal rows written before this field was added.
+        #[serde(default)]
+        minutes: Option<i64>,
     },
     /// An NPC moved between locations.
     NpcMoved {
@@ -92,21 +98,60 @@ impl WorldEvent {
     }
 }
 
+/// Upper bound (one game-week) on a single `ClockAdvanced` minutes value.
+///
+/// Journal rows with a value outside `(0, MAX_MINUTES_PER_EVENT)` are skipped
+/// on replay to keep monotonic-clock invariants intact even if the journal is
+/// corrupted. See [`replay_journal`].
+const MAX_MINUTES_PER_EVENT: i64 = 60 * 24 * 7;
+
 /// Replays a sequence of journal events onto live game state.
 ///
 /// Applies each event in order to bring the world and NPC manager
 /// up to date from the last snapshot. Events that reference unknown
 /// NPCs are silently skipped (the NPC may have been removed).
+///
+/// `ClockAdvanced` events with non-positive or out-of-range minutes are
+/// skipped with a warning so a corrupted journal cannot brick a save by
+/// moving the clock backward or jumping weeks into the future.
+///
+/// `PlayerMoved` events additionally:
+/// - record an edge traversal in `world.edge_traversals` when `from` and
+///   `to` are direct neighbours in the graph (so fog-of-war "worn paths"
+///   survive crash recovery),
+/// - advance the clock by `minutes` when the journal row carries it, and
+/// - trigger an `NpcManager::assign_tiers` call at the end of the replay
+///   so cognitive tiers reflect the player's final position.
 pub fn replay_journal(
     world: &mut parish_world::WorldState,
     npc_manager: &mut parish_npc::manager::NpcManager,
     events: &[WorldEvent],
 ) {
+    let mut player_moved = false;
     for event in events {
         match event {
-            WorldEvent::PlayerMoved { to, .. } => {
+            WorldEvent::PlayerMoved { from, to, minutes } => {
+                // Record the edge traversal so fog-of-war "worn paths"
+                // survive crash recovery. Only record when `from` and `to`
+                // are direct neighbours — otherwise we would fabricate an
+                // edge that does not exist in the graph.
+                if world
+                    .graph
+                    .neighbors(*from)
+                    .iter()
+                    .any(|(id, _)| *id == *to)
+                {
+                    world.record_path_traversal(&[*from, *to]);
+                }
+                if let Some(m) = minutes
+                    && *m > 0
+                    && *m < MAX_MINUTES_PER_EVENT
+                {
+                    world.clock.advance(*m);
+                }
                 world.player_location = *to;
                 world.visited_locations.insert(*to);
+                player_moved = true;
             }
             WorldEvent::NpcMoved { npc_id, to, .. } => {
                 if let Some(npc) = npc_manager.get_mut(*npc_id) {
@@ -153,7 +198,17 @@ pub fn replay_journal(
                 }
             }
             WorldEvent::ClockAdvanced { minutes } => {
-                world.clock.advance(*minutes);
+                // Reject non-positive or implausibly large values so a
+                // corrupted journal cannot violate the monotonic-clock
+                // invariants relied on by tier-transition bookkeeping.
+                if *minutes > 0 && *minutes < MAX_MINUTES_PER_EVENT {
+                    world.clock.advance(*minutes);
+                } else {
+                    tracing::warn!(
+                        "skipping invalid ClockAdvanced({}) in journal replay",
+                        minutes
+                    );
+                }
             }
             WorldEvent::DialogueOccurred { .. } => {
                 // Dialogue events are recorded for history but don't
@@ -161,6 +216,13 @@ pub fn replay_journal(
                 // changes are recorded as separate events).
             }
         }
+    }
+
+    // After any player movement, reassign cognitive tiers so Tier 1
+    // candidates reflect the player's final position rather than the
+    // stale snapshot-time location.
+    if player_moved {
+        let _ = npc_manager.assign_tiers(world, &[]);
     }
 }
 
@@ -173,6 +235,7 @@ mod tests {
         let event = WorldEvent::PlayerMoved {
             from: LocationId(1),
             to: LocationId(2),
+            minutes: None,
         };
         assert_eq!(event.event_type(), "PlayerMoved");
 
@@ -208,6 +271,7 @@ mod tests {
         let event = WorldEvent::PlayerMoved {
             from: LocationId(1),
             to: LocationId(2),
+            minutes: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"type\":\"PlayerMoved\""));
@@ -220,6 +284,7 @@ mod tests {
         let events = vec![WorldEvent::PlayerMoved {
             from: LocationId(1),
             to: LocationId(2),
+            minutes: None,
         }];
         replay_journal(&mut world, &mut npcs, &events);
         assert_eq!(world.player_location, LocationId(2));
@@ -233,6 +298,7 @@ mod tests {
         let events = vec![WorldEvent::PlayerMoved {
             from: LocationId(1),
             to: LocationId(2),
+            minutes: None,
         }];
         replay_journal(&mut world, &mut npcs, &events);
         assert!(world.visited_locations.contains(&LocationId(2)));
@@ -321,6 +387,7 @@ mod tests {
             WorldEvent::PlayerMoved {
                 from: LocationId(1),
                 to: LocationId(2),
+                minutes: None,
             },
             WorldEvent::WeatherChanged {
                 new_weather: "Fog".to_string(),
@@ -333,12 +400,196 @@ mod tests {
     }
 
     #[test]
+    fn test_replay_rejects_negative_clock_advance() {
+        // Regression: #344 — a corrupted journal row with a negative
+        // `minutes` must not move the clock backward.
+        let mut world = parish_world::WorldState::new();
+        let mut npcs = parish_npc::manager::NpcManager::new();
+        let time_before = world.clock.now();
+        let events = vec![WorldEvent::ClockAdvanced { minutes: -60 }];
+        replay_journal(&mut world, &mut npcs, &events);
+        assert_eq!(world.clock.now(), time_before);
+    }
+
+    #[test]
+    fn test_replay_rejects_huge_clock_advance() {
+        // Regression: #344 — a value beyond the one-week sanity bound is
+        // treated as corrupted and skipped, leaving the clock alone.
+        let mut world = parish_world::WorldState::new();
+        let mut npcs = parish_npc::manager::NpcManager::new();
+        let time_before = world.clock.now();
+        let events = vec![WorldEvent::ClockAdvanced {
+            minutes: MAX_MINUTES_PER_EVENT,
+        }];
+        replay_journal(&mut world, &mut npcs, &events);
+        assert_eq!(world.clock.now(), time_before);
+    }
+
+    #[test]
+    fn test_replay_rejects_zero_clock_advance() {
+        // Zero is treated the same as negative — not a valid mutation.
+        let mut world = parish_world::WorldState::new();
+        let mut npcs = parish_npc::manager::NpcManager::new();
+        let time_before = world.clock.now();
+        let events = vec![WorldEvent::ClockAdvanced { minutes: 0 }];
+        replay_journal(&mut world, &mut npcs, &events);
+        assert_eq!(world.clock.now(), time_before);
+    }
+
+    #[test]
+    fn test_replay_skips_invalid_clock_but_continues() {
+        // An invalid ClockAdvanced must not abort the replay — later
+        // events still apply.
+        let mut world = parish_world::WorldState::new();
+        let mut npcs = parish_npc::manager::NpcManager::new();
+        let events = vec![
+            WorldEvent::ClockAdvanced { minutes: -5 },
+            WorldEvent::WeatherChanged {
+                new_weather: "Rain".to_string(),
+            },
+            WorldEvent::ClockAdvanced { minutes: 15 },
+        ];
+        let time_before = world.clock.now();
+        replay_journal(&mut world, &mut npcs, &events);
+        assert_eq!(world.weather, parish_types::Weather::LightRain);
+        let diff = (world.clock.now() - time_before).num_minutes();
+        assert_eq!(diff, 15, "valid advance still applied after invalid one");
+    }
+
+    #[test]
+    fn test_replay_player_moved_advances_clock_when_minutes_present() {
+        // Regression: #345 — journal rows written with travel minutes
+        // should advance the clock on replay so crash-recovered state
+        // matches uninterrupted state.
+        let mut world = parish_world::WorldState::new();
+        let mut npcs = parish_npc::manager::NpcManager::new();
+        let time_before = world.clock.now();
+        let events = vec![WorldEvent::PlayerMoved {
+            from: LocationId(1),
+            to: LocationId(2),
+            minutes: Some(12),
+        }];
+        replay_journal(&mut world, &mut npcs, &events);
+        let diff = (world.clock.now() - time_before).num_minutes();
+        assert_eq!(diff, 12);
+    }
+
+    #[test]
+    fn test_replay_player_moved_legacy_row_leaves_clock_untouched() {
+        // Legacy rows (minutes = None) behave as before — no clock change
+        // from PlayerMoved alone.
+        let mut world = parish_world::WorldState::new();
+        let mut npcs = parish_npc::manager::NpcManager::new();
+        let time_before = world.clock.now();
+        let events = vec![WorldEvent::PlayerMoved {
+            from: LocationId(1),
+            to: LocationId(2),
+            minutes: None,
+        }];
+        replay_journal(&mut world, &mut npcs, &events);
+        assert_eq!(world.clock.now(), time_before);
+    }
+
+    #[test]
+    fn test_replay_player_moved_legacy_row_deserializes() {
+        // Rows written before `minutes` existed must still deserialize.
+        let legacy_json = r#"{"type":"PlayerMoved","from":1,"to":2}"#;
+        let event: WorldEvent = serde_json::from_str(legacy_json).unwrap();
+        match event {
+            WorldEvent::PlayerMoved { from, to, minutes } => {
+                assert_eq!(from, LocationId(1));
+                assert_eq!(to, LocationId(2));
+                assert_eq!(minutes, None);
+            }
+            _ => panic!("expected PlayerMoved"),
+        }
+    }
+
+    #[test]
+    fn test_replay_player_moved_rejects_out_of_range_minutes() {
+        // Guard #344's bounds when minutes arrive via PlayerMoved too.
+        let mut world = parish_world::WorldState::new();
+        let mut npcs = parish_npc::manager::NpcManager::new();
+        let time_before = world.clock.now();
+        let events = vec![
+            WorldEvent::PlayerMoved {
+                from: LocationId(1),
+                to: LocationId(2),
+                minutes: Some(-5),
+            },
+            WorldEvent::PlayerMoved {
+                from: LocationId(2),
+                to: LocationId(3),
+                minutes: Some(MAX_MINUTES_PER_EVENT),
+            },
+        ];
+        replay_journal(&mut world, &mut npcs, &events);
+        assert_eq!(world.clock.now(), time_before);
+        // Player still moved — only the clock advance was suppressed.
+        assert_eq!(world.player_location, LocationId(3));
+    }
+
+    #[test]
+    fn test_replay_player_moved_skips_edge_traversal_for_non_neighbours() {
+        // If `from` and `to` are not adjacent in the graph, do not
+        // fabricate an edge traversal for an edge that does not exist.
+        let mut world = parish_world::WorldState::new();
+        let mut npcs = parish_npc::manager::NpcManager::new();
+        let events = vec![WorldEvent::PlayerMoved {
+            from: LocationId(42),
+            to: LocationId(99),
+            minutes: None,
+        }];
+        replay_journal(&mut world, &mut npcs, &events);
+        assert!(world.edge_traversals.is_empty());
+    }
+
+    #[test]
+    fn test_replay_player_moved_records_edge_traversal_for_direct_neighbours() {
+        // Regression: #345 — fog-of-war "worn paths" should survive crash
+        // recovery. When `from` and `to` are direct graph neighbours, a
+        // traversal is recorded.
+        let graph_json = r#"{
+            "locations": [
+                {"id": 1, "name": "A", "description_template": "a",
+                 "indoor": false, "public": true, "lat": 0.0, "lon": 0.0,
+                 "connections": [{"target": 2, "path_description": "p"}],
+                 "associated_npcs": [], "mythological_significance": null},
+                {"id": 2, "name": "B", "description_template": "b",
+                 "indoor": false, "public": true, "lat": 0.0, "lon": 0.001,
+                 "connections": [{"target": 1, "path_description": "p"}],
+                 "associated_npcs": [], "mythological_significance": null}
+            ]
+        }"#;
+        let graph = parish_world::graph::WorldGraph::load_from_str(graph_json).unwrap();
+
+        let mut world = parish_world::WorldState::new();
+        world.graph = graph;
+        world.player_location = LocationId(1);
+        let mut npcs = parish_npc::manager::NpcManager::new();
+
+        let events = vec![WorldEvent::PlayerMoved {
+            from: LocationId(1),
+            to: LocationId(2),
+            minutes: Some(5),
+        }];
+        replay_journal(&mut world, &mut npcs, &events);
+
+        assert_eq!(
+            world.edge_traversals.get(&(LocationId(1), LocationId(2))),
+            Some(&1),
+            "direct neighbour traversal should be recorded"
+        );
+    }
+
+    #[test]
     fn test_all_event_types_covered() {
         // Ensure every variant has an event_type string
         let events = vec![
             WorldEvent::PlayerMoved {
                 from: LocationId(1),
                 to: LocationId(2),
+                minutes: None,
             },
             WorldEvent::NpcMoved {
                 npc_id: NpcId(1),


### PR DESCRIPTION
## Summary

Two related journal-replay bugs, both in `crates/parish-persistence/src/journal.rs`:

- **#344** — `WorldEvent::ClockAdvanced { minutes: i64 }` was replayed unconditionally via `world.clock.advance(*minutes)`. A negative value from a corrupted row could shift the clock backward (breaking the monotonic-clock invariants relied on by `last_tier2/3/4_game_time` bookkeeping); an enormous value could skip weeks of schedule/weather/tier transitions.
- **#345** — `WorldEvent::PlayerMoved` replay only updated `player_location` / `visited_locations`. It did **not** record the edge in `world.edge_traversals` (fog-of-war "worn paths" silently stopped working after any crash), advance the clock for travel time, or call `NpcManager::assign_tiers` — so crash-recovered sessions drifted from uninterrupted ones.

## Changes

`crates/parish-persistence/src/journal.rs`:

- New `MAX_MINUTES_PER_EVENT = 60 * 24 * 7` sanity bound (one game week).
- `ClockAdvanced` replay now requires `0 < minutes < MAX_MINUTES_PER_EVENT` or logs a warning and skips the event — replay continues for subsequent events.
- `PlayerMoved` gained an optional `minutes: Option<i64>` field (`#[serde(default)]` for legacy-row compatibility).
- On `PlayerMoved` replay:
  - If `from` and `to` are direct neighbours in `world.graph`, record a traversal via `world.record_path_traversal(&[from, to])`. Non-neighbour IDs are left alone rather than fabricating a bogus edge.
  - If `minutes` is present and in range, advance the clock.
  - After the full replay loop, if any player movement occurred, call `npc_manager.assign_tiers(world, &[])` once so Tier 1 candidates reflect the player's final position.

`crates/parish-persistence/src/database.rs`:
- Test construction of `WorldEvent::PlayerMoved` updated to include `minutes: None`.

## Test plan

New tests in `journal::tests` covering:
- [x] Negative, zero, and out-of-range `ClockAdvanced` values are skipped
- [x] Valid `ClockAdvanced` events still apply after an invalid one in the same batch
- [x] `PlayerMoved { minutes: Some(12) }` advances the clock by 12 minutes
- [x] `PlayerMoved { minutes: None }` (legacy row) leaves the clock alone
- [x] Legacy JSON `{"type":"PlayerMoved","from":1,"to":2}` deserialises to `minutes: None`
- [x] Out-of-range `PlayerMoved.minutes` is rejected but the move itself still applies
- [x] Direct-neighbour move records an edge traversal
- [x] Non-neighbour move does not fabricate an edge traversal

All 39 journal-related unit tests pass, plus the full non-Tauri workspace (all crates pass `cargo test`, `cargo clippy -- -D warnings`, and `cargo fmt --check`). `cargo run -p parish -- --script testing/fixtures/test_walkthrough.txt` still produces the expected JSON output.

https://claude.ai/code/session_01WvvuaRD6nP3pBsozoWtyjE