### PR TITLE
fix: make historic 6" OS tiles the default map source

### DIFF
--- a/crates/parish-config/src/engine.rs
+++ b/crates/parish-config/src/engine.rs
@@ -802,7 +802,7 @@ impl MapConfig {
 }
 
 fn default_tile_source_id() -> String {
-    "osm".to_string()
+    "historic".to_string()
 }
 
 fn default_tile_sources() -> BTreeMap<String, TileSourceConfig> {
@@ -1075,7 +1075,7 @@ memory_capacity = 30
     #[test]
     fn test_map_config_default_has_both_sources() {
         let cfg = MapConfig::default();
-        assert_eq!(cfg.default_tile_source, "osm");
+        assert_eq!(cfg.default_tile_source, "historic");
         assert!(cfg.tile_sources.contains_key("osm"));
         assert!(cfg.tile_sources.contains_key("historic"));
         let osm = &cfg.tile_sources["osm"];
@@ -1099,7 +1099,7 @@ memory_capacity = 30
     #[test]
     fn test_engine_config_includes_map_defaults() {
         let cfg = EngineConfig::default();
-        assert_eq!(cfg.map.default_tile_source, "osm");
+        assert_eq!(cfg.map.default_tile_source, "historic");
         assert_eq!(cfg.map.tile_sources.len(), 2);
     }
 
@@ -1144,7 +1144,7 @@ memory_capacity = 30
     #[test]
     fn test_load_engine_config_missing_file() {
         let cfg = load_engine_config(Some(Path::new("/nonexistent/parish.toml")));
-        assert_eq!(cfg.map.default_tile_source, "osm");
+        assert_eq!(cfg.map.default_tile_source, "historic");
         assert_eq!(cfg.map.tile_sources.len(), 2);
     }
 

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -355,6 +355,7 @@ fn capture_gdk_screenshot(_path: &std::path::Path) -> anyhow::Result<()> {
 ///
 /// If the GTK main thread is busy or the capture never completes, we bail
 /// instead of blocking the task indefinitely.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))] // Only called from dispatch_screenshot (Linux); tests exercise this cross-platform.
 const SCREENSHOT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Awaits a screenshot result on `rx`, bounded by `timeout`.
@@ -362,6 +363,7 @@ const SCREENSHOT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Returns the captured result, or an error if the channel closes or the
 /// timeout expires. Extracted so the timeout/close behavior can be unit-tested
 /// without GTK.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))] // Only called from dispatch_screenshot (Linux); tests exercise this cross-platform.
 async fn await_screenshot_result(
     rx: std::sync::mpsc::Receiver<anyhow::Result<()>>,
     timeout: Duration,

--- a/parish.example.toml
+++ b/parish.example.toml
@@ -103,7 +103,7 @@ journal_compaction_threshold = 1000  # Max journal entries before compaction (re
 # see MapConfig::apply_defaults in crates/parish-config/src/engine.rs.
 #
 # [engine.map]
-# default_tile_source = "osm"
+# default_tile_source = "historic"
 #
 # [engine.map.tile_sources.osm]
 # label = "OpenStreetMap"


### PR DESCRIPTION
## Summary

- Changes `default_tile_source_id()` in `parish-config` from `"osm"` to `"historic"`, so new players see the period-appropriate 1829–1842 Ordnance Survey of Ireland 6-inch map (served by the National Library of Scotland) on first load
- Updates three test assertions that checked for `"osm"` as the default
- Updates the commented example in `parish.example.toml` to reflect the new default
- Suppresses pre-existing dead_code clippy warnings for `SCREENSHOT_TIMEOUT` and `await_screenshot_result` in `parish-tauri` — both are Linux-only in production but tested cross-platform, so `#[cfg_attr(not(target_os = "linux"), allow(dead_code))]` is the right fix

Existing users are unaffected: the frontend persists the selected tile source in `localStorage` under `parish.tile-source` and prefers it over the backend default.

## Test plan

- [x] `cargo test -p parish-config` — 66 passed
- [x] `cargo test -p parish-core -- map_` — 10 passed
- [x] `just check` (fmt + clippy + full test suite) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)