### PR TITLE
fix(a11y): add aria-labels to gameplay chip buttons and debug panel

### DIFF
--- a/apps/ui/src/components/DebugPanel.svelte
+++ b/apps/ui/src/components/DebugPanel.svelte
@@ -68,10 +68,10 @@
 		<div class="debug-header">
 			<span class="debug-title">Debug</span>
 			<div class="debug-actions">
-				<button class="debug-dock-toggle" onclick={() => debugDockLeft.update((v) => !v)}>
+				<button class="debug-dock-toggle" aria-label={$debugDockLeft ? 'Dock panel to bottom' : 'Dock panel to left'} onclick={() => debugDockLeft.update((v) => !v)}>
 					{$debugDockLeft ? 'Dock Bottom' : 'Dock Left'}
 				</button>
-				<button class="debug-close" onclick={() => debugVisible.set(false)}>X</button>
+				<button class="debug-close" aria-label="Close debug panel" onclick={() => debugVisible.set(false)}>X</button>
 			</div>
 		</div>
 

--- a/apps/ui/src/components/InputField.svelte
+++ b/apps/ui/src/components/InputField.svelte
@@ -838,6 +838,7 @@
 			{#each $npcsHere as npc}
 				<button
 					class="npc-chip"
+					aria-label="Speak to {npc.name}"
 					onclick={() => insertNpcMention(npc.name)}
 				>
 					<span class="npc-chip-mood"><MoodIcon mood={npc.mood} /></span>
@@ -857,6 +858,7 @@
 			{#each adjacentLocations as loc}
 				<button
 					class="travel-chip"
+					aria-label="Travel to {loc.name}{loc.travel_minutes !== undefined ? `, ${loc.travel_minutes} minute walk` : ''}"
 					onclick={() => quickTravel(loc.name)}
 					disabled={$streamingActive}
 				>


### PR DESCRIPTION
## Summary

- Add `aria-label` attributes to NPC "Speak To" chip buttons (`"Speak to {name}"`) and travel "Go To" chip buttons (`"Travel to {location}, {N} minute walk"`) in `InputField.svelte`
- Add `aria-label` attributes to debug panel dock toggle and close buttons in `DebugPanel.svelte`

## 💡 What

Descriptive `aria-label` attributes on gameplay interaction chip buttons and debug panel controls so screen readers convey the *action* each button performs, not just its visible text.

## 🎯 Why

Screen reader users could click an NPC chip button and only hear the NPC's name — with no indication that the button's purpose is "speak to" that character. Similarly, the debug panel's "X" close button and "Dock Bottom"/"Dock Left" toggle lacked descriptive labels. These are the primary interaction surfaces for gameplay and debugging.

## ♿ Accessibility

- NPC chips: `aria-label="Speak to {npc.name}"` — clearly communicates the speech action
- Travel chips: `aria-label="Travel to {loc.name}, {N} minute walk"` — includes travel time context
- Debug dock toggle: dynamic `aria-label` matching the dock direction
- Debug close: `aria-label="Close debug panel"`

All changes are additive (aria-label attributes only) with no visual or behavioral impact.

https://claude.ai/code/session_01XDLZCUNfCB1UwPQjo2bjCc