### PR TITLE
feat: add /unexplored slash command to reveal/hide unexplored map locations

### DIFF
--- a/crates/parish-cli/src/app.rs
+++ b/crates/parish-cli/src/app.rs
@@ -99,6 +99,8 @@ pub struct App {
     pub pronunciation_hints: Vec<LanguageHint>,
     /// Whether improv craft mode is enabled for NPC dialogue.
     pub improv_enabled: bool,
+    /// Whether map APIs should reveal all unexplored locations.
+    pub reveal_unexplored_locations: bool,
     /// Whether the debug sidebar panel is visible.
     pub debug_sidebar_visible: bool,
     /// Active debug panel tab index (0=Overview, 1=NPCs, 2=World, 3=Events, 4=Inference).
@@ -196,6 +198,7 @@ impl App {
             sidebar_visible: false,
             pronunciation_hints: Vec::new(),
             improv_enabled: false,
+            reveal_unexplored_locations: false,
             debug_sidebar_visible: false,
             debug_tab: 0,
             debug_selected_npc: None,
@@ -368,6 +371,7 @@ impl App {
             cloud_api_key: self.cloud_api_key.clone(),
             cloud_base_url: self.cloud_base_url.clone(),
             improv_enabled: self.improv_enabled,
+            reveal_unexplored_locations: self.reveal_unexplored_locations,
             max_follow_up_turns: 2,
             idle_banter_after_secs: 25,
             auto_pause_after_secs: 60,
@@ -405,6 +409,7 @@ impl App {
         self.cloud_api_key = cfg.cloud_api_key.clone();
         self.cloud_base_url = cfg.cloud_base_url.clone();
         self.improv_enabled = cfg.improv_enabled;
+        self.reveal_unexplored_locations = cfg.reveal_unexplored_locations;
         self.flags = cfg.flags.clone();
 
         // Apply per-category overrides
@@ -447,6 +452,7 @@ mod tests {
         assert_eq!(app.scroll.offset, 0);
         assert!(!app.sidebar_visible);
         assert!(!app.improv_enabled);
+        assert!(!app.reveal_unexplored_locations);
         assert!(app.pronunciation_hints.is_empty());
         assert_eq!(app.idle_counter, 0);
     }

--- a/crates/parish-cli/tests/game_harness_integration.rs
+++ b/crates/parish-cli/tests/game_harness_integration.rs
@@ -464,6 +464,7 @@ fn test_fog_of_war_frontier_at_pub() {
     let map = build_map_data(
         &h.app.world,
         &parish_core::world::transport::TransportMode::walking(),
+        false,
     );
 
     // The player is at the pub

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -150,6 +150,10 @@ const HELP_ENTRIES: &[(&str, &str)] = &[
     ),
     ("/status", "Where am I?"),
     ("/time", "Time, weather, and season details"),
+    (
+        "/unexplored [reveal|hide]",
+        "Reveal or hide all unexplored locations",
+    ),
     ("/wait [minutes]", "Wait in place (default: 15 min)"),
 ];
 
@@ -495,6 +499,7 @@ pub fn handle_command(
         Command::Branches => CommandResult::effect_only(CommandEffect::ListBranches),
         Command::Log => CommandResult::effect_only(CommandEffect::ShowLog),
         Command::Map(arg) => handle_map_command(config, arg),
+        Command::Unexplored(arg) => handle_unexplored_command(config, arg),
         Command::Designer => CommandResult::effect_only(CommandEffect::OpenDesigner),
         Command::Debug(sub) => CommandResult::effect_only(CommandEffect::Debug(sub)),
         Command::Spinner(secs) => CommandResult::effect_only(CommandEffect::ShowSpinner(secs)),
@@ -543,6 +548,33 @@ pub fn handle_command(
                 }
             }
         },
+    }
+}
+
+/// Handles the `/unexplored` command (reveal/hide all unexplored map locations).
+fn handle_unexplored_command(config: &mut GameConfig, arg: Option<bool>) -> CommandResult {
+    match arg {
+        Some(true) => {
+            config.reveal_unexplored_locations = true;
+            CommandResult::text(
+                "All unexplored locations are now revealed on the map (still marked unvisited).",
+            )
+        }
+        Some(false) => {
+            config.reveal_unexplored_locations = false;
+            CommandResult::text("Unexplored locations are hidden again (fog-of-war frontier only).")
+        }
+        None => {
+            let status = if config.reveal_unexplored_locations {
+                "revealed"
+            } else {
+                "hidden"
+            };
+            CommandResult::text(format!(
+                "Unexplored locations are currently {}.\nUsage: /unexplored reveal|hide",
+                status
+            ))
+        }
     }
 }
 
@@ -1447,6 +1479,45 @@ mod tests {
         let (mut world, mut npc, mut config) = default_state();
         let result = handle_command(Command::Help, &mut world, &mut npc, &mut config);
         assert!(result.response.contains("/map"));
+        assert!(result.response.contains("/unexplored"));
+    }
+
+    #[test]
+    fn unexplored_reveal_updates_config() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Unexplored(Some(true)),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(config.reveal_unexplored_locations);
+        assert!(result.response.contains("revealed"));
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn unexplored_hide_updates_config() {
+        let (mut world, mut npc, mut config) = default_state();
+        config.reveal_unexplored_locations = true;
+        let result = handle_command(
+            Command::Unexplored(Some(false)),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(!config.reveal_unexplored_locations);
+        assert!(result.response.contains("hidden"));
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn unexplored_none_reports_status_and_usage() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Unexplored(None), &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("currently hidden"));
+        assert!(result.response.contains("/unexplored reveal|hide"));
+        assert!(result.effects.is_empty());
     }
 
     #[test]

--- a/crates/parish-core/src/ipc/config.rs
+++ b/crates/parish-core/src/ipc/config.rs
@@ -65,6 +65,12 @@ pub struct GameConfig {
     /// so the `/tiles` command handler can list and validate without taking
     /// a reference to the whole engine config.
     pub tile_sources: Vec<(String, String)>,
+    /// Whether the map should reveal all unexplored locations.
+    ///
+    /// When `false` (default), fog-of-war shows only visited locations and the
+    /// immediate frontier. When `true`, all graph nodes are shown with
+    /// unvisited locations still marked `visited: false`.
+    pub reveal_unexplored_locations: bool,
 }
 
 impl GameConfig {
@@ -163,6 +169,7 @@ impl Default for GameConfig {
             category_rate_limit: Default::default(),
             active_tile_source: String::new(),
             tile_sources: Vec::new(),
+            reveal_unexplored_locations: false,
         }
     }
 }
@@ -182,6 +189,7 @@ mod tests {
         assert_eq!(c.auto_pause_after_secs, 60);
         assert!(c.active_tile_source.is_empty());
         assert!(c.tile_sources.is_empty());
+        assert!(!c.reveal_unexplored_locations);
     }
 
     #[test]

--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -72,7 +72,11 @@ pub fn snapshot_from_world(world: &WorldState, _transport: &TransportMode) -> Wo
 /// adjacent to any visited location — also appears so the player can see
 /// where they could explore next. Frontier locations are marked with
 /// `visited: false` and have limited tooltip data.
-pub fn build_map_data(world: &WorldState, transport: &TransportMode) -> MapData {
+pub fn build_map_data(
+    world: &WorldState,
+    transport: &TransportMode,
+    reveal_unexplored_locations: bool,
+) -> MapData {
     let speed_m_per_s = transport.speed_m_per_s;
     let player_loc = world.player_location;
     let visited = &world.visited_locations;
@@ -90,12 +94,21 @@ pub fn build_map_data(world: &WorldState, transport: &TransportMode) -> MapData 
     // location at once, instead of running a separate BFS per visited location.
     let travel_time_map = world.graph.travel_times_from(player_loc, speed_m_per_s);
 
-    // Frontier: unvisited locations that neighbor at least one visited location
+    // Frontier: by default only unvisited locations neighboring the visited set.
+    // With reveal mode enabled, include all unvisited locations.
     let mut frontier: HashSet<LocationId> = HashSet::new();
-    for &v in visited {
-        for (neighbor_id, _) in world.graph.neighbors(v) {
-            if !visited.contains(&neighbor_id) {
-                frontier.insert(neighbor_id);
+    if reveal_unexplored_locations {
+        for id in world.graph.location_ids() {
+            if !visited.contains(&id) {
+                frontier.insert(id);
+            }
+        }
+    } else {
+        for &v in visited {
+            for (neighbor_id, _) in world.graph.neighbors(v) {
+                if !visited.contains(&neighbor_id) {
+                    frontier.insert(neighbor_id);
+                }
             }
         }
     }
@@ -778,7 +791,7 @@ mod tests {
     #[test]
     fn build_map_data_from_default_world() {
         let world = WorldState::new();
-        let map = build_map_data(&world, &TransportMode::walking());
+        let map = build_map_data(&world, &TransportMode::walking(), false);
         assert!(!map.player_location.is_empty());
         // At least the player's location should exist
         assert!(
@@ -795,7 +808,7 @@ mod tests {
             let start = world.player_location;
             let neighbor_count = world.graph.neighbors(start).len();
 
-            let map = build_map_data(&world, &TransportMode::walking());
+            let map = build_map_data(&world, &TransportMode::walking(), false);
 
             // Start location (visited) + its neighbors (frontier)
             assert_eq!(
@@ -854,7 +867,7 @@ mod tests {
             let neighbors = world.graph.neighbors(start);
             if let Some((neighbor_id, _)) = neighbors.first() {
                 world.mark_visited(*neighbor_id);
-                let map = build_map_data(&world, &TransportMode::walking());
+                let map = build_map_data(&world, &TransportMode::walking(), false);
 
                 // Visited locations should have visited=true
                 let visited: Vec<_> = map.locations.iter().filter(|l| l.visited).collect();
@@ -875,6 +888,25 @@ mod tests {
                     "frontier should appear unless all neighbors are visited"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn reveal_unexplored_shows_entire_graph_as_frontier_plus_visited() {
+        use crate::game_mod::{GameMod, find_default_mod};
+        if let Some(mod_dir) = find_default_mod() {
+            let game_mod = GameMod::load(&mod_dir).expect("should load default mod");
+            let world = crate::game_mod::world_state_from_mod(&game_mod).expect("world from mod");
+            let full_count = world.graph.location_ids().len();
+            let visited_count = world.visited_locations.len();
+
+            let map = build_map_data(&world, &TransportMode::walking(), true);
+            assert_eq!(map.locations.len(), full_count);
+
+            let visited_rendered = map.locations.iter().filter(|l| l.visited).count();
+            let frontier_rendered = map.locations.iter().filter(|l| !l.visited).count();
+            assert_eq!(visited_rendered, visited_count);
+            assert_eq!(visited_rendered + frontier_rendered, full_count);
         }
     }
 
@@ -991,7 +1023,7 @@ mod tests {
                 world.record_path_traversal(&[start, neighbor_id]);
                 world.mark_visited(neighbor_id);
 
-                let map = build_map_data(&world, &TransportMode::walking());
+                let map = build_map_data(&world, &TransportMode::walking(), false);
                 assert!(
                     !map.edge_traversals.is_empty(),
                     "should include edge traversals"

--- a/crates/parish-input/src/lib.rs
+++ b/crates/parish-input/src/lib.rs
@@ -115,6 +115,12 @@ pub enum Command {
     Tick,
     /// Show or change the UI theme.
     Theme(Option<String>),
+    /// Show or set whether unexplored map locations are fully revealed.
+    ///
+    /// `None` reports current usage/status text.
+    /// `Some(true)` reveals all unexplored locations.
+    /// `Some(false)` restores normal fog-of-war frontier visibility.
+    Unexplored(Option<bool>),
     /// Invalid branch name was provided.
     InvalidBranchName(String),
     /// Feature flag management (`/flag enable|disable|list <name>`).
@@ -322,6 +328,19 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
             Some(Command::Theme(None))
         } else {
             Some(Command::Theme(Some(arg)))
+        }
+    } else if lower == "/unexplored" {
+        Some(Command::Unexplored(None))
+    } else if lower.starts_with("/unexplored ") {
+        let arg = trimmed
+            .get("/unexplored ".len()..)
+            .unwrap_or("")
+            .trim()
+            .to_lowercase();
+        match arg.as_str() {
+            "reveal" | "show" | "on" => Some(Command::Unexplored(Some(true))),
+            "hide" | "off" => Some(Command::Unexplored(Some(false))),
+            _ => Some(Command::Unexplored(None)),
         }
     } else if let Some(cmd) = parse_category_command(trimmed, &lower) {
         Some(cmd)
@@ -1417,6 +1436,34 @@ mod tests {
         assert_eq!(
             parse_system_command("/THEME Solarized Dark"),
             Some(Command::Theme(Some("Solarized Dark".to_string())))
+        );
+    }
+
+    #[test]
+    fn test_parse_unexplored_command() {
+        assert_eq!(
+            parse_system_command("/unexplored"),
+            Some(Command::Unexplored(None))
+        );
+        assert_eq!(
+            parse_system_command("/unexplored reveal"),
+            Some(Command::Unexplored(Some(true)))
+        );
+        assert_eq!(
+            parse_system_command("/unexplored hide"),
+            Some(Command::Unexplored(Some(false)))
+        );
+        assert_eq!(
+            parse_system_command("/unexplored on"),
+            Some(Command::Unexplored(Some(true)))
+        );
+        assert_eq!(
+            parse_system_command("/unexplored off"),
+            Some(Command::Unexplored(Some(false)))
+        );
+        assert_eq!(
+            parse_system_command("/unexplored whatever"),
+            Some(Command::Unexplored(None))
         );
     }
 

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -341,6 +341,7 @@ fn build_client_and_config() -> (
         // Tile-source fields populated in build_app_state from engine config.
         active_tile_source: String::new(),
         tile_sources: Vec::new(),
+        reveal_unexplored_locations: false,
     };
 
     (client, config)

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -60,8 +60,13 @@ pub async fn get_world_snapshot(Extension(state): Extension<Arc<AppState>>) -> J
 /// `GET /api/map` — returns visited locations, edges, and player position.
 pub async fn get_map(Extension(state): Extension<Arc<AppState>>) -> Json<MapData> {
     let world = state.world.lock().await;
+    let config = state.config.lock().await;
     let transport = state.transport.default_mode();
-    Json(parish_core::ipc::build_map_data(&world, transport))
+    Json(parish_core::ipc::build_map_data(
+        &world,
+        transport,
+        config.reveal_unexplored_locations,
+    ))
 }
 
 /// `GET /api/npcs-here` — returns NPCs at the player's current location.
@@ -1891,6 +1896,7 @@ pub(crate) mod tests {
                 category_rate_limit: [None, None, None, None],
                 active_tile_source: String::new(),
                 tile_sources: Vec::new(),
+                reveal_unexplored_locations: false,
             },
             None,
             transport,

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -118,8 +118,10 @@ pub async fn get_world_snapshot(
 #[tauri::command]
 pub async fn get_map(state: tauri::State<'_, Arc<AppState>>) -> Result<MapData, String> {
     let world = state.world.lock().await;
+    let config = state.config.lock().await;
     let transport = state.transport.default_mode();
-    let core_map = parish_core::ipc::build_map_data(&world, transport);
+    let core_map =
+        parish_core::ipc::build_map_data(&world, transport, config.reveal_unexplored_locations);
 
     let player_loc = world.player_location;
     let (player_lat, player_lon) = world

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -619,6 +619,7 @@ pub fn run() {
             category_rate_limit: [None, None, None, None],
             active_tile_source,
             tile_sources: engine_config.map.id_label_pairs(),
+            reveal_unexplored_locations: false,
         }),
     });
 

--- a/testing/fixtures/play_prove.txt
+++ b/testing/fixtures/play_prove.txt
@@ -1,46 +1,8 @@
-# Prove: NPC conversation awareness — witness memories and conversation log
-# Goal: Talk to one NPC while another is present, then verify
-# the bystander has a memory of the overheard conversation.
+# Prove: /unexplored slash command toggles reveal mode for map visibility.
+# Goal: verify command responses for status, reveal, and hide.
 
-# Go to Darcy's Pub — Padraig and Niamh are both there
-go to Darcy's Pub
-
-# Confirm both NPCs are here
-/npcs
-
-# Check initial memory state — should be empty
-/debug memory Padraig Darcy
-/debug memory Niamh Darcy
-
-# Stub a response for Padraig (first NPC at location)
-/stub Padraig Darcy: Ah, dia dhuit! A fine soft day, isn't it? The roads are quiet this morning.
-
-# Talk to Padraig — Niamh should overhear this
-Tell me about the morning
-
-# CRITICAL CHECK: Niamh should now have an "Overheard" witness memory
-/debug memory Niamh Darcy
-
-# And Padraig should have his own memory of the conversation
-/debug memory Padraig Darcy
-
-# Now stub a response for Niamh and talk to her
-/stub Niamh Darcy: You've met my father already? He does love to talk. Welcome to Kilteevan!
-
-# Talk to Niamh — she should reference what she overheard
-Tell me about yourself
-
-# CRITICAL CHECK: Padraig should now have a witness memory of this exchange
-/debug memory Padraig Darcy
-
-# And Niamh should have both: her witness memory AND her own conversation memory
-/debug memory Niamh Darcy
-
-# Third exchange: stub Padraig again — he should be in continuity
-/stub Padraig Darcy: She's a sharp one, my Niamh. But she's right — what brings ye here?
-
-Hello again Padraig
-
-# Final memory check — both should have rich memory logs
-/debug memory Padraig Darcy
-/debug memory Niamh Darcy
+/unexplored
+/unexplored reveal
+/unexplored
+/unexplored hide
+/unexplored


### PR DESCRIPTION
### Motivation
- Provide a simple runtime toggle to reveal or hide all unexplored map locations (useful for designers, debugging, and players who want full visibility of the graph). 

### Description
- Add a new `Command::Unexplored(Option<bool>)` variant and parser support for `/unexplored`, `/unexplored reveal` (or `show/on`) and `/unexplored hide` (or `off`) in `crates/parish-input/src/lib.rs` with unit tests.  
- Implement `handle_unexplored_command` in `crates/parish-core/src/ipc/commands.rs` and wire it into `handle_command`, including help text and status responses.  
- Add a runtime config flag `reveal_unexplored_locations: bool` to `parish_core::ipc::GameConfig` (default `false`) and propagate it through backend initialisation (server/Tauri) and the CLI `App` snapshot/apply flow.  
- Extend `build_map_data` in `crates/parish-core/src/ipc/handlers.rs` to accept `reveal_unexplored_locations` and, when enabled, include all unvisited graph nodes as the frontier (locations still marked `visited: false`).  
- Wire the flag into server and Tauri map endpoints so frontends receive the adjusted `MapData`.  
- Update headless CLI state (`crates/parish-cli/src/app.rs`) to store and round-trip the new flag via `snapshot_config`/`apply_config`.  
- Add/update tests: parser tests, command handler tests, `build_map_data` unit test for full-graph reveal, adjust harness integration call sites, and add a prove script at `testing/fixtures/play_prove.txt` exercising the runtime commands.  

### Testing
- Ran formatting with `cargo fmt`. (succeeded)  
- Unit tests: `cargo test -p parish-input -p parish-core --lib` (all tests passed).  
- Integration: `cargo test -p parish --test game_harness_integration test_fog_of_war_frontier_at_pub` (passed).  
- Runtime prove script: `cargo run -- --script testing/fixtures/play_prove.txt` was executed and produced the expected `/unexplored` status, `reveal`, and `hide` responses. (observed success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19f9dcaa48325b5a28c5ec850ec86)