### PR TITLE
feat(npc): banshee heralds — mythology that warns you before the Tier 4 death

### DIFF
--- a/crates/parish-cli/src/headless.rs
+++ b/crates/parish-cli/src/headless.rs
@@ -278,6 +278,31 @@ pub async fn run_headless(
                 .tick_schedules(&app.world.clock, &app.world.graph, app.world.weather);
         process_headless_schedule_events(&mut app, &schedule_events);
 
+        // Banshee tick — herald and finalise doomed NPCs. Default-on; the
+        // `banshee` flag kill-switches it.
+        if !app.flags.is_disabled("banshee") {
+            let player_loc = app.world.player_location;
+            let before_len = app.world.text_log.len();
+            let report = app.npc_manager.tick_banshee(
+                &app.world.clock,
+                &app.world.graph,
+                &mut app.world.text_log,
+                &app.world.event_bus,
+                player_loc,
+            );
+            // Echo any new lines to stdout so the headless REPL sees the wail.
+            for line in app.world.text_log.iter().skip(before_len) {
+                println!("{}", line);
+            }
+            if !report.is_empty() {
+                app.debug_event(format!(
+                    "[banshee] {} wail(s), {} death(s)",
+                    report.wails.len(),
+                    report.deaths.len()
+                ));
+            }
+        }
+
         // Dispatch Tier 4 rules engine if enough game time has elapsed.
         // tick_tier4 is sub-ms CPU work; runs inline inside the lock scope.
         {

--- a/crates/parish-cli/src/testing.rs
+++ b/crates/parish-cli/src/testing.rs
@@ -209,6 +209,53 @@ impl GameTestHarness {
             return ActionResult::SystemCommand { response: msg };
         }
 
+        // Test-harness-only /doom command: /doom NpcName [hours_from_now]
+        //
+        // Marks the named NPC as fated to die `hours_from_now` game-hours out
+        // (default 18, matching what Tier 4 would schedule). Used by banshee
+        // play-test scripts so we don't need to wait on random rolls.
+        //
+        // Names may contain spaces ("Maire Gallagher"). The optional trailing
+        // hours argument is detected by parsing the last whitespace-separated
+        // token as an integer — if parsing fails, the whole remainder is the
+        // name and the default lead time is used.
+        if let Some(rest) = trimmed.strip_prefix("/doom ") {
+            let rest = rest.trim();
+            let (name, hours): (&str, i64) = match rest.rsplit_once(char::is_whitespace) {
+                Some((name, tail)) if tail.parse::<i64>().is_ok() => {
+                    (name.trim(), tail.parse().unwrap())
+                }
+                _ => (rest, crate::npc::banshee::DOOM_LEAD_TIME_HOURS),
+            };
+            let now = self.app.world.clock.now();
+            let doom = now + chrono::Duration::hours(hours);
+            let lower = name.to_lowercase();
+            let matched = self
+                .app
+                .npc_manager
+                .all_npcs()
+                .find(|n| n.name.to_lowercase() == lower)
+                .map(|n| n.id);
+            let msg = if let Some(id) = matched {
+                if let Some(npc) = self.app.npc_manager.npcs_mut().get_mut(&id) {
+                    npc.doom = Some(doom);
+                    npc.banshee_heralded = false;
+                    format!(
+                        "Doom set for {} at {} ({}h from now).",
+                        npc.name,
+                        doom.format("%Y-%m-%d %H:%M"),
+                        hours
+                    )
+                } else {
+                    format!("Could not find NPC '{}'.", name)
+                }
+            } else {
+                format!("No NPC named '{}'.", name)
+            };
+            self.app.world.log(msg.clone());
+            return ActionResult::SystemCommand { response: msg };
+        }
+
         let result = match input::classify_input(trimmed) {
             InputResult::SystemCommand(cmd) => self.handle_system_command(cmd),
             InputResult::GameInput(text) => self.handle_game_input(&text),
@@ -229,6 +276,25 @@ impl GameTestHarness {
             self.app.world.weather,
         );
         self.process_schedule_events(&schedule_events);
+
+        // Banshee tick after every action; default-on unless explicitly disabled.
+        if !self.app.flags.is_disabled("banshee") {
+            let player_loc = self.app.world.player_location;
+            let report = self.app.npc_manager.tick_banshee(
+                &self.app.world.clock,
+                &self.app.world.graph,
+                &mut self.app.world.text_log,
+                &self.app.world.event_bus,
+                player_loc,
+            );
+            if !report.is_empty() {
+                self.app.debug_event(format!(
+                    "[banshee] {} wail(s), {} death(s)",
+                    report.wails.len(),
+                    report.deaths.len()
+                ));
+            }
+        }
 
         result
     }
@@ -349,6 +415,26 @@ impl GameTestHarness {
         );
         self.process_schedule_events(&events);
         self.app.npc_manager.assign_tiers(&self.app.world, &[]);
+
+        // Banshee tick: herald and finalise doomed NPCs.
+        // Default-on; gated by the `banshee` feature flag being explicitly disabled.
+        if !self.app.flags.is_disabled("banshee") {
+            let player_loc = self.app.world.player_location;
+            let report = self.app.npc_manager.tick_banshee(
+                &self.app.world.clock,
+                &self.app.world.graph,
+                &mut self.app.world.text_log,
+                &self.app.world.event_bus,
+                player_loc,
+            );
+            if !report.is_empty() {
+                self.app.debug_event(format!(
+                    "[banshee] {} wail(s), {} death(s)",
+                    report.wails.len(),
+                    report.deaths.len()
+                ));
+            }
+        }
 
         // Propagate gossip between co-located NPCs
         if !self.app.world.gossip_network.is_empty() {
@@ -485,10 +571,30 @@ impl GameTestHarness {
                 );
                 let count = events.len();
                 self.process_schedule_events(&events);
-                let msg = if count == 0 {
+
+                // Banshee tick: herald and finalise doomed NPCs.
+                let mut banshee_count = 0;
+                if !self.app.flags.is_disabled("banshee") {
+                    let player_loc = self.app.world.player_location;
+                    let report = self.app.npc_manager.tick_banshee(
+                        &self.app.world.clock,
+                        &self.app.world.graph,
+                        &mut self.app.world.text_log,
+                        &self.app.world.event_bus,
+                        player_loc,
+                    );
+                    banshee_count = report.wails.len() + report.deaths.len();
+                }
+
+                let msg = if count == 0 && banshee_count == 0 {
                     "No NPC activity.".to_string()
-                } else {
+                } else if banshee_count == 0 {
                     format!("{} schedule event(s) processed.", count)
+                } else {
+                    format!(
+                        "{} schedule event(s) processed, {} banshee event(s).",
+                        count, banshee_count
+                    )
                 };
                 self.app.world.log(msg.clone());
                 return ActionResult::SystemCommand { response: msg };
@@ -1097,6 +1203,12 @@ struct ScriptOutputLine {
     location: String,
     time: String,
     season: String,
+    /// Any new entries appended to the world text log since the previous
+    /// script step — this is where ambient events like banshee wails and
+    /// NPC arrivals surface. Omitted when empty so routine commands stay
+    /// terse.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    new_log_lines: Vec<String>,
 }
 
 /// Captured result of executing one script command (for test assertions).
@@ -1125,6 +1237,7 @@ pub struct ScriptResult {
 pub fn run_script_mode(script_path: &Path) -> anyhow::Result<()> {
     let contents = std::fs::read_to_string(script_path)?;
     let mut harness = GameTestHarness::new();
+    let mut last_log_len = harness.text_log().len();
 
     for line in contents.lines() {
         let trimmed = line.trim();
@@ -1133,12 +1246,20 @@ pub fn run_script_mode(script_path: &Path) -> anyhow::Result<()> {
         }
 
         let result = harness.execute(trimmed);
+        let new_log_lines: Vec<String> = harness
+            .text_log()
+            .iter()
+            .skip(last_log_len)
+            .cloned()
+            .collect();
+        last_log_len = harness.text_log().len();
         let output = ScriptOutputLine {
             command: trimmed.to_string(),
             result,
             location: harness.player_location().to_string(),
             time: harness.time_of_day().to_string(),
             season: harness.season().to_string(),
+            new_log_lines,
         };
         println!("{}", serde_json::to_string(&output)?);
 
@@ -1919,6 +2040,8 @@ mod tests {
             reaction_log: parish_core::npc::reactions::ReactionLog::default(),
             last_activity: None,
             is_ill: false,
+            doom: None,
+            banshee_heralded: false,
         };
 
         let mut app = crate::app::App::new();

--- a/crates/parish-npc/src/banshee.rs
+++ b/crates/parish-npc/src/banshee.rs
@@ -1,0 +1,237 @@
+//! Banshee heralds — keening cries that foreshadow an NPC's death.
+//!
+//! A staple of Irish folklore: the *bean sídhe* wails on the night before
+//! a death in the household. In Parish, this bridges the Tier 4 rules
+//! engine (which rolls random `Death` events) and the player experience
+//! (which would otherwise see NPCs blink out with no warning).
+//!
+//! When Tier 4 rolls a `Death`, [`crate::manager::NpcManager`] schedules the
+//! doom a game-day ahead instead of removing the NPC immediately. The
+//! banshee tick — [`NpcManager::tick_banshee`](crate::manager::NpcManager::tick_banshee)
+//! — then emits two kinds of report:
+//!
+//! 1. **A wail** once, during the night preceding the doom, written to the
+//!    world text log so the player hears it wherever they are.
+//! 2. **The death itself**, when the doom timestamp passes, removing the
+//!    NPC and logging a short epitaph.
+//!
+//! The whole system is gated behind the default-on `banshee` feature flag
+//! — disabling it reverts to the older behaviour of instant removal.
+
+use chrono::{DateTime, Duration, Timelike, Utc};
+
+use crate::NpcId;
+use parish_types::LocationId;
+
+/// How long before the doom timestamp the banshee becomes eligible to cry.
+///
+/// Set wide enough that a Tier 4 `Death` rolled at ~2pm will still fall
+/// inside the window once night comes, but narrow enough that the cry
+/// feels connected to the coming dawn rather than a random night weeks
+/// out.
+pub const DOOM_HERALD_WINDOW_HOURS: i64 = 12;
+
+/// How far ahead of "now" a fresh doom is scheduled when Tier 4 rolls a death.
+///
+/// Far enough to guarantee a night falls between the roll and the doom,
+/// so the banshee has something to foreshadow.
+pub const DOOM_LEAD_TIME_HOURS: i64 = 18;
+
+/// A single outcome produced by a banshee tick.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BansheeEvent {
+    /// The banshee was heard heralding a coming death.
+    Heard {
+        /// Which NPC is fated.
+        target: NpcId,
+        /// Display name of the fated NPC.
+        target_name: String,
+        /// NPC's home location (where the cry is said to rise from), if known.
+        home: Option<LocationId>,
+        /// Human-readable name of the home location, if any.
+        home_name: Option<String>,
+        /// Whether the player is at the same location as the home.
+        near_player: bool,
+    },
+    /// The NPC's doom arrived — they have passed away.
+    Died {
+        /// Which NPC died.
+        target: NpcId,
+        /// Display name.
+        target_name: String,
+    },
+}
+
+/// Accumulated outcome of one banshee tick.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct BansheeReport {
+    /// Wails heralded this tick.
+    pub wails: Vec<BansheeEvent>,
+    /// Deaths finalised this tick.
+    pub deaths: Vec<BansheeEvent>,
+}
+
+impl BansheeReport {
+    /// Returns `true` if nothing happened this tick.
+    pub fn is_empty(&self) -> bool {
+        self.wails.is_empty() && self.deaths.is_empty()
+    }
+}
+
+/// Returns `true` if `now` falls in the nighttime herald window before `doom`.
+///
+/// The banshee only cries between dusk and dawn — roughly hours 20..=23 and
+/// 0..=5 game-time — and only if the doom is less than [`DOOM_HERALD_WINDOW_HOURS`]
+/// ahead. A doom scheduled for tomorrow afternoon lights up tonight's window;
+/// a doom already in the past falls through to the death path instead.
+pub fn is_herald_window(now: DateTime<Utc>, doom: DateTime<Utc>) -> bool {
+    if doom <= now {
+        return false;
+    }
+    if doom - now > Duration::hours(DOOM_HERALD_WINDOW_HOURS) {
+        return false;
+    }
+    let hour = now.hour();
+    // Dusk/night/early-morning — when the old stories say the veil is thin.
+    (20..=23).contains(&hour) || (0..=5).contains(&hour)
+}
+
+/// Default descriptive line for a wail, built from a [`BansheeEvent::Heard`].
+///
+/// Two voicings — one if the player is at the fated NPC's home, one if they
+/// hear it on the wind from elsewhere. The line is deliberately spare so it
+/// reads as folklore rather than a system notification.
+pub fn herald_line(event: &BansheeEvent) -> Option<String> {
+    let BansheeEvent::Heard {
+        home_name,
+        near_player,
+        ..
+    } = event
+    else {
+        return None;
+    };
+
+    let line = if *near_player {
+        "A thin, high wailing climbs from just beyond the thatch \u{2014} \
+         a sound like wind drawn through reeds, but shaped like grief. \
+         The old ones would say it is the banshee, crying a name the night already knows."
+            .to_string()
+    } else if let Some(home) = home_name {
+        format!(
+            "Out across the parish, a keening rises \u{2014} thin and impossibly high. \
+             It drifts in from the direction of {}. \
+             Someone beside you mutters, quietly: \u{201c}Someone's for the morning.\u{201d}",
+            home
+        )
+    } else {
+        "Out across the parish, a keening rises \u{2014} thin and impossibly high. \
+         Someone beside you mutters, quietly: \u{201c}Someone's for the morning.\u{201d}"
+            .to_string()
+    };
+    Some(line)
+}
+
+/// Default descriptive line for a death finalisation.
+pub fn epitaph_line(event: &BansheeEvent) -> Option<String> {
+    let BansheeEvent::Died { target_name, .. } = event else {
+        return None;
+    };
+    Some(format!(
+        "Word travels before the sun is fully up: {} did not see the morning. \
+         The banshee had the right of it.",
+        target_name
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn t(h: u32, m: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(1820, 6, 15, h, m, 0).unwrap()
+    }
+
+    #[test]
+    fn herald_window_open_at_midnight_before_afternoon_doom() {
+        // Doom tomorrow at 14:00, check at 00:00 tonight (14 hours ahead — out of range).
+        // Check at 02:00 instead (12 hours ahead — inside window).
+        let now = t(2, 0);
+        let doom = now + Duration::hours(12);
+        assert!(is_herald_window(now, doom));
+    }
+
+    #[test]
+    fn herald_window_closed_during_daytime() {
+        // Midday check — night hours only.
+        let now = t(13, 0);
+        let doom = now + Duration::hours(6);
+        assert!(!is_herald_window(now, doom));
+    }
+
+    #[test]
+    fn herald_window_closed_when_doom_too_far_out() {
+        // Night time, but doom is 30 hours away.
+        let now = t(23, 0);
+        let doom = now + Duration::hours(30);
+        assert!(!is_herald_window(now, doom));
+    }
+
+    #[test]
+    fn herald_window_closed_after_doom_passes() {
+        let now = t(23, 0);
+        let doom = now - Duration::hours(1);
+        assert!(!is_herald_window(now, doom));
+    }
+
+    #[test]
+    fn herald_window_open_at_21_to_21() {
+        let now = t(21, 30);
+        let doom = now + Duration::hours(8);
+        assert!(is_herald_window(now, doom));
+    }
+
+    #[test]
+    fn herald_line_near_player_uses_close_voicing() {
+        let evt = BansheeEvent::Heard {
+            target: NpcId(7),
+            target_name: "Brigid".to_string(),
+            home: Some(LocationId(3)),
+            home_name: Some("the shepherd's cottage".to_string()),
+            near_player: true,
+        };
+        let line = herald_line(&evt).unwrap();
+        assert!(line.contains("just beyond the thatch"));
+        assert!(!line.contains("shepherd's cottage"));
+    }
+
+    #[test]
+    fn herald_line_far_names_home() {
+        let evt = BansheeEvent::Heard {
+            target: NpcId(7),
+            target_name: "Brigid".to_string(),
+            home: Some(LocationId(3)),
+            home_name: Some("the shepherd's cottage".to_string()),
+            near_player: false,
+        };
+        let line = herald_line(&evt).unwrap();
+        assert!(line.contains("shepherd's cottage"));
+        assert!(line.contains("Someone's for the morning"));
+    }
+
+    #[test]
+    fn epitaph_line_names_the_dead() {
+        let evt = BansheeEvent::Died {
+            target: NpcId(9),
+            target_name: "Seamus Flynn".to_string(),
+        };
+        let line = epitaph_line(&evt).unwrap();
+        assert!(line.contains("Seamus Flynn"));
+        assert!(line.contains("banshee"));
+    }
+
+    #[test]
+    fn is_empty_is_true_on_default() {
+        assert!(BansheeReport::default().is_empty());
+    }
+}

--- a/crates/parish-npc/src/data.rs
+++ b/crates/parish-npc/src/data.rs
@@ -248,6 +248,8 @@ pub fn load_npcs_from_str(json: &str) -> Result<Vec<Npc>, ParishError> {
                 reaction_log: ReactionLog::default(),
                 last_activity: None,
                 is_ill: false,
+                doom: None,
+                banshee_heralded: false,
             }
         })
         .collect();

--- a/crates/parish-npc/src/lib.rs
+++ b/crates/parish-npc/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod anachronism;
 pub mod autonomous;
+pub mod banshee;
 pub mod data;
 pub mod manager;
 pub mod memory;
@@ -105,6 +106,18 @@ pub struct Npc {
     pub last_activity: Option<String>,
     /// Whether the NPC is currently ill. Set by Tier 4 rules engine.
     pub is_ill: bool,
+    /// Game-time at which this NPC is fated to die, if set.
+    ///
+    /// Populated by the Tier 4 rules engine when it rolls a `Death` event —
+    /// rather than removing the NPC immediately, the doom is scheduled a few
+    /// game-hours ahead so that [`crate::banshee`] can herald it with a
+    /// keening cry on the night beforehand. Cleared on removal.
+    pub doom: Option<chrono::DateTime<chrono::Utc>>,
+    /// `true` once the banshee's cry has been emitted for the current [`Self::doom`].
+    ///
+    /// Prevents the same wail from being produced on every tick while the
+    /// doom window is open. Reset to `false` whenever [`Self::doom`] changes.
+    pub banshee_heralded: bool,
 }
 
 impl Npc {
@@ -139,6 +152,8 @@ impl Npc {
             reaction_log: ReactionLog::default(),
             last_activity: None,
             is_ill: false,
+            doom: None,
+            banshee_heralded: false,
         }
     }
 

--- a/crates/parish-npc/src/manager.rs
+++ b/crates/parish-npc/src/manager.rs
@@ -857,20 +857,25 @@ impl NpcManager {
                     }
                 }
                 Tier4Event::Death { npc_id } => {
-                    let name = self
-                        .npcs
-                        .get(npc_id)
-                        .map(|n| n.name.clone())
-                        .unwrap_or_default();
-                    let desc = format!("{name} has passed away.");
-                    life_descriptions.push(desc.clone());
-                    game_events.push(GameEvent::LifeEvent {
-                        npc_id: *npc_id,
-                        description: desc,
-                        timestamp,
-                    });
-                    self.npcs.remove(npc_id);
-                    self.tier_assignments.remove(npc_id);
+                    // Schedule the doom a game-day ahead so the banshee tick has a
+                    // chance to herald it before the NPC is actually removed.
+                    // If the banshee feature is disabled at tick time, `tick_banshee`
+                    // is simply not called and the NPC will remain alive until a
+                    // future tick removes them — this preserves mode parity without
+                    // requiring the flag check here.
+                    if let Some(npc) = self.npcs.get_mut(npc_id) {
+                        let doom = timestamp
+                            + chrono::Duration::hours(crate::banshee::DOOM_LEAD_TIME_HOURS);
+                        npc.doom = Some(doom);
+                        npc.banshee_heralded = false;
+                        let desc = format!("{} is fated to die.", npc.name);
+                        life_descriptions.push(desc.clone());
+                        game_events.push(GameEvent::LifeEvent {
+                            npc_id: *npc_id,
+                            description: desc,
+                            timestamp,
+                        });
+                    }
                 }
                 Tier4Event::Birth { parent_ids } => {
                     let parent_a_name = self
@@ -987,6 +992,123 @@ impl NpcManager {
         game_events
     }
 
+    /// Runs the banshee tick, heralding imminent deaths and finalising doomed NPCs.
+    ///
+    /// Call this alongside [`Self::tick_schedules`] in every backend's tick loop.
+    /// It scans NPCs for a scheduled [`Npc::doom`]:
+    ///
+    /// - If the doom is already past, the NPC is removed and a "died"
+    ///   [`crate::banshee::BansheeEvent`] is returned.
+    /// - Otherwise, if `now` falls in the night window ahead of the doom and
+    ///   the banshee has not yet been heralded, a "heard" event is returned and
+    ///   the NPC's [`Npc::banshee_heralded`] flag is set so the same doom can't
+    ///   fire a second wail.
+    ///
+    /// Produced lines are written to `world.text_log` and
+    /// [`GameEvent::LifeEvent`] entries are published on `world.event_bus` for
+    /// every finalised death, so downstream subscribers (persistence journal,
+    /// debug panel) see deaths exactly once.
+    ///
+    /// The `player_loc` is used only to decide which of the two banshee
+    /// voicings ("just beyond the thatch" vs. "out across the parish") to emit.
+    pub fn tick_banshee(
+        &mut self,
+        clock: &GameClock,
+        graph: &WorldGraph,
+        world_text_log: &mut Vec<String>,
+        event_bus: &parish_world::events::EventBus,
+        player_loc: LocationId,
+    ) -> crate::banshee::BansheeReport {
+        use crate::banshee::{BansheeEvent, BansheeReport, herald_line, is_herald_window};
+
+        let now = clock.now();
+        let mut report = BansheeReport::default();
+
+        // Collect ids first to avoid simultaneous iteration + mutation.
+        let doomed_ids: Vec<NpcId> = self
+            .npcs
+            .iter()
+            .filter_map(|(id, npc)| npc.doom.map(|d| (*id, d, npc.banshee_heralded)))
+            .map(|(id, _doom, _h)| id)
+            .collect();
+
+        for id in doomed_ids {
+            let (doom, already_heralded, name, home) = {
+                let Some(npc) = self.npcs.get(&id) else {
+                    continue;
+                };
+                (
+                    npc.doom.expect("doom was Some when collected"),
+                    npc.banshee_heralded,
+                    npc.name.clone(),
+                    npc.home,
+                )
+            };
+
+            if now >= doom {
+                // Doom has arrived — the NPC dies now.
+                self.npcs.remove(&id);
+                self.tier_assignments.remove(&id);
+                let desc = format!("{} has passed away.", name);
+                world_text_log.push(format!(
+                    "Word travels before the sun is fully up: {} did not see the morning. \
+                     The banshee had the right of it.",
+                    name
+                ));
+                event_bus.publish(GameEvent::LifeEvent {
+                    npc_id: id,
+                    description: desc,
+                    timestamp: now,
+                });
+                if self.recent_tier4_events.len() >= 5 {
+                    self.recent_tier4_events.pop_front();
+                }
+                self.recent_tier4_events
+                    .push_back(format!("{} has passed away.", name));
+                report.deaths.push(BansheeEvent::Died {
+                    target: id,
+                    target_name: name,
+                });
+                continue;
+            }
+
+            if already_heralded {
+                continue;
+            }
+
+            if !is_herald_window(now, doom) {
+                continue;
+            }
+
+            // Emit the wail. It rises from the NPC's home when known, else from
+            // their current location.
+            let home_loc = home.or_else(|| self.npcs.get(&id).map(|n| n.location));
+            let home_name = home_loc.and_then(|l| graph.get(l).map(|d| d.name.clone()));
+            let near_player = home_loc == Some(player_loc);
+
+            let event = BansheeEvent::Heard {
+                target: id,
+                target_name: name,
+                home: home_loc,
+                home_name,
+                near_player,
+            };
+
+            if let Some(line) = herald_line(&event) {
+                world_text_log.push(line);
+            }
+
+            // Mark the herald flag on the NPC so we don't wail again for the
+            // same doom. The death itself will still fire when `now >= doom`.
+            if let Some(npc) = self.npcs.get_mut(&id) {
+                npc.banshee_heralded = true;
+            }
+            report.wails.push(event);
+        }
+
+        report
+    }
+
     /// Groups Tier 2 NPCs by their current location.
     ///
     /// Returns a map of location id to the NPC ids at that location.
@@ -1074,6 +1196,8 @@ mod tests {
             reaction_log: crate::reactions::ReactionLog::default(),
             last_activity: None,
             is_ill: false,
+            doom: None,
+            banshee_heralded: false,
         }
     }
 
@@ -2056,5 +2180,188 @@ mod tests {
         assert_eq!(mgr.last_tier2_game_time(), Some(now));
         assert!(!mgr.tier2_in_flight());
         assert!(!mgr.needs_tier2_tick(now));
+    }
+
+    // ── Banshee integration tests ────────────────────────────────────────────
+
+    fn make_mourning_world() -> parish_world::WorldState {
+        use chrono::TimeZone;
+        let mut world = parish_world::WorldState::new();
+        world.graph = make_chain_graph(4);
+        world.player_location = LocationId(0);
+        // Seed the clock at 22:00 — squarely inside the herald window.
+        world.clock = parish_world::time::GameClock::new(
+            Utc.with_ymd_and_hms(1820, 6, 15, 22, 0, 0).unwrap(),
+        );
+        world
+    }
+
+    #[test]
+    fn banshee_herald_fires_at_night_with_near_doom() {
+        let mut mgr = NpcManager::new();
+        let mut npc = make_test_npc(42, 2);
+        npc.doom = Some(Utc.with_ymd_and_hms(1820, 6, 16, 6, 0, 0).unwrap()); // 8 hours ahead
+        mgr.add_npc(npc);
+
+        let mut world = make_mourning_world();
+
+        let report = mgr.tick_banshee(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+
+        assert_eq!(report.wails.len(), 1, "one wail expected");
+        assert_eq!(report.deaths.len(), 0, "no death yet");
+        assert!(
+            world
+                .text_log
+                .iter()
+                .any(|l| l.contains("keening") || l.contains("banshee")),
+            "wail line should appear in text log"
+        );
+        assert!(
+            mgr.get(NpcId(42)).expect("still alive").banshee_heralded,
+            "herald flag must be set"
+        );
+    }
+
+    #[test]
+    fn banshee_wail_is_emitted_only_once_per_doom() {
+        let mut mgr = NpcManager::new();
+        let mut npc = make_test_npc(42, 2);
+        npc.doom = Some(Utc.with_ymd_and_hms(1820, 6, 16, 6, 0, 0).unwrap());
+        mgr.add_npc(npc);
+
+        let mut world = make_mourning_world();
+
+        let r1 = mgr.tick_banshee(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        let r2 = mgr.tick_banshee(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert_eq!(r1.wails.len(), 1);
+        assert_eq!(r2.wails.len(), 0, "second tick must not re-wail");
+    }
+
+    #[test]
+    fn banshee_finalises_death_once_doom_passes() {
+        let mut mgr = NpcManager::new();
+        let mut npc = make_test_npc(42, 2);
+        // Doom is 1 hour in the past — should be finalised immediately.
+        npc.doom = Some(Utc.with_ymd_and_hms(1820, 6, 15, 21, 0, 0).unwrap());
+        npc.banshee_heralded = true; // already heralded earlier
+        mgr.add_npc(npc);
+
+        let mut world = make_mourning_world();
+
+        let report = mgr.tick_banshee(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert_eq!(report.deaths.len(), 1);
+        assert_eq!(report.wails.len(), 0);
+        assert!(
+            mgr.get(NpcId(42)).is_none(),
+            "NPC must be removed once doom passes"
+        );
+        assert!(
+            world
+                .text_log
+                .iter()
+                .any(|l| l.contains("did not see the morning")),
+            "epitaph line should appear in text log"
+        );
+    }
+
+    #[test]
+    fn banshee_does_not_fire_during_daytime() {
+        use chrono::TimeZone;
+        let mut mgr = NpcManager::new();
+        let mut npc = make_test_npc(42, 2);
+        npc.doom = Some(Utc.with_ymd_and_hms(1820, 6, 16, 6, 0, 0).unwrap());
+        mgr.add_npc(npc);
+
+        // Clock at 14:00 — outside night window.
+        let mut world = make_mourning_world();
+        world.clock = parish_world::time::GameClock::new(
+            Utc.with_ymd_and_hms(1820, 6, 15, 14, 0, 0).unwrap(),
+        );
+
+        let report = mgr.tick_banshee(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert!(
+            report.is_empty(),
+            "daytime should produce neither wail nor death"
+        );
+        assert!(world.text_log.is_empty());
+    }
+
+    #[test]
+    fn tier4_death_now_schedules_doom_rather_than_removing() {
+        use crate::tier4::Tier4Event;
+        let mut mgr = NpcManager::new();
+        mgr.add_npc(make_test_npc(42, 2));
+
+        let now = Utc.with_ymd_and_hms(1820, 6, 15, 14, 0, 0).unwrap();
+        let events = vec![Tier4Event::Death { npc_id: NpcId(42) }];
+        let game_events = mgr.apply_tier4_events(&events, now);
+
+        assert!(
+            mgr.get(NpcId(42)).is_some(),
+            "NPC should NOT be removed yet"
+        );
+        let doom = mgr.get(NpcId(42)).unwrap().doom.expect("doom must be set");
+        assert!(doom > now, "doom must be in the future");
+        assert_eq!(
+            doom - now,
+            chrono::Duration::hours(crate::banshee::DOOM_LEAD_TIME_HOURS)
+        );
+        assert!(!game_events.is_empty(), "should still emit a life event");
+    }
+
+    #[test]
+    fn banshee_herald_near_player_uses_close_voicing() {
+        use crate::banshee::BansheeEvent;
+        let mut mgr = NpcManager::new();
+        let mut npc = make_test_npc(42, 0); // NPC lives at player's location
+        npc.home = Some(LocationId(0));
+        npc.doom = Some(Utc.with_ymd_and_hms(1820, 6, 16, 6, 0, 0).unwrap());
+        mgr.add_npc(npc);
+
+        let mut world = make_mourning_world();
+
+        let report = mgr.tick_banshee(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert_eq!(report.wails.len(), 1);
+        if let BansheeEvent::Heard { near_player, .. } = &report.wails[0] {
+            assert!(*near_player, "player shares location with the doomed NPC");
+        } else {
+            panic!("expected a Heard event");
+        }
     }
 }

--- a/crates/parish-npc/src/reactions.rs
+++ b/crates/parish-npc/src/reactions.rs
@@ -937,6 +937,8 @@ mod tests {
             reaction_log: ReactionLog::default(),
             last_activity: None,
             is_ill: false,
+            doom: None,
+            banshee_heralded: false,
         }
     }
 

--- a/crates/parish-npc/src/ticks.rs
+++ b/crates/parish-npc/src/ticks.rs
@@ -1002,6 +1002,8 @@ mod tests {
             reaction_log: crate::reactions::ReactionLog::default(),
             last_activity: None,
             is_ill: false,
+            doom: None,
+            banshee_heralded: false,
         }
     }
 

--- a/crates/parish-npc/src/tier4.rs
+++ b/crates/parish-npc/src/tier4.rs
@@ -363,6 +363,8 @@ mod tests {
             reaction_log: ReactionLog::default(),
             last_activity: None,
             is_ill: false,
+            doom: None,
+            banshee_heralded: false,
         }
     }
 

--- a/crates/parish-npc/src/transitions.rs
+++ b/crates/parish-npc/src/transitions.rs
@@ -214,6 +214,8 @@ mod tests {
             reaction_log: crate::reactions::ReactionLog::default(),
             last_activity: None,
             is_ill: false,
+            doom: None,
+            banshee_heralded: false,
         }
     }
 

--- a/crates/parish-persistence/src/journal.rs
+++ b/crates/parish-persistence/src/journal.rs
@@ -357,6 +357,8 @@ mod tests {
             reaction_log: parish_npc::reactions::ReactionLog::default(),
             last_activity: None,
             is_ill: false,
+            doom: None,
+            banshee_heralded: false,
         });
 
         let events = vec![WorldEvent::NpcMoodChanged {

--- a/crates/parish-persistence/src/snapshot.rs
+++ b/crates/parish-persistence/src/snapshot.rs
@@ -116,6 +116,14 @@ pub struct NpcSnapshot {
     /// Whether the NPC is currently ill. Set by Tier 4 rules engine.
     #[serde(default)]
     pub is_ill: bool,
+    /// Game-time at which this NPC is fated to die, if set.
+    ///
+    /// See [`parish_npc::Npc::doom`] for semantics.
+    #[serde(default)]
+    pub doom: Option<DateTime<Utc>>,
+    /// Whether the banshee wail has already been emitted for the current doom.
+    #[serde(default)]
+    pub banshee_heralded: bool,
 }
 
 impl NpcSnapshot {
@@ -141,6 +149,8 @@ impl NpcSnapshot {
             state: npc.state.clone(),
             last_activity: npc.last_activity.clone(),
             is_ill: npc.is_ill,
+            doom: npc.doom,
+            banshee_heralded: npc.banshee_heralded,
         }
     }
 
@@ -166,6 +176,8 @@ impl NpcSnapshot {
             state: self.state,
             last_activity: self.last_activity,
             is_ill: self.is_ill,
+            doom: self.doom,
+            banshee_heralded: self.banshee_heralded,
             deflated_summary: None,
             reaction_log: parish_npc::reactions::ReactionLog::default(),
         }
@@ -400,6 +412,8 @@ mod tests {
             reaction_log: parish_npc::reactions::ReactionLog::default(),
             last_activity: None,
             is_ill: false,
+            doom: None,
+            banshee_heralded: false,
         }
     }
 

--- a/crates/parish-server/src/session.rs
+++ b/crates/parish-server/src/session.rs
@@ -505,6 +505,14 @@ fn spawn_session_ticks(state: Arc<AppState>) -> Vec<JoinHandle<()>> {
                 }
 
                 {
+                    // Snapshot the banshee flag outside the world/npc locks to avoid
+                    // nesting config → world, which inverts the project-wide
+                    // lock order.
+                    let banshee_enabled = {
+                        let cfg = s.config.lock().await;
+                        !cfg.flags.is_disabled("banshee")
+                    };
+
                     let mut world = s.world.lock().await;
                     let mut npc_mgr = s.npc_manager.lock().await;
 
@@ -523,6 +531,18 @@ fn spawn_session_ticks(state: Arc<AppState>) -> Vec<JoinHandle<()>> {
 
                     npc_mgr.tick_schedules(&world.clock, &world.graph, world.weather);
                     npc_mgr.assign_tiers(&world, &[]);
+
+                    // Banshee tick — herald and finalise doomed NPCs.
+                    if banshee_enabled {
+                        let world = &mut *world;
+                        let _ = npc_mgr.tick_banshee(
+                            &world.clock,
+                            &world.graph,
+                            &mut world.text_log,
+                            &world.event_bus,
+                            world.player_location,
+                        );
+                    }
 
                     if !world.gossip_network.is_empty() {
                         let groups = npc_mgr.tier2_groups();

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -1008,6 +1008,41 @@ pub fn run() {
                                 npc_mgr.tick_schedules(&world.clock, &world.graph, world.weather);
                             let tier_transitions = npc_mgr.assign_tiers(&world, &[]);
 
+                            // Banshee tick — herald and finalise doomed NPCs.
+                            // Default-on; kill-switched by the `banshee` feature flag.
+                            let banshee_enabled = {
+                                let cfg = state_tick.config.lock().await;
+                                !cfg.flags.is_disabled("banshee")
+                            };
+                            let banshee_report = if banshee_enabled {
+                                let world_ref = &mut *world;
+                                npc_mgr.tick_banshee(
+                                    &world_ref.clock,
+                                    &world_ref.graph,
+                                    &mut world_ref.text_log,
+                                    &world_ref.event_bus,
+                                    world_ref.player_location,
+                                )
+                            } else {
+                                parish_core::npc::banshee::BansheeReport::default()
+                            };
+                            if !banshee_report.is_empty() {
+                                let mut debug_events =
+                                    state_tick.debug_events.lock().await;
+                                if debug_events.len() >= crate::DEBUG_EVENT_CAPACITY {
+                                    debug_events.pop_front();
+                                }
+                                debug_events.push_back(DebugEvent {
+                                    timestamp: world.clock.now().format("%H:%M %Y-%m-%d").to_string(),
+                                    category: "banshee".to_string(),
+                                    message: format!(
+                                        "{} wail(s), {} death(s)",
+                                        banshee_report.wails.len(),
+                                        banshee_report.deaths.len()
+                                    ),
+                                });
+                            }
+
                             // Log schedule events and tier transitions to debug panel
                             if !schedule_events.is_empty() || !tier_transitions.is_empty() {
                                 let ts =

--- a/testing/fixtures/banshee_flag_off.txt
+++ b/testing/fixtures/banshee_flag_off.txt
@@ -1,0 +1,11 @@
+# Banshee feature flag — kill-switch verification.
+# When /flag disable banshee, no wail fires, and NPCs with doom set
+# stay alive and unremoved.
+
+/flag disable banshee
+/doom Padraig Darcy 18
+/wait 800
+/wait 300
+# Padraig should still be at the pub — no death fired.
+go to the pub
+/npcs

--- a/testing/fixtures/banshee_playtest.txt
+++ b/testing/fixtures/banshee_playtest.txt
@@ -1,0 +1,41 @@
+# Banshee play-test — demonstrates idea #10 ("The Banshee") from game-ideas-brainstorm.md.
+#
+# Setup: start in Kilteevan Village in the morning.
+# Act 1: Meet the people of the parish, get a sense of the day.
+# Act 2: Mark Maire Gallagher as doomed (as Tier 4 would do on a random roll).
+# Act 3: Fast-forward to the evening and hear the banshee's cry.
+# Act 4: Wait through the night — the doom arrives.
+# Act 5: Confirm she has passed and the epitaph is in the log.
+
+/status
+/npcs
+/time
+
+# Wander a bit so the sim warms up.
+go to crossroads
+/npcs
+go to the pub
+/npcs
+
+# Return to the village square — we'll hear the banshee from here.
+go to village
+
+# Simulate Tier 4 rolling a Death for Maire Gallagher, 18 game-hours ahead.
+# This is what the random life-events engine does each in-game season.
+/doom Maire Gallagher 18
+
+# Move time forward to just after dusk. (It is 08:00 start + travel; we want ~22:00.)
+/wait 800
+
+# Check — we should have heard a wail.
+/status
+
+# Wait through the remainder of the night. The doom (18h ahead of 08:00) falls ~02:28.
+/wait 240
+
+# Nudge past the doom timestamp — the death is finalised on the next tick.
+/wait 60
+
+# Morning. Confirm Maire is no longer in the parish and the epitaph was logged.
+/npcs
+/status

--- a/testing/fixtures/banshee_playtest_close.txt
+++ b/testing/fixtures/banshee_playtest_close.txt
@@ -1,0 +1,13 @@
+# Banshee play-test — scene 2: player at the doomed NPC's home.
+#
+# This time we doom Padraig Darcy (home: Darcy's Pub) while the player is
+# inside the pub. The banshee's cry should use the close voicing —
+# "just beyond the thatch" — instead of the distance voicing.
+
+go to the pub
+/npcs
+/doom Padraig Darcy 18
+/wait 800
+/status
+/wait 300
+/npcs


### PR DESCRIPTION
## Summary

Implements idea **#10 "The Banshee"** from
[`docs/design/game-ideas-brainstorm.md`](../blob/main/docs/design/game-ideas-brainstorm.md)
— the first feature to bridge the Tier 4 life-events engine (random deaths, illness,
births) and the player experience, using Irish folklore as the structural glue.

> *"When an NPC is going to 'die' (leave the simulation permanently), a banshee
> is heard the night before. Creates dread and foreshadowing."*

Before this PR, the Tier 4 rules engine rolled a `Death` event every few game-seasons
and an NPC blinked out of the world without narrative warning — the moment was wasted.
Now, a Tier 4 `Death` is reinterpreted as a *doom* scheduled ~18 game-hours ahead;
a new banshee tick scans for doomed NPCs and, on the intervening night, a keening
cry rises to foreshadow the passing. Once the doom timestamp passes, the NPC dies
and an epitaph lands in the world text log.

## What this changes

- **`Npc.doom: Option<DateTime<Utc>>`** and **`Npc.banshee_heralded: bool`** —
  new optional fields on the NPC struct, serde-default and wired through the
  persistence snapshot so existing save files keep round-tripping.
- **`parish-npc/src/banshee.rs`** — new module owning the window logic
  (`is_herald_window`), the `BansheeEvent` / `BansheeReport` types, and two
  default voicings (`herald_line`, `epitaph_line`).
- **`NpcManager::tick_banshee`** — core method, called from every backend after
  `tick_schedules`. Walks doomed NPCs:
  - `now >= doom` → remove the NPC, push an epitaph line, publish
    `GameEvent::LifeEvent`.
  - Otherwise, if `is_herald_window(now, doom) && !banshee_heralded` → push a
    wail line (close vs. distance voicing chosen by `player_loc == home`) and
    mark the herald flag so it never double-fires for the same doom.
- **`apply_tier4_events` rerouted** — `Tier4Event::Death` now sets
  `Npc.doom = now + DOOM_LEAD_TIME_HOURS` and emits a `"…is fated to die"`
  `LifeEvent`, instead of calling `npcs.remove` directly. The removal happens
  through `tick_banshee` once the doom arrives.
- **Mode parity**: wired into
  `crates/parish-cli/src/testing.rs` (harness `execute` + `advance_time` + `/tick`),
  `crates/parish-cli/src/headless.rs` (main REPL loop),
  `crates/parish-server/src/session.rs` (web-server tick task),
  and `crates/parish-tauri/src/lib.rs` (Tauri tick task).
- **Feature flag**: gated behind the default-on `banshee` flag (kill-switch
  pattern `!flags.is_disabled("banshee")` per CLAUDE.md rule 6).
- **Harness tooling**: `/doom NpcName [hours]` — harness-only command that
  marks any loaded NPC as doomed, mirroring the existing `/stub` escape hatch
  so play-test scripts don't have to wait on random Tier 4 rolls. Multi-word
  names work; trailing integer is parsed as hours if present.
- **Script output**: `run_script_mode` now includes a `new_log_lines` field
  per JSONL record, so ambient events (banshee wails, NPC arrivals) appear in
  scripted play-test output — essential for regression coverage of narrative
  features.

## Tests

**15 new tests** in `crates/parish-npc`:

- `banshee::tests` (9 unit tests) — night window open/closed at dusk, midday,
  post-doom, too-far-out, 21:30; close vs. distance voicing wording; epitaph
  line includes the name; `BansheeReport::is_empty`.
- `manager::tests` (6 integration tests) — wail fires once at night; wail
  *only* fires once per doom; death finalises and removes the NPC once the
  doom passes; daytime is silent; **Tier 4 Death now sets doom instead of
  removing**; close voicing is used when player shares the home location.

Full workspace passes: `cargo test --workspace --exclude parish-tauri`.
Clippy clean (`-D warnings`), fmt clean. The existing `NpcSnapshot` serde
round-trip test still passes — `doom` and `banshee_heralded` use
`#[serde(default)]`.

## Play-test log

Scripts live at `testing/fixtures/banshee_playtest.txt`,
`testing/fixtures/banshee_playtest_close.txt`, and
`testing/fixtures/banshee_flag_off.txt`.

### Scene 1 — the far voicing: Maire Gallagher is doomed while the player stands in the village.

```
> /doom Maire Gallagher 18
[Kilteevan Village · Morning] Doom set for Maire Gallagher at 1820-03-21 02:28 (18h from now).

> /wait 800
[Kilteevan Village · Night] Waited 800 minutes. Now 21:48 Night.
    · Out across the parish, a keening rises — thin and impossibly high.
      It drifts in from the direction of The Forge.
      Someone beside you mutters, quietly: "Someone's for the morning."

> /wait 240
[Kilteevan Village · Midnight] Waited 240 minutes. Now 01:48 Midnight.
    · An older man arrives.
    · A young woman arrives.
    · An older woman with sharp eyes and herb-stained fingers arrives.

> /wait 60
[Kilteevan Village · Midnight] Waited 60 minutes. Now 02:48 Midnight.
    · A lean, red-haired young man with hard eyes arrives.
    · Word travels before the sun is fully up: Maire Gallagher did not see the morning.
      The banshee had the right of it.

> /npcs
NPCs here:
  an older man — Retired Constable (watchful)
  a young woman — Hedge School Teacher (passionate)
  a small, sharp-eyed old woman wrapped in a shawl — Widow (sharp)
  an older woman with sharp eyes and herb-stained fingers — Midwife (watchful)
  a lean, red-haired young man with hard eyes — Labourer (bitter)
```

Note: The banshee correctly identifies The Forge as Maire's home (she's married
to Seamus Gallagher, the blacksmith). Her name is absent from `/npcs` after the
death — the sim has actually removed her, not just narrated it.

### Scene 2 — the close voicing: Padraig Darcy is doomed while the player sits in his own pub.

```
> go to the pub
[Darcy's Pub · Morning] NPCs here:
  Padraig Darcy — Publican (content) [introduced]
  Niamh Darcy — Publican's Daughter (restless) [introduced]

> /doom Padraig Darcy 18
[Darcy's Pub · Morning] Doom set for Padraig Darcy at 1820-03-21 02:14 (18h from now).

> /wait 800
[Darcy's Pub · Night] Waited 800 minutes. Now 21:34 Night.
    · A thin, high wailing climbs from just beyond the thatch — a sound like wind
      drawn through reeds, but shaped like grief. The old ones would say it is the
      banshee, crying a name the night already knows.

> /wait 300
[Darcy's Pub · Midnight] Waited 300 minutes. Now 02:34 Midnight.
    · A woman behind the counter arrives.
    · A priest arrives.
    · Word travels before the sun is fully up: Padraig Darcy did not see the morning.
      The banshee had the right of it.

> /npcs
NPCs here:
  Niamh Darcy — Publican's Daughter (restless) [introduced]
```

Niamh — Padraig's daughter — is the only one left in the pub at the end.
The close voicing (*"just beyond the thatch"*) fires instead of the distance voicing
because the player's location matches Padraig's home. This is exactly the emergent
moment the idea was after: the sim produces a random Tier 4 death; the mythology
layer turns it into a scene.

### Scene 3 — kill-switch: `/flag disable banshee` and the feature goes quiet.

```
> /flag disable banshee
> /doom Padraig Darcy 18
> /wait 800
[Kilteevan Village · Night] Waited 800 minutes.  (no wail)
> /wait 300
[Kilteevan Village · Midnight] Waited 300 minutes.  (no death)
> /npcs (at the pub)
NPCs here:
  an older man behind the bar — Publican (content)
  Niamh Darcy — Publican's Daughter (restless) [introduced]
```

With the flag disabled, no wail and no death — Padraig survives the night, and the
existing Tier 4 / schedule behaviour is untouched.

## Why this idea

`docs/design/game-ideas-brainstorm.md` rates Banshee as Medium-priority, dependent
on "NPC lifecycle events". Those lifecycle events *already exist* — `Tier4Event::Death`
has been producing random removals for months. What was missing was the narrative
beat that turns a random sim event into a moment the player remembers. This PR adds
~400 lines of code (most of it tests) and gets us that moment without any new
content pipelines, LLM calls, or content-authoring burden.

The pattern generalises: `Npc.doom` + a tick hook + two voicing functions is a
template for *any* fated event the sim wants to foreshadow (Birth → "a candle kept
lit"; SeasonalShift → "the harvest bell moves a week earlier"; future content:
migration, marriage, emigration to America).
