### PR TITLE
fix(server): separate OAuth public URL from inference base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,7 +61,10 @@ PARISH_MODEL=google/gemma-3-1b-it:free
 
 # Public base URL of the web server. Used to build the OAuth callback URL
 # and must match what is registered in Google Cloud Console.
-# PARISH_BASE_URL=http://localhost:3001
+# Preferred over PARISH_BASE_URL for OAuth so inference and server URLs
+# can differ (e.g. PARISH_BASE_URL points to an LLM API while
+# PARISH_PUBLIC_URL points to your own server).
+# PARISH_PUBLIC_URL=http://localhost:3001
 
 # Google OAuth credentials — if either is unset, OAuth is silently disabled
 # and /auth/login/google is not registered. See docs/oauth-setup.md.

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -122,7 +122,8 @@ async fn cf_access_guard(
             .headers()
             .get("CF-Access-Authenticated-User-Email")
             .and_then(|v| v.to_str().ok())
-            .map(str::to_string);
+            .map(str::to_string)
+            .filter(|e| !e.is_empty() && e.contains('@'));
         if let Some(email) = debug_email {
             req.extensions_mut().insert(cf_auth::AuthContext { email });
             return Ok(next.run(req).await);
@@ -441,8 +442,9 @@ fn build_oauth_config() -> Option<OAuthConfig> {
     let client_secret = std::env::var("GOOGLE_CLIENT_SECRET")
         .ok()
         .filter(|s| !s.is_empty())?;
-    let base_url =
-        std::env::var("PARISH_BASE_URL").unwrap_or_else(|_| "http://localhost:3001".to_string());
+    let base_url = std::env::var("PARISH_PUBLIC_URL")
+        .or_else(|_| std::env::var("PARISH_BASE_URL"))
+        .unwrap_or_else(|_| "http://localhost:3001".to_string());
     Some(OAuthConfig {
         client_id,
         client_secret,
@@ -678,5 +680,42 @@ mod tests {
             std::env::remove_var("GOOGLE_CLIENT_SECRET");
         }
         assert!(build_oauth_config().is_none());
+    }
+
+    #[test]
+    fn build_oauth_config_prefers_public_url() {
+        // SAFETY: single-threaded test; no other thread reads these vars.
+        unsafe {
+            std::env::set_var("GOOGLE_CLIENT_ID", "test-id");
+            std::env::set_var("GOOGLE_CLIENT_SECRET", "test-secret");
+            std::env::set_var("PARISH_PUBLIC_URL", "https://myapp.example.com");
+            std::env::set_var("PARISH_BASE_URL", "https://api.openrouter.ai");
+        }
+        let cfg = build_oauth_config().expect("should build with credentials set");
+        assert_eq!(cfg.base_url, "https://myapp.example.com");
+        unsafe {
+            std::env::remove_var("GOOGLE_CLIENT_ID");
+            std::env::remove_var("GOOGLE_CLIENT_SECRET");
+            std::env::remove_var("PARISH_PUBLIC_URL");
+            std::env::remove_var("PARISH_BASE_URL");
+        }
+    }
+
+    #[test]
+    fn build_oauth_config_falls_back_to_base_url() {
+        // SAFETY: single-threaded test; no other thread reads these vars.
+        unsafe {
+            std::env::set_var("GOOGLE_CLIENT_ID", "test-id");
+            std::env::set_var("GOOGLE_CLIENT_SECRET", "test-secret");
+            std::env::remove_var("PARISH_PUBLIC_URL");
+            std::env::set_var("PARISH_BASE_URL", "https://myapp.example.com");
+        }
+        let cfg = build_oauth_config().expect("should build with credentials set");
+        assert_eq!(cfg.base_url, "https://myapp.example.com");
+        unsafe {
+            std::env::remove_var("GOOGLE_CLIENT_ID");
+            std::env::remove_var("GOOGLE_CLIENT_SECRET");
+            std::env::remove_var("PARISH_BASE_URL");
+        }
     }
 }

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -10,7 +10,7 @@ The web server (`crates/parish-server/`) reads three environment variables on st
 |----------|---------|
 | `GOOGLE_CLIENT_ID` | OAuth client ID from Google Cloud Console |
 | `GOOGLE_CLIENT_SECRET` | OAuth client secret from Google Cloud Console |
-| `PARISH_BASE_URL` | Public base URL of the server (defaults to `http://localhost:3001`) |
+| `PARISH_PUBLIC_URL` | Public base URL of the server (defaults to `http://localhost:3001`). Falls back to `PARISH_BASE_URL` if unset. |
 
 These are loaded via `dotenvy::dotenv()`, so a `.env` file at the repo root works. If either `GOOGLE_CLIENT_ID` or `GOOGLE_CLIENT_SECRET` is missing or empty, OAuth is silently disabled and the `/auth/login/google` + `/auth/callback/google` routes are not registered.
 
@@ -47,7 +47,7 @@ Put the credentials into a `.env` file at the repo root:
 ```env
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
-PARISH_BASE_URL=http://localhost:3001
+PARISH_PUBLIC_URL=http://localhost:3001
 ```
 
 Start the web server. On startup you should see:
@@ -61,13 +61,13 @@ in the logs — that confirms both credentials were picked up. Then visit http:/
 ## Gotchas
 
 - **Test users only.** While the consent screen is in "Testing" status, Google rejects logins from accounts not on the test user list. Publish the app (or add more test users) to widen access.
-- **Redirect URI must match exactly.** The code builds the callback URL as `${PARISH_BASE_URL}/auth/callback/google` (with any trailing slash on `PARISH_BASE_URL` trimmed via `trim_end_matches('/')`). Whatever you register in Google Cloud must match byte-for-byte, including scheme (`http` vs `https`) and port.
+- **Redirect URI must match exactly.** The code builds the callback URL as `${PARISH_PUBLIC_URL}/auth/callback/google` (with any trailing slash trimmed via `trim_end_matches('/')`). Whatever you register in Google Cloud must match byte-for-byte, including scheme (`http` vs `https`) and port. If `PARISH_PUBLIC_URL` is not set, `PARISH_BASE_URL` is used as a fallback.
 - **Silent disable.** Missing or empty credentials don't raise an error — the auth routes just aren't registered. If `/auth/login/google` returns 404, check that both env vars are actually set in the process's environment.
 
 ## Railway deployment
 
 When deploying to Railway (or any other host):
 
-1. Set `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `PARISH_BASE_URL` in the service's environment variables. `PARISH_BASE_URL` must be the public URL Railway assigns you (e.g. `https://parish-production.up.railway.app`).
-2. Add the production callback URL (`${PARISH_BASE_URL}/auth/callback/google`) to the authorized redirect URIs list in Google Cloud Console **before** the first production login attempt — Google rejects unregistered redirect URIs.
+1. Set `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `PARISH_PUBLIC_URL` in the service's environment variables. `PARISH_PUBLIC_URL` must be the public URL Railway assigns you (e.g. `https://parish-production.up.railway.app`).
+2. Add the production callback URL (`${PARISH_PUBLIC_URL}/auth/callback/google`) to the authorized redirect URIs list in Google Cloud Console **before** the first production login attempt — Google rejects unregistered redirect URIs.
 3. You can reuse the same OAuth client for local and production by listing both redirect URIs on the same credential, or create separate clients per environment.


### PR DESCRIPTION
## Summary

- **#477 (High):** `PARISH_BASE_URL` served double duty as both the LLM inference endpoint and the OAuth redirect base URL. Deployers who use both OAuth and a non-Ollama LLM provider hit a silent mis-configuration on one side or the other. Introduces `PARISH_PUBLIC_URL` as the dedicated OAuth redirect base, falling back to `PARISH_BASE_URL` for backwards compatibility.
- **#465 (Low):** The debug-build email fallback in `cf_access_guard` accepted any header value — including empty strings and values without `@` — as a session key. Now filters out malformed emails so debug sessions don't get keyed by garbage strings.

## Changes

| File | What changed |
|------|-------------|
| `crates/parish-server/src/lib.rs` | `build_oauth_config()` reads `PARISH_PUBLIC_URL` first, falls back to `PARISH_BASE_URL`; debug email fallback filters on non-empty + contains `@`; two new tests |
| `.env.example` | Documents `PARISH_PUBLIC_URL` with explanation of when to use it |
| `docs/oauth-setup.md` | All references updated from `PARISH_BASE_URL` to `PARISH_PUBLIC_URL` for OAuth context |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p parish-server -- -D warnings` — clean
- [x] `cargo test -p parish-server -- --test-threads=1` — 55 unit + 18 integration tests pass
- [x] `build_oauth_config_prefers_public_url` — verifies `PARISH_PUBLIC_URL` takes precedence
- [x] `build_oauth_config_falls_back_to_base_url` — verifies backwards compat when only `PARISH_BASE_URL` is set
- [x] Game harness walkthrough passes

https://claude.ai/code/session_01GinMnMhH11GRdg8Bav1MrN