### PR TITLE
docs: add README files for all parish crates

### DIFF
--- a/crates/parish-cli/README.md
+++ b/crates/parish-cli/README.md
@@ -1,0 +1,22 @@
+# parish-cli (package: `parish`)
+
+Headless/terminal entry point and runtime wiring for Parish.
+
+## Purpose
+
+This crate provides the primary binary (`parish`) and library helpers for
+starting the game in CLI/headless workflows, with shared setup used in tests
+and server-oriented execution paths.
+
+## Key modules
+
+- `main` — executable entry point.
+- `app` — top-level startup and mode routing.
+- `headless` — terminal REPL loop.
+- `config` — runtime config loading/wrapping.
+- `debug` / `testing` — diagnostics and test support helpers.
+
+## Notes
+
+Shared gameplay logic must live in `parish-core`; this crate should stay as an
+entry-point/orchestration layer.

--- a/crates/parish-config/README.md
+++ b/crates/parish-config/README.md
@@ -1,0 +1,19 @@
+# parish-config
+
+Configuration loading and typed config models for Parish.
+
+## Purpose
+
+`parish-config` centralizes engine/provider/feature-flag configuration so every
+runtime (CLI, server, Tauri) resolves settings the same way.
+
+## Key modules
+
+- `engine` — engine-level settings (runtime, simulation, speed, persistence).
+- `provider` — inference provider definitions and category overrides.
+- `flags` — runtime feature-flag parsing and querying.
+
+## Notes
+
+- Designed for parity across all modes.
+- Re-exports `SpeedConfig` from `parish-types` for downstream convenience.

--- a/crates/parish-core/README.md
+++ b/crates/parish-core/README.md
@@ -1,0 +1,23 @@
+# parish-core
+
+Core gameplay orchestration for the Parish engine.
+
+## Purpose
+
+`parish-core` is the backend-agnostic engine crate. It composes world, NPC,
+inference, input, and persistence crates into a coherent game session API used
+by CLI, web server, and Tauri backends.
+
+## Key modules
+
+- `game_session` — runtime session state and orchestration.
+- `loading` / `game_mod` — mod and data loading.
+- `ipc` — shared request/response/event types used by frontends.
+- `editor` — Parish Designer mod-editing support.
+- `prompts` — prompt templates/assembly helpers.
+- `debug_snapshot` — debug data structures for inspection tooling.
+
+## Re-exports
+
+Re-exports sub-crates (`config`, `inference`, `input`, `npc`, `persistence`,
+`world`) to preserve stable import paths across entry-point crates.

--- a/crates/parish-inference/README.md
+++ b/crates/parish-inference/README.md
@@ -1,0 +1,22 @@
+# parish-inference
+
+LLM inference queue and provider clients for Parish.
+
+## Purpose
+
+`parish-inference` handles prompt execution against OpenAI-compatible backends
+(Ollama, LM Studio, OpenRouter, and similar providers), including priority
+lanes, optional streaming token output, and request logging.
+
+## Key modules
+
+- `openai_client` — HTTP client for OpenAI-compatible APIs.
+- `client` — trait and polymorphic client interfaces.
+- `rate_limit` — request throttling helpers.
+- `setup` — worker wiring and queue construction.
+- `simulator` — deterministic/local simulation client for tests.
+
+## Notes
+
+- Keep provider-specific behavior isolated to this crate.
+- Shared request/response types are consumed by `parish-core` and other crates.

--- a/crates/parish-input/README.md
+++ b/crates/parish-input/README.md
@@ -1,0 +1,19 @@
+# parish-input
+
+Player input parsing and command interpretation.
+
+## Purpose
+
+`parish-input` converts raw text input into structured commands and
+intent-resolution prompts for downstream game systems.
+
+## Responsibilities
+
+- Parse slash commands (save/load/status/provider/map/theme/etc.).
+- Route natural-language input toward inference-backed intent parsing.
+- Return typed command/intent values for orchestration layers.
+
+## Notes
+
+This crate should stay focused on parsing and normalization, not world mutation
+or session lifecycle management.

--- a/crates/parish-npc/README.md
+++ b/crates/parish-npc/README.md
@@ -1,0 +1,20 @@
+# parish-npc
+
+NPC simulation, memory, schedules, and reaction systems.
+
+## Purpose
+
+`parish-npc` contains behavior and state models for non-player characters,
+including tiered cognition and autonomous updates.
+
+## Key modules
+
+- `manager` — orchestration and tier management for NPC updates.
+- `autonomous` / `ticks` — simulation loops and periodic updates.
+- `memory` — short/long-term memory representations.
+- `transitions` / `tier4` — cognition tier transitions and low-fidelity rules.
+- `reactions`, `overhear`, `mood`, `anachronism` — dialogue/social subsystems.
+
+## Notes
+
+Shared schema types for NPC data files are re-exported for mod/editor tooling.

--- a/crates/parish-persistence/README.md
+++ b/crates/parish-persistence/README.md
@@ -1,0 +1,19 @@
+# parish-persistence
+
+SQLite persistence for saves, snapshots, journals, and branch history.
+
+## Purpose
+
+`parish-persistence` provides the durable storage layer used by all runtimes.
+It supports branch-style saves, journal replay, and snapshot restore flows.
+
+## Key modules
+
+- `database` — schema access and core DB operations.
+- `snapshot` — snapshot serialization/deserialization.
+- `journal` / `journal_bridge` — event journal writing and replay.
+- `picker` — save-file and branch selection helpers.
+
+## Notes
+
+Uses SQLite in WAL mode via `rusqlite` for reliability and simple deployment.

--- a/crates/parish-server/README.md
+++ b/crates/parish-server/README.md
@@ -1,0 +1,19 @@
+# parish-server
+
+Axum web backend for running Parish in a browser.
+
+## Purpose
+
+`parish-server` hosts the Svelte UI and exposes HTTP/WebSocket endpoints that
+mirror the desktop/headless game behavior.
+
+## Key modules
+
+- `routes` and `ws` — API routes and real-time game channel.
+- `session` and `state` — per-user session lifecycle and shared app state.
+- `auth`, `cf_auth`, `middleware` — authentication and request policy.
+- `editor_routes` — mod editor API surface.
+
+## Notes
+
+Each browser visitor gets an isolated session with persisted save state.

--- a/crates/parish-tauri/README.md
+++ b/crates/parish-tauri/README.md
@@ -1,0 +1,20 @@
+# parish-tauri
+
+Tauri backend bridge between Parish engine and Svelte desktop UI.
+
+## Purpose
+
+`parish-tauri` provides desktop app initialization, typed command handlers, and
+event streaming between the Rust engine (`parish-core`) and the frontend.
+
+## Key modules
+
+- `commands` — game runtime IPC commands exposed to the frontend.
+- `editor_commands` — mod editor-specific command surface.
+- `events` — event emission for world/chat/simulation updates.
+- `main` / `lib` — Tauri startup and state wiring.
+
+## Notes
+
+Keep UI transport concerns here; gameplay behavior belongs in shared engine
+crates for parity with CLI and web modes.

--- a/crates/parish-types/README.md
+++ b/crates/parish-types/README.md
@@ -1,0 +1,23 @@
+# parish-types
+
+Shared foundational types for the Parish engine.
+
+## Purpose
+
+`parish-types` is the leaf crate used by the rest of the workspace. It contains
+stable, serialization-friendly types and helpers that should not depend on
+higher-level gameplay modules.
+
+## Key modules
+
+- `ids` — strongly typed IDs and core world entity structs.
+- `time` — game clock, seasons, festivals, and speed settings.
+- `events` — event bus and game event definitions.
+- `conversation` and `gossip` — shared narrative/social data structures.
+- `error` — `ParishError` and cross-crate error variants.
+- `dice` — deterministic and random utility rolling helpers.
+
+## Used by
+
+All `parish-*` engine crates (`parish-core`, `parish-world`, `parish-npc`,
+`parish-server`, etc.). Keep this crate dependency-light and broadly reusable.

--- a/crates/parish-world/README.md
+++ b/crates/parish-world/README.md
@@ -1,0 +1,20 @@
+# parish-world
+
+World graph, movement, weather, and environment state for Parish.
+
+## Purpose
+
+`parish-world` owns location topology and simulation-facing world state used by
+NPC systems, UI snapshots, and persistence.
+
+## Key modules
+
+- `graph` and `geo` — location graph structure and geographic helpers.
+- `movement` and `transport` — travel rules and path interaction.
+- `weather` — weather transitions tied to game time.
+- `description`, `encounter`, `palette` — text and presentation helpers.
+
+## Primary type
+
+- `WorldState` — central container for clock, player location, graph, weather,
+  logs, visited locations, and shared event/gossip/conversation state.


### PR DESCRIPTION
### Motivation

- Provide per-crate README documentation so contributors can quickly understand each crate's purpose and surface area. 
- Make module ownership and mode-parity guidance explicit at the crate level to reduce accidental duplication of shared gameplay logic. 
- Improve workspace discoverability and onboarding for engine, server, UI, and tooling crates. 

### Description

- Add `README.md` for each `crates/*` parish crate: `parish-cli`, `parish-config`, `parish-core`, `parish-inference`, `parish-input`, `parish-npc`, `parish-persistence`, `parish-server`, `parish-tauri`, `parish-types`, and `parish-world`. 
- Each README documents the crate purpose, key modules/responsibilities, and notes about boundaries (e.g., keep gameplay logic in `parish-core`). 
- Content emphasizes parity across runtimes (CLI, Tauri, server) and where to find editor/mod tooling or IPC types. 
- Committed the new files under a single docs-focused change. 

### Testing

- Verified presence of each README with `for d in crates/*; do test -f "$d/README.md" && echo "ok $d" || echo "missing $d"; done`, which reported all crate READMEs present. 
- Ran `cargo check -p parish-core --quiet`, which failed due to a crates.io network fetch `403` in this environment and not because of code or doc errors. 
- No other automated tests were required for documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38d8a529c8325b139a4cb647bda8f)