### PR TITLE
fix: patch rustls-webpki CVEs and schedule cargo audit in CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,50 @@
+name: Security audit
+
+on:
+  # Daily sweep catches newly-published advisories against existing deps.
+  # Offset minute to avoid top-of-hour runner contention.
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+  # Re-audit immediately when the dependency tree changes on main, so we
+  # don't wait up to 24h to notice a bad lockfile bump.
+  push:
+    branches: [main]
+    paths:
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'crates/**/Cargo.toml'
+      - '.github/workflows/audit.yml'
+
+concurrency:
+  group: audit-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-audit:
+    name: cargo audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Pinned to match rust-quality-gate in ci.yml. Bump deliberately.
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.95.0
+
+      # Caches ~/.cargo/bin so cargo-audit does not recompile each run.
+      # cache-targets: false — there is no workspace target/ to preserve.
+      - name: Cache cargo-audit binary and advisory DB
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+          shared-key: audit
+
+      - name: Install cargo-audit
+        run: cargo install --locked cargo-audit
+
+      - name: Run cargo audit
+        run: cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3765,9 +3765,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Bumped \`rustls-webpki\` 0.103.9 → 0.103.12, clearing RUSTSEC-2026-0098, RUSTSEC-2026-0099, and RUSTSEC-2026-0049 pulled in transitively via \`rustls\` / \`reqwest\`. \`just audit\` exits 0 after the bump.
- Added \`.github/workflows/audit.yml\` — runs \`cargo audit\` on daily cron (06:17 UTC), on \`Cargo.lock\` / \`Cargo.toml\` push to \`main\`, and via \`workflow_dispatch\`. Scheduled rather than per-PR so unrelated advisories don't block unrelated PRs.

## Test plan
- [x] \`just audit\` — exit 0; 0 errors; 23 pre-existing unmaintained/unsound warnings unchanged
- [x] \`just check\` — fmt + clippy + full workspace tests green
- [ ] Confirm first scheduled run (or \`workflow_dispatch\`) of the new audit workflow succeeds on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)