### PR TITLE
feat(npc): LLM-informed NPC reactions for player messages (background inference)

### DIFF
--- a/crates/parish-npc/src/reactions.rs
+++ b/crates/parish-npc/src/reactions.rs
@@ -158,6 +158,13 @@ const KEYWORD_REACTIONS: &[(&[&str], &str)] = &[
     (&["strange", "ghost", "haunted", "spirit"], "😳"),
 ];
 
+/// Structured output for a player-message NPC reaction inference call.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LlmReactionDecision {
+    /// Emoji from [`REACTION_PALETTE`] or `None` for no reaction.
+    pub emoji: Option<String>,
+}
+
 /// Generates a rule-based NPC reaction to player input.
 ///
 /// Returns `Some(emoji)` if a keyword match triggers a reaction (60% chance),
@@ -175,6 +182,78 @@ pub fn generate_rule_reaction(player_input: &str) -> Option<String> {
     }
 
     None
+}
+
+/// Builds the system + user prompts used to infer an NPC emoji reaction.
+pub fn build_player_message_reaction_prompt(npc: &Npc, player_input: &str) -> (String, String) {
+    let mut palette_lines: Vec<String> = REACTION_PALETTE
+        .iter()
+        .map(|(emoji, desc)| format!("- {emoji}: {desc}"))
+        .collect();
+    palette_lines.push("- null: no visible reaction".to_string());
+
+    let keyword_examples = KEYWORD_REACTIONS
+        .iter()
+        .map(|(group, emoji)| format!("- {:?} -> {}", group, emoji))
+        .collect::<Vec<String>>()
+        .join("\n");
+
+    let system = format!(
+        "You decide whether a single NPC would visibly react to a player's spoken line.\n\
+         Return STRICT JSON only with schema: {{\"emoji\": <emoji-or-null>}}.\n\
+         If unsure or neutral, return {{\"emoji\": null}}.\n\
+         Never invent new emoji.\n\
+         Available palette:\n{}\n\
+         Legacy keyword cues (weak examples only; use full meaning and tone):\n{}",
+        palette_lines.join("\n"),
+        keyword_examples
+    );
+
+    let personality_snippet: String = npc.personality.chars().take(300).collect();
+    let user = format!(
+        "NPC:\n\
+         - Name: {}\n\
+         - Occupation: {}\n\
+         - Mood: {}\n\
+         - Personality: {}\n\n\
+         Player message:\n\
+         \"{}\"\n\n\
+         Choose one emoji or null.",
+        npc.name, npc.occupation, npc.mood, personality_snippet, player_input
+    );
+
+    (system, user)
+}
+
+/// Uses the LLM to infer an NPC emoji reaction for a player message.
+///
+/// Returns `Some(emoji)` only when:
+/// - inference succeeds,
+/// - the output emoji is in [`REACTION_PALETTE`], and
+/// - the 60% probabilistic gate fires.
+///
+/// Returns `None` for all errors, unknown emoji, explicit null output, or
+/// when the probabilistic gate does not fire.
+pub async fn infer_player_message_reaction(
+    client: &OpenAiClient,
+    model: &str,
+    npc: &Npc,
+    player_input: &str,
+    timeout: Duration,
+) -> Option<String> {
+    let (system, prompt) = build_player_message_reaction_prompt(npc, player_input);
+    let call =
+        client.generate_json::<LlmReactionDecision>(model, &prompt, Some(&system), Some(40), None);
+
+    let response = tokio::time::timeout(timeout, call).await.ok()?.ok()?;
+    let emoji = response.emoji?;
+    if reaction_description(&emoji).is_none() {
+        return None;
+    }
+    if rand::random::<f64>() >= 0.6 {
+        return None;
+    }
+    Some(emoji)
 }
 
 /// Deterministic variant for testing — always returns a reaction if keywords match.
@@ -1109,6 +1188,26 @@ mod tests {
             generate_rule_reaction_deterministic("Good morning to you"),
             None
         );
+    }
+
+    #[test]
+    fn build_player_message_reaction_prompt_contains_palette_and_examples() {
+        let npc = test_npc(1, "Padraig Darcy", "Publican", Some(LocationId(2)));
+        let (system, user) =
+            build_player_message_reaction_prompt(&npc, "Your landlord's agent is at the door.");
+
+        assert!(system.contains("Available palette"));
+        assert!(system.contains("null: no visible reaction"));
+        assert!(system.contains("Legacy keyword cues"));
+        assert!(system.contains("landlord"));
+        assert!(user.contains("Padraig Darcy"));
+        assert!(user.contains("Player message"));
+    }
+
+    #[test]
+    fn llm_reaction_decision_allows_null() {
+        let parsed: LlmReactionDecision = serde_json::from_str(r#"{"emoji":null}"#).unwrap();
+        assert!(parsed.emoji.is_none());
     }
 
     #[test]

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -174,8 +174,8 @@ pub async fn submit_input(
             state.event_bus.emit("text-log", &player_msg);
             let raw_for_reactions = raw.clone();
             handle_game_input(raw, body.addressed_to, &state).await;
-            // Generate rule-based NPC reactions to the player's message
-            emit_npc_reactions(&player_msg_id, &raw_for_reactions, &state).await;
+            // Generate NPC reactions to the player's message in the background.
+            emit_npc_reactions(&player_msg_id, &raw_for_reactions, &state);
         }
     }
 
@@ -1307,33 +1307,71 @@ pub async fn react_to_message(
     StatusCode::OK
 }
 
-/// Generates rule-based NPC reactions to a player message and emits events.
+/// Generates LLM-informed NPC reactions to a player message and emits events.
 ///
-/// Called after processing player input. Each NPC at the player's location
-/// has a chance to react with an emoji based on keyword matching.
-async fn emit_npc_reactions(player_msg_id: &str, player_input: &str, state: &Arc<AppState>) {
-    let npc_names: Vec<String> = {
-        let world = state.world.lock().await;
-        let npc_manager = state.npc_manager.lock().await;
-        npc_manager
-            .npcs_at(world.player_location)
-            .iter()
-            .map(|n| n.name.clone())
-            .collect()
-    };
+/// Runs as a detached background task so player input handling remains
+/// responsive while reactions resolve.
+fn emit_npc_reactions(player_msg_id: &str, player_input: &str, state: &Arc<AppState>) {
+    let state = Arc::clone(state);
+    let player_msg_id = player_msg_id.to_string();
+    let player_input = player_input.to_string();
 
-    for name in npc_names {
-        if let Some(emoji) = reactions::generate_rule_reaction(player_input) {
-            state.event_bus.emit(
-                "npc-reaction",
-                &NpcReactionPayload {
-                    message_id: player_msg_id.to_string(),
-                    emoji,
-                    source: capitalize_first(&name),
-                },
-            );
+    tokio::spawn(async move {
+        let npcs_here = {
+            let world = state.world.lock().await;
+            let npc_manager = state.npc_manager.lock().await;
+            npc_manager
+                .npcs_at(world.player_location)
+                .iter()
+                .map(|npc| (*npc).clone())
+                .collect::<Vec<_>>()
+        };
+
+        if npcs_here.is_empty() {
+            return;
         }
-    }
+
+        let (reaction_client, reaction_model, enabled) = {
+            let config = state.config.lock().await;
+            let base_client = state.client.lock().await;
+            let (client, model) =
+                config.resolve_category_client(InferenceCategory::Reaction, base_client.as_ref());
+            (
+                client,
+                model,
+                !config.flags.is_disabled("llm-player-message-reactions"),
+            )
+        };
+
+        if !enabled {
+            return;
+        }
+
+        let Some(client) = reaction_client else {
+            return;
+        };
+
+        for npc in npcs_here {
+            if let Some(emoji) = reactions::infer_player_message_reaction(
+                &client,
+                &reaction_model,
+                &npc,
+                &player_input,
+                std::time::Duration::from_secs(2),
+            )
+            .await
+            {
+                state.event_bus.emit(
+                    "npc-reaction",
+                    &NpcReactionPayload {
+                        message_id: player_msg_id.clone(),
+                        emoji,
+                        source: capitalize_first(&npc.name),
+                    },
+                );
+            }
+        }
+    });
 }
 
 // ── Persistence helpers (called by both REST handlers and CommandEffect) ─────

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -260,8 +260,8 @@ pub async fn submit_input(
             let _ = app.emit(EVENT_TEXT_LOG, player_msg);
             let raw_for_reactions = raw.clone();
             handle_game_input(raw, addressed_to, state.clone(), app.clone()).await;
-            // Generate rule-based NPC reactions to the player's message
-            emit_npc_reactions(&player_msg_id, &raw_for_reactions, &state, &app).await;
+            // Generate NPC reactions to the player's message in the background.
+            emit_npc_reactions(&player_msg_id, &raw_for_reactions, &state, &app);
         }
     }
 
@@ -1855,33 +1855,75 @@ pub async fn react_to_message(
     Ok(())
 }
 
-/// Generates rule-based NPC reactions to a player message and emits events.
-async fn emit_npc_reactions(
+/// Generates LLM-informed NPC reactions to a player message and emits events.
+///
+/// Runs as a detached background task so player input handling remains
+/// responsive while reactions resolve.
+fn emit_npc_reactions(
     player_msg_id: &str,
     player_input: &str,
     state: &Arc<AppState>,
     app: &tauri::AppHandle,
 ) {
-    let npc_names: Vec<String> = {
-        let world = state.world.lock().await;
-        let npc_manager = state.npc_manager.lock().await;
-        npc_manager
-            .npcs_at(world.player_location)
-            .iter()
-            .map(|n| n.name.clone())
-            .collect()
-    };
+    let state = Arc::clone(state);
+    let app = app.clone();
+    let player_msg_id = player_msg_id.to_string();
+    let player_input = player_input.to_string();
 
-    for name in npc_names {
-        if let Some(emoji) = reactions::generate_rule_reaction(player_input) {
-            let _ = app.emit(
-                crate::events::EVENT_NPC_REACTION,
-                NpcReactionPayload {
-                    message_id: player_msg_id.to_string(),
-                    emoji,
-                    source: capitalize_first(&name),
-                },
-            );
+    tokio::spawn(async move {
+        let npcs_here = {
+            let world = state.world.lock().await;
+            let npc_manager = state.npc_manager.lock().await;
+            npc_manager
+                .npcs_at(world.player_location)
+                .iter()
+                .map(|npc| (*npc).clone())
+                .collect::<Vec<_>>()
+        };
+
+        if npcs_here.is_empty() {
+            return;
         }
-    }
+
+        let (reaction_client, reaction_model, enabled) = {
+            let config = state.config.lock().await;
+            let base_client = state.client.lock().await;
+            let (client, model) =
+                config.resolve_category_client(InferenceCategory::Reaction, base_client.as_ref());
+            (
+                client,
+                model,
+                !config.flags.is_disabled("llm-player-message-reactions"),
+            )
+        };
+
+        if !enabled {
+            return;
+        }
+
+        let Some(client) = reaction_client else {
+            return;
+        };
+
+        for npc in npcs_here {
+            if let Some(emoji) = reactions::infer_player_message_reaction(
+                &client,
+                &reaction_model,
+                &npc,
+                &player_input,
+                std::time::Duration::from_secs(2),
+            )
+            .await
+            {
+                let _ = app.emit(
+                    crate::events::EVENT_NPC_REACTION,
+                    NpcReactionPayload {
+                        message_id: player_msg_id.clone(),
+                        emoji,
+                        source: capitalize_first(&npc.name),
+                    },
+                );
+            }
+        }
+    });
 }


### PR DESCRIPTION
### Motivation
- Replace brittle keyword-only emoji reactions with semantic, per-NPC judgements so NPCs can react to tone and implied meaning of player messages.
- Use a small/fast structured-output LLM call per message so reactions can be richer while remaining low-latency and configurable separately from dialogue models.
- Keep player input handling responsive by performing reaction inference asynchronously in detached background tasks and preserve a simple kill-switch for safe rollout.

### Description
- Add `LlmReactionDecision` and `build_player_message_reaction_prompt` in `crates/parish-npc/src/reactions.rs` to request strict JSON `{ "emoji": <emoji-or-null> }` with the canonical `REACTION_PALETTE` and legacy keyword cues as few-shot examples.
- Implement `infer_player_message_reaction` which calls `OpenAiClient::generate_json`, validates the returned emoji against `REACTION_PALETTE`, and preserves the existing 60% probabilistic gate before emitting a reaction.
- Replace synchronous keyword-emission sites with detached background spawns in both server and Tauri backends (`emit_npc_reactions`), resolving a per-category client/model via `InferenceCategory::Reaction` so a small/fast model can be used for reactions.
- Honor a default-on kill switch via `config.flags.is_disabled("llm-player-message-reactions")` and fall back to no reaction when no reaction client is configured, when the model returns `null`/invalid emoji, or on timeout/errors.
- Add unit tests covering prompt composition and nullable structured-output parsing in `crates/parish-npc/src/reactions.rs` and keep existing deterministic/rule tests intact.

### Testing
- Ran `cargo fmt --all` successfully to format changes.
- Ran `cargo test -p parish-npc` (reaction tests) and all relevant tests passed (`34` tests passed, 0 failed).
- Ran `cargo check -p parish-server` successfully; full `cargo check -p parish-server -p parish-tauri` failed in this environment due to a missing system `glib-2.0` pkg-config dependency required by the Tauri build stack (environment limitation, not a code error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1be9be8a483258ddf6c4c96d4593a)