### PR TITLE
fix: unblock Rust quality gate for Rust 1.95.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Pinned to 1.95.0 so a new stable Rust release does not silently
+      # break PRs via newly-activated clippy lints. Bump deliberately in
+      # a dedicated PR alongside any lint fixes the new version surfaces.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: rustfmt, clippy
 
@@ -94,7 +97,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,14 @@ jobs:
           cache: npm
           cache-dependency-path: apps/ui/package-lock.json
 
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.95.0
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: .
+
       - name: Install dependencies
         run: npm ci
 
@@ -176,6 +184,12 @@ jobs:
 
       - name: Install Playwright browser and deps
         run: npx playwright install --with-deps chromium
+
+      # Prebuild parish so Playwright's webServer starts under its 120s
+      # timeout — a cold `cargo run` on this job was busting the deadline.
+      - name: Prebuild parish web server binary
+        working-directory: .
+        run: cargo build -p parish
 
       - name: Run Playwright e2e
         run: npx playwright test

--- a/crates/geo-tool/src/merge.rs
+++ b/crates/geo-tool/src/merge.rs
@@ -100,15 +100,13 @@ pub fn merge_locations(
         .collect();
 
     // Reassign IDs for generated locations
-    let mut next_id = max_curated_id + 1;
     let mut id_remap: HashMap<u32, u32> = HashMap::new();
     let mut result = curated;
 
-    for mut generated_loc in filtered_generated {
+    for (next_id, mut generated_loc) in (max_curated_id + 1..).zip(filtered_generated) {
         let old_id = generated_loc.data.id.0;
         id_remap.insert(old_id, next_id);
         generated_loc.data.id = LocationId(next_id);
-        next_id += 1;
         result.push(generated_loc);
     }
 

--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -781,7 +781,7 @@ fn build_world_debug(world: &WorldState, npc_manager: &NpcManager) -> WorldDebug
             count: *count,
         })
         .collect();
-    edge_traversals.sort_by(|a, b| b.count.cmp(&a.count));
+    edge_traversals.sort_by_key(|edge| std::cmp::Reverse(edge.count));
 
     let text_log_len = world.text_log.len();
     let text_log_tail: Vec<String> = world

--- a/crates/parish-inference/src/openai_client.rs
+++ b/crates/parish-inference/src/openai_client.rs
@@ -470,10 +470,8 @@ fn parse_sse_line(line: &str) -> Option<SseData> {
     // Strip the "data: " or "data:" prefix
     let data = if let Some(d) = line.strip_prefix("data: ") {
         d
-    } else if let Some(d) = line.strip_prefix("data:") {
-        d
     } else {
-        return None;
+        line.strip_prefix("data:")?
     };
 
     let data = data.trim();

--- a/crates/parish-npc/src/memory.rs
+++ b/crates/parish-npc/src/memory.rs
@@ -316,7 +316,7 @@ impl LongTermMemory {
     /// Returns all entries for debug display, sorted newest first.
     pub fn all_entries(&self) -> Vec<&LongTermEntry> {
         let mut entries: Vec<&LongTermEntry> = self.entries.iter().collect();
-        entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.timestamp));
         entries
     }
 

--- a/crates/parish-types/src/gossip.rs
+++ b/crates/parish-types/src/gossip.rs
@@ -124,7 +124,7 @@ impl GossipNetwork {
     /// Sorted newest first.
     pub fn recent_known_by(&self, npc_id: NpcId, n: usize) -> Vec<&GossipItem> {
         let mut items: Vec<&GossipItem> = self.known_by(npc_id);
-        items.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        items.sort_by_key(|item| std::cmp::Reverse(item.timestamp));
         items.truncate(n);
         items
     }


### PR DESCRIPTION
## Summary

Rust 1.95.0 stable was released today (2026-04-16). CI used `dtolnay/rust-toolchain@stable` (unpinned), so the `rust-quality-gate` job started pulling 1.95.0 the moment it went live and began failing on newly-promoted clippy lints in pre-existing code. The `rust-multi-channel` matrix job kept passing because it runs `cargo check`, not `cargo clippy --all-targets -- -D warnings` — so unrelated UI-only PRs (e.g. [#386](https://github.com/dmooney/Parish/pull/386), [#387](https://github.com/dmooney/Parish/pull/387)) suddenly went red on a gate whose failure had nothing to do with their diff.

### Diagnosis timeline (same workspace HEAD `525e0ac`, only docs changes since [#356](https://github.com/dmooney/Parish/pull/356))

| When (UTC) | PR | Quality gate | Matrix (stable) |
| --- | --- | --- | --- |
| 2026-04-16 12:28 | #383 (last code-touching CI before release) | ✅ pass | ✅ pass |
| 2026-04-16 14:03 | #386 (UI-only) | ❌ fail in 1m44s | ✅ pass |
| 2026-04-16 14:14 | #387 (UI-only) | ❌ fail in 1m44s | ✅ pass |

Local repro against `rustc 1.95.0 (59807616e 2026-04-14)` surfaces five warnings, all in code untouched by the red PRs:

- `clippy::unnecessary_sort_by` — `parish-types/gossip.rs:127`, `parish-npc/memory.rs:319`, `parish-core/debug_snapshot.rs:784`
- `clippy::question_mark` — `parish-inference/openai_client.rs:473`
- `clippy::explicit_counter_loop` — `geo-tool/merge.rs:107`

### Fixes in this PR

- **`clippy::unnecessary_sort_by`** (3 files): rewrite `sort_by(|a, b| b.field.cmp(&a.field))` as `sort_by_key(|x| std::cmp::Reverse(x.field))`. Same sort order, one heap-free closure instead of two-argument comparison.
- **`clippy::question_mark`** (`parish-inference/openai_client.rs`): collapse `else if let Some(d) = line.strip_prefix("data:") { d } else { return None }` into `line.strip_prefix("data:")?`. The outer function already returns `Option<SseData>`, so `?` short-circuits correctly.
- **`clippy::explicit_counter_loop`** (`geo-tool/merge.rs`): replace the `let mut next_id = start; for x in xs { ...; next_id += 1; }` hand-rolled counter with `for (next_id, x) in (start..).zip(xs)`.

### Guard against the next stable release

Pin `dtolnay/rust-toolchain` to `1.95.0` in `rust-quality-gate` and `game-harness` jobs. The next Rust release is then a deliberate, reviewed bump in a dedicated PR — not a surprise red CI on a docs-only change to `main`. The `rust-multi-channel` job intentionally stays unpinned on `stable`/`beta` so it keeps serving as an upstream canary.

## Test plan

- [x] `cargo +1.95.0 fmt --all --check` — clean
- [x] `cargo +1.95.0 clippy --workspace --exclude parish-tauri --all-targets -- -D warnings` — clean (`parish-tauri` requires `libgtk-3-dev`/`libwebkit2gtk-4.1-dev` which I couldn't install in this sandbox; Rust channel matrix job already confirms parish-tauri compiles under 1.95, and the failing job dies before reaching parish-tauri in the compile order)
- [x] `cargo +1.95.0 test --workspace --exclude parish-tauri --all-targets` — 1741+ tests pass, zero failures, zero warnings
- [x] `cargo +1.94.1` clippy + test on the same set — also clean (fix is compatible with the previous stable in case anyone hasn't run `rustup update` yet)
- [ ] CI verifies parish-tauri clippy + test + game-harness fixture sweep on 1.95.0
- [ ] Rebase one of the UI-only red PRs (#386 or #387) onto this branch and confirm Rust quality gate goes green