### PR TITLE
docs: refresh .env.example to match current config surface

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -105,5 +105,8 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "commit-commands@claude-plugins-official": true
   }
 }

--- a/.env.example
+++ b/.env.example
@@ -2,17 +2,21 @@
 # Copy this file to .env and fill in your values.
 # .env is gitignored and will not be committed.
 
-# Provider: ollama (default), lmstudio, openrouter, openai, google,
-#           groq, xai, mistral, deepseek, together, custom
+# ─── Local / primary provider ────────────────────────────────────────────────
+
+# Provider: ollama (default), lmstudio, vllm, openrouter, openai, anthropic,
+#           google, groq, xai, mistral, deepseek, together, custom, simulator
 PARISH_PROVIDER=openrouter
 
-# API key (required for cloud providers — all except ollama, lmstudio)
+# API key (required for cloud providers — not needed for ollama, lmstudio,
+# vllm, or simulator)
 PARISH_API_KEY=
 
 # Model name (required for non-ollama providers)
 # Each provider has its own model naming — examples:
 #   openrouter: google/gemma-3-1b-it:free  (see https://openrouter.ai/models)
 #   openai:     gpt-4o-mini
+#   anthropic:  claude-haiku-4-5
 #   google:     gemini-2.0-flash
 #   groq:       llama-3.3-70b-versatile
 #   xai:        grok-3-mini
@@ -23,3 +27,51 @@ PARISH_MODEL=google/gemma-3-1b-it:free
 
 # Base URL override (optional — defaults are set per provider)
 # PARISH_BASE_URL=https://openrouter.ai/api
+
+# ─── Per-category overrides (optional) ───────────────────────────────────────
+# Route a specific inference category to a different provider/model. Each
+# category (DIALOGUE, SIMULATION, INTENT, REACTION) supports the same four
+# knobs as above. Unset categories fall back to the primary provider.
+#
+# PARISH_DIALOGUE_PROVIDER=anthropic
+# PARISH_DIALOGUE_MODEL=claude-haiku-4-5
+# PARISH_DIALOGUE_API_KEY=
+# PARISH_DIALOGUE_BASE_URL=
+#
+# PARISH_SIMULATION_PROVIDER=
+# PARISH_INTENT_PROVIDER=
+# PARISH_REACTION_PROVIDER=
+
+# ─── Legacy cloud dialogue config (optional) ─────────────────────────────────
+# Older single-cloud pathway, superseded by per-category overrides above.
+# PARISH_CLOUD_PROVIDER=openrouter
+# PARISH_CLOUD_MODEL=
+# PARISH_CLOUD_API_KEY=
+# PARISH_CLOUD_BASE_URL=
+
+# ─── Gameplay / runtime ──────────────────────────────────────────────────────
+
+# Enable improv craft mode for NPC dialogue
+# PARISH_IMPROV=1
+
+# Path to a game mod directory (defaults to auto-detecting mods/rundale/)
+# PARISH_MOD=mods/rundale
+
+# ─── Web server (parish --web) ───────────────────────────────────────────────
+
+# Public base URL of the web server. Used to build the OAuth callback URL
+# and must match what is registered in Google Cloud Console.
+# PARISH_BASE_URL=http://localhost:3001
+
+# Google OAuth credentials — if either is unset, OAuth is silently disabled
+# and /auth/login/google is not registered. See docs/oauth-setup.md.
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+
+# WebSocket session signing key. REQUIRED for release builds; debug builds
+# fall back to a random ephemeral key with a warning.
+# PARISH_WS_SIGNING_KEY=
+
+# Comma-separated list of emails allowed to run admin commands
+# (e.g. /admin …). Unset means no user has admin privileges.
+# PARISH_ADMIN_EMAILS=operator@example.com


### PR DESCRIPTION
## Summary
- Expand \`PARISH_PROVIDER\` list to include \`vllm\`, \`anthropic\`, and \`simulator\`, and add an \`anthropic: claude-haiku-4-5\` model example
- Document per-category overrides (\`PARISH_DIALOGUE_*\`, \`PARISH_SIMULATION_*\`, \`PARISH_INTENT_*\`, \`PARISH_REACTION_*\`) and keep the legacy \`PARISH_CLOUD_*\` block as commented-out
- Add a web-server section covering \`GOOGLE_CLIENT_ID\` / \`GOOGLE_CLIENT_SECRET\`, \`PARISH_BASE_URL\`, \`PARISH_WS_SIGNING_KEY\`, and \`PARISH_ADMIN_EMAILS\`
- Include \`PARISH_IMPROV\` and \`PARISH_MOD\` gameplay/runtime knobs
- Enable the \`commit-commands\` plugin in \`.claude/settings.json\`

## Test plan
- [ ] Skim \`.env.example\` and confirm each listed variable is actually read by the codebase (spot-checked against \`parish-config/src/provider.rs\`, \`parish-cli/src/main.rs\`, \`parish-server/src/{lib,routes,cf_auth}.rs\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)