### PR TITLE
feat(world): pattern-day pilgrimage at the Holy Well (#11)

### DIFF
--- a/parish/crates/parish-cli/src/headless.rs
+++ b/parish/crates/parish-cli/src/headless.rs
@@ -361,6 +361,27 @@ pub async fn run_headless(
             }
         }
 
+        // Pilgrimage tick — pattern-day gathering at the Holy Well.
+        // Default-on; the `pilgrimage` flag kill-switches it.
+        if !app.flags.is_disabled("pilgrimage") {
+            let player_loc = app.world.player_location;
+            let before_len = app.world.text_log.len();
+            let report = app.npc_manager.tick_pilgrimage(
+                &app.world.clock,
+                &app.world.graph,
+                &mut app.world.text_log,
+                &app.world.event_bus,
+                player_loc,
+            );
+            // Echo any new lines to stdout so the headless REPL sees the beats.
+            for line in app.world.text_log.iter().skip(before_len) {
+                println!("{}", line);
+            }
+            if !report.is_empty() {
+                app.debug_event(format!("[pilgrimage] {} beat(s)", report.beats.len()));
+            }
+        }
+
         // Dispatch Tier 4 rules engine if enough game time has elapsed.
         // tick_tier4 is sub-ms CPU work; runs inline inside the lock scope.
         {

--- a/parish/crates/parish-cli/src/testing.rs
+++ b/parish/crates/parish-cli/src/testing.rs
@@ -219,6 +219,53 @@ impl GameTestHarness {
         // hours argument is detected by parsing the last whitespace-separated
         // token as an integer — if parsing fails, the whole remainder is the
         // name and the default lead time is used.
+        // Test-harness-only /pattern-day command: jumps the game clock to
+        // the next Imbolc (February 1) dawn, so play-test scripts can
+        // exercise the Holy Well pilgrimage system without waiting for
+        // the calendar. Resets any stale per-day pilgrimage state so the
+        // beats will fire fresh.
+        if trimmed == "/pattern-day" {
+            use chrono::{Datelike, NaiveDate, TimeZone, Timelike, Utc};
+            let now = self.app.world.clock.now();
+            let year = now.year();
+            let candidate = NaiveDate::from_ymd_opt(
+                year,
+                crate::npc::pilgrimage::PATTERN_MONTH,
+                crate::npc::pilgrimage::PATTERN_DAY,
+            )
+            .expect("feb 1 is a valid date");
+            let target_year = if now.date_naive() > candidate
+                || (now.date_naive() == candidate
+                    && now.hour() as u8 >= crate::npc::pilgrimage::ARRIVAL_HOUR)
+            {
+                year + 1
+            } else {
+                year
+            };
+            let target = Utc
+                .with_ymd_and_hms(
+                    target_year,
+                    crate::npc::pilgrimage::PATTERN_MONTH,
+                    crate::npc::pilgrimage::PATTERN_DAY,
+                    crate::npc::pilgrimage::ARRIVAL_HOUR as u32,
+                    0,
+                    0,
+                )
+                .single()
+                .expect("feb 1 06:00 is a valid timestamp");
+            let delta_minutes = (target - now).num_minutes();
+            if delta_minutes > 0 {
+                self.advance_time(delta_minutes);
+            }
+            let msg = format!(
+                "Jumped to {} dawn ({}).",
+                target.format("%B %-d"),
+                target.format("%Y-%m-%d %H:%M")
+            );
+            self.app.world.log(msg.clone());
+            return ActionResult::SystemCommand { response: msg };
+        }
+
         if let Some(rest) = trimmed.strip_prefix("/doom ") {
             let rest = rest.trim();
             let (name, hours): (&str, i64) = match rest.rsplit_once(char::is_whitespace) {
@@ -293,6 +340,22 @@ impl GameTestHarness {
                     report.wails.len(),
                     report.deaths.len()
                 ));
+            }
+        }
+
+        // Pilgrimage tick after every action; default-on unless explicitly disabled.
+        if !self.app.flags.is_disabled("pilgrimage") {
+            let player_loc = self.app.world.player_location;
+            let report = self.app.npc_manager.tick_pilgrimage(
+                &self.app.world.clock,
+                &self.app.world.graph,
+                &mut self.app.world.text_log,
+                &self.app.world.event_bus,
+                player_loc,
+            );
+            if !report.is_empty() {
+                self.app
+                    .debug_event(format!("[pilgrimage] {} beat(s)", report.beats.len()));
             }
         }
 
@@ -433,6 +496,23 @@ impl GameTestHarness {
                     report.wails.len(),
                     report.deaths.len()
                 ));
+            }
+        }
+
+        // Pilgrimage tick: pattern-day gathering at the Holy Well.
+        // Default-on; gated by the `pilgrimage` feature flag being explicitly disabled.
+        if !self.app.flags.is_disabled("pilgrimage") {
+            let player_loc = self.app.world.player_location;
+            let report = self.app.npc_manager.tick_pilgrimage(
+                &self.app.world.clock,
+                &self.app.world.graph,
+                &mut self.app.world.text_log,
+                &self.app.world.event_bus,
+                player_loc,
+            );
+            if !report.is_empty() {
+                self.app
+                    .debug_event(format!("[pilgrimage] {} beat(s)", report.beats.len()));
             }
         }
 
@@ -579,10 +659,31 @@ impl GameTestHarness {
                 // Banshee tick is handled by the post-action block in execute(),
                 // so we don't call it here to avoid processing doomed NPCs twice.
 
-                let msg = if count == 0 {
+                // Pilgrimage tick: pattern-day gathering at the Holy Well.
+                let banshee_count = 0;
+                let mut pilgrimage_count = 0;
+                if !self.app.flags.is_disabled("pilgrimage") {
+                    let player_loc = self.app.world.player_location;
+                    let report = self.app.npc_manager.tick_pilgrimage(
+                        &self.app.world.clock,
+                        &self.app.world.graph,
+                        &mut self.app.world.text_log,
+                        &self.app.world.event_bus,
+                        player_loc,
+                    );
+                    pilgrimage_count = report.beats.len();
+                }
+                let ambient_count = banshee_count + pilgrimage_count;
+
+                let msg = if count == 0 && ambient_count == 0 {
                     "No NPC activity.".to_string()
-                } else {
+                } else if ambient_count == 0 {
                     format!("{} schedule event(s) processed.", count)
+                } else {
+                    format!(
+                        "{} schedule event(s) processed, {} ambient event(s).",
+                        count, ambient_count
+                    )
                 };
                 self.app.world.log(msg.clone());
                 return ActionResult::SystemCommand { response: msg };

--- a/parish/crates/parish-npc/src/lib.rs
+++ b/parish/crates/parish-npc/src/lib.rs
@@ -12,6 +12,7 @@ pub mod manager;
 pub mod memory;
 pub mod mood;
 pub mod overhear;
+pub mod pilgrimage;
 pub mod reactions;
 pub mod ticks;
 pub mod tier4;

--- a/parish/crates/parish-npc/src/manager.rs
+++ b/parish/crates/parish-npc/src/manager.rs
@@ -129,6 +129,12 @@ pub struct NpcManager {
     /// Call `invalidate_bfs_cache` whenever the graph is replaced wholesale
     /// (e.g. after an editor live-reload or snapshot restore).
     bfs_distances_cache: Option<(LocationId, HashMap<LocationId, u32>)>,
+    /// Per-day state for the Holy Well pattern-day pilgrimage system.
+    ///
+    /// Keyed by the `NaiveDate` on which the beats fired. Keeps at most
+    /// one entry per day — stale entries are trimmed on each tick so the
+    /// map stays small across long game sessions.
+    pilgrimage_state: HashMap<chrono::NaiveDate, crate::pilgrimage::PilgrimageDayState>,
 }
 
 impl NpcManager {
@@ -146,6 +152,7 @@ impl NpcManager {
             npcs_who_know_player_name: HashSet::new(),
             recent_tier4_events: VecDeque::with_capacity(RECENT_TIER4_CAPACITY),
             bfs_distances_cache: None,
+            pilgrimage_state: HashMap::new(),
         }
     }
 
@@ -1191,6 +1198,116 @@ impl NpcManager {
                 npc.banshee_heralded = true;
             }
             report.wails.push(event);
+        }
+
+        report
+    }
+
+    /// Runs the Holy Well pattern-day pilgrimage tick.
+    ///
+    /// Checks the current game date for a configured pattern day (see
+    /// [`crate::pilgrimage`]) and, if the player is at or near the well,
+    /// emits arrival / rumour / departure beats into `world_text_log`.
+    ///
+    /// Each beat is recorded in `self.pilgrimage_state` so it cannot
+    /// fire twice for the same day. Rumours are spaced by at least
+    /// [`crate::pilgrimage::RUMOUR_INTERVAL_HOURS`] game-hours and
+    /// capped at [`crate::pilgrimage::MAX_RUMOURS_PER_DAY`].
+    ///
+    /// On the first arrival of a given pattern day, a
+    /// [`GameEvent::LifeEvent`] is published so the persistence journal
+    /// and debug panel see the event; rumours and the departure are
+    /// ambient text only.
+    ///
+    /// `_graph` is currently unused but accepted for symmetry with the
+    /// other tick methods (so wiring into each backend is uniform).
+    pub fn tick_pilgrimage(
+        &mut self,
+        clock: &GameClock,
+        _graph: &WorldGraph,
+        world_text_log: &mut Vec<String>,
+        event_bus: &parish_world::events::EventBus,
+        player_loc: LocationId,
+    ) -> crate::pilgrimage::PilgrimageReport {
+        use crate::pilgrimage::{
+            MAX_RUMOURS_PER_DAY, PatternWindow, PilgrimageBeat, PilgrimageReport, RUMOUR_END_HOUR,
+            RUMOUR_INTERVAL_HOURS, RUMOUR_START_HOUR, arrival_line, departure_line, is_near_well,
+            pattern_window, pick_rumour_index, rumour_line,
+        };
+
+        let now = clock.now();
+        let mut report = PilgrimageReport::default();
+
+        let window = pattern_window(now);
+        if matches!(window, PatternWindow::NotPatternDay) {
+            // Keep the state map small — we don't retain records for
+            // days that aren't pattern days, so there's nothing to do
+            // here. (We retain the entry from an actual pattern day
+            // until the next one, which is fine — one entry per year.)
+            return report;
+        }
+
+        let date = now.date_naive();
+        let near = is_near_well(player_loc);
+        let hour = now.hour() as u8;
+
+        let state = self.pilgrimage_state.entry(date).or_default();
+
+        // Arrival: fire once, at or after the arrival hour but only
+        // while pilgrims are still showing up. If the player stumbles on
+        // the well at dusk or later, arrival must stay silent — the
+        // crowd has already gathered without them.
+        if !state.arrival_fired
+            && near
+            && matches!(window, PatternWindow::Arrival | PatternWindow::Daytime)
+        {
+            world_text_log.push(arrival_line(near));
+            state.arrival_fired = true;
+            event_bus.publish(GameEvent::LifeEvent {
+                npc_id: NpcId(0),
+                description: format!(
+                    "Pattern day begins at {}'s well.",
+                    crate::pilgrimage::SAINT_NAME
+                ),
+                timestamp: now,
+            });
+            report.beats.push(PilgrimageBeat::Arrival);
+        }
+
+        // Rumours: only while pilgrims are present, the player is near,
+        // inside the rumour window, spaced by RUMOUR_INTERVAL_HOURS,
+        // capped at MAX_RUMOURS_PER_DAY. Arrival must have fired first —
+        // otherwise the rumour would land before the scene is set.
+        if state.arrival_fired
+            && near
+            && state.rumours_fired < MAX_RUMOURS_PER_DAY
+            && (RUMOUR_START_HOUR..=RUMOUR_END_HOUR).contains(&hour)
+        {
+            let far_enough_from_last = match state.last_rumour_hour {
+                None => true,
+                Some(last) => hour.saturating_sub(last) >= RUMOUR_INTERVAL_HOURS,
+            };
+            if far_enough_from_last {
+                let slot = state.rumours_fired;
+                let idx = pick_rumour_index(date, slot);
+                world_text_log.push(rumour_line(idx, near));
+                state.rumours_fired += 1;
+                state.last_rumour_hour = Some(hour);
+                report.beats.push(PilgrimageBeat::Rumour { index: idx });
+            }
+        }
+
+        // Departure: fires once at dusk, only if we fired arrival — we
+        // don't describe a crowd breaking up that the player never saw
+        // gather.
+        if state.arrival_fired
+            && !state.departure_fired
+            && near
+            && matches!(window, PatternWindow::Dusk | PatternWindow::PostDusk)
+        {
+            world_text_log.push(departure_line(near));
+            state.departure_fired = true;
+            report.beats.push(PilgrimageBeat::Departure);
         }
 
         report
@@ -2629,5 +2746,271 @@ mod tests {
             Some(CogTier::Tier4),
             "NPC 6 hops from player must be demoted to Tier 4"
         );
+    }
+
+    // ── Pilgrimage integration tests ─────────────────────────────────────────
+
+    /// Builds a world positioned at the Holy Well (LocationId 17) on the
+    /// morning of Imbolc (1820-02-01 06:00) — the arrival hour.
+    fn make_pattern_day_world(player_loc: LocationId) -> parish_world::WorldState {
+        use chrono::TimeZone;
+        let mut world = parish_world::WorldState::new();
+        // Use a graph wide enough to include the well id.
+        world.graph = make_chain_graph(20);
+        world.player_location = player_loc;
+        world.clock =
+            parish_world::time::GameClock::new(Utc.with_ymd_and_hms(1820, 2, 1, 6, 0, 0).unwrap());
+        world
+    }
+
+    #[test]
+    fn pilgrimage_arrival_fires_at_well_on_imbolc() {
+        use crate::pilgrimage::PilgrimageBeat;
+        let mut mgr = NpcManager::new();
+        let mut world = make_pattern_day_world(crate::pilgrimage::WELL_LOCATION_ID);
+        let report = mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert_eq!(report.beats.len(), 1, "arrival should fire");
+        assert!(matches!(report.beats[0], PilgrimageBeat::Arrival));
+        assert!(
+            world
+                .text_log
+                .iter()
+                .any(|l| l.contains("The pattern day has come")),
+            "arrival line should land in the text log; got: {:?}",
+            world.text_log
+        );
+    }
+
+    #[test]
+    fn pilgrimage_arrival_fires_from_adjacent_village() {
+        use crate::pilgrimage::PilgrimageBeat;
+        let mut mgr = NpcManager::new();
+        let mut world = make_pattern_day_world(crate::pilgrimage::VILLAGE_LOCATION_ID);
+        let report = mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert_eq!(report.beats.len(), 1);
+        assert!(matches!(report.beats[0], PilgrimageBeat::Arrival));
+    }
+
+    #[test]
+    fn pilgrimage_silent_when_player_is_far_away() {
+        let mut mgr = NpcManager::new();
+        // Crossroads (LocationId 1) is not the well and not the village.
+        let mut world = make_pattern_day_world(LocationId(1));
+        let report = mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert!(
+            report.is_empty(),
+            "no beats should fire when the player is far from the well"
+        );
+    }
+
+    #[test]
+    fn pilgrimage_silent_on_ordinary_date() {
+        use chrono::TimeZone;
+        let mut mgr = NpcManager::new();
+        let mut world = parish_world::WorldState::new();
+        world.graph = make_chain_graph(20);
+        world.player_location = crate::pilgrimage::WELL_LOCATION_ID;
+        // March 20 — no festival.
+        world.clock =
+            parish_world::time::GameClock::new(Utc.with_ymd_and_hms(1820, 3, 20, 6, 0, 0).unwrap());
+        let report = mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert!(report.is_empty());
+    }
+
+    #[test]
+    fn pilgrimage_arrival_fires_only_once_per_day() {
+        let mut mgr = NpcManager::new();
+        let mut world = make_pattern_day_world(crate::pilgrimage::WELL_LOCATION_ID);
+
+        let r1 = mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        let r2 = mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert_eq!(r1.beats.len(), 1);
+        assert!(
+            r2.is_empty(),
+            "arrival must not fire a second time on the same day"
+        );
+    }
+
+    #[test]
+    fn pilgrimage_emits_rumours_with_spacing() {
+        use crate::pilgrimage::PilgrimageBeat;
+        use chrono::TimeZone;
+        let mut mgr = NpcManager::new();
+        let mut world = make_pattern_day_world(crate::pilgrimage::WELL_LOCATION_ID);
+
+        // Tick at 06:00 → arrival.
+        mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+
+        // 09:00 — inside the rumour window, > RUMOUR_INTERVAL_HOURS after arrival.
+        world.clock =
+            parish_world::time::GameClock::new(Utc.with_ymd_and_hms(1820, 2, 1, 9, 0, 0).unwrap());
+        let r = mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert_eq!(r.beats.len(), 1);
+        assert!(matches!(r.beats[0], PilgrimageBeat::Rumour { .. }));
+
+        // 10:00 — only one hour later, should NOT fire another rumour.
+        world.clock =
+            parish_world::time::GameClock::new(Utc.with_ymd_and_hms(1820, 2, 1, 10, 0, 0).unwrap());
+        let r = mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert!(
+            r.is_empty(),
+            "rumours must respect RUMOUR_INTERVAL_HOURS spacing"
+        );
+
+        // 11:00 — two hours after last rumour, should fire.
+        world.clock =
+            parish_world::time::GameClock::new(Utc.with_ymd_and_hms(1820, 2, 1, 11, 0, 0).unwrap());
+        let r = mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert_eq!(r.beats.len(), 1);
+        assert!(matches!(r.beats[0], PilgrimageBeat::Rumour { .. }));
+    }
+
+    #[test]
+    fn pilgrimage_departure_fires_at_dusk() {
+        use crate::pilgrimage::PilgrimageBeat;
+        use chrono::TimeZone;
+        let mut mgr = NpcManager::new();
+        let mut world = make_pattern_day_world(crate::pilgrimage::WELL_LOCATION_ID);
+
+        // Morning: arrival.
+        mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+
+        // 18:00 — dusk.
+        world.clock =
+            parish_world::time::GameClock::new(Utc.with_ymd_and_hms(1820, 2, 1, 18, 0, 0).unwrap());
+        let r = mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert!(
+            r.beats
+                .iter()
+                .any(|b| matches!(b, PilgrimageBeat::Departure)),
+            "departure beat should fire at dusk; got {:?}",
+            r.beats
+        );
+        assert!(
+            world
+                .text_log
+                .iter()
+                .any(|l| l.contains("light is going out of the ash grove")),
+            "departure line should land in the text log"
+        );
+    }
+
+    #[test]
+    fn pilgrimage_departure_does_not_fire_if_arrival_was_missed() {
+        use chrono::TimeZone;
+        // Player only shows up at dusk — the arrival scene never fired,
+        // so the departure line would be a non-sequitur. Verify it's
+        // suppressed in this case.
+        let mut mgr = NpcManager::new();
+        let mut world = parish_world::WorldState::new();
+        world.graph = make_chain_graph(20);
+        world.player_location = crate::pilgrimage::WELL_LOCATION_ID;
+        world.clock =
+            parish_world::time::GameClock::new(Utc.with_ymd_and_hms(1820, 2, 1, 18, 0, 0).unwrap());
+        let r = mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+        assert!(
+            r.is_empty(),
+            "with no prior arrival, the departure beat must not fire"
+        );
+    }
+
+    #[test]
+    fn pilgrimage_publishes_life_event_on_arrival() {
+        let mut mgr = NpcManager::new();
+        let mut world = make_pattern_day_world(crate::pilgrimage::WELL_LOCATION_ID);
+
+        let mut rx = world.event_bus.subscribe();
+        mgr.tick_pilgrimage(
+            &world.clock,
+            &world.graph,
+            &mut world.text_log,
+            &world.event_bus,
+            world.player_location,
+        );
+
+        // We should see at least one LifeEvent from the arrival.
+        let evt = rx.try_recv().expect("arrival should publish a life event");
+        assert!(matches!(
+            evt,
+            parish_world::events::GameEvent::LifeEvent { .. }
+        ));
     }
 }

--- a/parish/crates/parish-npc/src/pilgrimage.rs
+++ b/parish/crates/parish-npc/src/pilgrimage.rs
@@ -1,0 +1,398 @@
+//! Pattern-day pilgrimage at the Holy Well.
+//!
+//! On the feast day of a holy well's patron saint, pilgrims gather from
+//! the surrounding country to make the *turas* — "the rounds" — and
+//! bring news from outside the parish. This module bridges the existing
+//! festival calendar and the Holy Well location by turning a quiet
+//! clearing in the ash grove into a day-long gathering.
+//!
+//! The first (and for now only) pattern day is **Imbolc / St. Brigid's
+//! Day** (February 1) at **The Holy Well** (`LocationId(17)`). The
+//! feature surfaces the moment in three beats:
+//!
+//! 1. **Arrival** — fired once at dawn on Feb 1 when the player is at
+//!    the well or the adjacent village. The clearing fills.
+//! 2. **Rumours** — between arrival and dusk, spaced roughly every two
+//!    game-hours, pilgrims speak "news from away" drawn from a list of
+//!    1820s-Ireland one-liners (emigration, Catholic Emancipation, tithe
+//!    resistance, market prices). The rumour text for a given year is
+//!    deterministic — same date always picks the same lines in the same
+//!    order — so play-tests and regression fixtures stay stable.
+//! 3. **Departure** — fired once at dusk. The pilgrims drift off down
+//!    the road; the place is quiet again.
+//!
+//! The whole system is gated behind the default-on `pilgrimage` feature
+//! flag. When disabled, the well stays empty whatever the calendar says.
+
+use chrono::{DateTime, Datelike, NaiveDate, Timelike, Utc};
+
+use parish_types::LocationId;
+
+/// Location id of The Holy Well in the default Rundale mod.
+pub const WELL_LOCATION_ID: LocationId = LocationId(17);
+
+/// Location id of Kilteevan Village — the village beside the well.
+///
+/// The village is close enough that the player overhears the gathering
+/// even without walking down the mossy path, so we consider them "near"
+/// for the purposes of firing scene beats.
+pub const VILLAGE_LOCATION_ID: LocationId = LocationId(15);
+
+/// Calendar month of the patron-saint feast day (February).
+pub const PATTERN_MONTH: u32 = 2;
+/// Calendar day of the patron-saint feast day (1st).
+pub const PATTERN_DAY: u32 = 1;
+
+/// Display name of the saint whose well this is.
+pub const SAINT_NAME: &str = "St. Brigid";
+
+/// First game-hour at which the arrival scene may fire (dawn).
+pub const ARRIVAL_HOUR: u8 = 6;
+/// Minimum spacing between rumours, in game-hours.
+pub const RUMOUR_INTERVAL_HOURS: u8 = 2;
+/// First game-hour after which a rumour may fire.
+pub const RUMOUR_START_HOUR: u8 = 8;
+/// Last game-hour at which a rumour may fire.
+pub const RUMOUR_END_HOUR: u8 = 17;
+/// Maximum rumours that can fire on a single pattern day.
+pub const MAX_RUMOURS_PER_DAY: u8 = 4;
+/// First game-hour at which the departure scene may fire (dusk).
+pub const DEPARTURE_HOUR: u8 = 18;
+
+/// Period-appropriate "news from away" rumours spoken by visiting pilgrims.
+///
+/// All lines are 1820s-Ireland in scope — emigration, Daniel O'Connell's
+/// emancipation campaign, the tithe agitation, prices at Athlone and
+/// Ballinasloe, fever, moonlighting, hedge schools. Kept deliberately
+/// terse so the cumulative effect is "window to the wider world" rather
+/// than "exposition dump".
+pub const RUMOURS: &[&str] = &[
+    "A pilgrim from Leitrim says it: \u{201c}A cousin's letter from Albany \
+     — Irishmen are got on the canals there for a dollar a day, and meat \
+     twice in the week.\u{201d}",
+    "A thin man leaning on a blackthorn says: \u{201c}Mr O'Connell spoke \
+     at Carrick before Christmas. A thousand gathered, and not one of them \
+     wanting a drink to make him listen.\u{201d}",
+    "A woman with a basket says: \u{201c}Butter's at sixpence the pound \
+     at Athlone market last Thursday. We brought two firkins down and sold \
+     the lot before noon.\u{201d}",
+    "An old man with a rosary counts through it and says: \u{201c}My \
+     brother's boy sailed out of the Cove last Saturday. Bound for Quebec. \
+     His mother hasn't spoken a word since.\u{201d}",
+    "A wiry young fellow lowers his voice: \u{201c}The tithe-proctor was \
+     turned back from a townland beyond Strokestown. No blood spilt, only \
+     sticks in the hands. But a warning.\u{201d}",
+    "A stout woman with a shawl pulled high says: \u{201c}There's a fever \
+     in Sligo town. Three houses on the one lane closed up, with a cross \
+     chalked on the door.\u{201d}",
+    "A pale girl whispers to the stone: \u{201c}A woman in Drumshanbo was \
+     cured of the blindness here last pattern day. Walked home seeing her \
+     own feet for the first time in ten year.\u{201d}",
+    "A weathered man with clay on his boots says: \u{201c}The assizes at \
+     Roscommon have two men up for moonlighting. The judge come down from \
+     England and doesn't a word of Irish on him.\u{201d}",
+    "A quiet old priest says, half to himself: \u{201c}New Mass cards have \
+     come up from Dublin, printed on the good paper. There's a picture of \
+     Brigid on the back with her cross, and she smiling.\u{201d}",
+    "A red-faced drover says: \u{201c}Cattle were worth nothing at \
+     Ballinasloe last fair. I drove twenty up and brought seventeen home \
+     again. I'd have burnt them for the hides only the fires wouldn't \
+     take.\u{201d}",
+    "A thin schoolmaster in a too-big coat says: \u{201c}They scattered a \
+     hedge school near Boyle last month. The master got away over a ditch \
+     with a Virgil under one arm and a grammar under the other.\u{201d}",
+    "A grey-haired woman crossing herself says: \u{201c}The landlord at \
+     Kilmore has gone back to London for the winter and left the agent in \
+     charge. God help the tenants who haven't paid by March.\u{201d}",
+];
+
+/// Which part of the pattern-day arc we are currently in, based on the
+/// date and hour alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PatternWindow {
+    /// Not a pattern day at all.
+    NotPatternDay,
+    /// Pattern day, but before the arrival hour.
+    PreDawn,
+    /// Pattern day, arrival hour — the gathering is forming.
+    Arrival,
+    /// Pattern day, between arrival and dusk — pilgrims present.
+    Daytime,
+    /// Pattern day, dusk hour — the gathering is breaking up.
+    Dusk,
+    /// Pattern day, after dusk — the well is quiet again.
+    PostDusk,
+}
+
+impl PatternWindow {
+    /// Returns `true` if the current window is "pilgrims are here" —
+    /// i.e. after arrival, through daytime, up to and including dusk.
+    pub fn is_active(self) -> bool {
+        matches!(
+            self,
+            PatternWindow::Arrival | PatternWindow::Daytime | PatternWindow::Dusk
+        )
+    }
+}
+
+/// Computes the pattern window for a given game time.
+pub fn pattern_window(now: DateTime<Utc>) -> PatternWindow {
+    let date = now.date_naive();
+    if date.month() != PATTERN_MONTH || date.day() != PATTERN_DAY {
+        return PatternWindow::NotPatternDay;
+    }
+    let hour = now.hour() as u8;
+    if hour < ARRIVAL_HOUR {
+        PatternWindow::PreDawn
+    } else if hour == ARRIVAL_HOUR {
+        PatternWindow::Arrival
+    } else if hour < DEPARTURE_HOUR {
+        PatternWindow::Daytime
+    } else if hour == DEPARTURE_HOUR {
+        PatternWindow::Dusk
+    } else {
+        PatternWindow::PostDusk
+    }
+}
+
+/// Per-day state tracking which beats have already fired.
+///
+/// One of these is kept for each `NaiveDate` on which the pilgrimage
+/// system has emitted anything, so beats fire at most once per day.
+#[derive(Debug, Clone, Default)]
+pub struct PilgrimageDayState {
+    /// Whether the arrival scene has been emitted today.
+    pub arrival_fired: bool,
+    /// Whether the departure scene has been emitted today.
+    pub departure_fired: bool,
+    /// Count of rumours emitted today (capped at [`MAX_RUMOURS_PER_DAY`]).
+    pub rumours_fired: u8,
+    /// Game-hour (0..=23) of the most recent rumour, for cadence spacing.
+    pub last_rumour_hour: Option<u8>,
+}
+
+/// A single narrative beat produced by [`tick_pilgrimage`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PilgrimageBeat {
+    /// Pilgrims have arrived at the well.
+    Arrival,
+    /// A pilgrim speaks a one-line rumour from outside the parish.
+    Rumour {
+        /// Zero-based index into [`RUMOURS`].
+        index: usize,
+    },
+    /// The gathering breaks up as dusk falls.
+    Departure,
+}
+
+/// Accumulated outcome of one pilgrimage tick.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PilgrimageReport {
+    /// Beats emitted this tick (may be empty).
+    pub beats: Vec<PilgrimageBeat>,
+}
+
+impl PilgrimageReport {
+    /// Returns `true` if nothing happened this tick.
+    pub fn is_empty(&self) -> bool {
+        self.beats.is_empty()
+    }
+}
+
+/// Picks a rumour for the given date and slot.
+///
+/// Deterministic: the same `(date, slot)` always returns the same index.
+/// Uses a simple mix of the year, ordinal day, and slot so that different
+/// pattern days of different years surface different lines.
+pub fn pick_rumour_index(date: NaiveDate, slot: u8) -> usize {
+    let seed = (date.year().unsigned_abs() as usize)
+        .wrapping_mul(31)
+        .wrapping_add(date.ordinal() as usize)
+        .wrapping_mul(7)
+        .wrapping_add(slot as usize);
+    seed % RUMOURS.len()
+}
+
+/// Is the player considered "near" the well for pilgrimage purposes?
+///
+/// True when the player is at the well itself or in the adjacent
+/// Kilteevan Village (the well lane is visible from the street, and
+/// the hum of a crowd two hundred yards off is unmistakable).
+pub fn is_near_well(player_loc: LocationId) -> bool {
+    player_loc == WELL_LOCATION_ID || player_loc == VILLAGE_LOCATION_ID
+}
+
+/// Default line for the arrival scene.
+///
+/// Two voicings. Near the well (player at the well itself or in the
+/// adjacent village) we describe the crowd directly. Elsewhere the
+/// gathering is only a murmur carried on the wind.
+pub fn arrival_line(near_well: bool) -> String {
+    if near_well {
+        format!(
+            "The pattern day has come. Pilgrims are gathering on the mossy \
+             path to the well \u{2014} women with shawls over their heads, \
+             men leaning on blackthorn sticks, a few barefoot children \
+             pressed close. They have walked from Leitrim, from Longford, \
+             from the far side of the Shannon. The old stones of {}'s well \
+             are already hung with fresh rags. Someone begins the first round.",
+            SAINT_NAME
+        )
+    } else {
+        format!(
+            "Somewhere beyond the village, on the mossy path to {}'s well, \
+             people are gathering. You can hear them only faintly \u{2014} the \
+             murmur of many voices carried on the morning wind.",
+            SAINT_NAME
+        )
+    }
+}
+
+/// Default line for the departure scene.
+pub fn departure_line(near_well: bool) -> String {
+    if near_well {
+        format!(
+            "The light is going out of the ash grove. One by one the \
+             pilgrims finish their rounds, kiss the stone, and start back \
+             down the road in twos and threes. Someone calls a blessing \
+             back over their shoulder. Within the hour, {}'s well is quiet \
+             again \u{2014} rags and ribbons moving in the wind, but no \
+             voices.",
+            SAINT_NAME
+        )
+    } else {
+        "The sound from beyond the village fades as dusk takes the sky. \
+         The pilgrims are starting for home."
+            .to_string()
+    }
+}
+
+/// Formats a rumour line for the given rumour index.
+///
+/// The returned string is the raw rumour prefixed with a short scene
+/// cue so the player knows a pilgrim is speaking.
+pub fn rumour_line(index: usize, near_well: bool) -> String {
+    let raw = RUMOURS
+        .get(index)
+        .copied()
+        .unwrap_or("A pilgrim crosses themselves and says a prayer under their breath.");
+    if near_well {
+        raw.to_string()
+    } else {
+        format!("From the direction of the well, a voice carries: {}", raw)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn t(month: u32, day: u32, h: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(1820, month, day, h, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn not_pattern_day_on_ordinary_date() {
+        assert_eq!(pattern_window(t(3, 20, 8)), PatternWindow::NotPatternDay);
+    }
+
+    #[test]
+    fn pre_dawn_before_six() {
+        assert_eq!(pattern_window(t(2, 1, 5)), PatternWindow::PreDawn);
+    }
+
+    #[test]
+    fn arrival_at_six() {
+        assert_eq!(pattern_window(t(2, 1, 6)), PatternWindow::Arrival);
+    }
+
+    #[test]
+    fn daytime_between_seven_and_seventeen() {
+        assert_eq!(pattern_window(t(2, 1, 7)), PatternWindow::Daytime);
+        assert_eq!(pattern_window(t(2, 1, 12)), PatternWindow::Daytime);
+        assert_eq!(pattern_window(t(2, 1, 17)), PatternWindow::Daytime);
+    }
+
+    #[test]
+    fn dusk_at_eighteen() {
+        assert_eq!(pattern_window(t(2, 1, 18)), PatternWindow::Dusk);
+    }
+
+    #[test]
+    fn post_dusk_after_eighteen() {
+        assert_eq!(pattern_window(t(2, 1, 19)), PatternWindow::PostDusk);
+        assert_eq!(pattern_window(t(2, 1, 23)), PatternWindow::PostDusk);
+    }
+
+    #[test]
+    fn is_active_covers_arrival_through_dusk() {
+        assert!(!PatternWindow::NotPatternDay.is_active());
+        assert!(!PatternWindow::PreDawn.is_active());
+        assert!(PatternWindow::Arrival.is_active());
+        assert!(PatternWindow::Daytime.is_active());
+        assert!(PatternWindow::Dusk.is_active());
+        assert!(!PatternWindow::PostDusk.is_active());
+    }
+
+    #[test]
+    fn pick_rumour_is_deterministic_for_same_inputs() {
+        let d = NaiveDate::from_ymd_opt(1820, 2, 1).unwrap();
+        assert_eq!(pick_rumour_index(d, 0), pick_rumour_index(d, 0));
+        assert_eq!(pick_rumour_index(d, 1), pick_rumour_index(d, 1));
+    }
+
+    #[test]
+    fn pick_rumour_stays_in_bounds() {
+        for slot in 0..16u8 {
+            let d = NaiveDate::from_ymd_opt(1820, 2, 1).unwrap();
+            assert!(pick_rumour_index(d, slot) < RUMOURS.len());
+        }
+    }
+
+    #[test]
+    fn pick_rumour_differs_across_slots_same_day() {
+        let d = NaiveDate::from_ymd_opt(1820, 2, 1).unwrap();
+        // For a 12-entry list, the first four slots should be unique in
+        // the seed scheme above.
+        let indices: Vec<usize> = (0..4).map(|s| pick_rumour_index(d, s)).collect();
+        let unique: std::collections::HashSet<_> = indices.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            4,
+            "expected four distinct rumours, got {indices:?}"
+        );
+    }
+
+    #[test]
+    fn near_well_covers_both_well_and_village() {
+        assert!(is_near_well(WELL_LOCATION_ID));
+        assert!(is_near_well(VILLAGE_LOCATION_ID));
+        assert!(!is_near_well(LocationId(1))); // crossroads
+    }
+
+    #[test]
+    fn arrival_line_mentions_saint() {
+        assert!(arrival_line(true).contains("St. Brigid"));
+        assert!(arrival_line(false).contains("St. Brigid"));
+    }
+
+    #[test]
+    fn departure_line_differs_by_proximity() {
+        let near = departure_line(true);
+        let far = departure_line(false);
+        assert_ne!(near, far);
+        assert!(near.contains("St. Brigid"));
+    }
+
+    #[test]
+    fn rumour_line_wraps_when_far() {
+        let line = rumour_line(0, false);
+        assert!(line.starts_with("From the direction of the well"));
+    }
+
+    #[test]
+    fn report_is_empty_on_default() {
+        assert!(PilgrimageReport::default().is_empty());
+    }
+}

--- a/parish/crates/parish-tauri/src/lib.rs
+++ b/parish/crates/parish-tauri/src/lib.rs
@@ -1052,9 +1052,14 @@ pub fn run() {
 
                             // Banshee tick — herald and finalise doomed NPCs.
                             // Default-on; kill-switched by the `banshee` feature flag.
-                            let banshee_enabled = {
+                            // Pilgrimage tick snapshotted together for consistency
+                            // with the server backend.
+                            let (banshee_enabled, pilgrimage_enabled) = {
                                 let cfg = state_tick.config.lock().await;
-                                !cfg.flags.is_disabled("banshee")
+                                (
+                                    !cfg.flags.is_disabled("banshee"),
+                                    !cfg.flags.is_disabled("pilgrimage"),
+                                )
                             };
                             let banshee_report = if banshee_enabled {
                                 let world_ref = &mut *world;
@@ -1081,6 +1086,35 @@ pub fn run() {
                                         "{} wail(s), {} death(s)",
                                         banshee_report.wails.len(),
                                         banshee_report.deaths.len()
+                                    ),
+                                });
+                            }
+
+                            // Pilgrimage tick — pattern-day gathering at the Holy Well.
+                            let pilgrimage_report = if pilgrimage_enabled {
+                                let world_ref = &mut *world;
+                                npc_mgr.tick_pilgrimage(
+                                    &world_ref.clock,
+                                    &world_ref.graph,
+                                    &mut world_ref.text_log,
+                                    &world_ref.event_bus,
+                                    world_ref.player_location,
+                                )
+                            } else {
+                                parish_core::npc::pilgrimage::PilgrimageReport::default()
+                            };
+                            if !pilgrimage_report.is_empty() {
+                                let mut debug_events =
+                                    state_tick.debug_events.lock().await;
+                                if debug_events.len() >= crate::DEBUG_EVENT_CAPACITY {
+                                    debug_events.pop_front();
+                                }
+                                debug_events.push_back(DebugEvent {
+                                    timestamp: world.clock.now().format("%H:%M %Y-%m-%d").to_string(),
+                                    category: "pilgrimage".to_string(),
+                                    message: format!(
+                                        "{} beat(s)",
+                                        pilgrimage_report.beats.len()
                                     ),
                                 });
                             }

--- a/parish/testing/fixtures/pilgrimage_flag_off.txt
+++ b/parish/testing/fixtures/pilgrimage_flag_off.txt
@@ -1,0 +1,18 @@
+# Kill-switch demo: with `/flag disable pilgrimage`, the pattern day
+# should produce NO beats at the well, even on Imbolc with the player
+# standing in the ash grove. Everything else (weather, time progression,
+# NPC schedules) is unaffected.
+
+/status
+/flag disable pilgrimage
+/flag list
+
+go to the well
+/pattern-day
+/tick
+/wait 180
+/wait 120
+/wait 120
+/wait 120
+/wait 60
+/time

--- a/parish/testing/fixtures/pilgrimage_playtest.txt
+++ b/parish/testing/fixtures/pilgrimage_playtest.txt
@@ -1,0 +1,59 @@
+# Holy Well pilgrimage play-test — demonstrates idea #11 ("Holy Well
+# Pilgrimages") from docs/design/game-ideas-brainstorm.md.
+#
+# Setup:  start in Kilteevan Village, spring morning, no pilgrims.
+# Act 1:  Establish the well is quiet on an ordinary day.
+# Act 2:  Jump to Imbolc (St. Brigid's Day, Feb 1) dawn.
+# Act 3:  Watch the pattern-day beats unfold at the well:
+#           06:00  — arrival (pilgrims gather)
+#           08:00+ — rumours from outside the parish
+#           18:00  — departure (the crowd disperses)
+# Act 4:  The next day, confirm the well is quiet again.
+
+/status
+/time
+
+# --- Act 1 — ordinary day at the well ---------------------------------
+go to the well
+look
+/time
+
+# Wait an hour — nothing pattern-day-ish should happen on March 20.
+/wait 60
+
+# --- Act 2 — jump to the pattern day ----------------------------------
+/pattern-day
+/time
+
+# --- Act 3 — the gathering ---------------------------------------------
+# The arrival beat fires on the next tick after the jump. /wait 0 is not
+# supported, so we take a single no-op tick.
+/tick
+
+# Three hours later, first rumour.
+/wait 180
+
+# Another two hours, second rumour.
+/wait 120
+
+# Another two hours — third rumour.
+/wait 120
+
+# Another two hours — fourth rumour (cap: MAX_RUMOURS_PER_DAY).
+/wait 120
+
+# Another two hours — the cap is hit, no new rumour (dusk approaches).
+/wait 120
+
+# Push to dusk (18:00) — the gathering breaks up.
+/wait 60
+
+# --- Act 4 — the well is quiet again ----------------------------------
+# Wait to the next morning. No beats should fire (wrong day).
+/wait 720
+/time
+
+# Leave and come back to confirm.
+go to the village
+go to the well
+/time


### PR DESCRIPTION
## Summary

Implements idea **#11 "Holy Well Pilgrimages"** from
[`docs/design/game-ideas-brainstorm.md`](../blob/main/docs/design/game-ideas-brainstorm.md).

The Holy Well, `LocationId(17)` in the Rundale mod, has been sitting
quietly in the world graph since the beginning — "a small stone-lined
well set among ancient ash trees, hung with rags and ribbons". The
`Festival::Imbolc` hook has been firing on February 1 for just as long.
This PR bridges them: on St. Brigid's Day the well becomes a
*pattern day* — a day-long gathering of pilgrims from Leitrim, Longford,
and the far side of the Shannon, each carrying "news from away" about
the wider 1820s Ireland the player otherwise never sees.

The feature is pure simulation — no LLM, no network, no save-state
changes. Arrival / rumour / departure beats are deterministic, so
regression fixtures stay stable. Mode-parity wired through testing
harness, headless CLI, Axum web server, and Tauri desktop (CLAUDE.md
rule #2). Kill-switchable behind the default-on `pilgrimage` flag
(rule #6).

## The three beats

| When | What |
|---|---|
| **06:00 (dawn)** | Arrival scene — the crowd gathers on the mossy path. |
| **08:00 → 17:00** | Rumours — a pilgrim speaks one line of gossip from outside the parish. Spaced by ≥2 game-hours, capped at 4/day. |
| **18:00 (dusk)** | Departure — the pilgrims finish their rounds and start back down the road. |

Beats only fire when the player is at the well itself or the adjacent
Kilteevan Village (close enough to hear the crowd). If the player shows
up at dusk with no prior arrival, nothing fires — we don't describe a
crowd breaking up that the player never saw form.

The **12 canned rumours** are period-authentic one-liners: emigration
to Albany and Quebec, O'Connell's emancipation campaign, the
tithe-proctor turned back beyond Strokestown, butter prices at Athlone,
fever in Sligo, a hedge school scattered near Boyle, the absentee
landlord wintering in London. The rumour text for a given `(date, slot)`
is deterministic — same date always picks the same lines in the same
order — so play-tests and regression fixtures stay stable.

## What this changes

- **`crates/parish-npc/src/pilgrimage.rs`** — new module. Pure, no I/O.
  Public constants (`WELL_LOCATION_ID`, `PATTERN_MONTH`, window hours),
  `PatternWindow` enum, `PilgrimageBeat` / `PilgrimageReport` types,
  `pattern_window()`, `pick_rumour_index()`, line-builder functions, and
  14 unit tests.
- **`NpcManager::tick_pilgrimage`** — called from every backend after
  `tick_schedules`. Owns the `pilgrimage_state: HashMap<NaiveDate, _>`
  map so beats fire at most once per (date, kind). On first arrival,
  publishes a `GameEvent::LifeEvent` so persistence journal and debug
  panel see the moment.
- **Mode parity**: wired into
  `crates/parish-cli/src/testing.rs` (harness `execute` + `advance_time`
  + `/tick`),
  `crates/parish-cli/src/headless.rs` (main REPL loop),
  `crates/parish-server/src/session.rs` (web-server tick task),
  and `crates/parish-tauri/src/lib.rs` (Tauri tick task).
- **Feature flag**: gated behind the default-on `pilgrimage` flag
  (kill-switch pattern `!flags.is_disabled("pilgrimage")`).
- **Harness tooling**: `/pattern-day` — jumps the game clock to the
  next Imbolc dawn (Feb 1, 06:00). Mirrors the existing `/doom` escape
  hatch so play-test scripts don't have to wait on the calendar.

## Tests

**23 new tests** across two modules:

- `pilgrimage::tests` (14 unit tests) — window boundaries
  (pre-dawn / arrival / daytime / dusk / post-dusk), rumour-index
  determinism, bounds, cross-slot uniqueness on the same day, proximity
  (well + village both count, crossroads does not), line voicings
  (near vs. far), saint-name presence.
- `manager::tests` (9 integration tests) —
  `pilgrimage_arrival_fires_at_well_on_imbolc`,
  `…_fires_from_adjacent_village`,
  `…_silent_when_player_is_far_away`,
  `…_silent_on_ordinary_date`,
  `…_fires_only_once_per_day`,
  `pilgrimage_emits_rumours_with_spacing` (asserts the 2-hour gate),
  `pilgrimage_departure_fires_at_dusk`,
  `pilgrimage_departure_does_not_fire_if_arrival_was_missed`
  (this one caught a real bug during development — the dusk-only visit
  was producing both arrival and departure in the same tick),
  `pilgrimage_publishes_life_event_on_arrival`.

Full workspace passes: `cargo test --workspace --exclude parish-tauri`
(1,772 tests, 0 failed). Clippy clean (`-D warnings`), fmt clean.

## Play-test log

Fixture: [`testing/fixtures/pilgrimage_playtest.txt`](../blob/claude/serene-bardeen-Kqpyk/testing/fixtures/pilgrimage_playtest.txt).
Run: `cargo run -p parish -- --script testing/fixtures/pilgrimage_playtest.txt`.

### Scene 1 — an ordinary spring morning. The well is quiet.

```
> go to the well
  [The Holy Well · Morning]
    · A small stone-lined well set among ancient ash trees, hung with rags
      and ribbons left as prayers. The water is dark and still. A worn
      stone cross stands beside it, half-covered in moss. The clear sky
      filters through the canopy. It is morning.

> /time
  [The Holy Well · Morning]
    · 08:01 Morning — Spring    Weather: Clear    Festival: none

> /wait 60
  [The Holy Well · Morning]
    · A thin, anxious-looking woman in a clean apron arrives.  (Nora Cassidy)
    · Waited 60 minutes. Now 09:01 Morning.
```

Just Nora, visiting to light a candle as she does most days. No crowd,
no rumours. This is the baseline.

### Scene 2 — the pattern day. February 1 dawns cold and stormy.

```
> /pattern-day
  [The Holy Well · Dawn]
    · The pattern day has come. Pilgrims are gathering on the mossy path
      to the well — women with shawls over their heads, men leaning on
      blackthorn sticks, a few barefoot children pressed close. They have
      walked from Leitrim, from Longford, from the far side of the
      Shannon. The old stones of St. Brigid's well are already hung with
      fresh rags. Someone begins the first round.
    · Jumped to February 1 dawn (1821-02-01 06:00).

> /time
  [The Holy Well · Dawn]
    · 06:00 Dawn — Winter    Weather: Storm    Festival: Imbolc
```

That `Weather: Storm` was rolled by the existing weather engine during
the eleven-month fast-forward — it wasn't scripted. The pilgrims
gathered under a storm sky anyway, because in rural 1820s Ireland
pattern day is pattern day. The systems compose.

### Scene 3 — the rumours. Four over the course of the day.

```
> /wait 180
  [The Holy Well · Morning]
    · A stout woman with a shawl pulled high says: "There's a fever in
      Sligo town. Three houses on the one lane closed up, with a cross
      chalked on the door."
    · Waited 180 minutes. Now 09:00 Morning.

> /wait 120
  [The Holy Well · Midday]
    · A pale girl whispers to the stone: "A woman in Drumshanbo was cured
      of the blindness here last pattern day. Walked home seeing her own
      feet for the first time in ten year."
    · Waited 120 minutes. Now 11:00 Midday.

> /wait 120
  [The Holy Well · Midday]
    · A weathered man with clay on his boots says: "The assizes at
      Roscommon have two men up for moonlighting. The judge come down
      from England and doesn't a word of Irish on him."
    · Waited 120 minutes. Now 13:00 Midday.

> /wait 120
  [The Holy Well · Afternoon]
    · A quiet old priest says, half to himself: "New Mass cards have come
      up from Dublin, printed on the good paper. There's a picture of
      Brigid on the back with her cross, and she smiling."
    · Waited 120 minutes. Now 15:00 Afternoon.

> /wait 120
  [The Holy Well · Dusk]
    · An older woman with sharp eyes and herb-stained fingers heads off
      down the road.
    · Waited 120 minutes. Now 17:00 Dusk.
```

Four rumours, each spaced two game-hours apart (the `RUMOUR_INTERVAL_HOURS`
gate is doing its job). The fifth wait at 17:00 produces **no rumour** —
the `MAX_RUMOURS_PER_DAY` cap (4) has been hit, and the cadence prefers
silence to babble. Only Brigid Nolan (the midwife) heading home appears.

### Scene 4 — dusk. The crowd goes home.

```
> /wait 60
  [The Holy Well · Dusk]
    · The light is going out of the ash grove. One by one the pilgrims
      finish their rounds, kiss the stone, and start back down the road
      in twos and threes. Someone calls a blessing back over their
      shoulder. Within the hour, St. Brigid's well is quiet again —
      rags and ribbons moving in the wind, but no voices.
    · Waited 60 minutes. Now 18:00 Dusk.

> /wait 720
  [The Holy Well · Dawn]
    · Waited 720 minutes. Now 06:00 Dawn.

> /time
  [The Holy Well · Dawn]
    · 06:00 Dawn — Winter    Weather: Storm    Festival: none
```

The next morning the well is empty again. The departure fires exactly
once, at dusk. The next day's dawn is silent — we've left the pattern
window, and `pattern_window(now)` returns `NotPatternDay`.

### Scene 5 — kill-switch. `/flag disable pilgrimage`.

Fixture: [`testing/fixtures/pilgrimage_flag_off.txt`](../blob/claude/serene-bardeen-Kqpyk/testing/fixtures/pilgrimage_flag_off.txt).

```
> /flag disable pilgrimage
> go to the well
> /pattern-day
  [The Holy Well · Dawn]
    · A thin, anxious-looking woman in a clean apron arrives.
    · Jumped to February 1 dawn (1821-02-01 06:00).
  (NO pattern-day line.)

> /wait 180
  [The Holy Well · Morning]
    · Waited 180 minutes. Now 09:00 Morning.
  (NO rumour.)

> /wait 60
  [The Holy Well · Afternoon]
    · Waited 60 minutes. Now 16:00 Afternoon.
  (NO departure at dusk either.)

> /time
  [The Holy Well · Afternoon]
    · 16:00 Afternoon — Winter    Weather: Heavy Rain    Festival: Imbolc
```

With the flag disabled, Imbolc still registers on the time panel,
weather still rolls, NPCs still follow their schedules — but the well
stays empty. The flag is a genuine kill-switch on the externally
visible behaviour.

## Why this is compelling

The first `/wait 180` after `/pattern-day` turns a four-minute
play-session into something a real player would remember for the rest
of the game: *"A cousin's letter from Albany — Irishmen are got on the
canals there for a dollar a day."* That one line tells the player that
people leave this parish. The next one adds the edge — *"There's a
fever in Sligo town. Three houses on the one lane closed up."* — and
the one after that ratchets it further: *"The assizes at Roscommon
have two men up for moonlighting."*

Before this PR, 1820 Ireland stopped at the parish boundary. After this
PR, it reaches in exactly once a year, for exactly one day, at exactly
one location — and it does so in character, in the voice of strangers
who will be gone by dusk. That asymmetry is the point.

The pattern also generalises: `PatternDay + tick hook + voicing
functions` is a template for any calendar-gated scene. Bealtaine
bonfires at the hurling green, Lughnasa fair day at the crossroads, a
Midsummer procession at the church — same shape, different content.

## Test plan

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --workspace --exclude parish-tauri --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace --exclude parish-tauri` — 1,772 passing,
      0 failed. Includes 23 new pilgrimage tests.
- [x] `cargo run -p parish -- --script testing/fixtures/pilgrimage_playtest.txt` —
      produces the log above.
- [x] `cargo run -p parish -- --script testing/fixtures/pilgrimage_flag_off.txt` —
      no beats fire with the flag disabled.
- [ ] Manual walk in the running CLI / web UI (not in CI because of the
      LLM dependency; covered by the script harness fixtures instead).

## Follow-ups (explicitly deferred)

- Move the `WELL_LOCATION_ID` / `PATTERN_MONTH` / `RUMOURS` constants
  into `mods/rundale/festivals.json` (or a new `pilgrimages.json`) so
  mod authors can add their own pattern days without touching Rust.
- Let co-located NPCs (e.g. Brigid Nolan the midwife) pick up pilgrim
  rumours as `GossipItem`s so they propagate into the existing gossip
  network after the pattern day ends.
- Surface rumours as `Knowledge` the player can query by asking
  villagers *"Have you heard anything lately?"* in the weeks after
  Imbolc — letting the pattern-day news live on in conversation.
