### PR TITLE
fix(ui): travel dot follows waypoint path when full map is panned

### DIFF
--- a/apps/ui/src/lib/map/controller.test.ts
+++ b/apps/ui/src/lib/map/controller.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { positionAlongPath } from './controller';
+import type { TravelWaypoint } from '$lib/types';
+
+function buildSegments(waypoints: TravelWaypoint[]): { segs: number[]; total: number } {
+	const segs: number[] = [];
+	let total = 0;
+	for (let i = 1; i < waypoints.length; i += 1) {
+		const a = waypoints[i - 1];
+		const b = waypoints[i];
+		const d = Math.hypot(b.lon - a.lon, b.lat - a.lat);
+		segs.push(d);
+		total += d;
+	}
+	return { segs, total };
+}
+
+describe('positionAlongPath', () => {
+	const straight: TravelWaypoint[] = [
+		{ id: 'a', lat: 0, lon: 0 },
+		{ id: 'b', lat: 0, lon: 10 }
+	];
+
+	it('returns first waypoint at t=0', () => {
+		const { segs, total } = buildSegments(straight);
+		expect(positionAlongPath(straight, segs, total, 0)).toEqual([0, 0]);
+	});
+
+	it('returns last waypoint at t=1', () => {
+		const { segs, total } = buildSegments(straight);
+		expect(positionAlongPath(straight, segs, total, 1)).toEqual([10, 0]);
+	});
+
+	it('returns midpoint at t=0.5 for a single segment', () => {
+		const { segs, total } = buildSegments(straight);
+		const [lon, lat] = positionAlongPath(straight, segs, total, 0.5);
+		expect(lon).toBeCloseTo(5, 10);
+		expect(lat).toBeCloseTo(0, 10);
+	});
+
+	it('clamps t > 1 to the last waypoint', () => {
+		const { segs, total } = buildSegments(straight);
+		expect(positionAlongPath(straight, segs, total, 1.5)).toEqual([10, 0]);
+	});
+
+	it('weights multi-segment progress by distance', () => {
+		// Two legs of different lengths: short horizontal, long vertical.
+		const path: TravelWaypoint[] = [
+			{ id: 'a', lat: 0, lon: 0 },
+			{ id: 'b', lat: 0, lon: 1 },
+			{ id: 'c', lat: 9, lon: 1 }
+		];
+		const { segs, total } = buildSegments(path);
+		expect(total).toBeCloseTo(10, 10);
+
+		// At t=0.1, we've travelled 1 unit — exactly the first leg.
+		const [lonMid, latMid] = positionAlongPath(path, segs, total, 0.1);
+		expect(lonMid).toBeCloseTo(1, 10);
+		expect(latMid).toBeCloseTo(0, 10);
+
+		// At t=0.5, we've travelled 5 units — 1 on leg 1 + 4 up leg 2.
+		const [lonHalf, latHalf] = positionAlongPath(path, segs, total, 0.5);
+		expect(lonHalf).toBeCloseTo(1, 10);
+		expect(latHalf).toBeCloseTo(4, 10);
+	});
+
+	it('handles a degenerate zero-length path', () => {
+		const degenerate: TravelWaypoint[] = [
+			{ id: 'a', lat: 3, lon: 7 },
+			{ id: 'b', lat: 3, lon: 7 }
+		];
+		const { segs, total } = buildSegments(degenerate);
+		expect(positionAlongPath(degenerate, segs, total, 0.4)).toEqual([7, 3]);
+	});
+});

--- a/apps/ui/src/lib/map/controller.ts
+++ b/apps/ui/src/lib/map/controller.ts
@@ -231,17 +231,13 @@ export class MapController {
 	/**
 	 * Starts (or updates) a travel-dot animation along the given waypoints.
 	 *
-	 * The dot is placed at the first waypoint and the camera animates toward
-	 * the destination over `durationMs`. Callers that pass `targetBounds`
-	 * (the minimap, typically the destination's neighborhood box) get a
-	 * `fitBounds` — so both center and zoom interpolate smoothly in-flight
-	 * and the post-travel fitBounds has nothing left to snap. Without
-	 * target bounds we fall back to a straight `easeTo` on the last waypoint,
-	 * preserving zoom (used by the full-map overlay).
-	 *
-	 * On each animation frame we sync the marker's world position to the
-	 * camera's current center so the dot reads as a follow-cam — the
-	 * traveller stays at screen center while the map tiles scroll beneath.
+	 * The dot is interpolated along the waypoint polyline in world coordinates
+	 * (distance-proportional over `durationMs`), so it tracks the true path
+	 * regardless of where the user has panned the camera. The camera animates
+	 * independently: when `targetBounds` is supplied (minimap case) we
+	 * `fitBounds` so center AND zoom interpolate smoothly to the destination
+	 * neighborhood; otherwise (full map) we leave the camera alone so user
+	 * pans aren't overridden mid-travel.
 	 *
 	 * Call `stopTravel()` when the animation should end.
 	 */
@@ -274,18 +270,28 @@ export class MapController {
 				easing: (t) => t,
 				linear: true
 			});
-		} else {
-			const last = waypoints[waypoints.length - 1];
-			this.map.easeTo({
-				center: [last.lon, last.lat],
-				duration: durationMs,
-				easing: (t) => t,
-				animate: true
-			});
 		}
 
+		// Flat-earth distance is fine at parish scale — all travel fits inside
+		// a few kilometres, so lat/lon Euclidean approximates arc length well
+		// enough for a pulsing dot.
+		const segLengths: number[] = [];
+		let totalLength = 0;
+		for (let i = 1; i < waypoints.length; i += 1) {
+			const a = waypoints[i - 1];
+			const b = waypoints[i];
+			const d = Math.hypot(b.lon - a.lon, b.lat - a.lat);
+			segLengths.push(d);
+			totalLength += d;
+		}
+
+		const startTime = performance.now();
 		const tick = () => {
-			marker.setLngLat(this.map.getCenter());
+			const t = durationMs > 0
+				? Math.min(1, (performance.now() - startTime) / durationMs)
+				: 1;
+			const [lon, lat] = positionAlongPath(waypoints, segLengths, totalLength, t);
+			marker.setLngLat([lon, lat]);
 			if (this.travelAnim) {
 				this.travelAnim.rafId = requestAnimationFrame(tick);
 			}
@@ -433,6 +439,42 @@ function setSourceData(
 	if (source && source.type === 'geojson') {
 		(source as maplibregl.GeoJSONSource).setData(data);
 	}
+}
+
+/**
+ * Returns `[lon, lat]` at fractional progress `t ∈ [0, 1]` along the polyline
+ * formed by `waypoints`, weighted by segment length so progress matches
+ * distance travelled rather than waypoint count.
+ */
+export function positionAlongPath(
+	waypoints: TravelWaypoint[],
+	segLengths: number[],
+	totalLength: number,
+	t: number
+): [number, number] {
+	if (waypoints.length === 0) return [0, 0];
+	if (t <= 0 || totalLength === 0) {
+		const first = waypoints[0];
+		return [first.lon, first.lat];
+	}
+	if (t >= 1) {
+		const last = waypoints[waypoints.length - 1];
+		return [last.lon, last.lat];
+	}
+	const target = t * totalLength;
+	let consumed = 0;
+	for (let i = 0; i < segLengths.length; i += 1) {
+		const segLen = segLengths[i];
+		if (consumed + segLen >= target) {
+			const frac = segLen === 0 ? 0 : (target - consumed) / segLen;
+			const a = waypoints[i];
+			const b = waypoints[i + 1];
+			return [a.lon + (b.lon - a.lon) * frac, a.lat + (b.lat - a.lat) * frac];
+		}
+		consumed += segLen;
+	}
+	const last = waypoints[waypoints.length - 1];
+	return [last.lon, last.lat];
 }
 
 function buildTravelEdgeKeys(waypoints: TravelWaypoint[]): Set<string> {


### PR DESCRIPTION
## Summary
- Fixes a bug where the travel dot on the full map drifted off the path whenever the user had panned the camera. The dot was being placed at `map.getCenter()` every frame, so the interactive full map's `easeTo` animation effectively dragged it from the panned-to location toward the destination instead of tracing the route.
- Interpolate the dot along the waypoint polyline in world coordinates (distance-weighted over `durationMs`) and drop the `easeTo` in the full-map case so the user's pan is preserved during travel. The minimap keeps its `fitBounds` follow-cam.
- Adds `positionAlongPath` helper with unit tests (endpoints, midpoint, multi-segment distance weighting, clamping, degenerate zero-length path).

## Test plan
- [x] `npx vitest run` — 176 tests pass (170 existing + 6 new)
- [x] Live Chrome verification: opened full map, panned away from path, triggered travel — full-map dot's screen position animates smoothly along the route (448,194 → 452,243 sampled during animation) while the minimap dot stays centered as its camera follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)