### PR TITLE
fix(ui): restore MapLibre location icons, travel-edge highlight, and lit glow

### DIFF
--- a/apps/ui/src/components/FullMapOverlay.svelte
+++ b/apps/ui/src/components/FullMapOverlay.svelte
@@ -176,26 +176,28 @@
 		width: 100%;
 	}
 
-	/* ── Travel animation dot (HTML marker) ── */
+	/* ── Travel animation dot (HTML marker) ──
+	   Animating `transform` would clobber the `translate(…)` MapLibre sets
+	   each frame to position the marker, collapsing it to the canvas
+	   top-left. Pulse via opacity + box-shadow only. */
 	:global(.travel-dot-marker) {
 		width: 14px;
 		height: 14px;
 		border-radius: 50%;
 		background: var(--color-accent);
 		border: 2px solid var(--color-fg);
-		box-shadow: 0 0 8px var(--color-accent);
 		animation: travel-pulse 0.6s ease-in-out infinite alternate;
 		pointer-events: none;
 	}
 
 	@keyframes travel-pulse {
 		from {
-			opacity: 0.8;
-			transform: scale(0.9);
+			opacity: 0.85;
+			box-shadow: 0 0 4px var(--color-accent);
 		}
 		to {
 			opacity: 1;
-			transform: scale(1.1);
+			box-shadow: 0 0 12px var(--color-accent);
 		}
 	}
 

--- a/apps/ui/src/components/MapPanel.svelte
+++ b/apps/ui/src/components/MapPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { mapData, fullMapOpen, pushErrorLog, formatIpcError } from '../stores/game';
 	import { travelState } from '../stores/travel';
 	import { tiles, currentTileSource } from '../stores/tiles';
@@ -189,12 +189,20 @@
 	});
 
 	// Push map data changes into the controller and reframe the camera.
+	//
+	// `$mapData` updates every game tick (NPC movement, clock, etc.), so we
+	// skip the instantaneous `fitBounds` call while travel is animating —
+	// otherwise the minimap re-centers on the player's origin between ticks,
+	// pinning the travel dot near the viewport center even though it's
+	// sliding correctly in world coordinates.
 	$effect(() => {
 		if (!mounted || !controller) return;
 		const m = $mapData;
 		if (!m) return;
 		const visible = visibleIdSet(m.locations);
 		controller.updateMap(m, visible);
+
+		if ($travelState) return;
 
 		const player = m.locations.find((l) => l.id === m.player_location);
 		if (!player) return;
@@ -208,15 +216,45 @@
 	});
 
 	// Drive travel animation from the shared travel store.
+	//
+	// `destinationBounds` reads `$mapData`, but we wrap it in `untrack` so
+	// the effect only runs on `$travelState` transitions — without this,
+	// every mapData tick during travel restarts the animation.
 	$effect(() => {
 		if (!mounted || !controller) return;
 		const ts = $travelState;
 		if (ts) {
-			controller.startTravel(ts.waypoints, ts.animationMs);
+			const bounds = untrack(() => destinationBounds(ts.destination));
+			controller.startTravel(ts.waypoints, ts.animationMs, bounds);
 		} else {
 			controller.stopTravel();
 		}
 	});
+
+	/**
+	 * Builds the bounding box we want the minimap to settle into once the
+	 * player arrives at `destId`. We use the same player-centered algorithm
+	 * the `$mapData` effect uses — just evaluated against the destination's
+	 * neighbors (looked up from the current graph) rather than the current
+	 * player's. Passing this to `startTravel` lets the camera smoothly
+	 * interpolate both center AND zoom over the animation window, so the
+	 * post-travel view is already in place when the dot arrives.
+	 */
+	function destinationBounds(
+		destId: string
+	): Array<{ lat: number; lon: number }> | undefined {
+		const m = $mapData;
+		if (!m) return undefined;
+		const dest = m.locations.find((l) => l.id === destId);
+		if (!dest) return undefined;
+		const neighborIds = new Set<string>();
+		for (const [a, b] of m.edges) {
+			if (a === destId) neighborIds.add(b);
+			else if (b === destId) neighborIds.add(a);
+		}
+		const neighbors = m.locations.filter((l) => neighborIds.has(l.id));
+		return computePlayerCenteredBounds(dest, neighbors);
+	}
 
 	// Keep minimap base tiles in sync with `/tiles` selection.
 	$effect(() => {
@@ -344,6 +382,33 @@
 		stroke-width: 1.2;
 		opacity: 0.5;
 		stroke-dasharray: 3 2;
+	}
+
+	/* Travel animation dot — also defined in FullMapOverlay.svelte; mirrored
+	   here because Svelte scopes :global styles to the mounting component,
+	   so the minimap needs its own copy when the full map isn't open.
+	   The pulse animates opacity + box-shadow only; animating `transform`
+	   would clobber the `translate(…)` MapLibre sets each frame to position
+	   the marker, collapsing it to the canvas top-left. */
+	:global(.travel-dot-marker) {
+		width: 14px;
+		height: 14px;
+		border-radius: 50%;
+		background: var(--color-accent);
+		border: 2px solid var(--color-fg);
+		animation: travel-pulse 0.6s ease-in-out infinite alternate;
+		pointer-events: none;
+	}
+
+	@keyframes travel-pulse {
+		from {
+			opacity: 0.85;
+			box-shadow: 0 0 4px var(--color-accent);
+		}
+		to {
+			opacity: 1;
+			box-shadow: 0 0 12px var(--color-accent);
+		}
 	}
 
 	.tooltip-unexplored {

--- a/apps/ui/src/components/MapPanel.test.ts
+++ b/apps/ui/src/components/MapPanel.test.ts
@@ -29,6 +29,10 @@ vi.mock('maplibre-gl', () => {
 		fitBounds() {}
 		addControl() {}
 		removeControl() {}
+		hasImage() {
+			return false;
+		}
+		addImage() {}
 	}
 	class FakeMarker {
 		setLngLat() {

--- a/apps/ui/src/lib/map/controller.ts
+++ b/apps/ui/src/lib/map/controller.ts
@@ -95,6 +95,19 @@ export class MapController {
 	private hoverLeaveHandler: (() => void) | null = null;
 	/** Current tile source, mirrored so `setTileSource` can rebuild the style. */
 	private tileSource: TileSource | undefined;
+	/** Whether layer-delegated event handlers are currently attached. MapLibre
+	 *  stores per-layer delegated listeners on the map instance itself, so
+	 *  they survive `setStyle()` — if we call `wireLayerEvents` twice without
+	 *  tearing the previous set down first, every click fires N handlers and
+	 *  the same `submitInput` runs N times. */
+	private layerEventsWired = false;
+	private layerClickHandler:
+		| ((e: MapMouseEvent & { features?: MapGeoJSONFeature[] }) => void)
+		| null = null;
+	private layerMouseEnterHandler:
+		| ((e: MapMouseEvent & { features?: MapGeoJSONFeature[] }) => void)
+		| null = null;
+	private layerMouseLeaveHandler: (() => void) | null = null;
 
 	constructor(options: MapControllerOptions) {
 		this.variant = options.variant;
@@ -217,12 +230,26 @@ export class MapController {
 
 	/**
 	 * Starts (or updates) a travel-dot animation along the given waypoints.
-	 * Creates an HTMLMarker with a pulsing dot element; on each frame the
-	 * marker's lat/lon is interpolated between consecutive waypoints.
+	 *
+	 * The dot is placed at the first waypoint and the camera animates toward
+	 * the destination over `durationMs`. Callers that pass `targetBounds`
+	 * (the minimap, typically the destination's neighborhood box) get a
+	 * `fitBounds` — so both center and zoom interpolate smoothly in-flight
+	 * and the post-travel fitBounds has nothing left to snap. Without
+	 * target bounds we fall back to a straight `easeTo` on the last waypoint,
+	 * preserving zoom (used by the full-map overlay).
+	 *
+	 * On each animation frame we sync the marker's world position to the
+	 * camera's current center so the dot reads as a follow-cam — the
+	 * traveller stays at screen center while the map tiles scroll beneath.
 	 *
 	 * Call `stopTravel()` when the animation should end.
 	 */
-	startTravel(waypoints: TravelWaypoint[], durationMs: number): void {
+	startTravel(
+		waypoints: TravelWaypoint[],
+		durationMs: number,
+		targetBounds?: Array<{ lat: number; lon: number }>
+	): void {
 		this.stopTravel();
 		if (waypoints.length < 2) return;
 		this.activeTravelEdgeKeys = buildTravelEdgeKeys(waypoints);
@@ -237,21 +264,29 @@ export class MapController {
 			.setLngLat([waypoints[0].lon, waypoints[0].lat])
 			.addTo(this.map);
 
-		const startTs = performance.now();
-		const segCount = waypoints.length - 1;
+		if (targetBounds && targetBounds.length > 0) {
+			const bounds = new LngLatBounds();
+			for (const c of targetBounds) bounds.extend([c.lon, c.lat]);
+			this.map.fitBounds(bounds, {
+				padding: 16,
+				maxZoom: 16,
+				duration: durationMs,
+				easing: (t) => t,
+				linear: true
+			});
+		} else {
+			const last = waypoints[waypoints.length - 1];
+			this.map.easeTo({
+				center: [last.lon, last.lat],
+				duration: durationMs,
+				easing: (t) => t,
+				animate: true
+			});
+		}
 
 		const tick = () => {
-			const now = performance.now();
-			const t = Math.min(1, Math.max(0, (now - startTs) / durationMs));
-			const segFloat = t * segCount;
-			const segIdx = Math.min(Math.floor(segFloat), segCount - 1);
-			const segT = segFloat - segIdx;
-			const from = waypoints[segIdx];
-			const to = waypoints[segIdx + 1];
-			const lat = from.lat + (to.lat - from.lat) * segT;
-			const lon = from.lon + (to.lon - from.lon) * segT;
-			marker.setLngLat([lon, lat]);
-			if (t < 1 && this.travelAnim) {
+			marker.setLngLat(this.map.getCenter());
+			if (this.travelAnim) {
 				this.travelAnim.rafId = requestAnimationFrame(tick);
 			}
 		};
@@ -308,12 +343,17 @@ export class MapController {
 	}
 
 	/**
-	 * Wires click & hover listeners onto the `location-circles` layer once
-	 * the map has finished loading. A single layer handles both the visual
-	 * and the hit-testing — clicks on the invisible-at-zoom labels still
-	 * fall through to this because the circle sits beneath.
+	 * Wires click & hover listeners onto the location layers.
+	 *
+	 * Called on first `load` and again after every `setStyle` (which wipes
+	 * layers but NOT MapLibre's `_delegatedListeners` map). We stash the
+	 * bound handler refs and tear them down before re-adding — otherwise
+	 * each `setTileSource` call stacks another handler and every click
+	 * fires `submitInput` N times.
 	 */
 	private wireLayerEvents(): void {
+		this.unwireLayerEvents();
+
 		const canvas = this.map.getCanvas();
 
 		const handleClick = (e: MapMouseEvent & { features?: MapGeoJSONFeature[] }) => {
@@ -348,10 +388,33 @@ export class MapController {
 			this.hoverLeaveHandler?.();
 		};
 
+		this.layerClickHandler = handleClick;
+		this.layerMouseEnterHandler = handleMouseEnter;
+		this.layerMouseLeaveHandler = handleMouseLeave;
+
 		this.map.on('click', 'location-circles', handleClick);
 		this.map.on('click', 'location-labels', handleClick);
 		this.map.on('mouseenter', 'location-circles', handleMouseEnter);
 		this.map.on('mouseleave', 'location-circles', handleMouseLeave);
+		this.layerEventsWired = true;
+	}
+
+	private unwireLayerEvents(): void {
+		if (!this.layerEventsWired) return;
+		if (this.layerClickHandler) {
+			this.map.off('click', 'location-circles', this.layerClickHandler);
+			this.map.off('click', 'location-labels', this.layerClickHandler);
+		}
+		if (this.layerMouseEnterHandler) {
+			this.map.off('mouseenter', 'location-circles', this.layerMouseEnterHandler);
+		}
+		if (this.layerMouseLeaveHandler) {
+			this.map.off('mouseleave', 'location-circles', this.layerMouseLeaveHandler);
+		}
+		this.layerClickHandler = null;
+		this.layerMouseEnterHandler = null;
+		this.layerMouseLeaveHandler = null;
+		this.layerEventsWired = false;
 	}
 }
 
@@ -386,23 +449,26 @@ function registerLocationIcons(map: MapLibreMap): void {
 	for (const [icon, path] of Object.entries(ICON_PATHS) as Array<[LocationIcon, string]>) {
 		const imageId = `icon-${icon}`;
 		if (map.hasImage(imageId)) continue;
-		map.addImage(imageId, drawIconImage(path), { sdf: true });
+		const image = drawIconImage(path);
+		if (!image) continue;
+		map.addImage(imageId, image, { sdf: true });
 	}
 }
 
-function drawIconImage(pathData: string): ImageData {
+// Returns null when the host lacks a usable 2D canvas (jsdom in unit tests).
+// Real browsers always provide one; MapLibre then falls back to a square
+// placeholder for `icon-image: icon-…` which keeps the rest of the style
+// valid rather than hard-failing the test render.
+function drawIconImage(pathData: string): ImageData | null {
 	const size = 64;
 	const canvas = document.createElement('canvas');
 	canvas.width = size;
 	canvas.height = size;
 	const ctx = canvas.getContext('2d');
-	if (!ctx) {
-		throw new Error('Could not initialize icon canvas context');
-	}
+	if (!ctx || typeof Path2D === 'undefined') return null;
 	ctx.clearRect(0, 0, size, size);
 	ctx.fillStyle = '#ffffff';
-	ctx.translate(0, size);
-	ctx.scale(size / 256, -size / 256);
+	ctx.scale(size / 256, size / 256);
 	const path = new Path2D(pathData);
 	ctx.fill(path);
 	return ctx.getImageData(0, 0, size, size);

--- a/apps/ui/src/lib/map/controller.ts
+++ b/apps/ui/src/lib/map/controller.ts
@@ -31,10 +31,12 @@ import {
 	locationsToGeoJSON,
 	edgesToGeoJSON,
 	computeOffMapCounts,
+	edgeKey,
 	type LocationFeatureProps,
 	type EdgeFeatureProps
 } from './geojson';
 import type { FeatureCollection, Point, LineString } from 'geojson';
+import { ICON_PATHS, type LocationIcon } from '$lib/map-icons';
 
 /** Options passed to the controller at construction time. */
 export interface MapControllerOptions {
@@ -84,6 +86,8 @@ export class MapController {
 	private lastVisibleIds: Set<string> | null = null;
 	/** Active travel animation, cleared when travel ends. */
 	private travelAnim: TravelAnimation | null = null;
+	/** Canonical edge keys for the active travel path (for line highlighting). */
+	private activeTravelEdgeKeys = new Set<string>();
 	/** Registered click handler, if any. */
 	private clickHandler: ((info: LocationClickInfo) => void) | null = null;
 	/** Registered hover handler, if any. */
@@ -110,6 +114,7 @@ export class MapController {
 		});
 
 		this.map.on('load', () => {
+			registerLocationIcons(this.map);
 			this.ready = true;
 			this.wireLayerEvents();
 			if (this.pendingMapData) {
@@ -136,6 +141,7 @@ export class MapController {
 		this.ready = false;
 		this.map.setStyle(buildStyle(this.variant, theme, source));
 		this.map.once('styledata', () => {
+			registerLocationIcons(this.map);
 			this.ready = true;
 			this.wireLayerEvents();
 			const data = this.pendingMapData ?? this.lastMapData;
@@ -171,7 +177,10 @@ export class MapController {
 			filterIds: visibleIds,
 			offMapCounts
 		});
-		const edgeFC = edgesToGeoJSON(mapData, { filterIds: visibleIds });
+		const edgeFC = edgesToGeoJSON(mapData, {
+			filterIds: visibleIds,
+			traversingEdgeKeys: this.activeTravelEdgeKeys
+		});
 
 		setSourceData(this.map, 'locations', locationFC);
 		setSourceData(this.map, 'edges', edgeFC);
@@ -216,6 +225,10 @@ export class MapController {
 	startTravel(waypoints: TravelWaypoint[], durationMs: number): void {
 		this.stopTravel();
 		if (waypoints.length < 2) return;
+		this.activeTravelEdgeKeys = buildTravelEdgeKeys(waypoints);
+		if (this.lastMapData) {
+			this.updateMap(this.lastMapData, this.lastVisibleIds ?? undefined);
+		}
 
 		const el = document.createElement('div');
 		el.className = 'travel-dot-marker';
@@ -248,6 +261,11 @@ export class MapController {
 
 	/** Stops and removes any active travel animation. */
 	stopTravel(): void {
+		const hadActivePath = this.activeTravelEdgeKeys.size > 0;
+		this.activeTravelEdgeKeys.clear();
+		if (hadActivePath && this.lastMapData) {
+			this.updateMap(this.lastMapData, this.lastVisibleIds ?? undefined);
+		}
 		if (!this.travelAnim) return;
 		cancelAnimationFrame(this.travelAnim.rafId);
 		this.travelAnim.marker.remove();
@@ -352,4 +370,40 @@ function setSourceData(
 	if (source && source.type === 'geojson') {
 		(source as maplibregl.GeoJSONSource).setData(data);
 	}
+}
+
+function buildTravelEdgeKeys(waypoints: TravelWaypoint[]): Set<string> {
+	const keys = new Set<string>();
+	for (let i = 0; i < waypoints.length - 1; i += 1) {
+		const a = waypoints[i];
+		const b = waypoints[i + 1];
+		keys.add(edgeKey(a.id, b.id));
+	}
+	return keys;
+}
+
+function registerLocationIcons(map: MapLibreMap): void {
+	for (const [icon, path] of Object.entries(ICON_PATHS) as Array<[LocationIcon, string]>) {
+		const imageId = `icon-${icon}`;
+		if (map.hasImage(imageId)) continue;
+		map.addImage(imageId, drawIconImage(path), { sdf: true });
+	}
+}
+
+function drawIconImage(pathData: string): ImageData {
+	const size = 64;
+	const canvas = document.createElement('canvas');
+	canvas.width = size;
+	canvas.height = size;
+	const ctx = canvas.getContext('2d');
+	if (!ctx) {
+		throw new Error('Could not initialize icon canvas context');
+	}
+	ctx.clearRect(0, 0, size, size);
+	ctx.fillStyle = '#ffffff';
+	ctx.translate(0, size);
+	ctx.scale(size / 256, -size / 256);
+	const path = new Path2D(pathData);
+	ctx.fill(path);
+	return ctx.getImageData(0, 0, size, size);
 }

--- a/apps/ui/src/lib/map/geojson.test.ts
+++ b/apps/ui/src/lib/map/geojson.test.ts
@@ -71,6 +71,14 @@ describe('locationsToGeoJSON', () => {
 		expect(plain?.properties.lit).toBe(false);
 	});
 
+	it('assigns a semantic icon key from the location name', () => {
+		const fc = locationsToGeoJSON(buildMap());
+		const church = fc.features.find((f) => f.properties.id === 'b');
+		const plain = fc.features.find((f) => f.properties.id === 'a');
+		expect(church?.properties.icon).toBe('church');
+		expect(plain?.properties.icon).toBe('map-pin');
+	});
+
 	it('filters to the given id set when provided', () => {
 		const fc = locationsToGeoJSON(buildMap(), {
 			filterIds: new Set(['a', 'b'])
@@ -106,6 +114,16 @@ describe('edgesToGeoJSON', () => {
 		const bc = fc.features.find((f) => f.properties.src === 'b');
 		expect(ab?.properties.frontier).toBe(false);
 		expect(bc?.properties.frontier).toBe(true); // touches unvisited 'c'
+	});
+
+	it('marks active travel path edges as traversing', () => {
+		const fc = edgesToGeoJSON(buildMap(), {
+			traversingEdgeKeys: new Set([edgeKey('a', 'b')])
+		});
+		const ab = fc.features.find((f) => f.properties.src === 'a');
+		const bc = fc.features.find((f) => f.properties.src === 'b');
+		expect(ab?.properties.traversing).toBe(true);
+		expect(bc?.properties.traversing).toBe(false);
 	});
 
 	it('filters edges whose endpoints are not all in the visible set', () => {

--- a/apps/ui/src/lib/map/geojson.ts
+++ b/apps/ui/src/lib/map/geojson.ts
@@ -9,6 +9,7 @@
 
 import type { FeatureCollection, Point, LineString } from 'geojson';
 import type { MapData, MapLocation } from '$lib/types';
+import { getLocationIcon, type LocationIcon } from '$lib/map-icons';
 
 /** Feature-state hint patterns for "lit" locations (glow at night / standout). */
 const LIT_PATTERNS = /pub|church|house|village|town|shop|school|letter/i;
@@ -17,6 +18,7 @@ const LIT_PATTERNS = /pub|church|house|village|town|shop|school|letter/i;
 export interface LocationFeatureProps {
 	id: string;
 	name: string;
+	icon: LocationIcon;
 	isPlayer: boolean;
 	adjacent: boolean;
 	hops: number;
@@ -38,6 +40,8 @@ export interface EdgeFeatureProps {
 	traversalWeight: number;
 	/** True when either endpoint is unvisited (fog-of-war frontier). */
 	frontier: boolean;
+	/** True when the edge is part of the currently active travel path. */
+	traversing: boolean;
 }
 
 /**
@@ -101,6 +105,7 @@ function buildLocationProps(
 	return {
 		id: loc.id,
 		name: loc.name,
+		icon: getLocationIcon(loc.name),
 		isPlayer: loc.id === playerLocation,
 		adjacent: loc.adjacent,
 		hops: loc.hops,
@@ -121,9 +126,12 @@ function buildLocationProps(
  */
 export function edgesToGeoJSON(
 	map: MapData,
-	options: { filterIds?: ReadonlySet<string> } = {}
+	options: {
+		filterIds?: ReadonlySet<string>;
+		traversingEdgeKeys?: ReadonlySet<string>;
+	} = {}
 ): FeatureCollection<LineString, EdgeFeatureProps> {
-	const { filterIds } = options;
+	const { filterIds, traversingEdgeKeys } = options;
 	const locById = new Map(map.locations.map((l) => [l.id, l]));
 	const traversalsByKey = buildTraversalMap(map.edge_traversals);
 	const maxTraversal = Math.max(1, ...(map.edge_traversals ?? []).map(([, , c]) => c));
@@ -153,7 +161,8 @@ export function edgesToGeoJSON(
 				dst: b,
 				traversals,
 				traversalWeight: weight,
-				frontier: srcLoc.visited === false || dstLoc.visited === false
+				frontier: srcLoc.visited === false || dstLoc.visited === false,
+				traversing: traversingEdgeKeys?.has(key) ?? false
 			}
 		});
 	}

--- a/apps/ui/src/lib/map/style.test.ts
+++ b/apps/ui/src/lib/map/style.test.ts
@@ -97,4 +97,27 @@ describe('buildStyle', () => {
 		expect(style.sources.locations.type).toBe('geojson');
 		expect(style.sources.edges.type).toBe('geojson');
 	});
+
+	it('renders custom icon symbols and glow layer for locations', () => {
+		const style = buildStyle('full', THEME, osm());
+		const glow = style.layers.find((l) => l.id === 'location-glow');
+		expect(glow).toBeDefined();
+		expect(glow?.type).toBe('circle');
+
+		const icons = style.layers.find((l) => l.id === 'location-circles');
+		expect(icons).toBeDefined();
+		expect(icons?.type).toBe('symbol');
+	});
+
+	it('adds traversing-edge highlight styling to solid edges', () => {
+		const style = buildStyle('full', THEME, osm());
+		const solid = style.layers.find((l) => l.id === 'edges-solid');
+		expect(solid).toBeDefined();
+		expect((solid as { paint: { 'line-color': unknown } }).paint['line-color']).toEqual([
+			'case',
+			['get', 'traversing'],
+			THEME.accent,
+			THEME.border
+		]);
+	});
 });

--- a/apps/ui/src/lib/map/style.ts
+++ b/apps/ui/src/lib/map/style.ts
@@ -218,14 +218,25 @@ export function buildStyle(
 		source: 'locations',
 		layout: {
 			'icon-image': ['concat', 'icon-', ['get', 'icon']],
+			// Icon sprites are drawn onto a 64px canvas (see drawIconImage in
+			// controller.ts), so rendered pixel size is `64 * icon-size`. The
+			// minimap runs a few points larger than the full map so locations
+			// remain readable at the panel's 240px viewport. Icons scale
+			// linearly with zoom and max out at ~3× their zoomed-out size so
+			// a fully zoomed-in view reads comfortably without dominating
+			// the map tiles.
 			'icon-size': [
 				'interpolate',
 				['linear'],
 				['zoom'],
 				10,
-				['case', ['get', 'isPlayer'], 0.09, 0.075],
+				variant === 'minimap'
+					? ['case', ['get', 'isPlayer'], 0.32, 0.26]
+					: ['case', ['get', 'isPlayer'], 0.3, 0.22],
 				18,
-				['case', ['get', 'isPlayer'], 0.12, 0.1]
+				variant === 'minimap'
+					? ['case', ['get', 'isPlayer'], 0.96, 0.78]
+					: ['case', ['get', 'isPlayer'], 0.9, 0.66]
 			],
 			'icon-allow-overlap': true,
 			'icon-ignore-placement': true
@@ -245,10 +256,15 @@ export function buildStyle(
 				'case',
 				['get', 'visited'],
 				1,
-				0.45
+				0.55
 			],
+			// Halo matches the label halo so icons read against the
+			// desaturated historic map tiles — the pre-fix 0.8 px width was
+			// invisible once the icon color sat near the parchment tones.
+			// Unvisited locations get a thinner halo so they read as softer
+			// fog-of-war hints rather than equal-weight siblings.
 			'icon-halo-color': theme.bg,
-			'icon-halo-width': 0.8,
+			'icon-halo-width': ['case', ['get', 'visited'], 1.5, 0.6],
 			'icon-halo-blur': 0.2
 		}
 	});

--- a/apps/ui/src/lib/map/style.ts
+++ b/apps/ui/src/lib/map/style.ts
@@ -114,12 +114,26 @@ export function buildStyle(
 		filter: ['!', ['get', 'frontier']],
 		layout: { 'line-cap': 'round', 'line-join': 'round' },
 		paint: {
-			'line-color': theme.border,
-			'line-opacity': 0.85,
+			'line-color': ['case', ['get', 'traversing'], theme.accent, theme.border],
+			'line-opacity': ['case', ['get', 'traversing'], 1, 0.85],
 			'line-width': [
-				'interpolate', ['linear'], ['zoom'],
-				10, ['+', 1, ['*', ['get', 'traversalWeight'], 2]],
-				18, ['+', 2, ['*', ['get', 'traversalWeight'], 4]]
+				'interpolate',
+				['linear'],
+				['zoom'],
+				10,
+				[
+					'case',
+					['get', 'traversing'],
+					4,
+					['+', 1, ['*', ['get', 'traversalWeight'], 2]]
+				],
+				18,
+				[
+					'case',
+					['get', 'traversing'],
+					7,
+					['+', 2, ['*', ['get', 'traversalWeight'], 4]]
+				]
 			]
 		}
 	});
@@ -143,20 +157,30 @@ export function buildStyle(
 		}
 	});
 
-	// 3. Location dots — small circle beneath each symbol so there's always
-	//    something visible even when the icon sprite fails to register.
+	// 3. Glow underlay for lit and player locations.
 	layers.push({
-		id: 'location-circles',
+		id: 'location-glow',
 		type: 'circle',
 		source: 'locations',
 		paint: {
 			'circle-radius': [
 				'case',
 				['get', 'isPlayer'],
-				variant === 'minimap' ? 9 : 11,
-				variant === 'minimap' ? 5 : 7
+				variant === 'minimap' ? 12 : 16,
+				['get', 'lit'],
+				variant === 'minimap' ? 8 : 10,
+				0.01
 			],
-			'circle-color': [
+			'circle-blur': [
+				'case',
+				['get', 'isPlayer'],
+				0.9,
+				['get', 'lit'],
+				0.75,
+				0
+			],
+			'circle-color': theme.accent,
+			'circle-stroke-color': [
 				'case',
 				['get', 'isPlayer'],
 				theme.accent,
@@ -164,25 +188,19 @@ export function buildStyle(
 				theme.accent,
 				theme.panelBg
 			],
-			'circle-stroke-color': [
-				'case',
-				['get', 'isPlayer'],
-				theme.fg,
-				['get', 'adjacent'],
-				theme.accent,
-				theme.muted
-			],
 			'circle-stroke-width': [
 				'case',
 				['get', 'isPlayer'],
-				2,
-				1.25
+				2.5,
+				['get', 'lit'],
+				1.5,
+				0
 			],
 			'circle-opacity': [
 				'case',
-				['get', 'visited'],
+				['any', ['get', 'isPlayer'], ['get', 'lit']],
 				1,
-				0.45
+				0
 			],
 			'circle-stroke-opacity': [
 				'case',
@@ -193,7 +211,49 @@ export function buildStyle(
 		}
 	});
 
-	// 4. Location labels — the whole point of this migration.
+	// 4. Location icons (custom Phosphor glyphs registered at runtime).
+	layers.push({
+		id: 'location-circles',
+		type: 'symbol',
+		source: 'locations',
+		layout: {
+			'icon-image': ['concat', 'icon-', ['get', 'icon']],
+			'icon-size': [
+				'interpolate',
+				['linear'],
+				['zoom'],
+				10,
+				['case', ['get', 'isPlayer'], 0.09, 0.075],
+				18,
+				['case', ['get', 'isPlayer'], 0.12, 0.1]
+			],
+			'icon-allow-overlap': true,
+			'icon-ignore-placement': true
+		},
+		paint: {
+			'icon-color': [
+				'case',
+				['get', 'isPlayer'],
+				theme.fg,
+				['get', 'lit'],
+				theme.accent,
+				['get', 'adjacent'],
+				theme.accent,
+				theme.muted
+			],
+			'icon-opacity': [
+				'case',
+				['get', 'visited'],
+				1,
+				0.45
+			],
+			'icon-halo-color': theme.bg,
+			'icon-halo-width': 0.8,
+			'icon-halo-blur': 0.2
+		}
+	});
+
+	// 5. Location labels — the whole point of this migration.
 	//
 	//    MapLibre's symbol layer does the collision-aware placement we were
 	//    hand-rolling in `map-labels.ts`: variable anchors pick the best side

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -374,6 +374,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
             HeaderValue::from_static(
                 "default-src 'self'; \
                  script-src 'self' 'unsafe-inline'; \
+                 worker-src 'self' blob:; \
                  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
                  img-src 'self' data: blob: https:; \
                  connect-src 'self' ws: wss: https:; \


### PR DESCRIPTION
### Motivation
- The MapLibre migration lost three visual affordances from the old SVG map: per-location Phosphor icons, travel-route edge highlighting, and the night "glow" for lit/player locations.  
- Restoring these improves parity with the previous UX and ensures travel and important locations remain visually prominent.  
- Keep styling data-driven so labels/tiles benefits from MapLibre's collision handling while retaining the previous visual cues.

### Description
- Add an `icon` property to location GeoJSON and map name→icon via `getLocationIcon()` so features carry a semantic icon key.  
- Extend edge feature props with `traversing` and accept a `traversingEdgeKeys` option in `edgesToGeoJSON()` so the style can highlight active travel edges.  
- Update `buildStyle()` to: add a `location-glow` circle layer approximating glow with `circle-blur`/stroke expressions, add a `symbol` layer that places icons using `icon-image: ['concat', 'icon-', ['get', 'icon']]`, and change `edges-solid` paint to conditionally use accent color + larger width when `traversing` is true.  
- In `MapController` register the Phosphor SVG paths as MapLibre images on `load`/`styledata` via `map.addImage(.., { sdf: true })`, derive canonical travel edge keys from waypoints, and pass them into `edgesToGeoJSON()` so travel animations highlight the route; also re-push overlays when the active path changes.

### Testing
- Ran the unit tests for the modified map adapters and style with `cd apps/ui && pnpm vitest src/lib/map/geojson.test.ts src/lib/map/style.test.ts`, and all tests passed.  
- No browser screenshot verification was performed in this environment (visual QA should be done locally in a browser session to confirm icon rendering and glow effects).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1be71f8b88325ace81d44103402ac)