### PR TITLE
fix: render configured map tiles on minimap

### DIFF
--- a/apps/ui/src/components/MapPanel.svelte
+++ b/apps/ui/src/components/MapPanel.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { mapData, fullMapOpen, pushErrorLog, formatIpcError } from '../stores/game';
 	import { travelState } from '../stores/travel';
+	import { tiles, currentTileSource } from '../stores/tiles';
 	import { submitInput } from '$lib/ipc';
 	import { MapController, type LocationHoverInfo } from '$lib/map/controller';
 	import type { MapLocation } from '$lib/types';
@@ -122,7 +123,8 @@
 		controller = new MapController({
 			container,
 			variant: 'minimap',
-			interactive: false
+			interactive: false,
+			tileSource: currentTileSource($tiles)
 		});
 
 		controller.onLocationClick(async (info) => {
@@ -205,6 +207,12 @@
 		} else {
 			controller.stopTravel();
 		}
+	});
+
+	// Keep minimap base tiles in sync with `/tiles` selection.
+	$effect(() => {
+		if (!mounted || !controller) return;
+		controller.setTileSource(currentTileSource($tiles));
 	});
 
 	function toggleFullMap() {

--- a/apps/ui/src/components/MapPanel.test.ts
+++ b/apps/ui/src/components/MapPanel.test.ts
@@ -9,6 +9,9 @@ import MapPanel from './MapPanel.svelte';
 vi.mock('maplibre-gl', () => {
 	class FakeMap {
 		on() {}
+		once(_event: string, cb: () => void) {
+			cb();
+		}
 		remove() {}
 		getCanvas() {
 			const el = document.createElement('canvas');

--- a/apps/ui/src/lib/map/controller.ts
+++ b/apps/ui/src/lib/map/controller.ts
@@ -44,8 +44,8 @@ export interface MapControllerOptions {
 	interactive: boolean;
 	/** Initial zoom level. Minimap uses a fixed zoom; full map fits bounds. */
 	initialZoom?: number;
-	/** Raster tile source to use for the base layer (full map only). Undefined
-	 *  or a source with an empty URL yields a flat-bg fallback. */
+	/** Raster tile source to use for the base layer. Undefined or a source
+	 *  with an empty URL yields a flat-background fallback. */
 	tileSource?: TileSource;
 }
 
@@ -127,8 +127,8 @@ export class MapController {
 	 * to restore the location/edge overlays. Using `.once()` avoids re-entry
 	 * on repeated `styledata` fires.
 	 *
-	 * Called by the full-map component's `$effect` when the `tiles` store's
-	 * active id changes (driven by the `tiles-switch` event from `/tiles`).
+	 * Called by map components' `$effect`s when the `tiles` store's active id
+	 * changes (driven by the `tiles-switch` event from `/tiles`).
 	 */
 	setTileSource(source: TileSource | undefined): void {
 		this.tileSource = source;

--- a/apps/ui/src/lib/map/style.test.ts
+++ b/apps/ui/src/lib/map/style.test.ts
@@ -79,11 +79,17 @@ describe('buildStyle', () => {
 		expect(style.layers.find((l) => l.id === 'background')).toBeDefined();
 	});
 
-	it('minimap ignores tileSource and always uses flat background', () => {
+	it('minimap uses raster tiles when a tile source is provided', () => {
 		const style = buildStyle('minimap', THEME, osm());
+		expect(style.sources['map-tiles']).toBeDefined();
+		expect(style.layers.find((l) => l.id === 'background')).toBeUndefined();
+		expect(style.layers.find((l) => l.id === 'map-tiles-layer')).toBeDefined();
+	});
+
+	it('minimap with no tile source falls back to flat background', () => {
+		const style = buildStyle('minimap', THEME);
 		expect(style.sources['map-tiles']).toBeUndefined();
 		expect(style.layers.find((l) => l.id === 'background')).toBeDefined();
-		expect(style.layers.find((l) => l.id === 'map-tiles-layer')).toBeUndefined();
 	});
 
 	it('always carries empty GeoJSON sources for locations and edges', () => {

--- a/apps/ui/src/lib/map/style.ts
+++ b/apps/ui/src/lib/map/style.ts
@@ -4,7 +4,7 @@
  * Produces a `StyleSpecification` tailored to either the minimap or the
  * full-parish overlay. The style wires up:
  *
- *   - a raster OSM base (full map only) or a flat panel-bg (minimap)
+ *   - a raster tile base (when configured) or a flat panel background
  *   - an `edges` line layer with data-driven width for traversal footprints
  *   - a `locations` symbol layer with MapLibre's production-grade label
  *     placement — variable anchors, symbol sort keys, halo, and zoom-level
@@ -57,9 +57,9 @@ const GLYPHS_URL = 'https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf'
  *
  * The style has two GeoJSON sources (`locations` and `edges`) that start
  * empty — the controller populates them via `setData()` as game state
- * changes. On the full map a raster base is added beneath, sourced from
- * the `tileSource` parameter (ships with OSM by default; the `/tiles`
- * slash command swaps this via `MapController.setTileSource()`).
+ * changes. A raster base is added beneath when `tileSource` has a URL
+ * (ships with OSM by default; the `/tiles` slash command swaps this via
+ * `MapController.setTileSource()`).
  *
  * Passing a `tileSource` with an empty `url` (e.g. a user-added source
  * that hasn't had its URL filled in yet) falls back to the flat-bg layer
@@ -73,9 +73,9 @@ export function buildStyle(
 ): StyleSpecification {
 	const layers: LayerSpecification[] = [];
 	const rasterSourceId = 'map-tiles';
-	const hasUsableTiles = variant === 'full' && tileSource && tileSource.url.length > 0;
+	const hasUsableTiles = !!tileSource && tileSource.url.length > 0;
 
-	// 1. Base layer — flat color on the minimap, configured raster on the full map.
+	// 1. Base layer — configured raster when available, otherwise flat background.
 	if (hasUsableTiles) {
 		layers.push({
 			id: 'map-tiles-layer',
@@ -87,12 +87,11 @@ export function buildStyle(
 			}
 		});
 	} else {
-		if (variant === 'full' && tileSource && tileSource.url.length === 0) {
+		if (tileSource && tileSource.url.length === 0) {
 			// Informational — a source was registered without a URL; the
 			// operator needs to paste a real endpoint into parish.toml.
 			warnMissingTileUrl(tileSource.id);
 		}
-		// Minimap: flat panel background, no tiles.
 		layers.push({
 			id: 'background',
 			type: 'background',


### PR DESCRIPTION
### Motivation

- Ensure visual parity between the minimap and the full-map overlay by rendering configured raster tiles on the minimap when a tile source is available instead of always using a flat background.
- Let UI tile-source changes (via `/tiles`) affect both map views so the minimap reflects the active tile selection.

### Description

- Wire the minimap `MapPanel` to the shared `tiles` store and initialize the controller with `tileSource: currentTileSource($tiles)`, and add a reactive effect that calls `controller.setTileSource(...)` when the active tile changes (`apps/ui/src/components/MapPanel.svelte`).
- Remove the variant-only restriction in `buildStyle` so raster tiles are used whenever `tileSource.url` is present (minimap and full map), while keeping the flat-background fallback and the one-shot missing-URL warning (`apps/ui/src/lib/map/style.ts`).
- Update `MapController` docs to reflect that `setTileSource()` may be called by any map component (not only the full map) and preserve behavior that re-pushes overlay GeoJSON after a `setStyle()` (`apps/ui/src/lib/map/controller.ts`).
- Adjust unit tests to cover the new minimap tile behavior and make the MapLibre mock support `.once()` used during style swaps (`apps/ui/src/lib/map/style.test.ts`, `apps/ui/src/components/MapPanel.test.ts`).

### Testing

- Attempted `npm test -- --run src/lib/map/style.test.ts src/components/MapPanel.test.ts`, which failed because the UI package has no `test` script (expected `npm` script layout), so switched to a direct runner.
- Ran `npx vitest run src/lib/map/style.test.ts src/components/MapPanel.test.ts`, and all tests passed (`12 tests` across the two files).
- No backend or engine code was changed; only frontend behavior and tests were modified to verify the UI parity fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ea98473483258af71e3123919f70)