### PR TITLE
docs: refresh README project status and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,38 +12,42 @@ The player arrives as a newcomer to **Kilteevan Village** in the parish of Kilto
 
 ## Current Status
 
-**Phases 1–3 complete** (Core Loop, World Graph, NPCs & Simulation). **Phase 4 — Persistence** is next.
+**Phases 1–4 complete** (Core Loop, World Graph, NPCs & Simulation, Persistence). **Phase 5 — Full LOD & Scale** is in progress: sub-phases 5A–5E are done (event bus, weather state machine, long-term memory & gossip, Tier 3 batch inference, Tier 4 rules engine & seasonal effects), and 5F (world graph expansion to Roscommon/Athlone/Dublin) is the next open item. **Phase 8 — Tauri GUI** is landed (one screenshot-capture polish item outstanding).
 
 See the [Roadmap](docs/requirements/roadmap.md) for per-item status tracking.
 
 ## Quick Start
 
+The workspace ships with a [`justfile`](justfile); run `just --list` for the full set of recipes.
+
+**Requirements:** Rust (edition 2024), [Node.js](https://nodejs.org/) (v20+), an OpenAI-compatible LLM endpoint (e.g. [Ollama](https://ollama.ai/) on `localhost:11434`, LM Studio, OpenRouter, or a custom provider configured in `parish.toml`).
+
+```sh
+# One-time: install system deps, Rust, Node, and frontend packages
+just setup
+```
+
 ### GUI Mode (Tauri Desktop App)
 
 The default experience is a Tauri 2 desktop app with a Svelte 5 frontend.
 
-**Requirements:** Rust (edition 2024), [Node.js](https://nodejs.org/) (v20+), [Ollama](https://ollama.ai/) on `localhost:11434`
-
 ```sh
-# Install the Tauri CLI (one-time)
-cargo install tauri-cli
-
-# Install frontend dependencies (one-time)
-cd apps/ui && npm install && cd ../..
-
-# Launch the desktop app
-cargo tauri dev
+just run          # launches cargo tauri dev
 ```
 
 ### Headless Mode (Terminal REPL)
 
-The default mode is a plain stdin/stdout REPL:
+Plain stdin/stdout REPL — useful for scripting, fixtures, and servers without a display:
 
 ```sh
-cargo run
+just run-headless
 ```
 
 On startup, a save picker shows existing save files (in `saves/`) with their timeline branches, or lets you start a new game. In-game, use `/load` to switch saves, `/save` to snapshot, `/fork <name>` to branch timelines.
+
+### Web Server
+
+An Axum backend in `crates/parish-server` serves the Svelte UI over WebSockets (see [OAuth setup](docs/oauth-setup.md) and the `deploy/` artifacts for Dockerfile + Railway config).
 
 **Platform guides:** [macOS](docs/macos-setup.md) | [Linux](docs/linux-setup.md) | [Windows](docs/windows-setup.md)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See the [Roadmap](docs/requirements/roadmap.md) for per-item status tracking.
 
 The workspace ships with a [`justfile`](justfile); run `just --list` for the full set of recipes.
 
-**Requirements:** Rust (edition 2024), [Node.js](https://nodejs.org/) (v20+), an OpenAI-compatible LLM endpoint (e.g. [Ollama](https://ollama.ai/) on `localhost:11434`, LM Studio, OpenRouter, or a custom provider configured in `parish.toml`).
+**Requirements:** Rust (edition 2024), [Node.js](https://nodejs.org/) (v20+), [`just`](https://github.com/casey/just) (`cargo install just` or your package manager's equivalent), and an OpenAI-compatible LLM endpoint (e.g. [Ollama](https://ollama.ai/) on `localhost:11434`, LM Studio, OpenRouter, or a custom provider configured in `parish.toml`).
 
 ```sh
 # One-time: install system deps, Rust, Node, and frontend packages


### PR DESCRIPTION
## Summary

The README's project status was several phases out of date and the Quick Start instructions predated the `just` recipe workflow described in `CLAUDE.md`.

- **Status:** updated from "Phases 1–3 complete / Phase 4 next" to reflect the actual roadmap — Phases 1–4 complete, Phase 5A–5E complete, Phase 5F (world graph expansion) open, and Phase 8 Tauri GUI landed with one screenshot-capture polish item remaining.
- **Quick Start:** replaced raw `cargo install tauri-cli` / `cd apps/ui && npm install` / `cargo tauri dev` / `cargo run` steps with the canonical `just setup`, `just run`, and `just run-headless` recipes.
- **Requirements:** broadened the LLM line from Ollama-specific to "any OpenAI-compatible provider", matching the project description one line above it.
- **Web Server:** added a small section pointing at `crates/parish-server`, `docs/oauth-setup.md`, and the `deploy/` Dockerfile + Railway config.

## Test plan

- [x] `docs/requirements/roadmap.md` cross-checked for each phase claim in the new status paragraph
- [x] `justfile` cross-checked for the `setup`, `run`, and `run-headless` recipes referenced
- [x] `crates/parish-server` and `deploy/Dockerfile` confirmed to exist before linking

https://claude.ai/code/session_01Sy86sfcchkYMC6uXmyB8ns