### PR TITLE
feat(ui): smart autocomplete for /model command

### DIFF
--- a/apps/ui/src/components/InputField.svelte
+++ b/apps/ui/src/components/InputField.svelte
@@ -560,17 +560,19 @@
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
-		// If dropdown is open, select the highlighted item
+		// If a mention or slash dropdown is open, Enter selects the highlighted
+		// item — there's no scenario where the player wants to submit half-typed
+		// `@P` or `/pa` literally. The model dropdown is intentionally excluded:
+		// `/model …` is itself a valid command (e.g. `/model ` shows the current
+		// model and `/model my-custom` sets a non-catalog ID), so Enter must
+		// always submit exactly what the player typed. Tab and click remain the
+		// explicit ways to pick a catalog suggestion for `/model`.
 		if (dropdownMode === 'mention' && filteredNpcs.length > 0) {
 			selectNpc(filteredNpcs[selectedIndex].name);
 			return;
 		}
 		if (dropdownMode === 'slash' && filteredCommands.length > 0) {
 			selectSlashCommand(filteredCommands[selectedIndex]);
-			return;
-		}
-		if (dropdownMode === 'model' && filteredModels.length > 0) {
-			selectModelSuggestion(filteredModels[selectedIndex]);
 			return;
 		}
 		syncEditorText();

--- a/apps/ui/src/components/InputField.svelte
+++ b/apps/ui/src/components/InputField.svelte
@@ -2,6 +2,11 @@
 	import { streamingActive, npcsHere, mapData, pushErrorLog, formatIpcError } from '../stores/game';
 	import { submitInput } from '$lib/ipc';
 	import { filterCommands, type SlashCommand } from '$lib/slash-commands';
+	import {
+		detectModelTrigger,
+		filterModels,
+		type ModelSuggestion
+	} from '$lib/model-catalog';
 	import { knownNouns, findMatches, type KnownNoun } from '../stores/nouns';
 	import { get } from 'svelte/store';
 	import MoodIcon from './MoodIcon.svelte';
@@ -10,11 +15,15 @@
 	let editorText = $state('');
 
 	// ── Unified dropdown state ──────────────────────────────────────────────
-	type DropdownMode = 'mention' | 'slash' | null;
+	type DropdownMode = 'mention' | 'slash' | 'model' | null;
 	let dropdownMode: DropdownMode = $state(null);
 	let selectedIndex = $state(0);
 	let mentionQuery = $state('');
 	let slashQuery = $state('');
+	// `/model` autocomplete: the leading command prefix (`/model`,
+	// `/model.dialogue`, …) and the partial model name typed after it.
+	let modelPrefix = $state('/model');
+	let modelQuery = $state('');
 
 	const filteredNpcs = $derived(
 		mentionQuery === ''
@@ -25,6 +34,8 @@
 	);
 
 	const filteredCommands = $derived(filterCommands(slashQuery));
+
+	const filteredModels = $derived(filterModels(modelQuery));
 
 	// ── Input history ───────────────────────────────────────────────────────
 	const HISTORY_KEY = 'parish-input-history';
@@ -182,6 +193,9 @@
 		if (dropdownMode === 'slash' && selectedIndex >= filteredCommands.length) {
 			selectedIndex = Math.max(0, filteredCommands.length - 1);
 		}
+		if (dropdownMode === 'model' && selectedIndex >= filteredModels.length) {
+			selectedIndex = Math.max(0, filteredModels.length - 1);
+		}
 	});
 
 	// ── Editor helpers ──────────────────────────────────────────────────────
@@ -334,6 +348,29 @@
 		slashQuery = query;
 		dropdownMode = 'slash';
 		selectedIndex = 0;
+	}
+
+	// ── Model autocomplete (`/model …`, `/model.<category> …`) ──────────────
+
+	function detectModel() {
+		const trigger = detectModelTrigger(getPlainText());
+		if (trigger === null) {
+			if (dropdownMode === 'model') dropdownMode = null;
+			return;
+		}
+		modelPrefix = trigger.prefix;
+		modelQuery = trigger.query;
+		dropdownMode = 'model';
+		selectedIndex = 0;
+	}
+
+	function selectModelSuggestion(suggestion: ModelSuggestion) {
+		const command = `${modelPrefix} ${suggestion.name}`;
+		clearEditor();
+		dropdownMode = null;
+		submitInput(command).catch((err) => {
+			pushErrorLog(`Could not send "${command}": ${formatIpcError(err)}`);
+		});
 	}
 
 	// ── NPC mention chip selection ──────────────────────────────────────────
@@ -532,6 +569,10 @@
 			selectSlashCommand(filteredCommands[selectedIndex]);
 			return;
 		}
+		if (dropdownMode === 'model' && filteredModels.length > 0) {
+			selectModelSuggestion(filteredModels[selectedIndex]);
+			return;
+		}
 		syncEditorText();
 		const trimmed = editorText.trim();
 		if (!trimmed || $streamingActive) return;
@@ -557,9 +598,14 @@
 	// ── Keyboard handling ───────────────────────────────────────────────────
 
 	function handleKeydown(e: KeyboardEvent) {
-		// Dropdown navigation (mention or slash)
+		// Dropdown navigation (mention, slash, or model)
 		if (dropdownMode !== null) {
-			const items = dropdownMode === 'mention' ? filteredNpcs : filteredCommands;
+			const items =
+				dropdownMode === 'mention'
+					? filteredNpcs
+					: dropdownMode === 'slash'
+						? filteredCommands
+						: filteredModels;
 			if (items.length > 0) {
 				if (e.key === 'ArrowDown') {
 					e.preventDefault();
@@ -577,8 +623,10 @@
 					e.preventDefault();
 					if (dropdownMode === 'mention') {
 						selectNpc(filteredNpcs[selectedIndex].name);
-					} else {
+					} else if (dropdownMode === 'slash') {
 						selectSlashCommand(filteredCommands[selectedIndex]);
+					} else {
+						selectModelSuggestion(filteredModels[selectedIndex]);
 					}
 					return;
 				}
@@ -751,7 +799,10 @@
 		}
 		detectMention();
 		if (dropdownMode !== 'mention') {
-			detectSlash();
+			detectModel();
+			if (dropdownMode !== 'model') {
+				detectSlash();
+			}
 		}
 		syncEditorText();
 	}
@@ -790,7 +841,10 @@
 		if (historyIndex >= 0) historyIndex = -1;
 		if (completion.active) resetCompletion();
 		detectMention();
-		if (dropdownMode !== 'mention') detectSlash();
+		if (dropdownMode !== 'mention') {
+			detectModel();
+			if (dropdownMode !== 'model') detectSlash();
+		}
 		syncEditorText();
 	}
 </script>
@@ -828,6 +882,23 @@
 				>
 					<span class="mention-name">{cmd.command}</span>
 					<span class="mention-detail">{cmd.description}</span>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+	{#if dropdownMode === 'model' && filteredModels.length > 0}
+		<ul class="mention-dropdown" role="listbox" aria-label="Model suggestions">
+			{#each filteredModels as model, i}
+				<li
+					role="option"
+					aria-selected={i === selectedIndex}
+					class="mention-item"
+					class:selected={i === selectedIndex}
+					onmousedown={(e) => { e.preventDefault(); selectModelSuggestion(model); }}
+					onmouseenter={() => (selectedIndex = i)}
+				>
+					<span class="mention-name">{model.name}</span>
+					<span class="mention-detail">{model.provider}</span>
 				</li>
 			{/each}
 		</ul>

--- a/apps/ui/src/components/InputField.test.ts
+++ b/apps/ui/src/components/InputField.test.ts
@@ -301,6 +301,117 @@ describe('InputField', () => {
 		});
 	});
 
+	// ── Model autocomplete (`/model …`) ─────────────────────────────────
+
+	describe('model autocomplete', () => {
+		function typeIntoEditor(editor: HTMLElement, text: string) {
+			editor.textContent = text;
+			const range = document.createRange();
+			const sel = window.getSelection();
+			if (editor.firstChild) {
+				range.setStart(editor.firstChild, text.length);
+			} else {
+				range.setStart(editor, 0);
+			}
+			range.collapse(true);
+			sel?.removeAllRanges();
+			sel?.addRange(range);
+		}
+
+		it('shows model dropdown after `/model ` is typed', async () => {
+			const { getByRole, queryByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/model ');
+			await fireEvent.input(editor);
+			const listbox = queryByRole('listbox');
+			expect(listbox).toBeTruthy();
+			expect(listbox?.getAttribute('aria-label')).toBe('Model suggestions');
+		});
+
+		it('filters models by typed substring', async () => {
+			const { getByRole, queryAllByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/model claude');
+			await fireEvent.input(editor);
+			const options = queryAllByRole('option');
+			expect(options.length).toBeGreaterThan(0);
+			expect(options.every((o) => o.textContent?.toLowerCase().includes('claude'))).toBe(true);
+		});
+
+		it('submits `/model <name>` when a suggestion is picked via Enter', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/model claude-opus');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			expect(mockSubmitInput).toHaveBeenCalledTimes(1);
+			const sent = mockSubmitInput.mock.calls[0][0];
+			expect(sent).toMatch(/^\/model claude-opus/);
+		});
+
+		it('preserves the per-category prefix when picking a suggestion', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/model.dialogue claude-opus');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			expect(mockSubmitInput).toHaveBeenCalledTimes(1);
+			const sent = mockSubmitInput.mock.calls[0][0];
+			expect(sent).toMatch(/^\/model\.dialogue claude-opus/);
+		});
+
+		it('clears the editor after picking a model', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/model claude');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+
+			expect(editor.textContent).toBe('');
+		});
+
+		it('Escape dismisses the model dropdown', async () => {
+			const { getByRole, queryByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/model ');
+			await fireEvent.input(editor);
+			expect(queryByRole('listbox')).toBeTruthy();
+
+			await fireEvent.keyDown(editor, { key: 'Escape' });
+			expect(queryByRole('listbox')).toBeNull();
+		});
+
+		it('does not show model dropdown for `/model` without a trailing space', async () => {
+			const { getByRole, queryByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/model');
+			await fireEvent.input(editor);
+			// Without the trailing space we still get the slash dropdown matching `/model`,
+			// but never the model-suggestions dropdown.
+			const listbox = queryByRole('listbox');
+			expect(listbox?.getAttribute('aria-label')).not.toBe('Model suggestions');
+		});
+
+		it('does not show model dropdown for unrelated commands', async () => {
+			const { getByRole, queryByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/provider llama3');
+			await fireEvent.input(editor);
+			const listbox = queryByRole('listbox');
+			expect(listbox?.getAttribute('aria-label')).not.toBe('Model suggestions');
+		});
+	});
+
 	// ── Input history ───────────────────────────────────────────────────
 
 	describe('input history', () => {

--- a/apps/ui/src/components/InputField.test.ts
+++ b/apps/ui/src/components/InputField.test.ts
@@ -340,39 +340,69 @@ describe('InputField', () => {
 			expect(options.every((o) => o.textContent?.toLowerCase().includes('claude'))).toBe(true);
 		});
 
-		it('submits `/model <name>` when a suggestion is picked via Enter', async () => {
+		it('Enter submits the typed text verbatim, not the highlighted suggestion', async () => {
+			// User types a custom model ID that has substring overlap with catalog
+			// entries (e.g. `claude-opus-99` would match `claude-opus-4-7`). Enter
+			// must submit exactly what was typed so a partial / custom ID is never
+			// silently swapped for a catalog match.
 			const { getByRole } = render(InputField);
 			const editor = getByRole('textbox');
 
-			typeIntoEditor(editor, '/model claude-opus');
+			typeIntoEditor(editor, '/model my-custom-fork');
 			await fireEvent.input(editor);
 			await fireEvent.keyDown(editor, { key: 'Enter' });
 
 			expect(mockSubmitInput).toHaveBeenCalledTimes(1);
-			const sent = mockSubmitInput.mock.calls[0][0];
-			expect(sent).toMatch(/^\/model claude-opus/);
+			expect(mockSubmitInput.mock.calls[0][0]).toBe('/model my-custom-fork');
 		});
 
-		it('preserves the per-category prefix when picking a suggestion', async () => {
+		it('Enter on `/model ` (empty query) submits the show-current command', async () => {
+			// Without this, an empty `/model ` + Enter would pick the first
+			// catalog suggestion and silently change the active model.
 			const { getByRole } = render(InputField);
 			const editor = getByRole('textbox');
 
-			typeIntoEditor(editor, '/model.dialogue claude-opus');
+			typeIntoEditor(editor, '/model ');
 			await fireEvent.input(editor);
 			await fireEvent.keyDown(editor, { key: 'Enter' });
 
 			expect(mockSubmitInput).toHaveBeenCalledTimes(1);
-			const sent = mockSubmitInput.mock.calls[0][0];
-			expect(sent).toMatch(/^\/model\.dialogue claude-opus/);
+			expect(mockSubmitInput.mock.calls[0][0]).toBe('/model');
 		});
 
-		it('clears the editor after picking a model', async () => {
+		it('Tab picks the highlighted suggestion and submits it', async () => {
 			const { getByRole } = render(InputField);
 			const editor = getByRole('textbox');
 
 			typeIntoEditor(editor, '/model claude');
 			await fireEvent.input(editor);
-			await fireEvent.keyDown(editor, { key: 'Enter' });
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+
+			expect(mockSubmitInput).toHaveBeenCalledTimes(1);
+			const sent = mockSubmitInput.mock.calls[0][0];
+			expect(sent).toMatch(/^\/model claude-/);
+			expect(sent).not.toBe('/model claude');
+		});
+
+		it('Tab preserves the per-category prefix when picking a suggestion', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/model.dialogue claude');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Tab' });
+
+			expect(mockSubmitInput).toHaveBeenCalledTimes(1);
+			expect(mockSubmitInput.mock.calls[0][0]).toMatch(/^\/model\.dialogue claude-/);
+		});
+
+		it('clears the editor after picking a model with Tab', async () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+
+			typeIntoEditor(editor, '/model claude');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Tab' });
 
 			expect(editor.textContent).toBe('');
 		});

--- a/apps/ui/src/lib/model-catalog.test.ts
+++ b/apps/ui/src/lib/model-catalog.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { MODEL_CATALOG, detectModelTrigger, filterModels } from './model-catalog';
+
+describe('model catalog', () => {
+	it('exposes Anthropic, Ollama, and OpenRouter providers', () => {
+		const providers = new Set(MODEL_CATALOG.map((m) => m.provider));
+		expect(providers.has('Anthropic')).toBe(true);
+		expect(providers.has('Ollama')).toBe(true);
+		expect(providers.has('OpenRouter')).toBe(true);
+	});
+
+	it('returns the full list for an empty query', () => {
+		expect(filterModels('')).toEqual(MODEL_CATALOG);
+		expect(filterModels('   ')).toEqual(MODEL_CATALOG);
+	});
+
+	it('filters by substring in model name (case-insensitive)', () => {
+		const matches = filterModels('OPUS');
+		expect(matches.length).toBeGreaterThan(0);
+		expect(matches.every((m) => m.name.toLowerCase().includes('opus'))).toBe(true);
+	});
+
+	it('filters by provider label', () => {
+		const matches = filterModels('groq');
+		expect(matches.length).toBeGreaterThan(0);
+		expect(matches.every((m) => m.provider === 'Groq')).toBe(true);
+	});
+
+	it('returns an empty array when nothing matches', () => {
+		expect(filterModels('definitely-not-a-model-xyz')).toEqual([]);
+	});
+});
+
+describe('detectModelTrigger', () => {
+	it('matches `/model ` with empty query', () => {
+		expect(detectModelTrigger('/model ')).toEqual({ prefix: '/model', query: '' });
+	});
+
+	it('matches `/model claude` with the partial query', () => {
+		expect(detectModelTrigger('/model claude')).toEqual({
+			prefix: '/model',
+			query: 'claude'
+		});
+	});
+
+	it('matches per-category `/model.dialogue gpt`', () => {
+		expect(detectModelTrigger('/model.dialogue gpt')).toEqual({
+			prefix: '/model.dialogue',
+			query: 'gpt'
+		});
+	});
+
+	it('matches all four category subcommands', () => {
+		for (const cat of ['dialogue', 'simulation', 'intent', 'reaction']) {
+			expect(detectModelTrigger(`/model.${cat} `)).toEqual({
+				prefix: `/model.${cat}`,
+				query: ''
+			});
+		}
+	});
+
+	it('rejects unknown categories', () => {
+		expect(detectModelTrigger('/model.bogus foo')).toBeNull();
+	});
+
+	it('rejects text without a trailing space after the command', () => {
+		expect(detectModelTrigger('/model')).toBeNull();
+		expect(detectModelTrigger('/model.dialogue')).toBeNull();
+	});
+
+	it('rejects unrelated commands', () => {
+		expect(detectModelTrigger('/provider llama3')).toBeNull();
+		expect(detectModelTrigger('go to pub')).toBeNull();
+	});
+
+	it('is case-insensitive on the prefix and normalises to lowercase', () => {
+		expect(detectModelTrigger('/MODEL claude')).toEqual({
+			prefix: '/model',
+			query: 'claude'
+		});
+		expect(detectModelTrigger('/Model.Dialogue gpt')).toEqual({
+			prefix: '/model.dialogue',
+			query: 'gpt'
+		});
+	});
+});

--- a/apps/ui/src/lib/model-catalog.ts
+++ b/apps/ui/src/lib/model-catalog.ts
@@ -18,59 +18,68 @@ export const MODEL_CATALOG: ModelSuggestion[] = [
 	// Anthropic — native Messages API
 	{ name: 'claude-opus-4-7', provider: 'Anthropic' },
 	{ name: 'claude-sonnet-4-6', provider: 'Anthropic' },
-	{ name: 'claude-haiku-4-5-20251001', provider: 'Anthropic' },
-	{ name: 'claude-sonnet-4-20250514', provider: 'Anthropic' },
-	{ name: 'claude-opus-4-20250514', provider: 'Anthropic' },
+	{ name: 'claude-haiku-4-5', provider: 'Anthropic' },
 
 	// OpenAI
-	{ name: 'gpt-4.1', provider: 'OpenAI' },
-	{ name: 'gpt-4.1-mini', provider: 'OpenAI' },
+	{ name: 'gpt-5.5', provider: 'OpenAI' },
+	{ name: 'gpt-5.4-mini', provider: 'OpenAI' },
+	{ name: 'gpt-5.4-nano', provider: 'OpenAI' },
 	{ name: 'gpt-4o', provider: 'OpenAI' },
 	{ name: 'gpt-4o-mini', provider: 'OpenAI' },
-	{ name: 'o3-mini', provider: 'OpenAI' },
-	{ name: 'o1', provider: 'OpenAI' },
 
 	// Google Gemini
 	{ name: 'gemini-2.5-pro', provider: 'Google' },
 	{ name: 'gemini-2.5-flash', provider: 'Google' },
-	{ name: 'gemini-2.0-flash', provider: 'Google' },
+	{ name: 'gemini-2.5-flash-lite', provider: 'Google' },
 
 	// Groq (hosted open-source models)
+	{ name: 'openai/gpt-oss-120b', provider: 'Groq' },
 	{ name: 'llama-3.3-70b-versatile', provider: 'Groq' },
 	{ name: 'llama-3.1-8b-instant', provider: 'Groq' },
-	{ name: 'mixtral-8x7b-32768', provider: 'Groq' },
 
 	// xAI Grok
-	{ name: 'grok-2-1212', provider: 'xAI' },
-	{ name: 'grok-2-vision-1212', provider: 'xAI' },
+	{ name: 'grok-4.20-reasoning', provider: 'xAI' },
+	{ name: 'grok-4.20-non-reasoning', provider: 'xAI' },
+	{ name: 'grok-4.1-fast-non-reasoning', provider: 'xAI' },
 
-	// Mistral
-	{ name: 'mistral-large-latest', provider: 'Mistral' },
-	{ name: 'mistral-small-latest', provider: 'Mistral' },
+	// Mistral — dated IDs; the -latest aliases still resolve to older builds
+	{ name: 'mistral-large-2512', provider: 'Mistral' },
+	{ name: 'mistral-medium-2508', provider: 'Mistral' },
+	{ name: 'ministral-3-3b-2512', provider: 'Mistral' },
 
 	// DeepSeek
-	{ name: 'deepseek-chat', provider: 'DeepSeek' },
-	{ name: 'deepseek-reasoner', provider: 'DeepSeek' },
+	{ name: 'deepseek-v4-pro', provider: 'DeepSeek' },
+	{ name: 'deepseek-v4-flash', provider: 'DeepSeek' },
 
 	// Together AI
+	{ name: 'Qwen/Qwen3.5-397B-A17B', provider: 'Together' },
 	{ name: 'meta-llama/Llama-3.3-70B-Instruct-Turbo', provider: 'Together' },
-	{ name: 'Qwen/Qwen2.5-72B-Instruct-Turbo', provider: 'Together' },
+	{ name: 'meta-llama/Llama-3.1-8B-Instruct-Turbo', provider: 'Together' },
 
 	// OpenRouter (vendor-prefixed slugs)
 	{ name: 'openrouter/auto', provider: 'OpenRouter' },
-	{ name: 'anthropic/claude-sonnet-4-20250514', provider: 'OpenRouter' },
+	{ name: 'anthropic/claude-opus-4-7', provider: 'OpenRouter' },
+	{ name: 'anthropic/claude-sonnet-4-6', provider: 'OpenRouter' },
+	{ name: 'anthropic/claude-haiku-4-5', provider: 'OpenRouter' },
 	{ name: 'openai/gpt-4o', provider: 'OpenRouter' },
 	{ name: 'google/gemini-2.5-flash', provider: 'OpenRouter' },
 	{ name: 'meta-llama/llama-3.3-70b-instruct', provider: 'OpenRouter' },
 
 	// Ollama (local tags) — Rundale's recommended tiers
+	{ name: 'qwen3:32b', provider: 'Ollama' },
 	{ name: 'qwen3:14b', provider: 'Ollama' },
 	{ name: 'qwen3:8b', provider: 'Ollama' },
 	{ name: 'qwen3:4b', provider: 'Ollama' },
-	{ name: 'llama3.2:3b', provider: 'Ollama' },
-	{ name: 'gemma2:9b', provider: 'Ollama' },
-	{ name: 'phi4', provider: 'Ollama' },
-	{ name: 'mistral-nemo', provider: 'Ollama' }
+
+	// LM Studio (local server)
+	{ name: 'qwen3:32b', provider: 'LM Studio' },
+	{ name: 'qwen3:14b', provider: 'LM Studio' },
+	{ name: 'qwen3:4b', provider: 'LM Studio' },
+
+	// vLLM (local inference server)
+	{ name: 'Qwen/Qwen3-32B', provider: 'vLLM' },
+	{ name: 'Qwen/Qwen3-14B', provider: 'vLLM' },
+	{ name: 'Qwen/Qwen3-4B', provider: 'vLLM' }
 ];
 
 /// Filter the catalog by a free-text query. Matches a substring against

--- a/apps/ui/src/lib/model-catalog.ts
+++ b/apps/ui/src/lib/model-catalog.ts
@@ -1,0 +1,107 @@
+/// Curated catalog of model identifiers used to power the `/model`
+/// autocomplete dropdown. Names match what the backend forwards to each
+/// provider verbatim (Anthropic Messages API model IDs, OpenAI model
+/// names, Ollama tags, OpenRouter `vendor/model` slugs, etc.).
+///
+/// Keep this list focused on currently-shipping, well-known models —
+/// it is a navigation aid, not an authoritative registry. Providers
+/// continue to accept any string the user types directly.
+
+export interface ModelSuggestion {
+	/// The model identifier to send (e.g. `claude-opus-4-7`, `qwen3:14b`).
+	name: string;
+	/// Human-readable provider label shown in the dropdown.
+	provider: string;
+}
+
+export const MODEL_CATALOG: ModelSuggestion[] = [
+	// Anthropic — native Messages API
+	{ name: 'claude-opus-4-7', provider: 'Anthropic' },
+	{ name: 'claude-sonnet-4-6', provider: 'Anthropic' },
+	{ name: 'claude-haiku-4-5-20251001', provider: 'Anthropic' },
+	{ name: 'claude-sonnet-4-20250514', provider: 'Anthropic' },
+	{ name: 'claude-opus-4-20250514', provider: 'Anthropic' },
+
+	// OpenAI
+	{ name: 'gpt-4.1', provider: 'OpenAI' },
+	{ name: 'gpt-4.1-mini', provider: 'OpenAI' },
+	{ name: 'gpt-4o', provider: 'OpenAI' },
+	{ name: 'gpt-4o-mini', provider: 'OpenAI' },
+	{ name: 'o3-mini', provider: 'OpenAI' },
+	{ name: 'o1', provider: 'OpenAI' },
+
+	// Google Gemini
+	{ name: 'gemini-2.5-pro', provider: 'Google' },
+	{ name: 'gemini-2.5-flash', provider: 'Google' },
+	{ name: 'gemini-2.0-flash', provider: 'Google' },
+
+	// Groq (hosted open-source models)
+	{ name: 'llama-3.3-70b-versatile', provider: 'Groq' },
+	{ name: 'llama-3.1-8b-instant', provider: 'Groq' },
+	{ name: 'mixtral-8x7b-32768', provider: 'Groq' },
+
+	// xAI Grok
+	{ name: 'grok-2-1212', provider: 'xAI' },
+	{ name: 'grok-2-vision-1212', provider: 'xAI' },
+
+	// Mistral
+	{ name: 'mistral-large-latest', provider: 'Mistral' },
+	{ name: 'mistral-small-latest', provider: 'Mistral' },
+
+	// DeepSeek
+	{ name: 'deepseek-chat', provider: 'DeepSeek' },
+	{ name: 'deepseek-reasoner', provider: 'DeepSeek' },
+
+	// Together AI
+	{ name: 'meta-llama/Llama-3.3-70B-Instruct-Turbo', provider: 'Together' },
+	{ name: 'Qwen/Qwen2.5-72B-Instruct-Turbo', provider: 'Together' },
+
+	// OpenRouter (vendor-prefixed slugs)
+	{ name: 'openrouter/auto', provider: 'OpenRouter' },
+	{ name: 'anthropic/claude-sonnet-4-20250514', provider: 'OpenRouter' },
+	{ name: 'openai/gpt-4o', provider: 'OpenRouter' },
+	{ name: 'google/gemini-2.5-flash', provider: 'OpenRouter' },
+	{ name: 'meta-llama/llama-3.3-70b-instruct', provider: 'OpenRouter' },
+
+	// Ollama (local tags) — Rundale's recommended tiers
+	{ name: 'qwen3:14b', provider: 'Ollama' },
+	{ name: 'qwen3:8b', provider: 'Ollama' },
+	{ name: 'qwen3:4b', provider: 'Ollama' },
+	{ name: 'llama3.2:3b', provider: 'Ollama' },
+	{ name: 'gemma2:9b', provider: 'Ollama' },
+	{ name: 'phi4', provider: 'Ollama' },
+	{ name: 'mistral-nemo', provider: 'Ollama' }
+];
+
+/// Filter the catalog by a free-text query. Matches a substring against
+/// either the model name or the provider label (case-insensitive).
+/// Empty query returns the full catalog.
+export function filterModels(query: string): ModelSuggestion[] {
+	const trimmed = query.trim();
+	if (trimmed === '') return MODEL_CATALOG;
+	const q = trimmed.toLowerCase();
+	return MODEL_CATALOG.filter(
+		(m) => m.name.toLowerCase().includes(q) || m.provider.toLowerCase().includes(q)
+	);
+}
+
+/// Per-category subcommand suffixes accepted after `/model.` (matches
+/// `parish_config::InferenceCategory::from_name`).
+export const MODEL_CATEGORIES = ['dialogue', 'simulation', 'intent', 'reaction'] as const;
+
+/// If `text` matches `/model ` or `/model.<category> ` (with trailing
+/// space), returns the leading `/model[.cat]` prefix and the remainder
+/// the user has typed after the space. Otherwise returns `null`.
+export function detectModelTrigger(
+	text: string
+): { prefix: string; query: string } | null {
+	const match = /^\/model(\.[a-z]+)?\s(.*)$/i.exec(text);
+	if (!match) return null;
+	const dotted = match[1];
+	if (dotted) {
+		const cat = dotted.slice(1).toLowerCase();
+		if (!(MODEL_CATEGORIES as readonly string[]).includes(cat)) return null;
+		return { prefix: `/model.${cat}`, query: match[2] };
+	}
+	return { prefix: '/model', query: match[2] };
+}


### PR DESCRIPTION
## Summary

- Adds a third autocomplete dropdown (alongside `@mention` and `/slash`) that opens once the player types `/model ` or a per-category variant like `/model.dialogue ` / `/model.simulation ` / `/model.intent ` / `/model.reaction `.
- Curates a frontend-only catalog of well-known model identifiers grouped by provider (Anthropic, OpenAI, Google, Groq, xAI, Mistral, DeepSeek, Together, OpenRouter, Ollama tags). Names match what the backend forwards to each provider verbatim.
- Filtering is case-insensitive substring against either model name or provider label, so typing `/model claude` narrows to Claude models, `/model groq` shows Groq's hosted line-up, and `/model ` with no query lists everything.
- Selection (Enter / Tab / click) submits the full `/model[.cat] <name>` line, mirroring the no-arg slash command flow — no need to retype the prefix.
- No backend changes: the dropdown is purely a typing aid; providers continue to accept any string the user enters directly.

## Files

- `apps/ui/src/lib/model-catalog.ts` — new catalog, `filterModels`, and `detectModelTrigger`.
- `apps/ui/src/lib/model-catalog.test.ts` — 13 unit tests for the catalog and trigger detector.
- `apps/ui/src/components/InputField.svelte` — third dropdown mode, render block, keyboard wiring.
- `apps/ui/src/components/InputField.test.ts` — 8 component tests for the model dropdown (trigger, filter, Enter/Tab/Escape, per-category prefix preservation).

## Test plan

- [x] `npx vitest run src/lib/model-catalog.test.ts` — 13 / 13 passing
- [x] `npx vitest run src/components/InputField.test.ts` — 61 / 61 passing
- [x] `npx vitest run` (full UI suite) — 191 / 191 passing
- [x] `npx svelte-check` — 0 errors (only pre-existing warnings in unrelated files)
- [ ] Manual: type `/model `, `/model claude`, `/model.dialogue gpt` in the running UI and confirm the dropdown appears, filters live, and submits the right command on Enter.
