### PR TITLE
fix: close path-traversal in editor routes and CSS injection in loading phrase

### DIFF
--- a/apps/ui/src/stores/game.test.ts
+++ b/apps/ui/src/stores/game.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
-import { textLog, pushErrorLog, formatIpcError } from './game';
+import { textLog, pushErrorLog, formatIpcError, loadingColor } from './game';
 
 describe('pushErrorLog', () => {
 	beforeEach(() => {
@@ -25,6 +25,27 @@ describe('pushErrorLog', () => {
 		expect(log.length).toBe(2);
 		expect(log[0].content).toBe('Welcome.');
 		expect(log[1].subtype).toBe('error');
+	});
+});
+
+describe('loadingColor', () => {
+	beforeEach(() => {
+		loadingColor.set([72, 199, 142]);
+	});
+
+	it('clamps out-of-range values to [0, 255]', () => {
+		loadingColor.set([300, -5, 99]);
+		expect(get(loadingColor)).toEqual([255, 0, 99]);
+	});
+
+	it('clamps non-numeric values to 0', () => {
+		loadingColor.set([NaN, 'abc' as any, undefined as any]);
+		expect(get(loadingColor)).toEqual([0, 0, 0]);
+	});
+
+	it('rounds fractional inputs', () => {
+		loadingColor.set([12.7, 200.4, 50]);
+		expect(get(loadingColor)).toEqual([13, 200, 50]);
 	});
 });
 

--- a/apps/ui/src/stores/game.ts
+++ b/apps/ui/src/stores/game.ts
@@ -27,7 +27,19 @@ export const loadingSpinner = writable<string>('');
 export const loadingPhrase = writable<string>('');
 
 /// Current loading spinner colour as `[R, G, B]`.
-export const loadingColor = writable<[number, number, number]>([72, 199, 142]);
+function clampChannel(n: unknown): number {
+	const x = Math.round(Number(n));
+	return Number.isFinite(x) ? Math.max(0, Math.min(255, x)) : 0;
+}
+function createLoadingColor() {
+	const inner = writable<[number, number, number]>([72, 199, 142]);
+	return {
+		subscribe: inner.subscribe,
+		set: (c: [number, number, number]) =>
+			inner.set([clampChannel(c?.[0]), clampChannel(c?.[1]), clampChannel(c?.[2])]),
+	};
+}
+export const loadingColor = createLoadingColor();
 
 export const languageHints = writable<LanguageHint[]>([]);
 

--- a/crates/parish-core/src/ipc/editor.rs
+++ b/crates/parish-core/src/ipc/editor.rs
@@ -6,7 +6,7 @@
 //! `parish-core::editor` pure functions. All I/O happens here; the caller
 //! only needs to acquire the session lock.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
@@ -191,4 +191,79 @@ pub fn handle_editor_read_snapshot(
     branch_id: i64,
 ) -> Result<Option<SnapshotDetail>, String> {
     save_inspect::read_latest_snapshot(save_path, branch_id).map_err(|e| e.to_string())
+}
+
+// ── Path validation ─────────────────────────────────────────────────────────
+
+/// Canonicalises `raw` and ensures it resolves inside `root`.
+/// Returns a `String` error so both Axum and Tauri call-sites can map it.
+pub fn validate_within(raw: &Path, root: &Path) -> Result<PathBuf, String> {
+    let canonical = raw.canonicalize().map_err(|_| "invalid path".to_string())?;
+    let root_canonical = root
+        .canonicalize()
+        .map_err(|_| "invalid root directory".to_string())?;
+    if !canonical.starts_with(&root_canonical) {
+        return Err("path is outside allowed directory".to_string());
+    }
+    Ok(canonical)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn validate_within_happy_path() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("save.db");
+        fs::write(&file, b"").unwrap();
+        let result = validate_within(&file, dir.path());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_within_dotdot_escape() {
+        let dir = tempdir().unwrap();
+        let inner = dir.path().join("sub");
+        fs::create_dir(&inner).unwrap();
+        let file = dir.path().join("outside.db");
+        fs::write(&file, b"").unwrap();
+        // Try to escape from `inner` to `dir` using `..`
+        let traversal = inner.join("../outside.db");
+        // The resolved path is inside `dir`, not inside `inner`
+        let result = validate_within(&traversal, &inner);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("outside allowed directory"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_within_path_outside_root() {
+        let root = tempdir().unwrap();
+        let other = tempdir().unwrap();
+        let file = other.path().join("evil.db");
+        fs::write(&file, b"").unwrap();
+        let result = validate_within(&file, root.path());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("outside allowed directory"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_within_nonexistent_path() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("does_not_exist.db");
+        let result = validate_within(&missing, dir.path());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("invalid path"), "unexpected error: {err}");
+    }
 }

--- a/crates/parish-server/src/editor_routes.rs
+++ b/crates/parish-server/src/editor_routes.rs
@@ -47,7 +47,10 @@ pub async fn editor_open_mod(
     Json(body): Json<EditorOpenModBody>,
 ) -> Result<Json<EditorModSnapshot>, (StatusCode, String)> {
     let path = PathBuf::from(&body.mod_path);
-    editor::handle_editor_open_mod(&state.editor, &path)
+    let root = mods_root(&state);
+    let canonical =
+        editor::validate_within(&path, &root).map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+    editor::handle_editor_open_mod(&state.editor, &canonical)
         .map(|r| Json(r.snapshot))
         .map_err(|e| (StatusCode::BAD_REQUEST, e))
 }
@@ -166,10 +169,13 @@ pub struct SavePathBody {
 
 /// `POST /api/editor-list-branches`
 pub async fn editor_list_branches(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Json(body): Json<SavePathBody>,
 ) -> Result<Json<Vec<BranchSummary>>, (StatusCode, String)> {
-    editor::handle_editor_list_branches(&PathBuf::from(body.save_path))
+    let raw = PathBuf::from(&body.save_path);
+    let canonical = editor::validate_within(&raw, state.saves_dir.as_path())
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+    editor::handle_editor_list_branches(&canonical)
         .map(Json)
         .map_err(|e| (StatusCode::BAD_REQUEST, e))
 }
@@ -183,20 +189,82 @@ pub struct SavePathBranchBody {
 
 /// `POST /api/editor-list-snapshots`
 pub async fn editor_list_snapshots(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Json(body): Json<SavePathBranchBody>,
 ) -> Result<Json<Vec<SnapshotSummary>>, (StatusCode, String)> {
-    editor::handle_editor_list_snapshots(&PathBuf::from(body.save_path), body.branch_id)
+    let raw = PathBuf::from(&body.save_path);
+    let canonical = editor::validate_within(&raw, state.saves_dir.as_path())
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+    editor::handle_editor_list_snapshots(&canonical, body.branch_id)
         .map(Json)
         .map_err(|e| (StatusCode::BAD_REQUEST, e))
 }
 
 /// `POST /api/editor-read-snapshot`
 pub async fn editor_read_snapshot(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Json(body): Json<SavePathBranchBody>,
 ) -> Result<Json<Option<SnapshotDetail>>, (StatusCode, String)> {
-    editor::handle_editor_read_snapshot(&PathBuf::from(body.save_path), body.branch_id)
+    let raw = PathBuf::from(&body.save_path);
+    let canonical = editor::validate_within(&raw, state.saves_dir.as_path())
+        .map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+    editor::handle_editor_read_snapshot(&canonical, body.branch_id)
         .map(Json)
         .map_err(|e| (StatusCode::BAD_REQUEST, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::State;
+
+    #[tokio::test]
+    async fn editor_open_mod_rejects_path_traversal() {
+        let state = crate::routes::tests::test_app_state();
+        let body = EditorOpenModBody {
+            mod_path: "../../etc/passwd".to_string(),
+        };
+        let result = editor_open_mod(State(state), Json(body)).await;
+        assert!(result.is_err());
+        let (status, _msg) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn editor_list_branches_rejects_path_traversal() {
+        let state = crate::routes::tests::test_app_state();
+        let body = SavePathBody {
+            save_path: "../../etc/passwd".to_string(),
+        };
+        let result = editor_list_branches(State(state), Json(body)).await;
+        assert!(result.is_err());
+        let (status, _msg) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn editor_list_snapshots_rejects_path_traversal() {
+        let state = crate::routes::tests::test_app_state();
+        let body = SavePathBranchBody {
+            save_path: "../../etc/passwd".to_string(),
+            branch_id: 1,
+        };
+        let result = editor_list_snapshots(State(state), Json(body)).await;
+        assert!(result.is_err());
+        let (status, _msg) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn editor_read_snapshot_rejects_path_traversal() {
+        let state = crate::routes::tests::test_app_state();
+        let body = SavePathBranchBody {
+            save_path: "../../etc/passwd".to_string(),
+            branch_id: 1,
+        };
+        let result = editor_read_snapshot(State(state), Json(body)).await;
+        assert!(result.is_err());
+        let (status, _msg) = result.unwrap_err();
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    }
 }

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -1785,7 +1785,7 @@ pub async fn get_save_state(State(state): State<Arc<AppState>>) -> Json<SaveStat
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use std::collections::VecDeque;
     use std::sync::{Arc, Mutex as StdMutex};
@@ -1815,7 +1815,7 @@ mod tests {
     }
 
     /// Helper to build a minimal AppState from the real game data.
-    fn test_app_state() -> Arc<AppState> {
+    pub(crate) fn test_app_state() -> Arc<AppState> {
         let data_dir =
             std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../mods/rundale");
         let world =

--- a/crates/parish-tauri/src/editor_commands.rs
+++ b/crates/parish-tauri/src/editor_commands.rs
@@ -36,8 +36,10 @@ pub async fn editor_open_mod(
     mod_path: String,
     state: State<'_, Arc<AppState>>,
 ) -> Result<EditorModSnapshot, String> {
-    let path = PathBuf::from(mod_path);
-    editor::handle_editor_open_mod(&state.editor, &path).map(|r| r.snapshot)
+    let path = PathBuf::from(&mod_path);
+    let root = mods_root();
+    let canonical = parish_core::ipc::editor::validate_within(&path, &root)?;
+    editor::handle_editor_open_mod(&state.editor, &canonical).map(|r| r.snapshot)
 }
 
 #[tauri::command]
@@ -107,7 +109,10 @@ pub async fn editor_list_branches(
     save_path: String,
     _state: State<'_, Arc<AppState>>,
 ) -> Result<Vec<BranchSummary>, String> {
-    editor::handle_editor_list_branches(&PathBuf::from(save_path))
+    let raw = PathBuf::from(&save_path);
+    let root = saves_dir();
+    let canonical = parish_core::ipc::editor::validate_within(&raw, &root)?;
+    editor::handle_editor_list_branches(&canonical)
 }
 
 #[tauri::command]
@@ -116,7 +121,10 @@ pub async fn editor_list_snapshots(
     branch_id: i64,
     _state: State<'_, Arc<AppState>>,
 ) -> Result<Vec<SnapshotSummary>, String> {
-    editor::handle_editor_list_snapshots(&PathBuf::from(save_path), branch_id)
+    let raw = PathBuf::from(&save_path);
+    let root = saves_dir();
+    let canonical = parish_core::ipc::editor::validate_within(&raw, &root)?;
+    editor::handle_editor_list_snapshots(&canonical, branch_id)
 }
 
 #[tauri::command]
@@ -125,5 +133,8 @@ pub async fn editor_read_snapshot(
     branch_id: i64,
     _state: State<'_, Arc<AppState>>,
 ) -> Result<Option<SnapshotDetail>, String> {
-    editor::handle_editor_read_snapshot(&PathBuf::from(save_path), branch_id)
+    let raw = PathBuf::from(&save_path);
+    let root = saves_dir();
+    let canonical = parish_core::ipc::editor::validate_within(&raw, &root)?;
+    editor::handle_editor_read_snapshot(&canonical, branch_id)
 }

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -29,6 +29,8 @@ WORKDIR /app
 COPY --from=builder /build/target/release/parish ./
 COPY --from=frontend /build/dist ./apps/ui/dist/
 COPY mods/ ./mods/
+RUN useradd -m -u 1000 app && chown -R app:app /app
+USER app
 
 ENV RUST_LOG=info
 EXPOSE 3001


### PR DESCRIPTION
## Summary

Closes #388. Addresses four verified security bugs surfaced by a security-review sweep on this branch (3 parallel Explore agents + 2 Sonnet coding agents, triage notes in the commit body).

- **B1/B2 — Editor path traversal (High):** `/api/editor-open-mod`, `/api/editor-list-branches`, `/api/editor-list-snapshots`, and `/api/editor-read-snapshot` took a user-supplied path from the JSON body and passed it straight to the handler as a `PathBuf`. Any authenticated caller could read arbitrary SQLite or mod files on the server's filesystem. Now canonicalize + enforce containment via a new shared helper `parish_core::ipc::editor::validate_within`, mirroring the pattern from `load_branch` (closes-with #275).
- **B3 — Tauri parity (High):** the same four commands in `crates/parish-tauri/src/editor_commands.rs` had the same bug; validation added there too, using the same shared helper so mode parity (per `CLAUDE.md`) is preserved.
- **B4 — CSS injection via `loadingColor` (High):** the `loadingColor` store was a plain `writable<[number, number, number]>` set from a backend event and interpolated directly into `style="color: rgb(...)"`. A malformed or hostile tuple could break CSS parsing or enable minor style injection. Wrapped the store so every `set()` clamps each channel to `[0, 255]` integers (`NaN`/strings → 0).
- **B5 — Dockerfile runs as root (Medium):** `deploy/Dockerfile` now creates an `app` user and switches to it before `CMD`.

## Tests added

- 4 unit tests in `parish-core` covering `validate_within` (happy, `..` escape, outside-root, non-existent).
- 4 Axum integration tests in `parish-server` asserting `400 BAD_REQUEST` for `../../etc/passwd`-style input on each of the four affected routes.
- 3 Vitest cases in `apps/ui/src/stores/game.test.ts` verifying `loadingColor` clamping (out-of-range, non-numeric, fractional).

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p parish-core -p parish-server --all-targets -- -D warnings` — clean
- [x] `cargo test -p parish-core` — 223/223 pass (incl. 4 new validator tests)
- [x] `cargo test -p parish-server` — 25/25 pass (incl. 4 new route tests)
- [x] `npx vitest run` — 152/152 pass (incl. 3 new `loadingColor` tests)
- [ ] `cargo check -p parish-tauri` — **not runnable in sandbox** (GTK/pango/atk unavailable); diff reviewed manually and uses the same shared `validate_within` helper as the server routes with the same signature.
- [ ] `docker build -f deploy/Dockerfile .` — **not runnable in sandbox** (no docker daemon); Dockerfile reviewed for syntax and the `USER app` directive is placed before `CMD` with an unprivileged port.

## Follow-up issues filed

For defence-in-depth items found during the sweep but out of scope for this PR:

- #389 — missing CSP / `X-Frame-Options` / hardening response headers
- #390 — `innerHTML = ''` pattern in `InputField.svelte` (foot-gun for future XSS)
- #391 — UI state in localStorage is XSS-exfiltrable (informational)

Cross-checked against existing open issues; items already tracked by #276 (CF-Access JWT), #333 (debug-snapshot leak), #334 (shared event bus), #372 (global `EditorSession`), #373 (`/api/ui-config` leak), #377 (WS auth binding), #378 (`editor_reload` TOCTOU), #379 (loopback bypass), and #381 (rate-limiting) are **not** re-filed.

Refs #372, #378, #275.

https://claude.ai/code/session_01Vtpu2ySMJgq2U2osCFnCLG