### PR TITLE
refactor: replace separator-based LLM parsing with JSON structured output

### DIFF
--- a/crates/parish-cli/src/headless.rs
+++ b/crates/parish-cli/src/headless.rs
@@ -1035,6 +1035,7 @@ async fn handle_headless_game_input(
                             None,
                             Some(0.7),
                             parish_core::inference::InferencePriority::Interactive,
+                            true,
                         )
                         .await
                     {

--- a/crates/parish-core/src/editor/maintenance_tool.rs
+++ b/crates/parish-core/src/editor/maintenance_tool.rs
@@ -6,8 +6,6 @@
 //! Used during Phase 1a bring-up to normalize the source files so the
 //! byte-identical round-trip acceptance test holds.
 
-#![cfg(test)]
-
 use super::mod_io::load_mod_snapshot;
 use super::persist::save_mod;
 use super::types::EditorDoc;

--- a/crates/parish-core/src/ipc/mod.rs
+++ b/crates/parish-core/src/ipc/mod.rs
@@ -16,5 +16,5 @@ pub use commands::{
 };
 pub use config::GameConfig;
 pub use handlers::*;
-pub use streaming::{stream_npc_tokens, strip_trailing_json};
+pub use streaming::stream_npc_tokens;
 pub use types::*;

--- a/crates/parish-core/src/ipc/streaming.rs
+++ b/crates/parish-core/src/ipc/streaming.rs
@@ -1,9 +1,8 @@
 //! Shared NPC token streaming logic for all frontends.
 //!
 //! Reads tokens from an inference channel, extracts the `dialogue` field from
-//! the partial JSON buffer incrementally, batches emitted text, and calls a
-//! user-provided emit function. This eliminates duplicate streaming
-//! implementations across Tauri, the web server, and the CLI.
+//! JSON responses incrementally (or streams plain text directly for non-JSON),
+//! batches emitted text, and calls a user-provided emit function.
 
 use std::time::{Duration, Instant};
 
@@ -12,18 +11,17 @@ use parish_types::extract_dialogue_from_partial_json;
 /// How many milliseconds to batch streaming tokens before emitting.
 pub const BATCH_MS: u64 = 16;
 
-/// Reads tokens from `token_rx`, extracts the `dialogue` field from the
-/// accumulating JSON buffer, batches output every [`BATCH_MS`] ms, and calls
-/// `emit_token` with each batch of displayable dialogue text.
+/// Reads tokens from `token_rx`, detects whether the stream is JSON or plain
+/// text, and emits displayable dialogue incrementally.
 ///
-/// Returns the full accumulated JSON response so the caller can parse
-/// metadata (mood, action, language hints, etc.) after streaming completes.
+/// For JSON streams: extracts the `dialogue` field value incrementally via
+/// [`extract_dialogue_from_partial_json`], hiding metadata fields from display.
 ///
-/// The `emit_token` callback receives batches of dialogue text. Backends
-/// wire this to their event mechanism:
-/// - Tauri: `app.emit("stream-token", StreamTokenPayload { token })`
-/// - Web server: `bus.emit("stream-token", &StreamTokenPayload { token })`
-/// - CLI: `print!("{}", token)`
+/// For plain text streams (e.g. NPC arrival reactions): emits the raw text
+/// token-by-token, preserving progressive display.
+///
+/// Returns the full accumulated response so the caller can parse metadata
+/// (mood, action, language hints, etc.) after streaming completes.
 pub async fn stream_npc_tokens(
     mut token_rx: tokio::sync::mpsc::UnboundedReceiver<String>,
     mut emit_token: impl FnMut(&str),
@@ -32,15 +30,47 @@ pub async fn stream_npc_tokens(
     let mut displayed_len: usize = 0;
     let mut batch = String::new();
     let mut last_emit = Instant::now();
+    // None = undecided, true = JSON with dialogue field, false = plain text
+    let mut is_json: Option<bool> = None;
 
     while let Some(token) = token_rx.recv().await {
         accumulated.push_str(&token);
 
-        if let Some(dialogue) = extract_dialogue_from_partial_json(&accumulated)
-            && dialogue.len() > displayed_len
-        {
-            batch.push_str(&dialogue[displayed_len..]);
-            displayed_len = dialogue.len();
+        match is_json {
+            None => {
+                // Detect mode from the accumulated content so far.
+                let trimmed = accumulated.trim_start();
+                if trimmed.starts_with('{') {
+                    if let Some(dialogue) = extract_dialogue_from_partial_json(&accumulated) {
+                        is_json = Some(true);
+                        if dialogue.len() > displayed_len {
+                            batch.push_str(&dialogue[displayed_len..]);
+                            displayed_len = dialogue.len();
+                        }
+                    }
+                    // If starts with '{' but no dialogue field yet, stay undecided
+                    // (the field might appear in a later chunk).
+                } else if !trimmed.is_empty() {
+                    // Non-JSON: stream raw text incrementally
+                    is_json = Some(false);
+                    batch.push_str(&accumulated[displayed_len..]);
+                    displayed_len = accumulated.len();
+                }
+            }
+            Some(true) => {
+                if let Some(dialogue) = extract_dialogue_from_partial_json(&accumulated)
+                    && dialogue.len() > displayed_len
+                {
+                    batch.push_str(&dialogue[displayed_len..]);
+                    displayed_len = dialogue.len();
+                }
+            }
+            Some(false) => {
+                if accumulated.len() > displayed_len {
+                    batch.push_str(&accumulated[displayed_len..]);
+                    displayed_len = accumulated.len();
+                }
+            }
         }
 
         if !batch.is_empty() && last_emit.elapsed() >= Duration::from_millis(BATCH_MS) {
@@ -56,12 +86,10 @@ pub async fn stream_npc_tokens(
         batch.clear();
     }
 
-    // If no dialogue field was found, treat the entire response as plain text
-    if extract_dialogue_from_partial_json(&accumulated).is_none() && !accumulated.is_empty() {
-        let text = accumulated.trim();
-        if !text.is_empty() && displayed_len == 0 {
-            emit_token(text);
-        }
+    // Edge case: if we were still undecided (e.g. only received `{` with no
+    // dialogue field and no further tokens), treat it as plain text.
+    if is_json.is_none() && !accumulated.is_empty() && displayed_len == 0 {
+        emit_token(accumulated.trim());
     }
 
     accumulated
@@ -116,7 +144,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stream_plain_text_fallback() {
+    async fn stream_plain_text_incremental() {
+        let (tx, token_rx) = mpsc::unbounded_channel();
+        tx.send("Well, ".to_string()).unwrap();
+        tx.send("good day ".to_string()).unwrap();
+        tx.send("to ye".to_string()).unwrap();
+        drop(tx);
+
+        let mut collected = String::new();
+        let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
+        assert_eq!(full, "Well, good day to ye");
+        assert_eq!(collected, "Well, good day to ye");
+    }
+
+    #[tokio::test]
+    async fn stream_plain_text_single_chunk() {
         let (tx, token_rx) = mpsc::unbounded_channel();
         tx.send("Just plain text response.".to_string()).unwrap();
         drop(tx);

--- a/crates/parish-core/src/ipc/streaming.rs
+++ b/crates/parish-core/src/ipc/streaming.rs
@@ -1,25 +1,26 @@
 //! Shared NPC token streaming logic for all frontends.
 //!
-//! Reads tokens from an inference channel, applies separator holdback logic,
-//! batches them, and calls a user-provided emit function. This eliminates the
-//! duplicate streaming implementations in `src-tauri/src/events.rs` and
-//! `crates/parish-server/src/streaming.rs`.
+//! Reads tokens from an inference channel, extracts the `dialogue` field from
+//! the partial JSON buffer incrementally, batches emitted text, and calls a
+//! user-provided emit function. This eliminates duplicate streaming
+//! implementations across Tauri, the web server, and the CLI.
 
 use std::time::{Duration, Instant};
 
-use crate::npc::{SEPARATOR_HOLDBACK, find_response_separator, floor_char_boundary};
+use parish_types::extract_dialogue_from_partial_json;
 
 /// How many milliseconds to batch streaming tokens before emitting.
 pub const BATCH_MS: u64 = 16;
 
-/// Reads tokens from `token_rx`, applies the NPC separator holdback logic,
-/// batches them every [`BATCH_MS`] ms, and calls `emit_token` with each batch.
+/// Reads tokens from `token_rx`, extracts the `dialogue` field from the
+/// accumulating JSON buffer, batches output every [`BATCH_MS`] ms, and calls
+/// `emit_token` with each batch of displayable dialogue text.
 ///
-/// Returns the full accumulated response text (including the hidden JSON
-/// metadata section) so the caller can extract Irish word hints.
+/// Returns the full accumulated JSON response so the caller can parse
+/// metadata (mood, action, language hints, etc.) after streaming completes.
 ///
-/// The `emit_token` callback receives the batch text to display. Backends
-/// wire this to their own event mechanism:
+/// The `emit_token` callback receives batches of dialogue text. Backends
+/// wire this to their event mechanism:
 /// - Tauri: `app.emit("stream-token", StreamTokenPayload { token })`
 /// - Web server: `bus.emit("stream-token", &StreamTokenPayload { token })`
 /// - CLI: `print!("{}", token)`
@@ -29,28 +30,17 @@ pub async fn stream_npc_tokens(
 ) -> String {
     let mut accumulated = String::new();
     let mut displayed_len: usize = 0;
-    let mut separator_found = false;
     let mut batch = String::new();
     let mut last_emit = Instant::now();
 
     while let Some(token) = token_rx.recv().await {
         accumulated.push_str(&token);
 
-        if !separator_found {
-            if let Some((dialogue_end, _meta_start)) = find_response_separator(&accumulated) {
-                if dialogue_end > displayed_len {
-                    batch.push_str(&accumulated[displayed_len..dialogue_end]);
-                }
-                displayed_len = dialogue_end;
-                separator_found = true;
-            } else {
-                let raw_end = accumulated.len().saturating_sub(SEPARATOR_HOLDBACK);
-                let safe_end = floor_char_boundary(&accumulated, raw_end);
-                if safe_end > displayed_len {
-                    batch.push_str(&accumulated[displayed_len..safe_end]);
-                    displayed_len = safe_end;
-                }
-            }
+        if let Some(dialogue) = extract_dialogue_from_partial_json(&accumulated)
+            && dialogue.len() > displayed_len
+        {
+            batch.push_str(&dialogue[displayed_len..]);
+            displayed_len = dialogue.len();
         }
 
         if !batch.is_empty() && last_emit.elapsed() >= Duration::from_millis(BATCH_MS) {
@@ -66,54 +56,15 @@ pub async fn stream_npc_tokens(
         batch.clear();
     }
 
-    // Flush any remaining displayed text if no separator was ever found
-    if !separator_found && displayed_len < accumulated.len() {
-        let remaining = &accumulated[displayed_len..];
-        let clean = strip_trailing_json(remaining);
-        if !clean.is_empty() {
-            emit_token(clean);
+    // If no dialogue field was found, treat the entire response as plain text
+    if extract_dialogue_from_partial_json(&accumulated).is_none() && !accumulated.is_empty() {
+        let text = accumulated.trim();
+        if !text.is_empty() && displayed_len == 0 {
+            emit_token(text);
         }
     }
 
     accumulated
-}
-
-/// Strips trailing JSON metadata from a response that lacks a `---` separator.
-///
-/// Some weaker models emit the metadata JSON block directly after dialogue
-/// without the expected `---` delimiter. This function finds the last
-/// top-level `{...}` block at the end of the text and removes it, returning
-/// only the dialogue portion. If no trailing JSON is found, returns the
-/// original text trimmed.
-pub fn strip_trailing_json(text: &str) -> &str {
-    let trimmed = text.trim_end();
-    if !trimmed.ends_with('}') {
-        return trimmed;
-    }
-    // Walk backwards to find the matching opening brace
-    let mut depth = 0i32;
-    let mut json_start = None;
-    for (i, ch) in trimmed.char_indices().rev() {
-        match ch {
-            '}' => depth += 1,
-            '{' => {
-                depth -= 1;
-                if depth == 0 {
-                    json_start = Some(i);
-                    break;
-                }
-            }
-            _ => {}
-        }
-    }
-    if let Some(start) = json_start {
-        // Only strip if what we found actually parses as JSON
-        let candidate = &trimmed[start..];
-        if serde_json::from_str::<serde_json::Value>(candidate).is_ok() {
-            return trimmed[..start].trim_end();
-        }
-    }
-    trimmed
 }
 
 #[cfg(test)]
@@ -122,108 +73,64 @@ mod tests {
     use tokio::sync::mpsc;
 
     #[tokio::test]
-    async fn stream_simple_tokens() {
+    async fn stream_json_dialogue_field() {
         let (tx, token_rx) = mpsc::unbounded_channel();
-        tx.send("Hello ".to_string()).unwrap();
-        tx.send("world!".to_string()).unwrap();
-        drop(tx);
-
-        let mut collected = String::new();
-        let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
-        assert_eq!(full, "Hello world!");
-        assert_eq!(collected, "Hello world!");
-    }
-
-    #[tokio::test]
-    async fn stream_with_separator() {
-        let (tx, token_rx) = mpsc::unbounded_channel();
-        tx.send("Dialogue text\n---\n{\"hints\":[]}".to_string())
+        tx.send(r#"{"dialogue": "Hello world!"}"#.to_string())
             .unwrap();
         drop(tx);
 
         let mut collected = String::new();
         let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
-        assert_eq!(full, "Dialogue text\n---\n{\"hints\":[]}");
-        // Only dialogue portion should be emitted
-        assert!(!collected.contains("hints"));
-        assert!(collected.contains("Dialogue text"));
-    }
-
-    #[test]
-    fn strip_trailing_json_with_json() {
-        let text =
-            "(Looks up) Ah, good morning to ye! {\"action\": \"speaks\", \"mood\": \"friendly\"}";
-        assert_eq!(
-            strip_trailing_json(text),
-            "(Looks up) Ah, good morning to ye!"
-        );
-    }
-
-    #[test]
-    fn strip_trailing_json_no_json() {
-        let text = "Well hello there, stranger!";
-        assert_eq!(strip_trailing_json(text), text);
-    }
-
-    #[test]
-    fn strip_trailing_json_braces_in_dialogue() {
-        let text = "The rent is {too high} says I.";
-        assert_eq!(strip_trailing_json(text), text);
-    }
-
-    #[test]
-    fn strip_trailing_json_empty() {
-        assert_eq!(strip_trailing_json(""), "");
-    }
-
-    #[test]
-    fn strip_trailing_json_only_json() {
-        let text = "{\"action\": \"speaks\"}";
-        assert_eq!(strip_trailing_json(text), "");
+        assert_eq!(full, r#"{"dialogue": "Hello world!"}"#);
+        assert_eq!(collected, "Hello world!");
     }
 
     #[tokio::test]
-    async fn stream_utf8_multibyte_safety() {
-        // Emojis are 4 bytes each. If they land near the SEPARATOR_HOLDBACK
-        // boundary, floor_char_boundary must not split them.
+    async fn stream_json_incremental() {
         let (tx, token_rx) = mpsc::unbounded_channel();
-        // Build a string long enough that the holdback window slices into
-        // multi-byte territory: 30 chars of ASCII + emoji cluster.
-        let text = "A".repeat(30) + "🎉🍀🎶";
-        tx.send(text.clone()).unwrap();
+        tx.send(r#"{"dialogue": "Hel"#.to_string()).unwrap();
+        tx.send(r#"lo wor"#.to_string()).unwrap();
+        tx.send(r#"ld!", "mood": "happy"}"#.to_string()).unwrap();
         drop(tx);
 
         let mut collected = String::new();
         let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
-        assert_eq!(full, text, "full accumulation must preserve all bytes");
-        // The emitted portion must be valid UTF-8 (no panic) and contain the
-        // ASCII prefix. The emojis may or may not be emitted depending on
-        // holdback, but whatever IS emitted must be valid.
-        assert!(collected.starts_with("AAAAAA"));
+        assert!(full.contains("Hello world!"));
+        assert_eq!(collected, "Hello world!");
     }
 
     #[tokio::test]
-    async fn stream_pure_emoji_tokens() {
+    async fn stream_json_with_metadata_not_leaked() {
         let (tx, token_rx) = mpsc::unbounded_channel();
-        tx.send("🎉".to_string()).unwrap();
-        tx.send("🍀".to_string()).unwrap();
-        tx.send("🎶".to_string()).unwrap();
+        tx.send(
+            r#"{"dialogue": "Good morning!", "action": "nods", "mood": "friendly"}"#.to_string(),
+        )
+        .unwrap();
+        drop(tx);
+
+        let mut collected = String::new();
+        let _ = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
+        assert_eq!(collected, "Good morning!");
+        assert!(!collected.contains("nods"));
+        assert!(!collected.contains("friendly"));
+    }
+
+    #[tokio::test]
+    async fn stream_plain_text_fallback() {
+        let (tx, token_rx) = mpsc::unbounded_channel();
+        tx.send("Just plain text response.".to_string()).unwrap();
         drop(tx);
 
         let mut collected = String::new();
         let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
-        assert_eq!(full, "🎉🍀🎶");
-        // Total emitted length (in chars) should be 3 — all emojis survive
-        // even if batching delays some.
-        assert_eq!(collected.chars().count(), 3);
+        assert_eq!(full, "Just plain text response.");
+        assert_eq!(collected, "Just plain text response.");
     }
 
-    // ── Additional coverage for stream_npc_tokens edge cases ────────────────
-
     #[tokio::test]
-    async fn stream_empty_channel_returns_empty_string() {
+    async fn stream_empty_channel() {
         let (tx, token_rx) = mpsc::unbounded_channel::<String>();
-        drop(tx); // Close immediately without sending.
+        drop(tx);
 
         let mut collected = String::new();
         let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
@@ -232,94 +139,50 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stream_separator_split_across_tokens() {
-        // Receiver must stitch the separator together even when it arrives in pieces.
+    async fn stream_json_with_escapes() {
         let (tx, token_rx) = mpsc::unbounded_channel();
-        tx.send("Dialogue text\n".to_string()).unwrap();
-        tx.send("--".to_string()).unwrap();
-        tx.send("-\n".to_string()).unwrap();
-        tx.send("{\"hints\":[]}".to_string()).unwrap();
-        drop(tx);
-
-        let mut collected = String::new();
-        let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
-        assert_eq!(full, "Dialogue text\n---\n{\"hints\":[]}");
-        // No JSON metadata should have leaked into the collected output.
-        assert!(!collected.contains("hints"));
-        assert!(collected.contains("Dialogue text"));
-    }
-
-    #[tokio::test]
-    async fn stream_handles_multibyte_utf8_at_holdback_boundary() {
-        // The holdback window must never land inside a multi-byte char.
-        // Build a long dialogue so the sliding window actually engages, with
-        // Irish accented characters (é, á) around the boundary.
-        let (tx, token_rx) = mpsc::unbounded_channel();
-        let line = "Is fíor-álainn an lá é inniu — gealltanach agus éadrom, caithfidh mé a rá.";
-        tx.send(line.to_string()).unwrap();
-        drop(tx);
-
-        let mut collected = String::new();
-        let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
-        assert_eq!(full, line);
-        // Output must be valid UTF-8 and contain the full phrase.
-        assert!(collected.contains("fíor-álainn"));
-    }
-
-    #[tokio::test]
-    async fn stream_without_separator_strips_trailing_json() {
-        // Weak models sometimes omit the --- separator and emit metadata inline.
-        let (tx, token_rx) = mpsc::unbounded_channel();
-        tx.send("A fine morning it is. ".to_string()).unwrap();
-        tx.send("{\"action\":\"speaks\"}".to_string()).unwrap();
+        tx.send(r#"{"dialogue": "He said \"hello\" to me"}"#.to_string())
+            .unwrap();
         drop(tx);
 
         let mut collected = String::new();
         let _ = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
-        // The trailing JSON must be stripped from the emitted text.
-        assert!(collected.contains("fine morning"));
-        assert!(!collected.contains("action"));
+        assert_eq!(collected, r#"He said "hello" to me"#);
     }
 
     #[tokio::test]
-    async fn stream_short_text_under_holdback_window_still_emits() {
-        // Text shorter than SEPARATOR_HOLDBACK should flush through the
-        // "no separator found" tail path.
+    async fn stream_json_with_unicode() {
         let (tx, token_rx) = mpsc::unbounded_channel();
-        tx.send("Hi.".to_string()).unwrap();
+        tx.send(r#"{"dialogue": "Sláinte agus fáilte!"}"#.to_string())
+            .unwrap();
         drop(tx);
 
         let mut collected = String::new();
-        let full = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
-        assert_eq!(full, "Hi.");
-        assert_eq!(collected, "Hi.");
+        let _ = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
+        assert_eq!(collected, "Sláinte agus fáilte!");
     }
 
-    // ── strip_trailing_json edge cases ──────────────────────────────────────
+    #[tokio::test]
+    async fn stream_json_empty_dialogue() {
+        let (tx, token_rx) = mpsc::unbounded_channel();
+        tx.send(r#"{"dialogue": "", "mood": "silent"}"#.to_string())
+            .unwrap();
+        drop(tx);
 
-    #[test]
-    fn strip_trailing_json_ignores_unmatched_close_brace() {
-        // A lone '}' with no matching '{' should not crash; text is returned.
-        let text = "punctuation is weird}";
-        assert_eq!(strip_trailing_json(text), text);
+        let mut collected = String::new();
+        let _ = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
+        assert_eq!(collected, "");
     }
 
-    #[test]
-    fn strip_trailing_json_rejects_invalid_json() {
-        // The candidate block looks like JSON but isn't valid — keep the text.
-        let text = "the deal is {not, a: valid}";
-        assert_eq!(strip_trailing_json(text), text);
-    }
+    #[tokio::test]
+    async fn stream_json_no_space_after_colon() {
+        let (tx, token_rx) = mpsc::unbounded_channel();
+        tx.send(r#"{"dialogue":"Compact JSON!"}"#.to_string())
+            .unwrap();
+        drop(tx);
 
-    #[test]
-    fn strip_trailing_json_handles_whitespace_before_json() {
-        let text = "Good evening to ye.   {\"a\":1}";
-        assert_eq!(strip_trailing_json(text), "Good evening to ye.");
-    }
-
-    #[test]
-    fn strip_trailing_json_handles_nested_objects() {
-        let text = r#"(smiles) Welcome home. {"action":"speaks","meta":{"mood":"warm"}}"#;
-        assert_eq!(strip_trailing_json(text), "(smiles) Welcome home.");
+        let mut collected = String::new();
+        let _ = stream_npc_tokens(token_rx, |batch| collected.push_str(batch)).await;
+        assert_eq!(collected, "Compact JSON!");
     }
 }

--- a/crates/parish-inference/src/anthropic_client.rs
+++ b/crates/parish-inference/src/anthropic_client.rs
@@ -262,6 +262,38 @@ fn strip_json_fence(raw: &str) -> &str {
 // --- Streaming ----------------------------------------------------------
 
 impl AnthropicClient {
+    /// Streams a messages request with JSON mode, forwarding text deltas.
+    ///
+    /// Anthropic has no native `response_format` equivalent, so the system
+    /// prompt is augmented with a JSON-only instruction (same as
+    /// [`generate_json`]). The raw streamed text is returned — callers
+    /// extract dialogue incrementally from the partial JSON buffer.
+    pub async fn generate_stream_json(
+        &self,
+        model: &str,
+        prompt: &str,
+        system: Option<&str>,
+        token_tx: mpsc::UnboundedSender<String>,
+        max_tokens: Option<u32>,
+        temperature: Option<f32>,
+    ) -> Result<String, ParishError> {
+        const JSON_SUFFIX: &str =
+            "\n\nRespond ONLY with a single JSON object. No prose, no code fences, no commentary.";
+        let augmented_system = match system {
+            Some(s) => format!("{s}{JSON_SUFFIX}"),
+            None => JSON_SUFFIX.trim_start().to_string(),
+        };
+        self.generate_stream(
+            model,
+            prompt,
+            Some(&augmented_system),
+            token_tx,
+            max_tokens,
+            temperature,
+        )
+        .await
+    }
+
     /// Streams a messages request, forwarding text deltas as they arrive.
     ///
     /// Posts to `/v1/messages` with `stream: true` and parses the native

--- a/crates/parish-inference/src/lib.rs
+++ b/crates/parish-inference/src/lib.rs
@@ -191,6 +191,8 @@ pub struct InferenceRequest {
     pub temperature: Option<f32>,
     /// Priority lane for this request.
     pub priority: InferencePriority,
+    /// When true, the worker uses `generate_stream_json` (JSON mode + streaming).
+    pub json_mode: bool,
 }
 
 /// The response from an inference request.
@@ -247,6 +249,7 @@ impl InferenceQueue {
         max_tokens: Option<u32>,
         temperature: Option<f32>,
         priority: InferencePriority,
+        json_mode: bool,
     ) -> Result<oneshot::Receiver<InferenceResponse>, mpsc::error::SendError<InferenceRequest>>
     {
         let (response_tx, response_rx) = oneshot::channel();
@@ -260,6 +263,7 @@ impl InferenceQueue {
             max_tokens,
             temperature,
             priority,
+            json_mode,
         };
         let lane = match priority {
             InferencePriority::Interactive => &self.interactive_tx,
@@ -345,6 +349,7 @@ pub async fn submit_json<T: serde::de::DeserializeOwned>(
             None,
             None,
             priority,
+            false,
         )
         .await
         .map_err(|e| ParishError::Inference(format!("queue send failed: {e}")))?;
@@ -509,6 +514,36 @@ impl AnyClient {
         }
     }
 
+    /// Streams text with JSON mode enabled.
+    ///
+    /// Like [`generate_stream`] but constrains the provider to emit valid JSON.
+    /// Used for Tier 1 NPC responses where dialogue is embedded in a JSON
+    /// structure and extracted incrementally during streaming.
+    pub async fn generate_stream_json(
+        &self,
+        model: &str,
+        prompt: &str,
+        system: Option<&str>,
+        token_tx: mpsc::UnboundedSender<String>,
+        max_tokens: Option<u32>,
+        temperature: Option<f32>,
+    ) -> Result<String, ParishError> {
+        match self {
+            Self::OpenAi(c) => {
+                c.generate_stream_json(model, prompt, system, token_tx, max_tokens, temperature)
+                    .await
+            }
+            Self::Anthropic(c) => {
+                c.generate_stream_json(model, prompt, system, token_tx, max_tokens, temperature)
+                    .await
+            }
+            Self::Simulator(c) => {
+                c.generate_stream_json(model, prompt, system, token_tx, max_tokens, temperature)
+                    .await
+            }
+        }
+    }
+
     /// Generates a structured JSON response and deserializes it into `T`.
     pub async fn generate_json<T: serde::de::DeserializeOwned>(
         &self,
@@ -603,27 +638,42 @@ pub fn spawn_inference_worker(
             let req_id = request.id;
             let start = Instant::now();
 
-            let result = if let Some(token_tx) = request.token_tx {
-                client
-                    .generate_stream(
-                        &request.model,
-                        &request.prompt,
-                        request.system.as_deref(),
-                        token_tx,
-                        request.max_tokens,
-                        request.temperature,
-                    )
-                    .await
-            } else {
-                client
-                    .generate(
-                        &request.model,
-                        &request.prompt,
-                        request.system.as_deref(),
-                        request.max_tokens,
-                        request.temperature,
-                    )
-                    .await
+            let result = match (request.token_tx, request.json_mode) {
+                (Some(token_tx), true) => {
+                    client
+                        .generate_stream_json(
+                            &request.model,
+                            &request.prompt,
+                            request.system.as_deref(),
+                            token_tx,
+                            request.max_tokens,
+                            request.temperature,
+                        )
+                        .await
+                }
+                (Some(token_tx), false) => {
+                    client
+                        .generate_stream(
+                            &request.model,
+                            &request.prompt,
+                            request.system.as_deref(),
+                            token_tx,
+                            request.max_tokens,
+                            request.temperature,
+                        )
+                        .await
+                }
+                (None, _) => {
+                    client
+                        .generate(
+                            &request.model,
+                            &request.prompt,
+                            request.system.as_deref(),
+                            request.max_tokens,
+                            request.temperature,
+                        )
+                        .await
+                }
             };
 
             let elapsed = start.elapsed();
@@ -762,6 +812,7 @@ mod tests {
                 None,
                 None,
                 InferencePriority::Interactive,
+                false,
             )
             .await
             .unwrap();
@@ -803,6 +854,7 @@ mod tests {
                 None,
                 None,
                 InferencePriority::Interactive,
+                false,
             )
             .await
             .unwrap();
@@ -828,6 +880,7 @@ mod tests {
                 None,
                 None,
                 InferencePriority::Interactive,
+                false,
             )
             .await
             .unwrap();
@@ -1022,6 +1075,7 @@ mod tests {
                 None,
                 None,
                 InferencePriority::Interactive,
+                false,
             )
             .await
             .unwrap();
@@ -1035,6 +1089,7 @@ mod tests {
                 None,
                 None,
                 InferencePriority::Background,
+                false,
             )
             .await
             .unwrap();
@@ -1048,6 +1103,7 @@ mod tests {
                 None,
                 None,
                 InferencePriority::Batch,
+                false,
             )
             .await
             .unwrap();
@@ -1085,6 +1141,7 @@ mod tests {
                 None,
                 None,
                 InferencePriority::Batch,
+                false,
             )
             .await
             .unwrap();
@@ -1098,6 +1155,7 @@ mod tests {
                 None,
                 None,
                 InferencePriority::Interactive,
+                false,
             )
             .await
             .unwrap();
@@ -1164,6 +1222,7 @@ mod tests {
             max_tokens: None,
             temperature: None,
             priority: InferencePriority::Interactive,
+            json_mode: false,
         };
         // send returns Err when the receiver has been dropped by the aborted task.
         let send_result = interactive_tx.send(req).await;

--- a/crates/parish-inference/src/openai_client.rs
+++ b/crates/parish-inference/src/openai_client.rs
@@ -302,6 +302,59 @@ impl OpenAiClient {
         Ok(accumulated)
     }
 
+    /// Sends a streaming chat completion request with JSON mode enabled.
+    ///
+    /// Identical to [`generate_stream`] but sets `response_format: json_object`
+    /// so the LLM is constrained to return valid JSON. Used for Tier 1 NPC
+    /// responses where dialogue is embedded in a JSON structure.
+    pub async fn generate_stream_json(
+        &self,
+        model: &str,
+        prompt: &str,
+        system: Option<&str>,
+        token_tx: mpsc::UnboundedSender<String>,
+        max_tokens: Option<u32>,
+        temperature: Option<f32>,
+    ) -> Result<String, ParishError> {
+        self.acquire_slot().await;
+        let body = self.build_request(model, prompt, system, true, true, max_tokens, temperature);
+
+        let url = format!("{}/v1/chat/completions", self.base_url);
+        let mut req = self.streaming_client.post(&url).json(&body);
+        req = self.apply_auth_headers(req);
+
+        let resp = req
+            .send()
+            .await?
+            .error_for_status()
+            .map_err(|e| ParishError::Inference(e.to_string()))?;
+
+        let mut accumulated = String::new();
+        let mut line_buf = String::new();
+        let mut decoder = crate::utf8_stream::Utf8StreamDecoder::new();
+
+        let mut response = resp;
+        while let Some(chunk) = response.chunk().await? {
+            line_buf.push_str(&decoder.push(&chunk));
+
+            while let Some(newline_pos) = line_buf.find('\n') {
+                let line: String = line_buf.drain(..=newline_pos).collect();
+                match process_sse_line(&line, &token_tx, &mut accumulated) {
+                    SseResult::Continue => {}
+                    SseResult::Done => return Ok(accumulated),
+                }
+            }
+        }
+
+        line_buf.push_str(&decoder.flush());
+        let remaining = line_buf.trim();
+        if !remaining.is_empty() {
+            process_sse_line(remaining, &token_tx, &mut accumulated);
+        }
+
+        Ok(accumulated)
+    }
+
     /// Sends a non-streaming request and deserializes the response as structured JSON.
     ///
     /// Requests JSON output via `response_format: {"type": "json_object"}` and

--- a/crates/parish-inference/src/simulator.rs
+++ b/crates/parish-inference/src/simulator.rs
@@ -294,6 +294,36 @@ impl SimulatorClient {
         Ok(text)
     }
 
+    /// Streams a JSON response word-by-word through `token_tx`.
+    ///
+    /// Wraps the Markov output in a JSON object with a `dialogue` field,
+    /// streaming the complete JSON string token-by-token.
+    pub async fn generate_stream_json(
+        &self,
+        _model: &str,
+        prompt: &str,
+        system: Option<&str>,
+        token_tx: mpsc::UnboundedSender<String>,
+        _max_tokens: Option<u32>,
+        _temperature: Option<f32>,
+    ) -> Result<String, ParishError> {
+        let seed = fnv1a(prompt);
+        let length = target_length(system);
+        let dialogue = walk_chain(&self.chain, seed, length);
+        let escaped = dialogue.replace('"', "\\\"").replace('\n', " ");
+        let json = format!(
+            r#"{{"dialogue":"{escaped}","action":"","mood":"neutral","internal_thought":null,"language_hints":[],"mentioned_people":[]}}"#
+        );
+
+        for word in json.split_whitespace() {
+            let chunk = format!("{} ", word);
+            let _ = token_tx.send(chunk);
+            tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+        }
+
+        Ok(json)
+    }
+
     /// Generates a JSON-typed response.
     ///
     /// For intent-parsing requests (detected by system prompt keywords), returns

--- a/crates/parish-npc/src/lib.rs
+++ b/crates/parish-npc/src/lib.rs
@@ -38,8 +38,7 @@ use types::{Intelligence, NpcState, Relationship, SeasonalSchedule};
 
 // Re-export shared types from parish-types
 pub use parish_types::{
-    IrishWordHint, LanguageHint, NpcId, SEPARATOR_HOLDBACK, find_response_separator,
-    floor_char_boundary,
+    IrishWordHint, LanguageHint, NpcId, extract_dialogue_from_partial_json, floor_char_boundary,
 };
 
 // Re-export the NPC data-file schema so downstream crates (e.g. the Parish
@@ -194,19 +193,46 @@ impl Npc {
     }
 }
 
-/// Parsed result from a streaming NPC response.
+/// Parsed result from an NPC LLM response.
 ///
 /// Contains the player-visible dialogue/action text and the optional
-/// metadata parsed from the JSON block after the `---` separator.
+/// metadata parsed from the JSON response.
 #[derive(Debug, Clone)]
 pub struct NpcStreamResponse {
     /// The dialogue and action text shown to the player.
     pub dialogue: String,
-    /// Parsed metadata from the JSON block, if present.
+    /// Parsed metadata from the JSON response, if present.
     pub metadata: Option<NpcMetadata>,
 }
 
-/// Metadata block from an NPC response (parsed from JSON after separator).
+/// Full JSON response from an NPC interaction (Tier 1).
+///
+/// The LLM returns this as a complete JSON object via `response_format: json_object`.
+/// Contains both the player-visible dialogue and simulation metadata in a single
+/// structured response, eliminating the need for separator-based parsing.
+#[derive(Debug, Clone, Deserialize)]
+pub struct NpcJsonResponse {
+    /// The NPC's spoken words and actions, as shown to the player.
+    #[serde(default)]
+    pub dialogue: String,
+    /// What the NPC physically does (e.g. "speaks warmly", "nods", "sighs").
+    #[serde(default)]
+    pub action: String,
+    /// The NPC's mood after this interaction.
+    #[serde(default)]
+    pub mood: String,
+    /// Internal thought (not shown to player, used for simulation).
+    #[serde(default)]
+    pub internal_thought: Option<String>,
+    /// Pronunciation hints for any secondary-language words used in dialogue.
+    #[serde(default, alias = "irish_words")]
+    pub language_hints: Vec<LanguageHint>,
+    /// People the NPC mentioned by name in their dialogue (self-declared by the LLM).
+    #[serde(default)]
+    pub mentioned_people: Vec<String>,
+}
+
+/// Metadata block from an NPC response.
 #[derive(Debug, Clone, Deserialize)]
 pub struct NpcMetadata {
     /// What the NPC physically does.
@@ -226,59 +252,27 @@ pub struct NpcMetadata {
     pub mentioned_people: Vec<String>,
 }
 
-/// Structured action output from an NPC's LLM response.
+/// Parses a complete NPC response (JSON format) into dialogue and metadata.
 ///
-/// Deserialized from JSON returned by the Ollama inference call.
-/// All optional fields use `#[serde(default)]` for robustness against
-/// partial or malformed LLM output.
-#[derive(Debug, Clone, Deserialize)]
-pub struct NpcAction {
-    /// What the NPC does (e.g. "speaks", "moves", "gestures").
-    #[serde(default)]
-    pub action: String,
-    /// The target of the action (e.g. "the player", "the door").
-    #[serde(default)]
-    pub target: Option<String>,
-    /// Dialogue spoken by the NPC.
-    #[serde(default)]
-    pub dialogue: Option<String>,
-    /// The NPC's current mood after this action.
-    #[serde(default)]
-    pub mood: String,
-    /// Internal thought (not shown to player, used for simulation).
-    #[serde(default)]
-    pub internal_thought: Option<String>,
-}
-
-/// Parses a complete NPC response into dialogue and metadata.
-///
-/// Splits on a `---` separator line (with optional surrounding whitespace).
-/// Everything before is player-visible dialogue/actions. Everything after
-/// is parsed as JSON metadata.
-/// If no separator is found, the entire text is treated as dialogue.
+/// Expects a JSON object with a `dialogue` field and metadata fields.
+/// Falls back to treating the entire text as plain dialogue if JSON parsing fails.
 pub fn parse_npc_stream_response(full_text: &str) -> NpcStreamResponse {
-    if let Some((dialogue_end, metadata_start)) = find_response_separator(full_text) {
-        let dialogue = full_text[..dialogue_end].trim().to_string();
-        let meta_text = full_text[metadata_start..].trim();
-        let metadata = serde_json::from_str::<NpcMetadata>(meta_text).ok();
-        return NpcStreamResponse { dialogue, metadata };
-    }
+    let trimmed = full_text.trim();
 
-    // Fallback: try parsing entire response as legacy JSON NpcAction
-    if let Ok(action) = serde_json::from_str::<NpcAction>(full_text) {
-        let dialogue = action.dialogue.clone().unwrap_or_default();
+    if let Ok(json_resp) = serde_json::from_str::<NpcJsonResponse>(trimmed) {
+        let dialogue = json_resp.dialogue.clone();
         let metadata = Some(NpcMetadata {
-            action: action.action,
-            mood: action.mood,
-            internal_thought: action.internal_thought,
-            language_hints: Vec::new(),
-            mentioned_people: Vec::new(),
+            action: json_resp.action,
+            mood: json_resp.mood,
+            internal_thought: json_resp.internal_thought,
+            language_hints: json_resp.language_hints,
+            mentioned_people: json_resp.mentioned_people,
         });
         return NpcStreamResponse { dialogue, metadata };
     }
 
     NpcStreamResponse {
-        dialogue: full_text.trim().to_string(),
+        dialogue: trimmed.to_string(),
         metadata: None,
     }
 }
@@ -307,9 +301,9 @@ const IMPROV_CRAFT_SECTION: &str = "\n\
 /// When `improv` is true, includes the improv craft guidelines section
 /// to improve improvisational quality of NPC responses.
 ///
-/// The prompt instructs the model to output dialogue first (which is
-/// streamed to the player), then a `---` separator, then a JSON metadata
-/// block (which is parsed silently for simulation state).
+/// The prompt instructs the model to return a JSON object containing
+/// both the dialogue (streamed to the player) and metadata fields
+/// (parsed for simulation state).
 pub fn build_tier1_system_prompt(npc: &Npc, improv: bool) -> String {
     let improv_section = if improv { IMPROV_CRAFT_SECTION } else { "" };
     let intel_guidance = npc.intelligence.prompt_guidance();
@@ -336,23 +330,27 @@ pub fn build_tier1_system_prompt(npc: &Npc, improv: bool) -> String {
         {intel_guidance}\
         Current mood: {mood}\n\
         \n\
-        Respond in character as {name}. Write only what you say aloud — \
+        Respond in character as {name}. You MUST respond with a JSON object. \
+        Put the \"dialogue\" field FIRST. The dialogue should contain only what you say aloud — \
         pure dialogue, no narration or action descriptions. \
         Pepper your speech naturally with the occasional Irish word or phrase.\n\
         \n\
         LENGTH: 2-4 sentences. Be conversational, not a monologue.\n\
         \n\
-        FORMAT: Write your dialogue, then on a new line write exactly: ---\n\
-        Then a JSON metadata block:\n\
-        {{\"action\": \"what you physically do\", \"mood\": \"your mood after this\", \
-        \"internal_thought\": \"what you think but don't say\", \
-        \"irish_words\": [{{\"word\": \"...\", \"pronunciation\": \"...\", \"meaning\": \"...\"}}]}}\n\
+        JSON fields:\n\
+        - \"dialogue\": your spoken words (this is shown to the player)\n\
+        - \"action\": what you physically do (e.g. \"speaks warmly\", \"nods\", \"sighs\")\n\
+        - \"mood\": your mood after this interaction\n\
+        - \"internal_thought\": what you're thinking but not saying (optional)\n\
+        - \"irish_words\": array of any Irish words you used, each with:\n\
+          - \"word\": the Irish word as written\n\
+          - \"pronunciation\": phonetic guide in English (e.g. \"SLAWN-cha\" for \"sláinte\")\n\
+          - \"meaning\": English translation\n\
         \n\
-        Example:\n\
-        Ah, good morning to ye! Dia dhuit — fine day for it, so it is. \
-        Will ye have a drop of something to warm the bones?\n\
-        ---\n\
-        {{\"action\": \"looks up from polishing glass, speaks warmly\", \"mood\": \"friendly\", \
+        Example response:\n\
+        {{\"dialogue\": \"Ah, good morning to ye! Dia dhuit — fine day for it, so it is. \
+        Will ye have a drop of something to warm the bones?\", \
+        \"action\": \"looks up from polishing glass, speaks warmly\", \"mood\": \"friendly\", \
         \"internal_thought\": \"New face around here\", \
         \"irish_words\": [{{\"word\": \"Dia dhuit\", \"pronunciation\": \"DEE-ah gwit\", \
         \"meaning\": \"Hello (lit. God to you)\"}}]}}",
@@ -809,81 +807,78 @@ mod tests {
     }
 
     #[test]
-    fn test_npc_action_deserialize_full() {
+    fn test_npc_json_response_deserialize_full() {
         let json = r#"{
-            "action": "speaks",
-            "target": "the player",
             "dialogue": "Ah, good morning to ye!",
+            "action": "speaks",
             "mood": "friendly",
-            "internal_thought": "Haven't seen this one before."
+            "internal_thought": "Haven't seen this one before.",
+            "irish_words": [{"word": "Dia dhuit", "pronunciation": "DEE-ah gwit", "meaning": "Hello"}]
         }"#;
-        let action: NpcAction = serde_json::from_str(json).unwrap();
-        assert_eq!(action.action, "speaks");
-        assert_eq!(action.target, Some("the player".to_string()));
-        assert_eq!(action.dialogue, Some("Ah, good morning to ye!".to_string()));
-        assert_eq!(action.mood, "friendly");
+        let resp: NpcJsonResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.dialogue, "Ah, good morning to ye!");
+        assert_eq!(resp.action, "speaks");
+        assert_eq!(resp.mood, "friendly");
         assert_eq!(
-            action.internal_thought,
+            resp.internal_thought,
             Some("Haven't seen this one before.".to_string())
         );
+        assert_eq!(resp.language_hints.len(), 1);
     }
 
     #[test]
-    fn test_npc_action_deserialize_minimal() {
-        let json = r#"{"action": "nods"}"#;
-        let action: NpcAction = serde_json::from_str(json).unwrap();
-        assert_eq!(action.action, "nods");
-        assert!(action.target.is_none());
-        assert!(action.dialogue.is_none());
-        assert_eq!(action.mood, "");
-        assert!(action.internal_thought.is_none());
+    fn test_npc_json_response_deserialize_minimal() {
+        let json = r#"{"dialogue": "Hello!"}"#;
+        let resp: NpcJsonResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.dialogue, "Hello!");
+        assert_eq!(resp.action, "");
+        assert_eq!(resp.mood, "");
+        assert!(resp.internal_thought.is_none());
+        assert!(resp.language_hints.is_empty());
     }
 
     #[test]
-    fn test_parse_npc_stream_response_empty_metadata() {
-        let text = "Hello there!\n---\n{}";
+    fn test_parse_npc_stream_response_json() {
+        let text = r#"{"dialogue": "(Looks up) Ah, good morning to ye!", "action": "speaks", "mood": "friendly"}"#;
         let parsed = parse_npc_stream_response(text);
-        assert_eq!(parsed.dialogue, "Hello there!");
+        assert_eq!(parsed.dialogue, "(Looks up) Ah, good morning to ye!");
         let meta = parsed.metadata.unwrap();
-        assert_eq!(meta.action, "");
-        assert_eq!(meta.mood, "");
-        assert!(meta.internal_thought.is_none());
-        assert!(meta.language_hints.is_empty());
+        assert_eq!(meta.action, "speaks");
+        assert_eq!(meta.mood, "friendly");
     }
 
     #[test]
-    fn test_parse_npc_stream_response_separator_only_newlines() {
-        let text = "\n---\n";
+    fn test_parse_npc_stream_response_plain_text_fallback() {
+        let text = "Well hello there, stranger!";
         let parsed = parse_npc_stream_response(text);
+        assert_eq!(parsed.dialogue, "Well hello there, stranger!");
+        assert!(parsed.metadata.is_none());
+    }
+
+    #[test]
+    fn test_parse_npc_stream_response_empty() {
+        let parsed = parse_npc_stream_response("");
         assert_eq!(parsed.dialogue, "");
         assert!(parsed.metadata.is_none());
     }
 
     #[test]
-    fn test_parse_npc_stream_response_multiline_dialogue() {
-        let text = "Ah, hello there!\nWelcome to Kilteevan.\nCome in, come in.\n---\n{\"action\": \"beckons\", \"mood\": \"welcoming\"}";
+    fn test_parse_npc_stream_response_invalid_json() {
+        let text = "{not valid json at all";
         let parsed = parse_npc_stream_response(text);
-        assert!(parsed.dialogue.contains("Welcome to Kilteevan."));
-        assert!(parsed.dialogue.contains("Come in, come in."));
-        let meta = parsed.metadata.unwrap();
-        assert_eq!(meta.action, "beckons");
+        assert_eq!(parsed.dialogue, "{not valid json at all");
+        assert!(parsed.metadata.is_none());
     }
 
     #[test]
-    fn test_parse_npc_stream_response_triple_dash_in_dialogue() {
-        let text = "The road is long --- perhaps too long.\n---\n{\"mood\": \"weary\"}";
-        let parsed = parse_npc_stream_response(text);
-        assert_eq!(parsed.dialogue, "The road is long --- perhaps too long.");
-        let meta = parsed.metadata.unwrap();
-        assert_eq!(meta.mood, "weary");
-    }
-
-    #[test]
-    fn test_parse_npc_stream_response_whitespace_only_dialogue() {
-        let text = "   \n---\n{\"action\": \"silent\", \"mood\": \"pensive\"}";
+    fn test_parse_npc_stream_response_empty_json() {
+        let text = "{}";
         let parsed = parse_npc_stream_response(text);
         assert_eq!(parsed.dialogue, "");
         let meta = parsed.metadata.unwrap();
-        assert_eq!(meta.action, "silent");
+        assert_eq!(meta.action, "");
+        assert_eq!(meta.mood, "");
+        assert!(meta.internal_thought.is_none());
+        assert!(meta.language_hints.is_empty());
     }
 }

--- a/crates/parish-npc/src/lib.rs
+++ b/crates/parish-npc/src/lib.rs
@@ -255,11 +255,14 @@ pub struct NpcMetadata {
 /// Parses a complete NPC response (JSON format) into dialogue and metadata.
 ///
 /// Expects a JSON object with a `dialogue` field and metadata fields.
+/// Strips Markdown code fences (`` ```json ... ``` ``) that some providers
+/// (notably Anthropic) occasionally wrap around JSON output.
 /// Falls back to treating the entire text as plain dialogue if JSON parsing fails.
 pub fn parse_npc_stream_response(full_text: &str) -> NpcStreamResponse {
     let trimmed = full_text.trim();
+    let stripped = strip_json_fence(trimmed);
 
-    if let Ok(json_resp) = serde_json::from_str::<NpcJsonResponse>(trimmed) {
+    if let Ok(json_resp) = serde_json::from_str::<NpcJsonResponse>(stripped) {
         let dialogue = json_resp.dialogue.clone();
         let metadata = Some(NpcMetadata {
             action: json_resp.action,
@@ -275,6 +278,24 @@ pub fn parse_npc_stream_response(full_text: &str) -> NpcStreamResponse {
         dialogue: trimmed.to_string(),
         metadata: None,
     }
+}
+
+/// Strips Markdown code-fence wrappers that some models emit around JSON.
+fn strip_json_fence(raw: &str) -> &str {
+    let t = raw.trim();
+    if let Some(inner) = t.strip_prefix("```json") {
+        return inner
+            .trim_start_matches('\n')
+            .trim_end_matches("```")
+            .trim();
+    }
+    if let Some(inner) = t.strip_prefix("```") {
+        return inner
+            .trim_start_matches('\n')
+            .trim_end_matches("```")
+            .trim();
+    }
+    t
 }
 
 /// The improv craft guidelines injected into the system prompt when improv mode is enabled.
@@ -644,8 +665,14 @@ mod tests {
         assert!(prompt.contains("58-year-old"));
         assert!(prompt.contains("Publican"));
         assert!(prompt.contains("content"));
-        assert!(prompt.contains("---"));
-        assert!(prompt.contains("JSON metadata block"));
+        assert!(
+            prompt.contains("JSON object"),
+            "prompt should instruct JSON object response format"
+        );
+        assert!(
+            prompt.contains("\"dialogue\""),
+            "prompt should mention the dialogue field"
+        );
         assert!(
             prompt.contains("1820"),
             "prompt should specify the year 1820"
@@ -880,5 +907,33 @@ mod tests {
         assert_eq!(meta.mood, "");
         assert!(meta.internal_thought.is_none());
         assert!(meta.language_hints.is_empty());
+    }
+
+    #[test]
+    fn test_parse_npc_stream_response_fenced_json() {
+        let text = "```json\n{\"dialogue\": \"Hello there!\", \"mood\": \"friendly\"}\n```";
+        let parsed = parse_npc_stream_response(text);
+        assert_eq!(parsed.dialogue, "Hello there!");
+        let meta = parsed.metadata.unwrap();
+        assert_eq!(meta.mood, "friendly");
+    }
+
+    #[test]
+    fn test_parse_npc_stream_response_fenced_json_untagged() {
+        let text = "```\n{\"dialogue\": \"Good day!\", \"action\": \"waves\"}\n```";
+        let parsed = parse_npc_stream_response(text);
+        assert_eq!(parsed.dialogue, "Good day!");
+        let meta = parsed.metadata.unwrap();
+        assert_eq!(meta.action, "waves");
+    }
+
+    #[test]
+    fn test_strip_json_fence_plain() {
+        assert_eq!(strip_json_fence(r#"{"a":1}"#), r#"{"a":1}"#);
+    }
+
+    #[test]
+    fn test_strip_json_fence_markdown() {
+        assert_eq!(strip_json_fence("```json\n{\"a\":1}\n```"), r#"{"a":1}"#);
     }
 }

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -2156,7 +2156,7 @@ pub(crate) mod tests {
                 prompt_log.lock().unwrap().push(request.prompt.clone());
 
                 let text = scripted.pop_front().unwrap_or_else(|| {
-                    "Aye.\n---\n{\"action\":\"speaks\",\"mood\":\"content\"}".to_string()
+                    r#"{"dialogue":"Aye.","action":"speaks","mood":"content"}"#.to_string()
                 });
 
                 let _ = request.response_tx.send(InferenceResponse {
@@ -2311,8 +2311,8 @@ pub(crate) mod tests {
         let (prompts, worker) = install_scripted_inference_queue(
             &state,
             vec![
-                "I heard the fair will be lively.\n---\n{\"action\":\"speaks\",\"mood\":\"curious\"}",
-                "If it is, Siobhan, I'll bring the cart.\n---\n{\"action\":\"speaks\",\"mood\":\"content\"}",
+                r#"{"dialogue":"I heard the fair will be lively.","action":"speaks","mood":"curious"}"#,
+                r#"{"dialogue":"If it is, Siobhan, I'll bring the cart.","action":"speaks","mood":"content"}"#,
             ],
         )
         .await;
@@ -2416,9 +2416,9 @@ pub(crate) mod tests {
         let (_prompts, worker) = install_scripted_inference_queue(
             &state,
             vec![
-                "I heard the fair will be lively.\n---\n{\"action\":\"speaks\",\"mood\":\"curious\"}",
-                "If it is, Siobhan, I'll bring the cart.\n---\n{\"action\":\"speaks\",\"mood\":\"content\"}",
-                "I'd come too if my hand wasn't burnt at the forge.\n---\n{\"action\":\"speaks\",\"mood\":\"content\"}",
+                r#"{"dialogue":"I heard the fair will be lively.","action":"speaks","mood":"curious"}"#,
+                r#"{"dialogue":"If it is, Siobhan, I'll bring the cart.","action":"speaks","mood":"content"}"#,
+                r#"{"dialogue":"I'd come too if my hand wasn't burnt at the forge.","action":"speaks","mood":"content"}"#,
             ],
         )
         .await;
@@ -2477,8 +2477,8 @@ pub(crate) mod tests {
         let (prompts, worker) = install_scripted_inference_queue(
             &state,
             vec![
-                "Quiet morning for it.\n---\n{\"action\":\"speaks\",\"mood\":\"content\"}",
-                "Too quiet. Even the crows have given up.\n---\n{\"action\":\"speaks\",\"mood\":\"content\"}",
+                r#"{"dialogue":"Quiet morning for it.","action":"speaks","mood":"content"}"#,
+                r#"{"dialogue":"Too quiet. Even the crows have given up.","action":"speaks","mood":"content"}"#,
             ],
         )
         .await;

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -783,6 +783,7 @@ async fn run_npc_turn(
             None,
             Some(0.7),
             parish_core::inference::InferencePriority::Interactive,
+            true,
         )
         .await;
 

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -857,6 +857,7 @@ async fn run_npc_turn(
             None,
             Some(0.7),
             parish_core::inference::InferencePriority::Interactive,
+            true,
         )
         .await;
 

--- a/crates/parish-types/src/ids.rs
+++ b/crates/parish-types/src/ids.rs
@@ -107,11 +107,6 @@ pub struct LanguageHint {
 /// Backward-compatible alias for [`LanguageHint`].
 pub type IrishWordHint = LanguageHint;
 
-/// Maximum number of bytes to hold back during streaming to detect
-/// the separator pattern. Must be large enough to catch ` --- ` inline
-/// or `  ---\n` on its own line, even when preceded by text on the same line.
-pub const SEPARATOR_HOLDBACK: usize = 24;
-
 /// Rounds a byte offset down to the nearest UTF-8 char boundary in `s`.
 ///
 /// If `pos` is already a char boundary, returns it unchanged. Otherwise
@@ -128,41 +123,80 @@ pub fn floor_char_boundary(s: &str, pos: usize) -> usize {
     p
 }
 
-/// Finds the separator between dialogue and metadata in an NPC response.
+/// Extracts the dialogue field value from a partial JSON string during streaming.
 ///
-/// Looks for `---` as a separator. Handles two cases:
-/// 1. `---` on its own line (with optional whitespace)
-/// 2. `---` appearing inline, e.g. `(smiles) --- {"action": ...}`
+/// Scans the accumulated JSON buffer for the `"dialogue"` field and extracts
+/// its string value as it streams in. Returns `Some(text)` with the dialogue
+/// content extracted so far, or `None` if the dialogue field hasn't started yet.
 ///
-/// Returns `Some((dialogue_end, metadata_start))` — the byte offset where
-/// dialogue ends and where metadata begins (after the separator).
-/// Returns `None` if no separator is found.
-pub fn find_response_separator(text: &str) -> Option<(usize, usize)> {
-    // First try: --- on its own line
-    let mut byte_offset = 0;
-    for line in text.split('\n') {
-        if line.trim() == "---" {
-            let dialogue_end = byte_offset;
-            let metadata_start = (byte_offset + line.len() + 1).min(text.len());
-            return Some((dialogue_end, metadata_start));
+/// This enables token-by-token streaming of NPC dialogue to the player while
+/// the full JSON response (including metadata) is still being generated.
+pub fn extract_dialogue_from_partial_json(buffer: &str) -> Option<String> {
+    let dialogue_key_patterns = ["\"dialogue\":\"", "\"dialogue\": \""];
+    let mut value_start = None;
+
+    for pattern in &dialogue_key_patterns {
+        if let Some(pos) = buffer.find(pattern) {
+            value_start = Some(pos + pattern.len());
+            break;
         }
-        byte_offset += line.len() + 1; // +1 for the \n
     }
 
-    // Second try: --- appearing inline (e.g. "text --- {json}")
-    // Look for " --- " or " ---\n" pattern
-    if let Some(pos) = text.find(" --- ") {
-        let dialogue_end = pos;
-        let metadata_start = pos + 5; // skip " --- "
-        return Some((dialogue_end, metadata_start));
-    }
-    if let Some(pos) = text.find(" ---\n") {
-        let dialogue_end = pos;
-        let metadata_start = pos + 5;
-        return Some((dialogue_end, metadata_start));
+    let start = value_start?;
+    let value_bytes = &buffer.as_bytes()[start..];
+
+    let mut result = String::new();
+    let mut i = 0;
+    while i < value_bytes.len() {
+        match value_bytes[i] {
+            b'"' => {
+                return Some(result);
+            }
+            b'\\' if i + 1 < value_bytes.len() => {
+                match value_bytes[i + 1] {
+                    b'"' => result.push('"'),
+                    b'\\' => result.push('\\'),
+                    b'n' => result.push('\n'),
+                    b'r' => result.push('\r'),
+                    b't' => result.push('\t'),
+                    b'/' => result.push('/'),
+                    b'u' => {
+                        if i + 5 < value_bytes.len() {
+                            if let Ok(hex) = std::str::from_utf8(&value_bytes[i + 2..i + 6])
+                                && let Ok(code) = u32::from_str_radix(hex, 16)
+                                && let Some(c) = char::from_u32(code)
+                            {
+                                result.push(c);
+                            }
+                            i += 6;
+                            continue;
+                        } else {
+                            return Some(result);
+                        }
+                    }
+                    _ => {
+                        result.push('\\');
+                        result.push(value_bytes[i + 1] as char);
+                    }
+                }
+                i += 2;
+            }
+            _ => {
+                if let Some(rest) = buffer.get(start + i..) {
+                    if let Some(ch) = rest.chars().next() {
+                        result.push(ch);
+                        i += ch.len_utf8();
+                    } else {
+                        break;
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
     }
 
-    None
+    Some(result)
 }
 
 #[cfg(test)]
@@ -334,49 +368,74 @@ mod tests {
         assert_eq!(floor_char_boundary(s, 5), 5);
     }
 
-    // ── find_response_separator ──────────────────────────────────────────────
+    // ── extract_dialogue_from_partial_json ─────────────────────────────────
 
     #[test]
-    fn separator_found_on_own_line() {
-        let text = "Hello there.\n---\n{\"action\":\"speaks\"}";
-        let (d, m) = find_response_separator(text).unwrap();
-        // dialogue_end sits just past the newline that ends the dialogue —
-        // callers trim trailing whitespace themselves.
-        assert_eq!(&text[..d], "Hello there.\n");
-        assert_eq!(&text[m..], "{\"action\":\"speaks\"}");
+    fn extract_dialogue_complete() {
+        let buf = r#"{"dialogue": "Hello there!", "action": "speaks"}"#;
+        assert_eq!(
+            extract_dialogue_from_partial_json(buf),
+            Some("Hello there!".to_string())
+        );
     }
 
     #[test]
-    fn separator_found_inline() {
-        let text = "Quick line --- {\"action\":\"speaks\"}";
-        let (d, m) = find_response_separator(text).unwrap();
-        assert_eq!(&text[..d], "Quick line");
-        assert_eq!(&text[m..], "{\"action\":\"speaks\"}");
+    fn extract_dialogue_streaming() {
+        let buf = r#"{"dialogue": "Hello th"#;
+        assert_eq!(
+            extract_dialogue_from_partial_json(buf),
+            Some("Hello th".to_string())
+        );
     }
 
     #[test]
-    fn separator_inline_with_newline_suffix() {
-        let text = "Short ---\n{\"a\":1}";
-        let (d, m) = find_response_separator(text).unwrap();
-        assert_eq!(&text[..d], "Short");
-        assert_eq!(&text[m..], "{\"a\":1}");
+    fn extract_dialogue_not_yet_started() {
+        assert_eq!(extract_dialogue_from_partial_json(r#"{"act"#), None);
     }
 
     #[test]
-    fn separator_absent_returns_none() {
-        assert!(find_response_separator("no separator here").is_none());
-        assert!(find_response_separator("").is_none());
+    fn extract_dialogue_with_escapes() {
+        let buf = r#"{"dialogue": "He said \"hello\" to me"}"#;
+        assert_eq!(
+            extract_dialogue_from_partial_json(buf),
+            Some("He said \"hello\" to me".to_string())
+        );
     }
 
     #[test]
-    fn separator_own_line_takes_precedence() {
-        // When both patterns are present, the own-line one wins because
-        // it's checked first.
-        let text = "Intro\n---\ntail --- more";
-        let (d, m) = find_response_separator(text).unwrap();
-        assert_eq!(&text[..d], "Intro\n");
-        // After the own-line separator, the rest includes "tail --- more".
-        assert!(text[m..].starts_with("tail"));
+    fn extract_dialogue_with_newlines() {
+        let buf = r#"{"dialogue": "Line one\nLine two"}"#;
+        assert_eq!(
+            extract_dialogue_from_partial_json(buf),
+            Some("Line one\nLine two".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_dialogue_with_unicode() {
+        let buf = r#"{"dialogue": "Sláinte!"}"#;
+        assert_eq!(
+            extract_dialogue_from_partial_json(buf),
+            Some("Sláinte!".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_dialogue_no_space_after_colon() {
+        let buf = r#"{"dialogue":"Hello!"}"#;
+        assert_eq!(
+            extract_dialogue_from_partial_json(buf),
+            Some("Hello!".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_dialogue_empty_string() {
+        let buf = r#"{"dialogue": ""}"#;
+        assert_eq!(
+            extract_dialogue_from_partial_json(buf),
+            Some(String::new())
+        );
     }
 
     // ── LanguageHint serde ───────────────────────────────────────────────────

--- a/crates/parish-types/src/ids.rs
+++ b/crates/parish-types/src/ids.rs
@@ -432,10 +432,7 @@ mod tests {
     #[test]
     fn extract_dialogue_empty_string() {
         let buf = r#"{"dialogue": ""}"#;
-        assert_eq!(
-            extract_dialogue_from_partial_json(buf),
-            Some(String::new())
-        );
+        assert_eq!(extract_dialogue_from_partial_json(buf), Some(String::new()));
     }
 
     // ── LanguageHint serde ───────────────────────────────────────────────────

--- a/crates/parish-types/src/ids.rs
+++ b/crates/parish-types/src/ids.rs
@@ -132,17 +132,20 @@ pub fn floor_char_boundary(s: &str, pos: usize) -> usize {
 /// This enables token-by-token streaming of NPC dialogue to the player while
 /// the full JSON response (including metadata) is still being generated.
 pub fn extract_dialogue_from_partial_json(buffer: &str) -> Option<String> {
-    let dialogue_key_patterns = ["\"dialogue\":\"", "\"dialogue\": \""];
-    let mut value_start = None;
+    let key = "\"dialogue\"";
+    let key_pos = buffer.find(key)?;
+    let after_key = key_pos + key.len();
 
-    for pattern in &dialogue_key_patterns {
-        if let Some(pos) = buffer.find(pattern) {
-            value_start = Some(pos + pattern.len());
-            break;
-        }
-    }
+    // Skip whitespace between key and colon
+    let rest = &buffer[after_key..];
+    let colon_offset = rest.find(':')?;
+    let after_colon = after_key + colon_offset + 1;
 
-    let start = value_start?;
+    // Skip whitespace between colon and opening quote
+    let rest = &buffer[after_colon..];
+    let quote_offset = rest.find('"')?;
+    let start = after_colon + quote_offset + 1;
+
     let value_bytes = &buffer.as_bytes()[start..];
 
     let mut result = String::new();
@@ -152,7 +155,12 @@ pub fn extract_dialogue_from_partial_json(buffer: &str) -> Option<String> {
             b'"' => {
                 return Some(result);
             }
-            b'\\' if i + 1 < value_bytes.len() => {
+            b'\\' => {
+                if i + 1 >= value_bytes.len() {
+                    // Incomplete escape at end of buffer — stop before it so
+                    // the next chunk can complete the sequence.
+                    return Some(result);
+                }
                 match value_bytes[i + 1] {
                     b'"' => result.push('"'),
                     b'\\' => result.push('\\'),
@@ -433,6 +441,36 @@ mod tests {
     fn extract_dialogue_empty_string() {
         let buf = r#"{"dialogue": ""}"#;
         assert_eq!(extract_dialogue_from_partial_json(buf), Some(String::new()));
+    }
+
+    #[test]
+    fn extract_dialogue_extra_whitespace_around_colon() {
+        let buf = r#"{"dialogue" : "Spaced out!"}"#;
+        assert_eq!(
+            extract_dialogue_from_partial_json(buf),
+            Some("Spaced out!".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_dialogue_newline_after_colon() {
+        let buf = "{ \"dialogue\" :\n  \"Multiline format!\" }";
+        assert_eq!(
+            extract_dialogue_from_partial_json(buf),
+            Some("Multiline format!".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_dialogue_trailing_backslash_at_chunk_boundary() {
+        // Buffer ends mid-escape — should stop before the incomplete escape
+        let buf = r#"{"dialogue": "Hello \"#;
+        let result = extract_dialogue_from_partial_json(buf).unwrap();
+        assert_eq!(result, "Hello ");
+        // When more data arrives, the full escape is re-parsed correctly
+        let buf2 = r#"{"dialogue": "Hello \"world\""}"#;
+        let result2 = extract_dialogue_from_partial_json(buf2).unwrap();
+        assert_eq!(result2, "Hello \"world\"");
     }
 
     // ── LanguageHint serde ───────────────────────────────────────────────────

--- a/crates/parish-types/src/lib.rs
+++ b/crates/parish-types/src/lib.rs
@@ -17,8 +17,8 @@ pub use error::ParishError;
 pub use events::{EventBus, GameEvent};
 pub use gossip::{GossipItem, GossipNetwork};
 pub use ids::{
-    IrishWordHint, LanguageHint, Location, LocationId, NpcId, SEPARATOR_HOLDBACK, Weather,
-    find_response_separator, floor_char_boundary,
+    IrishWordHint, LanguageHint, Location, LocationId, NpcId, Weather,
+    extract_dialogue_from_partial_json, floor_char_boundary,
 };
 pub use time::{DayType, Festival, GameClock, GameSpeed, Season, SpeedConfig, TimeOfDay};
 

--- a/docs/adr/019-json-structured-output-for-npc-dialogue.md
+++ b/docs/adr/019-json-structured-output-for-npc-dialogue.md
@@ -1,0 +1,59 @@
+# ADR 019: JSON Structured Output for NPC Dialogue
+
+**Status:** Accepted
+**Date:** 2026-04-22
+
+## Context
+
+Tier 1 NPC responses used a `---` separator convention: the LLM wrote dialogue
+as free text, followed by `---`, followed by a JSON metadata block. This was
+brittle for several reasons:
+
+- LLMs occasionally produce `---` in dialogue (e.g. Markdown formatting).
+- The separator could split across streaming chunks, requiring a holdback buffer.
+- Parsing relied on prompt compliance — if the LLM ignored format instructions,
+  metadata was silently lost.
+- The fallback chain (separator → legacy NpcAction JSON → plain text) was complex
+  and hard to test.
+
+## Decision
+
+Replace the separator approach with **JSON structured output** using the
+provider's native `response_format: { "type": "json_object" }` mode. The Tier 1
+response is now a single JSON object:
+
+```json
+{
+  "dialogue": "(nods slowly) Aye, the road to Clifden is long...",
+  "action": "nods slowly",
+  "mood": "contemplative",
+  "internal_thought": "This stranger asks too many questions",
+  "language_hints": [{"word": "bóthar", "pronunciation": "BOH-her", "meaning": "road"}],
+  "mentioned_people": []
+}
+```
+
+During streaming, the `dialogue` field is extracted incrementally from the
+partial JSON buffer using `extract_dialogue_from_partial_json()` in
+`parish-types`. Metadata fields are parsed from the complete JSON after
+streaming finishes.
+
+## Consequences
+
+**Positive:**
+- Eliminates separator detection, holdback buffer, and multi-fallback parsing.
+- JSON mode is natively supported by Ollama, OpenAI, and all major providers.
+- Streaming UX is preserved — dialogue appears token-by-token.
+- Metadata (mood, action, language hints) is reliably extracted.
+
+**Negative:**
+- Research suggests forcing JSON can degrade creative output by 17-26% for
+  complex schemas. Our schema is simple (one free-text string field), so the
+  impact is expected to be minimal.
+- Anthropic has no native `response_format` equivalent; we augment the system
+  prompt with a JSON-only instruction instead.
+
+**Neutral:**
+- The `NpcJsonResponse` struct and `NpcMetadata` struct coexist — the former is
+  the deserialization target, the latter is the downstream-facing type used by
+  the rest of the codebase.

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -319,8 +319,8 @@ streaming, and NPC conversation setup across backends.
   `capitalize_first`, `prepare_npc_conversation` (includes anachronism checking),
   `compute_name_hints`, `mask_key`, `render_look_text`. Shared constants:
   `IDLE_MESSAGES`, `INFERENCE_FAILURE_MESSAGES` (Irish-themed canned fallbacks).
-- **`streaming.rs`** — `stream_npc_tokens()` with separator holdback and
-  callback-based token emission; `strip_trailing_json()` for weak models.
+- **`streaming.rs`** — `stream_npc_tokens()` extracts the `dialogue` field
+  incrementally from streaming JSON responses via `extract_dialogue_from_partial_json()`.
 - **`types.rs`** — Serializable IPC types: `WorldSnapshot`, `MapData`, `NpcInfo`,
   `ThemePalette`, `TextLogPayload`, `StreamTokenPayload`, `StreamEndPayload`,
   `NpcReactionPayload`, `LoadingPayload` (with spinner/phrase/color animation),
@@ -333,7 +333,7 @@ All backends share these features through core:
 - LLM-based intent parsing (local keywords first, LLM fallback for ambiguous input)
 - Per-category inference client/model resolution (dialogue, simulation, intent, reaction)
 - System command handling via `CommandEffect` dispatch
-- Token streaming with separator holdback
+- Token streaming with incremental JSON dialogue extraction
 - Loading animation (Celtic cross spinner + Irish phrases) including `/spinner` command
 - Game clock pause/resume during inference (with world-update notification)
 - Weather ticking, NPC schedule ticking, tier assignment

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -14,9 +14,10 @@
 **Fix:** `build_enhanced_context_with_config()` in `npc/ticks.rs` now injects recent short-term memories (up to 5), long-term memory recall (keyword-based, up to 3), and gossip context (up to 2) into every Tier 1 prompt.
 
 ### 3. Inline separator metadata leaks into NPC dialogue
-**Severity:** Medium — **Fixed 2026-03-20**
+**Severity:** Medium — **Fixed 2026-03-20** — **Superseded 2026-04-22**
 **Description:** When the LLM puts `---` inline with dialogue instead of on its own line (e.g., `(smiles) --- {"action":...}`), the separator filter failed to detect it, causing JSON metadata to display to the player.
-**Fix:** Extended `find_response_separator()` to detect `" --- "` and `" ---\n"` inline patterns in addition to `---` on its own line. Increased `SEPARATOR_HOLDBACK` from 16 to 24 bytes.
+**Original fix:** Extended `find_response_separator()` to detect inline patterns. Increased `SEPARATOR_HOLDBACK` from 16 to 24 bytes.
+**Superseded:** The entire separator approach was replaced with JSON structured output (`response_format: json_object`). Tier 1 NPC responses are now full JSON with a `dialogue` field. The `extract_dialogue_from_partial_json()` function extracts dialogue incrementally during streaming. See `parish-types/src/ids.rs`.
 
 ### 2. LLM fallback fails for unusual movement verbs
 **Severity:** Medium — **Fixed 2026-03-20**


### PR DESCRIPTION
Switch Tier 1 NPC responses from brittle `---` separator parsing to
JSON-mode structured output (`response_format: json_object`). The LLM
now returns a single JSON object with `dialogue` as the first field,
enabling reliable streaming extraction via `extract_dialogue_from_partial_json`.

- Add `NpcJsonResponse` struct for direct JSON deserialization
- Add `extract_dialogue_from_partial_json()` for streaming display
- Add `generate_stream_json()` to OpenAI client (sets json_mode flag)
- Add `json_mode` parameter to `InferenceQueue::send()`
- Update system prompt to request JSON output instead of separator format
- Remove `SEPARATOR_HOLDBACK`, `find_response_separator`, `NpcAction`
- Update headless.rs and Tauri events.rs streaming consumers
- Rewrite all tests for JSON-based parsing

https://claude.ai/code/session_013JMc5M7xLHqBvLZUUQYFto