### PR TITLE
[codex] Fix web pause flicker

### DIFF
--- a/apps/ui/e2e/mock-data.ts
+++ b/apps/ui/e2e/mock-data.ts
@@ -83,12 +83,14 @@ function makeSnapshot(
 		season: 'Spring',
 		festival: null,
 		paused: false,
+		inference_paused: false,
 		game_epoch_ms: epochForHour(hour),
 		speed_factor: 0, // Frozen: clock stays at the anchored hour during tests
 		name_hints: [
 			{ word: 'Baile Átha Cliath', pronunciation: 'BAHL-ya AH-ha KLEE-ah', meaning: 'town of the hurdled ford (Dublin)' },
 			{ word: 'Aoife', pronunciation: 'EE-fa', meaning: 'beauty, radiance' }
-		]
+		],
+		day_of_week: 'Monday'
 	};
 }
 

--- a/apps/ui/src/components/StatusBar.svelte
+++ b/apps/ui/src/components/StatusBar.svelte
@@ -13,7 +13,7 @@
 	let anchorRealMs = 0;
 	let anchorGameMs = 0;
 	let speedFactor = 36.0;
-	let paused = false;
+	let clockFrozen = false;
 
 	let rafId: number;
 
@@ -28,7 +28,7 @@
 	}
 
 	function tick() {
-		if (paused) {
+		if (clockFrozen) {
 			// Use the anchored game time directly
 			const d = new Date(anchorGameMs);
 			displayHour = d.getUTCHours();
@@ -51,7 +51,7 @@
 			anchorRealMs = Date.now();
 			anchorGameMs = snap.game_epoch_ms;
 			speedFactor = snap.speed_factor;
-			paused = snap.paused;
+			clockFrozen = snap.paused || snap.inference_paused;
 		}
 	});
 

--- a/apps/ui/src/components/StatusBar.test.ts
+++ b/apps/ui/src/components/StatusBar.test.ts
@@ -24,6 +24,7 @@ const snapshot: WorldSnapshot = {
 	season: 'Spring',
 	festival: null,
 	paused: false,
+	inference_paused: false,
 	game_epoch_ms: morningEpoch(),
 	speed_factor: 0,
 	name_hints: [],
@@ -63,6 +64,12 @@ describe('StatusBar', () => {
 		worldState.set({ ...snapshot, paused: true });
 		const { getByText } = render(StatusBar);
 		expect(getByText('⏸ Paused')).toBeTruthy();
+	});
+
+	it('does not show paused indicator when only inference is paused', () => {
+		worldState.set({ ...snapshot, inference_paused: true });
+		const { queryByText } = render(StatusBar);
+		expect(queryByText('⏸ Paused')).toBeNull();
 	});
 
 	it('renders the clock element', () => {

--- a/apps/ui/src/lib/auto-pause.ts
+++ b/apps/ui/src/lib/auto-pause.ts
@@ -18,7 +18,7 @@ export interface AutoPauseTrackerOptions {
 	mousemoveThrottleMs: number;
 	/** Function to invoke pause/resume commands. */
 	submitInput: (text: string) => Promise<void>;
-	/** Returns whether the world is currently paused (any source). */
+	/** Returns whether the world is currently player-paused. */
 	isWorldPaused: () => boolean;
 }
 

--- a/apps/ui/src/lib/types.ts
+++ b/apps/ui/src/lib/types.ts
@@ -10,6 +10,7 @@ export interface WorldSnapshot {
 	season: string;
 	festival: string | null;
 	paused: boolean;
+	inference_paused: boolean;
 	game_epoch_ms: number;
 	speed_factor: number;
 	name_hints: LanguageHint[];

--- a/crates/parish-core/src/ipc/handlers.rs
+++ b/crates/parish-core/src/ipc/handlers.rs
@@ -57,7 +57,8 @@ pub fn snapshot_from_world(world: &WorldState, _transport: &TransportMode) -> Wo
         weather: weather_str,
         season: season.to_string(),
         festival,
-        paused: world.clock.is_paused() || world.clock.is_inference_paused(),
+        paused: world.clock.is_paused(),
+        inference_paused: world.clock.is_inference_paused(),
         game_epoch_ms: now.timestamp_millis() as f64,
         speed_factor: world.clock.speed_factor(),
         name_hints: vec![],
@@ -761,6 +762,17 @@ mod tests {
         assert!(snap.hour <= 23);
         assert!(snap.minute <= 59);
         assert!(snap.speed_factor > 0.0);
+    }
+
+    #[test]
+    fn snapshot_keeps_inference_pause_separate_from_player_pause() {
+        let mut world = WorldState::new();
+        world.clock.inference_pause();
+
+        let snap = snapshot_from_world(&world, &TransportMode::walking());
+
+        assert!(!snap.paused);
+        assert!(snap.inference_paused);
     }
 
     #[test]

--- a/crates/parish-core/src/ipc/types.rs
+++ b/crates/parish-core/src/ipc/types.rs
@@ -32,8 +32,11 @@ pub struct WorldSnapshot {
     pub season: String,
     /// Optional festival name if today is a festival day.
     pub festival: Option<String>,
-    /// Whether the game clock is currently paused.
+    /// Whether the game clock is currently player-paused.
     pub paused: bool,
+    /// Whether the game clock is frozen while waiting on inference.
+    #[serde(default)]
+    pub inference_paused: bool,
     /// Game time as milliseconds since Unix epoch (for client-side interpolation).
     pub game_epoch_ms: f64,
     /// Clock speed multiplier (1 real second = speed_factor game seconds).
@@ -358,6 +361,7 @@ mod tests {
             season: "Summer".to_string(),
             festival: None,
             paused: false,
+            inference_paused: false,
             game_epoch_ms: 1234567890.0,
             speed_factor: 36.0,
             name_hints: vec![],

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -85,6 +85,7 @@ fn snapshot_from_world(
         season: core.season,
         festival: core.festival,
         paused: core.paused,
+        inference_paused: core.inference_paused,
         game_epoch_ms: core.game_epoch_ms,
         speed_factor: core.speed_factor,
         name_hints: vec![],

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -50,8 +50,10 @@ pub struct WorldSnapshot {
     pub season: String,
     /// Optional festival name if today is a festival day.
     pub festival: Option<String>,
-    /// Whether the game clock is currently paused.
+    /// Whether the game clock is currently player-paused.
     pub paused: bool,
+    /// Whether the game clock is frozen while waiting on inference.
+    pub inference_paused: bool,
     /// Game time as milliseconds since Unix epoch (for client-side interpolation).
     pub game_epoch_ms: f64,
     /// Clock speed multiplier (1 real second = speed_factor game seconds).


### PR DESCRIPTION
## Summary
Fix the web pause-status flicker by separating player pause from inference pause in the shared world snapshot.

## What Changed
- Added `inference_paused` to the shared `WorldSnapshot` shape and propagated it through the Tauri/UI types.
- Changed the shared snapshot builder to report `paused` only for explicit player pause, while keeping inference pause separate.
- Updated the status bar to freeze the clock for either paused state, but only show the `Paused` badge for real player pauses.
- Added regression coverage for the snapshot split and the status-bar behavior.
- Updated frontend mock snapshot data to match the new IPC shape.

## Root Cause
The UI consumed a single `paused` flag that was derived from `player_paused || inference_paused`, so every inference freeze looked like a player pause and made the web status indicator flap between paused and running.

## Impact
The web client should no longer show a false pause flicker during inference, while still freezing time correctly when inference is in flight.

## Validation
- `cargo test -p parish-core snapshot_keeps_inference_pause_separate_from_player_pause --lib`
- `cargo test -p parish-core world_snapshot_serialization_round_trip --lib`
- `cargo check -p parish-server -p parish-tauri`
- `cargo fmt --check`
- `cd apps/ui && npx vitest run src/components/StatusBar.test.ts src/lib/auto-pause.test.ts`

## Notes
A live Playwright smoke test was attempted against the real web server, but it hit an existing unrelated selector issue (`[data-testid="input-field"]` not found on load), so it was not used as the gate for this fix.