### PR TITLE
fix: gate /unexplored behind feature flag and fix aria-label (#413, #418)

### DIFF
--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -582,7 +582,7 @@
 			class="mobile-btn"
 			class:active={$focailOpen}
 			aria-pressed={$focailOpen}
-			aria-label="Toggle Irish words panel"
+			aria-label="Language Hints — toggle Irish words panel"
 			onclick={() => {
 				if ($focailOpen) {
 					focailOpen.set(false);

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -552,7 +552,17 @@ pub fn handle_command(
 }
 
 /// Handles the `/unexplored` command (reveal/hide all unexplored map locations).
+///
+/// Gated by the `reveal-unexplored` feature flag (default-enabled per
+/// CLAUDE.md rule #6). Uses `is_disabled` semantics so the feature ships
+/// on without needing to seed the flags file.
 fn handle_unexplored_command(config: &mut GameConfig, arg: Option<bool>) -> CommandResult {
+    if config.flags.is_disabled("reveal-unexplored") {
+        return CommandResult::text(
+            "The /unexplored command is disabled. Re-enable with /flag enable reveal-unexplored.",
+        );
+    }
+
     match arg {
         Some(true) => {
             config.reveal_unexplored_locations = true;
@@ -1518,6 +1528,21 @@ mod tests {
         assert!(result.response.contains("currently hidden"));
         assert!(result.response.contains("/unexplored reveal|hide"));
         assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn unexplored_disabled_flag_returns_refusal() {
+        let (mut world, mut npc, mut config) = default_state();
+        config.flags.disable("reveal-unexplored");
+        let result = handle_command(
+            Command::Unexplored(Some(true)),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("/flag enable"));
+        assert!(result.effects.is_empty());
+        assert!(!config.reveal_unexplored_locations);
     }
 
     #[test]

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -558,6 +558,12 @@ pub fn handle_command(
 /// on without needing to seed the flags file.
 fn handle_unexplored_command(config: &mut GameConfig, arg: Option<bool>) -> CommandResult {
     if config.flags.is_disabled("reveal-unexplored") {
+        // Kill-switch: if reveal was active when the flag was disabled, clear it
+        // so the map rendering paths no longer treat unexplored areas as visible.
+        // Without this, the player is stuck in a revealed-but-no-way-to-hide state.
+        if config.reveal_unexplored_locations {
+            config.reveal_unexplored_locations = false;
+        }
         return CommandResult::text(
             "The /unexplored command is disabled. Re-enable with /flag enable reveal-unexplored.",
         );
@@ -1543,6 +1549,34 @@ mod tests {
         assert!(result.response.contains("/flag enable"));
         assert!(result.effects.is_empty());
         assert!(!config.reveal_unexplored_locations);
+    }
+
+    /// Codex P1: disabling the flag while reveal is already active must clear
+    /// `reveal_unexplored_locations`, making the kill-switch effective.
+    /// Previously the early return left the boolean true, so map rendering
+    /// continued to show unexplored areas even though the feature flag was off.
+    #[test]
+    fn unexplored_disabled_flag_clears_active_reveal_state() {
+        let (mut world, mut npc, mut config) = default_state();
+        // Simulate: player ran `/unexplored reveal` while flag was enabled.
+        config.reveal_unexplored_locations = true;
+        // Now an operator disables the feature flag.
+        config.flags.disable("reveal-unexplored");
+        // Any attempt to use /unexplored should clear reveal state, not just refuse.
+        let result = handle_command(
+            Command::Unexplored(Some(true)),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("/flag enable"));
+        assert!(result.effects.is_empty());
+        // Kill-switch must be complete: reveal state cleared even though we
+        // could not execute the command.
+        assert!(
+            !config.reveal_unexplored_locations,
+            "reveal_unexplored_locations must be false when the feature flag is disabled"
+        );
     }
 
     #[test]

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -564,12 +564,7 @@ pub fn handle_command(
 /// on without needing to seed the flags file.
 fn handle_unexplored_command(config: &mut GameConfig, arg: Option<bool>) -> CommandResult {
     if config.flags.is_disabled("reveal-unexplored") {
-        // Kill-switch: if reveal was active when the flag was disabled, clear it
-        // so the map rendering paths no longer treat unexplored areas as visible.
-        // Without this, the player is stuck in a revealed-but-no-way-to-hide state.
-        if config.reveal_unexplored_locations {
-            config.reveal_unexplored_locations = false;
-        }
+        config.reveal_unexplored_locations = false;
         return CommandResult::text(
             "The /unexplored command is disabled. Re-enable with /flag enable reveal-unexplored.",
         );
@@ -1603,6 +1598,19 @@ mod tests {
         assert!(
             !config.reveal_unexplored_locations,
             "reveal_unexplored_locations must be false when the feature flag is disabled"
+        );
+    }
+
+    #[test]
+    fn unexplored_disabled_flag_clears_active_reveal() {
+        let (mut world, mut npc, mut config) = default_state();
+        config.reveal_unexplored_locations = true;
+        config.flags.disable("reveal-unexplored");
+        let result = handle_command(Command::Unexplored(None), &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("/flag enable"));
+        assert!(
+            !config.reveal_unexplored_locations,
+            "should clear reveal state when flag is disabled"
         );
     }
 

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -483,6 +483,12 @@ pub fn handle_command(
         }
         Command::Flag(FlagSubcommand::Disable(name)) => {
             config.flags.disable(&name);
+            // When disabling a flag that has associated cached state, clear
+            // that state immediately so the next render sees the correct value
+            // without requiring the player to run another command first.
+            if name == "reveal-unexplored" {
+                config.reveal_unexplored_locations = false;
+            }
             CommandResult::with_effect(
                 format!("Feature '{}' disabled.", name),
                 CommandEffect::SaveFlags,
@@ -1186,6 +1192,27 @@ mod tests {
         );
         assert!(result.effects.contains(&CommandEffect::SaveFlags));
         assert!(result.response.contains("disabled"));
+    }
+
+    #[test]
+    fn flag_disable_reveal_unexplored_clears_active_reveal_state() {
+        let (mut world, mut npc, mut config) = default_state();
+        // Simulate: reveal mode is active (e.g. player ran `/unexplored reveal`).
+        config.reveal_unexplored_locations = true;
+        // Operator runs `/flag disable reveal-unexplored` — this must immediately
+        // clear the cached reveal state, not wait for the next `/unexplored` call.
+        let result = handle_command(
+            Command::Flag(FlagSubcommand::Disable("reveal-unexplored".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.contains(&CommandEffect::SaveFlags));
+        assert!(result.response.contains("disabled"));
+        assert!(
+            !config.reveal_unexplored_locations,
+            "reveal_unexplored_locations must be cleared immediately when the flag is disabled"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **#413 — /unexplored not gated behind feature flag**: Added `reveal-unexplored` feature flag (default-enabled) to the `/unexplored` command, matching the `/map` command's `period-map-tiles` pattern per project rule #6. When disabled, returns a message directing the user to re-enable via `/flag enable reveal-unexplored`.
- **#418 — Focail button aria-label violates WCAG 2.5.3**: Changed the mobile Language Hints button's `aria-label` from `"Toggle Irish words panel"` to `"Language Hints — toggle Irish words panel"` so the visible button text is included in the accessible name, allowing speech-input users to activate it by saying what they see.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p parish-core -- -D warnings` — clean
- [x] `cargo test -p parish-core -- commands` — 71 tests pass, including new `unexplored_disabled_flag_returns_refusal`
- [x] Game harness walkthrough (`--script testing/fixtures/test_walkthrough.txt`) — passes
- [ ] Manual: run `/unexplored reveal`, then `/flag disable reveal-unexplored`, then `/unexplored reveal` — should see refusal message
- [ ] Manual: inspect mobile layout in browser — Language Hints button aria-label should read "Language Hints — toggle Irish words panel"

https://claude.ai/code/session_01F9Um3XFUvpUFpr39D81WZC