### PR TITLE
Refactor API key masking and improve test coverage

### DIFF
--- a/crates/parish-cli/src/main.rs
+++ b/crates/parish-cli/src/main.rs
@@ -197,12 +197,18 @@ async fn main() -> Result<()> {
     let clients = build_inference_clients(&client, &model, &category_configs);
 
     for (cat, cfg) in &category_configs {
+        let key_status = if cfg.api_key.is_some() {
+            "(set)"
+        } else {
+            "(not set)"
+        };
         tracing::info!(
-            "{:?} category: {:?} provider at {} with model {}",
+            "{:?} category: {:?} provider at {} with model {} (API key: {})",
             cat,
             cfg.provider,
             cfg.base_url,
-            cfg.model.as_deref().unwrap_or("(auto)")
+            cfg.model.as_deref().unwrap_or("(auto)"),
+            key_status
         );
     }
 

--- a/crates/parish-npc/src/lib.rs
+++ b/crates/parish-npc/src/lib.rs
@@ -823,4 +823,52 @@ mod tests {
         assert_eq!(action.mood, "");
         assert!(action.internal_thought.is_none());
     }
+
+    #[test]
+    fn test_parse_npc_stream_response_empty_metadata() {
+        let text = "Hello there!\n---\n{}";
+        let parsed = parse_npc_stream_response(text);
+        assert_eq!(parsed.dialogue, "Hello there!");
+        let meta = parsed.metadata.unwrap();
+        assert_eq!(meta.action, "");
+        assert_eq!(meta.mood, "");
+        assert!(meta.internal_thought.is_none());
+        assert!(meta.language_hints.is_empty());
+    }
+
+    #[test]
+    fn test_parse_npc_stream_response_separator_only_newlines() {
+        let text = "\n---\n";
+        let parsed = parse_npc_stream_response(text);
+        assert_eq!(parsed.dialogue, "");
+        assert!(parsed.metadata.is_none());
+    }
+
+    #[test]
+    fn test_parse_npc_stream_response_multiline_dialogue() {
+        let text = "Ah, hello there!\nWelcome to Kilteevan.\nCome in, come in.\n---\n{\"action\": \"beckons\", \"mood\": \"welcoming\"}";
+        let parsed = parse_npc_stream_response(text);
+        assert!(parsed.dialogue.contains("Welcome to Kilteevan."));
+        assert!(parsed.dialogue.contains("Come in, come in."));
+        let meta = parsed.metadata.unwrap();
+        assert_eq!(meta.action, "beckons");
+    }
+
+    #[test]
+    fn test_parse_npc_stream_response_triple_dash_in_dialogue() {
+        let text = "The road is long --- perhaps too long.\n---\n{\"mood\": \"weary\"}";
+        let parsed = parse_npc_stream_response(text);
+        assert_eq!(parsed.dialogue, "The road is long --- perhaps too long.");
+        let meta = parsed.metadata.unwrap();
+        assert_eq!(meta.mood, "weary");
+    }
+
+    #[test]
+    fn test_parse_npc_stream_response_whitespace_only_dialogue() {
+        let text = "   \n---\n{\"action\": \"silent\", \"mood\": \"pensive\"}";
+        let parsed = parse_npc_stream_response(text);
+        assert_eq!(parsed.dialogue, "");
+        let meta = parsed.metadata.unwrap();
+        assert_eq!(meta.action, "silent");
+    }
 }

--- a/crates/parish-types/src/ids.rs
+++ b/crates/parish-types/src/ids.rs
@@ -321,6 +321,19 @@ mod tests {
         assert_eq!(floor_char_boundary("", 10), 0);
     }
 
+    #[test]
+    fn floor_char_boundary_four_byte_char() {
+        // 🍀 is 4 bytes (F0 9F 8D 80)
+        let s = "a🍀b";
+        // bytes: a(0) F0(1) 9F(2) 8D(3) 80(4) b(5)
+        assert_eq!(floor_char_boundary(s, 0), 0);
+        assert_eq!(floor_char_boundary(s, 1), 1);
+        assert_eq!(floor_char_boundary(s, 2), 1);
+        assert_eq!(floor_char_boundary(s, 3), 1);
+        assert_eq!(floor_char_boundary(s, 4), 1);
+        assert_eq!(floor_char_boundary(s, 5), 5);
+    }
+
     // ── find_response_separator ──────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary
This PR consolidates API key masking logic into a shared utility function and adds comprehensive test coverage for string boundary handling and response parsing functions.

## Key Changes

- **Centralized API key masking**: Extracted the `mask_key()` function to `parish_core::ipc` module and replaced duplicate implementations across `headless.rs` and `src-tauri/src/commands.rs` with calls to the shared utility
- **Enhanced test coverage**: Added 9 new test cases for `floor_char_boundary()` covering edge cases (empty strings, multi-byte UTF-8 characters) and `parse_npc_stream_response()` covering various input scenarios (empty metadata, multiline dialogue, whitespace handling)
- **Code cleanup**: 
  - Fixed unused variable warning by prefixing `_npc` in `test_build_context()`
  - Replaced `.cloned().cloned()` with `.copied().cloned()` for better clarity when cloning `Option<Arc<T>>`
  - Updated logging in `main.rs` to display API key status alongside configuration details
- **Test fix**: Corrected `snapshot_from_world()` call in `ipc/handlers.rs` tests to include required `TransportMode` parameter

## Implementation Details

The `mask_key()` function now provides consistent behavior across all three entry points (headless CLI, Tauri commands, and server routes). The function masks keys longer than 8 bytes by showing the first 4 and last 4 characters, otherwise displays "(set, too short to mask)".

The new test cases ensure robust handling of UTF-8 character boundaries and various edge cases in response parsing, improving reliability when processing multi-byte characters and malformed input.

https://claude.ai/code/session_015BzDvW3thQnab9PuwY2TvC