### PR TITLE
feat(ui): add left-dock toggle for debug panel on wide screens

### DIFF
--- a/apps/ui/src/components/DebugPanel.svelte
+++ b/apps/ui/src/components/DebugPanel.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-	import { debugVisible, debugSnapshot, debugTab, selectedNpcId } from '../stores/debug';
+	import {
+		debugVisible,
+		debugSnapshot,
+		debugTab,
+		debugDockLeft,
+		selectedNpcId
+	} from '../stores/debug';
 	import type { NpcDebug, ScheduleVariantDebug } from '$lib/types';
 
 	const tabs = [
@@ -58,10 +64,15 @@
 </script>
 
 {#if $debugVisible && snap}
-	<div class="debug-panel">
+	<div class="debug-panel" class:left-dock={$debugDockLeft}>
 		<div class="debug-header">
 			<span class="debug-title">Debug</span>
-			<button class="debug-close" on:click={() => debugVisible.set(false)}>X</button>
+			<div class="debug-actions">
+				<button class="debug-dock-toggle" on:click={() => debugDockLeft.update((v) => !v)}>
+					{$debugDockLeft ? 'Dock Bottom' : 'Dock Left'}
+				</button>
+				<button class="debug-close" on:click={() => debugVisible.set(false)}>X</button>
+			</div>
 		</div>
 
 		<div class="tab-bar">
@@ -544,6 +555,13 @@
 		font-size: 0.7rem;
 	}
 
+	.debug-actions {
+		display: flex;
+		gap: 0.4rem;
+		align-items: center;
+	}
+
+	.debug-dock-toggle,
 	.debug-close {
 		background: none;
 		border: 1px solid var(--color-border);
@@ -553,9 +571,23 @@
 		font-size: 0.65rem;
 	}
 
+	.debug-dock-toggle:hover,
 	.debug-close:hover {
 		color: var(--color-fg);
 		border-color: var(--color-accent);
+	}
+
+	@media (min-width: 1200px) {
+		.debug-panel.left-dock {
+			position: fixed;
+			left: 0;
+			top: 0;
+			height: 100dvh;
+			width: min(28rem, 36vw);
+			border-top: none;
+			border-right: 2px solid var(--color-accent);
+			z-index: 45;
+		}
 	}
 
 	.tab-bar {

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -15,7 +15,7 @@
 
 	/** Which mobile-only panel is open (if any). Desktop ignores this. */
 	let mobilePanel = $state<'none' | 'map' | 'sidebar'>('none');
-	import { debugVisible, debugSnapshot } from '../stores/debug';
+	import { debugVisible, debugSnapshot, debugDockLeft } from '../stores/debug';
 	import { savePickerVisible } from '../stores/save';
 	import { palette } from '../stores/theme';
 	import { tiles } from '../stores/tiles';
@@ -533,7 +533,11 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div class="app-shell" class:debug-open={$debugVisible}>
+<div
+	class="app-shell"
+	class:debug-open-bottom={$debugVisible && !$debugDockLeft}
+	class:debug-open-left={$debugVisible && $debugDockLeft}
+>
 	<StatusBar />
 
 	<!-- Mobile-only toggle toolbar -->
@@ -599,8 +603,15 @@
 		padding-bottom: env(safe-area-inset-bottom);
 	}
 
-	.app-shell.debug-open {
+	.app-shell.debug-open-bottom {
 		height: 60vh;
+	}
+
+	@media (min-width: 1200px) {
+		.app-shell.debug-open-left {
+			margin-left: min(28rem, 36vw);
+			width: calc(100vw - min(28rem, 36vw));
+		}
 	}
 
 	.main-area {

--- a/apps/ui/src/stores/debug.ts
+++ b/apps/ui/src/stores/debug.ts
@@ -10,5 +10,8 @@ export const debugSnapshot = writable<DebugSnapshot | null>(null);
 /** Active debug tab index (0=Overview, 1=NPCs, 2=World, 3=Events, 4=Inference). */
 export const debugTab = writable<number>(0);
 
+/** Preferred dock position for debug panel on wide screens. */
+export const debugDockLeft = writable<boolean>(false);
+
 /** ID of the selected NPC for deep-dive, or null for list view. */
 export const selectedNpcId = writable<number | null>(null);


### PR DESCRIPTION
### Motivation
- Provide a quick way to reposition the debug panel to the left side on wide displays so it acts as a persistent sidebar instead of a bottom drawer. 

### Description
- Add a `debugDockLeft` Svelte store to track the user's preferred dock position for the debug panel (`apps/ui/src/stores/debug.ts`).
- Add a toggle button in the debug panel header (`Dock Left` / `Dock Bottom`) wired to the new store (`apps/ui/src/components/DebugPanel.svelte`).
- Implement left-dock styling for wide screens (`@media (min-width: 1200px)`) so the panel becomes a fixed left sidebar when enabled (`apps/ui/src/components/DebugPanel.svelte`).
- Update the page shell to apply different layout classes for bottom vs left dock so the main app content shifts right when left-docked instead of shrinking vertically (`apps/ui/src/routes/+page.svelte`).

### Testing
- Ran UI quality/type checks with `npm run check` in `apps/ui`, which completed successfully and reported 0 errors and existing Svelte warnings (17) unrelated to these changes. 
- No runtime tests were added since this is a UI layout toggle; manual visual verification expected during review on wide screens.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0edbb3b6c8325b5b5e7bf2ef73890)