### PR TITLE
fix(ui): map controller cleanup and error handling

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -271,6 +271,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -287,6 +288,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -303,6 +305,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -319,6 +322,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -335,6 +339,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -351,6 +356,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -367,6 +373,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -383,6 +390,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -399,6 +407,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -415,6 +424,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -431,6 +441,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -447,6 +458,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -463,6 +475,7 @@
 			"cpu": [
 				"mips64el"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -479,6 +492,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -495,6 +509,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -511,6 +526,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -527,6 +543,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -543,6 +560,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -559,6 +577,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -575,6 +594,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -591,6 +611,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -607,6 +628,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -623,6 +645,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -639,6 +662,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -655,6 +679,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -671,6 +696,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -878,6 +904,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -891,6 +918,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -904,6 +932,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -917,6 +946,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -930,6 +960,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -943,6 +974,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -956,6 +988,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -969,6 +1002,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -982,6 +1016,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -995,6 +1030,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1008,6 +1044,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1021,6 +1058,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1034,6 +1072,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1047,6 +1086,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1060,6 +1100,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1073,6 +1114,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1086,6 +1128,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1099,6 +1142,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1112,6 +1156,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1125,6 +1170,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1138,6 +1184,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1151,6 +1198,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1164,6 +1212,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1177,6 +1226,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1190,6 +1240,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1930,6 +1981,7 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,

--- a/apps/ui/src/components/FullMapOverlay.svelte
+++ b/apps/ui/src/components/FullMapOverlay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { mapData } from '../stores/game';
+	import { mapData, pushErrorLog, formatIpcError } from '../stores/game';
 	import { travelState } from '../stores/travel';
 	import { tiles, currentTileSource } from '../stores/tiles';
 	import { submitInput } from '$lib/ipc';
@@ -36,7 +36,13 @@
 
 		controller.onLocationClick(async (info) => {
 			if (!info.adjacent) return;
-			await submitInput(`go to ${info.name}`);
+			try {
+				await submitInput(`go to ${info.name}`);
+			} catch (err) {
+				pushErrorLog(
+					`Could not travel to ${info.name}: ${formatIpcError(err)}`
+				);
+			}
 		});
 
 		controller.onLocationHover(

--- a/apps/ui/src/components/MapPanel.test.ts
+++ b/apps/ui/src/components/MapPanel.test.ts
@@ -9,6 +9,7 @@ import MapPanel from './MapPanel.svelte';
 vi.mock('maplibre-gl', () => {
 	class FakeMap {
 		on() {}
+		off() {}
 		once(_event: string, cb: () => void) {
 			cb();
 		}

--- a/apps/ui/src/components/editor/LocationDetail.test.ts
+++ b/apps/ui/src/components/editor/LocationDetail.test.ts
@@ -80,6 +80,8 @@ vi.mock('maplibre-gl', () => {
 
 		easeTo() {}
 
+		off() {}
+
 		remove() {
 			mockState.mapRemoveCount += 1;
 		}

--- a/apps/ui/src/lib/map/controller.ts
+++ b/apps/ui/src/lib/map/controller.ts
@@ -292,7 +292,7 @@ export class MapController {
 				: 1;
 			const [lon, lat] = positionAlongPath(waypoints, segLengths, totalLength, t);
 			marker.setLngLat([lon, lat]);
-			if (this.travelAnim) {
+			if (t < 1 && this.travelAnim) {
 				this.travelAnim.rafId = requestAnimationFrame(tick);
 			}
 		};
@@ -345,6 +345,7 @@ export class MapController {
 	/** Cleans up the underlying MapLibre instance and any running animation. */
 	destroy(): void {
 		this.stopTravel();
+		this.unwireLayerEvents();
 		this.map.remove();
 	}
 


### PR DESCRIPTION
## Summary

- **#510**: Call `unwireLayerEvents()` in `destroy()` before `map.remove()` to clean up event handler references and the `layerEventsWired` flag, preventing dangling closures and stale state if the controller were ever reused.
- **#503**: Restore `t < 1` self-termination guard in the travel animation `requestAnimationFrame` loop. Without it, the rAF loop runs indefinitely at 60fps after the dot reaches its destination, wasting CPU/battery.
- **#502**: Wrap `FullMapOverlay`'s `submitInput` call in try/catch with `pushErrorLog`, matching the existing error-handling pattern in `MapPanel.svelte`. Prevents unhandled promise rejections on network or server errors.

Also adds `off()` to FakeMap mocks in `MapPanel.test.ts` and `LocationDetail.test.ts` so teardown doesn't throw during tests.

## Test plan

- [x] `svelte-check` passes with 0 errors
- [x] `vitest run` — all 176 tests pass, 0 errors
- [ ] Manual: open full map, click an adjacent location, verify travel works
- [ ] Manual: open full map, verify travel dot stops animating after reaching destination
- [ ] Manual: close full map, verify no console errors from stale event handlers

Fixes #510, #503, #502

https://claude.ai/code/session_01Pr6z4QfanGnZ6gexceVcY9