### PR TITLE
fix: add Space key support to SavePicker role="button" elements

### DIFF
--- a/apps/ui/src/components/SavePicker.svelte
+++ b/apps/ui/src/components/SavePicker.svelte
@@ -436,12 +436,12 @@
 						</div>
 					{/each}
 
-					<div class="ledger-row new-ledger" on:click={handleForkLedger} role="button" tabindex="0" on:keydown={(e) => { if (e.key === 'Enter') handleForkLedger(); }}>
+					<div class="ledger-row new-ledger" on:click={handleForkLedger} role="button" tabindex="0" on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleForkLedger(); } }}>
 						<span class="file-number">+</span>
 						<span class="file-name">Fork New Ledger</span>
 					</div>
 
-					<div class="ledger-row new-ledger" on:click={handleNewGame} role="button" tabindex="0" on:keydown={(e) => { if (e.key === 'Enter') handleNewGame(); }}>
+					<div class="ledger-row new-ledger" on:click={handleNewGame} role="button" tabindex="0" on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleNewGame(); } }}>
 						<span class="file-number">+</span>
 						<span class="file-name">New Game</span>
 					</div>

--- a/apps/ui/src/components/SavePicker.svelte
+++ b/apps/ui/src/components/SavePicker.svelte
@@ -436,12 +436,12 @@
 						</div>
 					{/each}
 
-					<div class="ledger-row new-ledger" on:click={handleForkLedger} role="button" tabindex="0" on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleForkLedger(); } }}>
+					<div class="ledger-row new-ledger" on:click={handleForkLedger} role="button" tabindex="0" on:keydown={(e) => { if (!e.repeat && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); handleForkLedger(); } }}>
 						<span class="file-number">+</span>
 						<span class="file-name">Fork New Ledger</span>
 					</div>
 
-					<div class="ledger-row new-ledger" on:click={handleNewGame} role="button" tabindex="0" on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleNewGame(); } }}>
+					<div class="ledger-row new-ledger" on:click={handleNewGame} role="button" tabindex="0" on:keydown={(e) => { if (!e.repeat && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); handleNewGame(); } }}>
 						<span class="file-number">+</span>
 						<span class="file-name">New Game</span>
 					</div>


### PR DESCRIPTION
## Summary

- **💡 What:** Added Space key activation to the "Fork New Ledger" and "New Game" `role="button"` divs in SavePicker, with `preventDefault()` to avoid page scrolling.
- **🎯 Why:** Per the [WAI-ARIA button pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/), elements with `role="button"` must respond to both Enter *and* Space. These two interactive elements only handled Enter, leaving keyboard-only users unable to activate them with the spacebar.
- **♿ Accessibility:** Fixes WCAG 2.1 Level A keyboard accessibility violation for two interactive elements in the save/load dialog.

## Changes

- `apps/ui/src/components/SavePicker.svelte` (lines 439, 444): Added `|| e.key === ' '` to keydown handlers and wrapped in braces with `e.preventDefault()` to prevent default spacebar scroll behavior.

## Test plan

- [ ] Open Save Picker dialog
- [ ] Tab to "Fork New Ledger" — verify focus ring appears (global `:focus-visible` style)
- [ ] Press Space — verify it activates (same as clicking)
- [ ] Tab to "New Game" — press Space — verify it activates
- [ ] Verify Enter still works on both elements
- [ ] Verify page does not scroll when pressing Space on these elements

https://claude.ai/code/session_01XQkGxvDtZAPfjadQ45i3N2