### PR TITLE
fix(deploy): point Railway healthcheck at /api/health

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "dockerfile"
 dockerfilePath = "deploy/Dockerfile"
 
 [deploy]
-# /api/ui-config is a lightweight endpoint — good for health checks
-healthcheckPath = "/api/ui-config"
+# /api/health is the public liveness probe; /api/ui-config is auth-gated (#373).
+healthcheckPath = "/api/health"
 healthcheckTimeout = 300
 restartPolicyType = "on_failure"


### PR DESCRIPTION
## Summary
- Railway deploys are failing the healthcheck step.
- Root cause: #439 auth-gated `/api/ui-config` (issue #373) and added a new public `/api/health` endpoint **specifically for liveness probes**, but `railway.toml` still pointed at the now-401 endpoint — so Railway's probe (no CF Access JWT) gets 401 and the deploy is marked unhealthy.
- Switch healthcheck path to `/api/health`.

## Follow-up to #450
#450 unblocked the *build*. This PR unblocks the *deploy*.

## Test plan
- [ ] Railway deploy passes healthcheck on this branch.
- [ ] `curl https://<host>/api/health` → `200 ok` from outside CF Access.
- [ ] `curl https://<host>/api/ui-config` still `401` without a valid JWT (security posture from #373 preserved).

https://claude.ai/code/session_016k5zShnX1gfzM1ZBvxhmxR