### PR TITLE
fix(ui): clamp minimap bounds so distant neighbors don't zoom out the historic map

### DIFF
--- a/apps/ui/src/components/MapPanel.svelte
+++ b/apps/ui/src/components/MapPanel.svelte
@@ -41,7 +41,14 @@
 	 * lat/lon bounding box centered on the player that encloses every
 	 * neighbor plus a small halo. Feeding this into `fitBounds` produces a
 	 * player-centered view whose zoom scales with neighbor spread.
+	 *
+	 * The half-span is clamped to `MAX_HALF_SPAN` so one unusually distant
+	 * 1-hop neighbor (e.g. a road connection to the next townland) can't
+	 * force the camera so far out that the tile base becomes unreadable.
+	 * Neighbors beyond the clamp render as dots on the map edge with their
+	 * connection line sailing off the canvas.
 	 */
+	const MAX_HALF_SPAN = 0.008;
 	function computePlayerCenteredBounds(
 		player: MapLocation,
 		neighbors: MapLocation[]
@@ -60,6 +67,8 @@
 			maxDLat = Math.max(maxDLat, Math.abs(n.lat - player.lat));
 			maxDLon = Math.max(maxDLon, Math.abs(n.lon - player.lon));
 		}
+		maxDLat = Math.min(maxDLat, MAX_HALF_SPAN);
+		maxDLon = Math.min(maxDLon, MAX_HALF_SPAN);
 		// Add a small halo so the edge nodes aren't flush against the border.
 		maxDLat *= 1.4;
 		maxDLon *= 1.4;


### PR DESCRIPTION
## Summary
- **Root cause:** when the player's start moved to Kilteevan (loc 15) in `91b454a`, its 1-hop edge to Knockcroghery (loc 22, ~6.3 km south) made `computePlayerCenteredBounds` return a box that spans the full distance. `fitBounds` then zooms the minimap out to **z=10**, where each historic OS 6" tile covers ~39 km — the minimap panel shows a nearly empty patch and the user reads that as "the historic map isn't showing."
- **Fix:** clamp `maxDLat` / `maxDLon` to `MAX_HALF_SPAN = 0.008` (~800 m lat, ~530 m lon at 53°N) *before* the existing 1.4× halo. One far 1-hop neighbor can no longer drag the camera out; dots beyond the clamp still render with their connection line sailing off the canvas, which is the intended off-map affordance.
- **Not touched:** `MINIMAP_HOP_RADIUS` / `visibleIdSet` (load-bearing for label rendering) and the continuation-stub logic (fires only for edges leaving the visible set, unchanged here).

## Test plan
- [x] \`npx vitest run\` — 25/25 tests pass; MapPanel / style / tiles unchanged.
- [x] Playwright probe against live \`parish --web\` server: pre-fix = 2 tile requests at **z=10**; post-fix = 4 tile requests at **z=13**, and the minimap screenshot visibly shows the detailed NLS 6" OS map instead of a pale empty tile.
- [ ] Manual sanity check: run \`just run\`, confirm the minimap in the top-right shows the historic tiles at village scale on page load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)