### PR TITLE
⚡ Bolt: zero-clone recall_context_string

### DIFF
--- a/crates/parish-npc/src/memory.rs
+++ b/crates/parish-npc/src/memory.rs
@@ -399,8 +399,22 @@ impl LongTermMemory {
             return String::new();
         }
 
-        let lines: Vec<String> = recalled.iter().map(|entry| entry.content.clone()).collect();
-        format!("You recall: {}", lines.join(". "))
+        // Single allocation, zero clones: borrow content strings directly instead of
+        // cloning into a Vec<String> + join + format.
+        let prefix = "You recall: ";
+        let sep = ". ";
+        let cap = prefix.len()
+            + recalled.iter().map(|e| e.content.len()).sum::<usize>()
+            + recalled.len().saturating_sub(1) * sep.len();
+        let mut result = String::with_capacity(cap);
+        result.push_str(prefix);
+        for (i, entry) in recalled.iter().enumerate() {
+            if i > 0 {
+                result.push_str(sep);
+            }
+            result.push_str(&entry.content);
+        }
+        result
     }
 }
 


### PR DESCRIPTION
## 💡 What
Replace the clone-collect-join-format chain in `LongTermMemory::recall_context_string` with a single pre-sized `String` that borrows content directly.

**Before:** `recalled.iter().map(|e| e.content.clone()).collect::<Vec<String>>()` → `lines.join(". ")` → `format!("You recall: {}", ...)`

**After:** One `String::with_capacity(exact_size)` that `push_str`s borrowed content in a single pass.

## 🎯 Why
`recall_context_string` sits on the NPC dialogue hot path — called per conversation turn per NPC via `build_enhanced_context_with_config`. The old code performed:
- **N content clones** (one `String::clone()` per recalled memory entry)
- **1 Vec allocation** (to hold the cloned Strings)
- **1 join allocation** (intermediate joined String)
- **1 format allocation** (final result wrapping with prefix)

With a typical recall limit of 5, that's **8 heap allocations** per call, all unnecessary.

## 📊 Impact
- **N+3 → 1 heap allocations** per call (where N = recalled entries, typically 3–5)
- **Zero String clones** — content is borrowed directly via `push_str(&entry.content)`
- **Zero reallocations** — capacity is pre-computed exactly
- Estimated **~80% reduction in allocator pressure** for this function on every NPC dialogue turn

## 🔬 Measurement
- All 324 `parish-npc` tests pass (including `test_long_term_recall_context_string`)
- `cargo fmt` and `cargo clippy -D warnings` clean
- Output is byte-identical to the previous implementation

https://claude.ai/code/session_01A6oix1rAA2B6DnnNd2HMe2