### PR TITLE
fix: full-screen map covers sidebar and adds X close button

### DIFF
--- a/apps/ui/src/components/FullMapOverlay.svelte
+++ b/apps/ui/src/components/FullMapOverlay.svelte
@@ -107,6 +107,15 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <div class="map-embed">
+	<button
+		type="button"
+		class="close-btn"
+		aria-label="Close full map"
+		title="Close (M or Esc)"
+		onclick={onclose}
+	>
+		<span aria-hidden="true">&times;</span>
+	</button>
 	<div class="map-container" bind:this={container}></div>
 	{#if tooltip}
 		<div class="tooltip">
@@ -127,13 +136,38 @@
 
 <style>
 	.map-embed {
-		flex: 1;
-		min-height: 0;
+		position: absolute;
+		inset: 0;
+		z-index: 50;
 		display: flex;
 		flex-direction: column;
 		overflow: hidden;
 		background: var(--color-panel-bg);
-		position: relative;
+	}
+
+	.close-btn {
+		position: absolute;
+		top: 0.5rem;
+		right: 0.5rem;
+		z-index: 2;
+		background: var(--color-panel-bg);
+		border: 1px solid var(--color-border);
+		border-radius: 4px;
+		color: var(--color-muted);
+		font-size: 1.4rem;
+		line-height: 1;
+		padding: 2px 8px 4px;
+		cursor: pointer;
+	}
+
+	.close-btn:hover,
+	.close-btn:focus-visible {
+		color: var(--color-fg);
+	}
+
+	.close-btn:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: 2px;
 	}
 
 	.map-container {

--- a/apps/ui/src/components/MapPanel.svelte
+++ b/apps/ui/src/components/MapPanel.svelte
@@ -207,15 +207,15 @@
 		}
 	});
 
-	function openFullMap() {
-		fullMapOpen.set(true);
+	function toggleFullMap() {
+		fullMapOpen.update((v) => !v);
 	}
 </script>
 
 <div class="map-panel" data-testid="map-panel">
 	<div class="map-header">
 		<span class="map-title">Map</span>
-		<button type="button" class="expand-btn" onclick={openFullMap} title="Open full map (M)" aria-label="Open full map">
+		<button type="button" class="expand-btn" onclick={toggleFullMap} title="Toggle full map (M)" aria-label="Toggle full map">
 			<svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true" focusable="false">
 				<path d="M1 1h5v2H3v3H1V1zm9 0h5v5h-2V3h-3V1zM1 10h2v3h3v2H1v-5zm12 3h-3v2h5v-5h-2v3z" />
 			</svg>

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -552,9 +552,7 @@
 
 	<div class="main-area">
 		<div class="chat-col" class:mobile-hidden={mobilePanel !== 'none'}>
-			{#if $fullMapOpen}
-				<FullMapOverlay onclose={() => fullMapOpen.set(false)} />
-			{:else if $focailOpen}
+			{#if $focailOpen}
 				<Sidebar onclose={() => focailOpen.set(false)} />
 			{:else}
 				<ChatPanel />
@@ -565,6 +563,9 @@
 			<MapPanel />
 			<Sidebar />
 		</div>
+		{#if $fullMapOpen}
+			<FullMapOverlay onclose={() => fullMapOpen.set(false)} />
+		{/if}
 	</div>
 
 </div>
@@ -592,6 +593,7 @@
 		grid-template-columns: 1fr 220px;
 		overflow: hidden;
 		min-height: 0;
+		position: relative;
 	}
 
 	.chat-col {


### PR DESCRIPTION
## Summary
- **Toggle behavior**: minimap expand button now toggles via `fullMapOpen.update(v => !v)`, matching the existing `M` keyboard shortcut
- **Full coverage**: `FullMapOverlay` repositioned from inside `chat-col` to an absolute overlay covering the entire `main-area` (including sidebar), using `position: absolute; inset: 0; z-index: 50`
- **Close button**: added an accessible X button (top-right corner) with panel background for contrast over map tiles, plus `focus-visible` outline

## Test plan
- [ ] Click minimap expand icon → full-screen map covers both chat column and sidebar
- [ ] Click the X button → map dismisses, chat and sidebar reappear
- [ ] Press M to open, M again to close; Escape to close
- [ ] Tab to X button → visible focus outline
- [ ] Resize below 768px → overlay still fills viewport correctly
- [ ] Language hints sidebar still opens/closes independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)