### PR TITLE
[codex] Add /unexplored to slash autocomplete

### DIFF
--- a/apps/ui/src/lib/slash-commands.test.ts
+++ b/apps/ui/src/lib/slash-commands.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { SLASH_COMMANDS, filterCommands } from './slash-commands';
+
+describe('slash command registry', () => {
+	it('includes /unexplored in the autocomplete list', () => {
+		expect(SLASH_COMMANDS).toContainEqual({
+			command: '/unexplored',
+			description: 'Reveal or hide all unexplored locations',
+			hasArgs: true
+		});
+	});
+
+	it('returns /unexplored for the /un prefix', () => {
+		expect(filterCommands('un')).toEqual([
+			{
+				command: '/unexplored',
+				description: 'Reveal or hide all unexplored locations',
+				hasArgs: true
+			}
+		]);
+	});
+});

--- a/apps/ui/src/lib/slash-commands.ts
+++ b/apps/ui/src/lib/slash-commands.ts
@@ -37,6 +37,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
 	{ command: '/tick', description: 'Advance NPC schedules', hasArgs: false },
 	{ command: '/new', description: 'Start a new game', hasArgs: false },
 	{ command: '/theme', description: 'Change UI theme (solarized, default)', hasArgs: true },
+	{ command: '/unexplored', description: 'Reveal or hide all unexplored locations', hasArgs: true },
 	{ command: '/quit', description: 'Take your leave', hasArgs: false },
 	{ command: '/flag', description: 'Feature flags: enable/disable/list', hasArgs: true },
 	{ command: '/flags', description: 'List all feature flags', hasArgs: false }


### PR DESCRIPTION
## Summary
- add `/unexplored` to the frontend slash-command autocomplete registry
- add a focused Vitest regression test for registry membership and `/un` prefix filtering

## Why
The backend already parsed `/unexplored`, but the UI autocomplete list is maintained separately in `apps/ui/src/lib/slash-commands.ts`. The new command was added to the backend without being mirrored in the frontend registry, so it never appeared in the dropdown.

## Impact
Players can now discover and autocomplete `/unexplored` from the slash-command picker, matching backend support.

## Validation
- `npm --prefix apps/ui exec vitest run src/lib/slash-commands.test.ts`
