### PR TITLE
feat(letters): letter writing at the Letter Office — a window to the wider world

### DIFF
--- a/parish/crates/parish-core/src/ipc/commands.rs
+++ b/parish/crates/parish-core/src/ipc/commands.rs
@@ -730,7 +730,7 @@ fn handle_post_command(
     // Bare `/post` — just list recipients.
     let id = match correspondent.as_deref() {
         None => return CommandResult::text(render_correspondents_list()),
-        Some(s) if s.is_empty() => return CommandResult::text(render_correspondents_list()),
+        Some("") => return CommandResult::text(render_correspondents_list()),
         Some(s) => s,
     };
 

--- a/parish/crates/parish-core/src/ipc/commands.rs
+++ b/parish/crates/parish-core/src/ipc/commands.rs
@@ -138,10 +138,12 @@ const HELP_ENTRIES: &[(&str, &str)] = &[
     ("/irish", "Toggle Irish pronunciation sidebar"),
     ("/load <name>", "Load a named branch"),
     ("/log", "Show branch history"),
+    ("/mail", "Check the Letter Office for mail"),
     ("/map [id]", "List or switch map tile sources"),
     ("/new-game", "Start a fresh game"),
     ("/npcs", "Who is nearby?"),
     ("/pause", "Hold time still"),
+    ("/post <id> [topic]", "Post a letter at the Letter Office"),
     ("/resume", "Let time flow again"),
     ("/save", "Save the game"),
     (
@@ -578,6 +580,11 @@ pub fn handle_command(
         Command::Unexplored(arg) => handle_unexplored_command(config, arg),
         Command::Weather(arg) => handle_weather_command(world, arg),
         Command::Designer => CommandResult::effect_only(CommandEffect::OpenDesigner),
+        Command::Mail => handle_mail_command(world, config),
+        Command::PostLetter {
+            correspondent,
+            topic,
+        } => handle_post_command(world, npc_manager, config, correspondent, topic),
         Command::Debug(sub) => CommandResult::effect_only(CommandEffect::Debug(sub)),
         Command::Spinner(secs) => CommandResult::effect_only(CommandEffect::ShowSpinner(secs)),
         Command::NewGame => CommandResult::effect_only(CommandEffect::NewGame),
@@ -679,6 +686,168 @@ fn handle_weather_command(
             )),
         },
     }
+}
+
+/// Name of the Letter Office in `mods/rundale/world.json`. Kept as a string
+/// match (rather than an id) so mods are free to rename the location; the
+/// feature simply requires a location named "Letter Office".
+const LETTER_OFFICE_NAME: &str = "The Letter Office";
+
+/// Renders the list of correspondents as a single text block.
+fn render_correspondents_list() -> String {
+    let mut lines =
+        vec!["Correspondents — post to one of these with `/post <id> [topic]`:".to_string()];
+    for c in parish_world::letters::CORRESPONDENTS {
+        let delay = if c.delay_hours >= 48 {
+            format!("about {} days", c.delay_hours / 24)
+        } else {
+            format!("about {} hours", c.delay_hours)
+        };
+        lines.push(format!(
+            "  /post {:<7} {} ({}) — round trip {}",
+            c.id, c.name, c.place, delay
+        ));
+    }
+    lines.join("\n")
+}
+
+/// Handles `/post [id] [topic]` — writes a letter at the Letter Office.
+///
+/// Feature-gated on the `letters` flag (default-on, kill-switchable). Requires
+/// the player to be at the Letter Office; writing the letter advances the
+/// clock by ten minutes.
+fn handle_post_command(
+    world: &mut WorldState,
+    npc_manager: &mut NpcManager,
+    config: &GameConfig,
+    correspondent: Option<String>,
+    topic: String,
+) -> CommandResult {
+    if config.flags.is_disabled("letters") {
+        return CommandResult::text("Letter writing is disabled.");
+    }
+
+    // Bare `/post` — just list recipients.
+    let id = match correspondent.as_deref() {
+        None => return CommandResult::text(render_correspondents_list()),
+        Some(s) if s.is_empty() => return CommandResult::text(render_correspondents_list()),
+        Some(s) => s,
+    };
+
+    // Must be at the Letter Office.
+    let at_office = world.current_location().name == LETTER_OFFICE_NAME;
+    if !at_office {
+        return CommandResult::text(format!(
+            "You've no pen nor paper to hand. Come back to {} to post a letter.",
+            LETTER_OFFICE_NAME
+        ));
+    }
+
+    let correspondent = match parish_world::letters::find_correspondent(id) {
+        Some(c) => c,
+        None => {
+            return CommandResult::text(format!(
+                "No one by the name of \"{}\" on the mail rolls. Try `/post` alone for the list.",
+                id
+            ));
+        }
+    };
+
+    let now = world.clock.now();
+    let letter_id = world.letter_book.post(correspondent, &topic, now);
+
+    // Writing takes time. Advance the clock ten minutes (and let schedules
+    // catch up); same pattern `/wait` uses.
+    world.clock.advance(10);
+    let _ = npc_manager.tick_schedules(&world.clock, &world.graph, world.weather);
+
+    let topic_line = if topic.is_empty() {
+        String::new()
+    } else {
+        format!(" You write of {topic}.")
+    };
+
+    CommandResult::text(format!(
+        "Letter #{} to {} ({}).{}\n{}\nExpect a reply in about {} hours.",
+        letter_id,
+        correspondent.name,
+        correspondent.place,
+        topic_line,
+        correspondent.send_blurb,
+        correspondent.delay_hours,
+    ))
+}
+
+/// Handles `/mail` — reports status of all posted letters and, if the player
+/// is at the Letter Office, hands over any letters whose reply has arrived.
+fn handle_mail_command(world: &mut WorldState, config: &GameConfig) -> CommandResult {
+    if config.flags.is_disabled("letters") {
+        return CommandResult::text("Letter writing is disabled.");
+    }
+
+    let now = world.clock.now();
+    let season = world.clock.season();
+    let at_office = world.current_location().name == LETTER_OFFICE_NAME;
+
+    if world.letter_book.posted_count() == 0 {
+        return CommandResult::text(
+            "You've written no letters yet. Try `/post` at the Letter Office.",
+        );
+    }
+
+    let mut out: Vec<String> = Vec::new();
+
+    // Letters in transit — show count + ETA of the soonest arrival.
+    let in_transit = world.letter_book.in_transit(now);
+    if !in_transit.is_empty() {
+        let soonest = in_transit.iter().map(|l| l.reply_at).min().unwrap();
+        let hours = (soonest - now).num_hours().max(0);
+        out.push(format!(
+            "{} letter(s) still in transit (next reply in about {} hour(s)).",
+            in_transit.len(),
+            hours
+        ));
+    }
+
+    // Waiting letters — only delivered at the Letter Office.
+    let waiting_count = world.letter_book.waiting(now).len();
+    if waiting_count == 0 {
+        if !in_transit.is_empty() {
+            out.push("No letters waiting at the office yet.".to_string());
+        } else {
+            out.push(
+                "No mail at the office. All posted letters have been received and read."
+                    .to_string(),
+            );
+        }
+        return CommandResult::text(out.join("\n"));
+    }
+
+    if !at_office {
+        out.push(format!(
+            "{} letter(s) waiting at {}. Call in to collect them.",
+            waiting_count, LETTER_OFFICE_NAME
+        ));
+        return CommandResult::text(out.join("\n"));
+    }
+
+    // At the office, with mail — render every waiting letter in full.
+    let read = world.letter_book.collect_waiting(now, season);
+    out.push(format!(
+        "The postmaster thumbs through the bag and hands you {} letter(s).",
+        read.len()
+    ));
+    for letter in &read {
+        let from = format!(
+            "From {} ({}):",
+            letter.correspondent.name, letter.correspondent.place
+        );
+        out.push(String::new());
+        out.push(from);
+        out.push(letter.body.clone());
+    }
+
+    CommandResult::text(out.join("\n"))
 }
 
 /// Handles the `/unexplored` command (reveal/hide all unexplored map locations).

--- a/parish/crates/parish-input/src/commands.rs
+++ b/parish/crates/parish-input/src/commands.rs
@@ -114,6 +114,15 @@ pub enum Command {
     NewGame,
     /// Manually tick NPC schedules without advancing time.
     Tick,
+    /// Post a letter to a correspondent at the Letter Office.
+    PostLetter {
+        /// Correspondent ID or partial name.
+        correspondent: Option<String>,
+        /// Optional topic/subject for the letter.
+        topic: String,
+    },
+    /// Check mail status and collect letters at the Letter Office.
+    Mail,
     /// Show or change the UI theme.
     Theme(Option<String>),
     /// Show or set whether unexplored map locations are fully revealed.

--- a/parish/crates/parish-input/src/parser.rs
+++ b/parish/crates/parish-input/src/parser.rs
@@ -100,6 +100,22 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
         Some(Command::NewGame)
     } else if lower == "/tick" {
         Some(Command::Tick)
+    } else if lower == "/mail" {
+        Some(Command::Mail)
+    } else if lower == "/post" {
+        Some(Command::PostLetter {
+            correspondent: None,
+            topic: String::new(),
+        })
+    } else if lower.starts_with("/post ") {
+        let args = trimmed.get("/post ".len()..).unwrap_or("").trim();
+        let mut parts = args.splitn(2, ' ');
+        let correspondent = parts.next().map(|s| s.to_string());
+        let topic = parts.next().unwrap_or("").trim().to_string();
+        Some(Command::PostLetter {
+            correspondent,
+            topic,
+        })
     } else if lower == "/theme" {
         Some(Command::Theme(None))
     } else if lower.starts_with("/theme ") {

--- a/parish/crates/parish-persistence/src/database.rs
+++ b/parish/crates/parish-persistence/src/database.rs
@@ -537,6 +537,7 @@ mod tests {
             conversation_log: Default::default(),
             player_name: None,
             npcs_who_know_player_name: Default::default(),
+            letter_book: Default::default(),
         }
     }
 

--- a/parish/crates/parish-persistence/src/snapshot.rs
+++ b/parish/crates/parish-persistence/src/snapshot.rs
@@ -312,6 +312,9 @@ pub struct GameSnapshot {
     /// Set of NPC ids that know the player's name.
     #[serde(default)]
     pub npcs_who_know_player_name: HashSet<NpcId>,
+    /// The player's letter-book (posted letters and pending replies).
+    #[serde(default)]
+    pub letter_book: parish_world::letters::LetterBook,
 }
 
 impl GameSnapshot {
@@ -344,6 +347,7 @@ impl GameSnapshot {
             conversation_log: world.conversation_log.clone(),
             player_name: world.player_name.clone(),
             npcs_who_know_player_name: npc_manager.player_name_known_set(),
+            letter_book: world.letter_book.clone(),
         }
     }
 
@@ -458,6 +462,9 @@ impl GameSnapshot {
 
         // Restore NPC knowledge of player name
         npc_manager.restore_player_name_known(self.npcs_who_know_player_name);
+
+        // Restore letter-book
+        world.letter_book = self.letter_book;
     }
 }
 

--- a/parish/crates/parish-server/src/session.rs
+++ b/parish/crates/parish-server/src/session.rs
@@ -1485,6 +1485,7 @@ mod tests {
                 conversation_log: Default::default(),
                 player_name: None,
                 npcs_who_know_player_name: Default::default(),
+                letter_book: Default::default(),
             }
         }
 

--- a/parish/crates/parish-world/src/letters.rs
+++ b/parish/crates/parish-world/src/letters.rs
@@ -1,0 +1,307 @@
+//! Letter writing at the Letter Office — a window to the wider world.
+//!
+//! The player may post letters to a fixed roster of correspondents outside
+//! the parish. Each correspondent has a travel delay (in game-hours). When
+//! enough game-time has elapsed, the reply arrives at the Letter Office
+//! and can be fetched with `/mail`.
+//!
+//! Reply bodies are drawn from hand-written seasonal templates keyed by a
+//! deterministic hash of `(correspondent, send_time)` so play-tests are
+//! reproducible and the feature works with no LLM attached.
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+use parish_types::time::Season;
+
+/// A person the player may correspond with outside the parish.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Correspondent {
+    /// Machine id used in `/post <id>`; lowercase, no spaces.
+    pub id: &'static str,
+    /// Display name shown in listings and letter headers.
+    pub name: &'static str,
+    /// Short relationship descriptor, e.g. "sister in Dublin".
+    pub place: &'static str,
+    /// Round-trip delay in game-hours from post to reply arrival.
+    pub delay_hours: i64,
+    /// One-line flavour shown when the letter is posted.
+    pub send_blurb: &'static str,
+}
+
+/// The fixed roster of correspondents for the demo.
+///
+/// Hand-picked to offer varied reply latencies (a same-day courier, a few
+/// days by mail coach, weeks by packet-ship) and varied tonal registers
+/// (family, formal, clerical, emigrant).
+pub const CORRESPONDENTS: &[Correspondent] = &[
+    Correspondent {
+        id: "maire",
+        name: "Máire",
+        place: "your sister, in Dublin",
+        delay_hours: 60,
+        send_blurb:
+            "You seal the letter with a daub of candle-wax and slide it into the Dublin bag.",
+    },
+    Correspondent {
+        id: "aodh",
+        name: "Aodh",
+        place: "your cousin, in Galway",
+        delay_hours: 30,
+        send_blurb:
+            "A drover bound for Galway promises to carry the letter as far as Athenry himself.",
+    },
+    Correspondent {
+        id: "brown",
+        name: "Mr. Brown",
+        place: "the attorney, in Athlone",
+        delay_hours: 14,
+        send_blurb:
+            "The postmaster takes the letter with a nod; Athlone is only half a day's ride.",
+    },
+    Correspondent {
+        id: "gerald",
+        name: "Father Gerald",
+        place: "the priest, in Tuam",
+        delay_hours: 22,
+        send_blurb: "You fold the letter thrice and entrust it to the curate riding west at dawn.",
+    },
+    Correspondent {
+        id: "peadar",
+        name: "Uncle Peadar",
+        place: "your uncle, emigrated to Boston",
+        delay_hours: 900,
+        send_blurb:
+            "You hand the letter over for the Liverpool packet; it'll be weeks before Boston sees it.",
+    },
+];
+
+/// Looks up a correspondent by its machine id (case-insensitive).
+pub fn find_correspondent(id: &str) -> Option<&'static Correspondent> {
+    let lower = id.to_lowercase();
+    CORRESPONDENTS.iter().find(|c| c.id == lower)
+}
+
+/// A letter posted by the player that is either in transit or awaiting pickup.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Letter {
+    /// Stable, monotonic id assigned at post time.
+    pub id: u32,
+    /// Correspondent id — matches [`Correspondent::id`].
+    pub correspondent_id: String,
+    /// Short human-readable description the player supplied, e.g. `"news"`.
+    pub topic: String,
+    /// Game time at which the letter was posted.
+    pub sent_at: DateTime<Utc>,
+    /// Game time the reply becomes available at the Letter Office.
+    pub reply_at: DateTime<Utc>,
+    /// `true` once the player has fetched and read the reply.
+    #[serde(default)]
+    pub read: bool,
+}
+
+impl Letter {
+    /// Returns `true` if the reply has arrived by `now` and has not yet been read.
+    pub fn is_waiting(&self, now: DateTime<Utc>) -> bool {
+        !self.read && now >= self.reply_at
+    }
+
+    /// Returns `true` if the letter is still in transit at `now`.
+    pub fn is_in_transit(&self, now: DateTime<Utc>) -> bool {
+        !self.read && now < self.reply_at
+    }
+}
+
+/// The player's letter-book: every letter ever posted, by order of posting.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LetterBook {
+    /// All letters, oldest first.
+    #[serde(default)]
+    pub letters: Vec<Letter>,
+    /// Monotonic id counter for the next posted letter.
+    #[serde(default)]
+    next_id: u32,
+}
+
+impl LetterBook {
+    /// Creates an empty letter-book.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Posts a new letter and returns the scheduled arrival time.
+    ///
+    /// The arrival time is `now + correspondent.delay_hours`, i.e. a fixed
+    /// round-trip. Deterministic by design so play-tests and the snapshot
+    /// restore are bit-for-bit stable.
+    pub fn post(&mut self, correspondent: &Correspondent, topic: &str, now: DateTime<Utc>) -> u32 {
+        let id = self.next_id + 1;
+        self.next_id = id;
+        let reply_at = now + Duration::hours(correspondent.delay_hours);
+        self.letters.push(Letter {
+            id,
+            correspondent_id: correspondent.id.to_string(),
+            topic: topic.to_string(),
+            sent_at: now,
+            reply_at,
+            read: false,
+        });
+        id
+    }
+
+    /// Returns every letter whose reply has arrived but has not yet been read.
+    pub fn waiting(&self, now: DateTime<Utc>) -> Vec<&Letter> {
+        self.letters.iter().filter(|l| l.is_waiting(now)).collect()
+    }
+
+    /// Returns every letter still in transit at `now`.
+    pub fn in_transit(&self, now: DateTime<Utc>) -> Vec<&Letter> {
+        self.letters
+            .iter()
+            .filter(|l| l.is_in_transit(now))
+            .collect()
+    }
+
+    /// Marks every currently-waiting letter as read and returns the rendered
+    /// reply text for each, in posting order.
+    ///
+    /// The `season` and the player's elapsed delay are woven into the
+    /// rendered text so the reply feels situated in the story.
+    pub fn collect_waiting(&mut self, now: DateTime<Utc>, season: Season) -> Vec<ReadLetter> {
+        let mut out = Vec::new();
+        for letter in self.letters.iter_mut() {
+            if !letter.read && now >= letter.reply_at {
+                letter.read = true;
+                if let Some(correspondent) = find_correspondent(&letter.correspondent_id) {
+                    out.push(ReadLetter {
+                        id: letter.id,
+                        correspondent,
+                        topic: letter.topic.clone(),
+                        sent_at: letter.sent_at,
+                        reply_at: letter.reply_at,
+                        body: render_reply_body(correspondent, &letter.topic, letter.id, season),
+                    });
+                }
+            }
+        }
+        out
+    }
+
+    /// Returns the total number of letters ever posted.
+    pub fn posted_count(&self) -> usize {
+        self.letters.len()
+    }
+}
+
+/// A rendered, player-readable letter — the fully-baked output of
+/// [`LetterBook::collect_waiting`].
+#[derive(Debug, Clone)]
+pub struct ReadLetter {
+    pub id: u32,
+    pub correspondent: &'static Correspondent,
+    pub topic: String,
+    pub sent_at: DateTime<Utc>,
+    pub reply_at: DateTime<Utc>,
+    pub body: String,
+}
+
+/// Renders the reply body for a given correspondent / topic / season.
+///
+/// Each correspondent has a small table of hand-written seasonal paragraphs.
+/// Selection is deterministic — `(letter_id mod N)` — so a given letter always
+/// yields the same reply, which keeps play-test logs reproducible and makes
+/// snapshot restore trivially correct.
+fn render_reply_body(
+    correspondent: &Correspondent,
+    topic: &str,
+    letter_id: u32,
+    season: Season,
+) -> String {
+    let bank = reply_bank(correspondent.id, season);
+    let choice = bank[(letter_id as usize) % bank.len()];
+    let topic_line = if topic.is_empty() {
+        String::new()
+    } else {
+        format!(" You wrote of {topic}, and I've turned the matter over more than once.")
+    };
+    format!("{choice}{topic_line}\n\n— {}", correspondent.name)
+}
+
+/// Seasonal reply bank, keyed by correspondent id.
+///
+/// Tables are intentionally short (3 entries each) so that within a
+/// reasonable play-test the player sees the full variety. Prose is written
+/// plain-spoken, in a register loosely consistent with 1820s rural Ireland —
+/// no anachronistic idiom, no quest-giver pleasantries.
+fn reply_bank(id: &str, season: Season) -> &'static [&'static str] {
+    match (id, season) {
+        ("maire", Season::Spring) => &[
+            "Dublin is all smoke and bluster this spring, but the crocus is up along the canal and I think of home.",
+            "The lodgings above the apothecary are draughty but cheap. Write me about the lambs — I miss the noise of them.",
+            "A letter from Aunt Ellen at last: she is well. The city is no place for her, she says, and I cannot disagree.",
+        ],
+        ("maire", Season::Summer) => &[
+            "The heat in the city is something awful — the river stinks and the gentry are all fled to the sea.",
+            "Mr. Halpin has offered me work copying for the courts. It will keep me in tea and candles through the autumn.",
+            "I walked out to Rathfarnham on Sunday for the air. It nearly made a Christian of me.",
+        ],
+        ("maire", Season::Autumn) => &[
+            "The evenings are drawing in and the cough is back in my chest. Don't fret — it always comes with October.",
+            "Tell Father the oats fetched a fair price at Smithfield — better than last year, in any case.",
+            "There is talk everywhere of O'Connell and the Catholic Board. The pubs are thick with it.",
+        ],
+        ("maire", Season::Winter) => &[
+            "The Liffey half froze last week, a thing I'd never seen. Children skated on the canal at Portobello.",
+            "I have knitted you a muffler but will not post it till the coaches run safely again — the roads west are treacherous.",
+            "A midnight Mass in Marlborough Street, and I thought of our own chapel. Christmas blessings to you all.",
+        ],
+
+        ("aodh", Season::Spring) => &[
+            "The potatoes are in and the field is black with crows. Tell your father the new spade held up.",
+            "A fair at Loughrea next week — I may see you there if the roads dry out.",
+            "Brigid's girl was married Shrovetide. A quiet match, but a good one.",
+        ],
+        ("aodh", Season::Summer) => &[
+            "The hay is cut and standing in cocks. A wet week now would ruin us, but the glass holds steady.",
+            "We lost a heifer to the bloat — a bad loss. Otherwise the summer has been kind.",
+            "Two of the Keane boys have gone for the harvest in England. A terrible thing to watch them walk the road.",
+        ],
+        ("aodh", Season::Autumn) => &[
+            "Michaelmas goose was tough as rope this year. The geese have had a hard summer same as ourselves.",
+            "The rents were demanded on the dot. I paid and said nothing. What else is there to say?",
+            "A stranger came through asking after the Whiteboys. I told him nothing. Say the same if he comes your way.",
+        ],
+        ("aodh", Season::Winter) => &[
+            "The turf is in and the barn is dry. We will not starve, at any rate.",
+            "A wake for old Peg Hanratty — ninety-one and sharp to the last. The house was full three nights running.",
+            "Snow on the Sliabh for a fortnight. The children have never seen the like.",
+        ],
+
+        ("brown", Season::Spring) | ("brown", Season::Summer) => &[
+            "Sir, — I have lodged your enquiry with the Recorder's clerk. A reply may be expected within the month. Yours faithfully, E. Brown.",
+            "Sir, — Touching the matter of the disputed boundary: the surveyor's report favours your interest. Await my full opinion by next post. Yours, E. Brown.",
+            "Sir, — The fee is three shillings sixpence and a glass of brandy when next you are in Athlone. Yours faithfully, E. Brown.",
+        ],
+        ("brown", Season::Autumn) | ("brown", Season::Winter) => &[
+            "Sir, — The assizes sit the second Monday. I advise you attend in person; written depositions seldom carry the day. Yours, E. Brown.",
+            "Sir, — I have taken the liberty of writing to Dublin on your behalf. Expect no swift answer: the Four Courts are a slow beast. Yours, E. Brown.",
+            "Sir, — The magistrate is a reasonable man if approached sober and before noon. Govern yourself accordingly. Yours, E. Brown.",
+        ],
+
+        ("gerald", _) => &[
+            "Dear friend, — I had your letter at Vespers and read it twice. There is grace in plain speech; keep to it. Fr. G.",
+            "Dear friend, — The bishop visits in the autumn. Say a word for us all — it costs nothing and may do some good. Fr. G.",
+            "Dear friend, — I think often of Kilteevan and of the rain on the chapel roof. Pray for us in Tuam; we pray for you. Fr. G.",
+        ],
+
+        ("peadar", _) => &[
+            "Dear nephew, — The ship was sixty-three days at sea and the youngest took the fever, but we are all landed and well. Work is to be had on the waterfront if a man will take it.",
+            "Dear nephew, — Boston is loud as a fair-day and twice as strange. The Irish keep to one quarter and the Yankees to another and the two scarcely cross. I send two dollars, against the rent.",
+            "Dear nephew, — There is no going back — not for me — but I will not let you be forgotten here. Write again. Tell me of the land and the weather and who is living and who is not.",
+        ],
+
+        _ => &[
+            "Your letter reached me and I am grateful for it. Write again when you can.",
+        ],
+    }
+}

--- a/parish/crates/parish-world/src/letters.rs
+++ b/parish/crates/parish-world/src/letters.rs
@@ -40,24 +40,21 @@ pub const CORRESPONDENTS: &[Correspondent] = &[
         name: "Máire",
         place: "your sister, in Dublin",
         delay_hours: 60,
-        send_blurb:
-            "You seal the letter with a daub of candle-wax and slide it into the Dublin bag.",
+        send_blurb: "You seal the letter with a daub of candle-wax and slide it into the Dublin bag.",
     },
     Correspondent {
         id: "aodh",
         name: "Aodh",
         place: "your cousin, in Galway",
         delay_hours: 30,
-        send_blurb:
-            "A drover bound for Galway promises to carry the letter as far as Athenry himself.",
+        send_blurb: "A drover bound for Galway promises to carry the letter as far as Athenry himself.",
     },
     Correspondent {
         id: "brown",
         name: "Mr. Brown",
         place: "the attorney, in Athlone",
         delay_hours: 14,
-        send_blurb:
-            "The postmaster takes the letter with a nod; Athlone is only half a day's ride.",
+        send_blurb: "The postmaster takes the letter with a nod; Athlone is only half a day's ride.",
     },
     Correspondent {
         id: "gerald",
@@ -71,8 +68,7 @@ pub const CORRESPONDENTS: &[Correspondent] = &[
         name: "Uncle Peadar",
         place: "your uncle, emigrated to Boston",
         delay_hours: 900,
-        send_blurb:
-            "You hand the letter over for the Liverpool packet; it'll be weeks before Boston sees it.",
+        send_blurb: "You hand the letter over for the Liverpool packet; it'll be weeks before Boston sees it.",
     },
 ];
 
@@ -300,8 +296,6 @@ fn reply_bank(id: &str, season: Season) -> &'static [&'static str] {
             "Dear nephew, — There is no going back — not for me — but I will not let you be forgotten here. Write again. Tell me of the land and the weather and who is living and who is not.",
         ],
 
-        _ => &[
-            "Your letter reached me and I am grateful for it. Write again when you can.",
-        ],
+        _ => &["Your letter reached me and I am grateful for it. Write again when you can."],
     }
 }

--- a/parish/crates/parish-world/src/letters.rs
+++ b/parish/crates/parish-world/src/letters.rs
@@ -299,3 +299,107 @@ fn reply_bank(id: &str, season: Season) -> &'static [&'static str] {
         _ => &["Your letter reached me and I am grateful for it. Write again when you can."],
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn t(hours: i64) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(1820, 3, 20, 8, 0, 0).unwrap() + Duration::hours(hours)
+    }
+
+    #[test]
+    fn find_correspondent_is_case_insensitive() {
+        assert!(find_correspondent("MAIRE").is_some());
+        assert!(find_correspondent("Maire").is_some());
+        assert!(find_correspondent("nobody").is_none());
+    }
+
+    #[test]
+    fn post_schedules_reply_at_delay() {
+        let mut book = LetterBook::new();
+        let aodh = find_correspondent("aodh").unwrap();
+        let id = book.post(aodh, "the harvest", t(0));
+        assert_eq!(id, 1);
+        assert_eq!(book.posted_count(), 1);
+        let letter = &book.letters[0];
+        assert_eq!(letter.reply_at, t(aodh.delay_hours));
+        assert_eq!(letter.topic, "the harvest");
+        assert!(!letter.read);
+    }
+
+    #[test]
+    fn post_ids_are_monotonic() {
+        let mut book = LetterBook::new();
+        let c = find_correspondent("aodh").unwrap();
+        assert_eq!(book.post(c, "", t(0)), 1);
+        assert_eq!(book.post(c, "", t(0)), 2);
+        assert_eq!(book.post(c, "", t(0)), 3);
+    }
+
+    #[test]
+    fn letter_waiting_vs_in_transit_by_time() {
+        let mut book = LetterBook::new();
+        let brown = find_correspondent("brown").unwrap();
+        book.post(brown, "land title", t(0));
+        // Still in transit just before arrival.
+        assert_eq!(book.waiting(t(brown.delay_hours - 1)).len(), 0);
+        assert_eq!(book.in_transit(t(brown.delay_hours - 1)).len(), 1);
+        // Arrived at the delay threshold.
+        assert_eq!(book.waiting(t(brown.delay_hours)).len(), 1);
+        assert_eq!(book.in_transit(t(brown.delay_hours)).len(), 0);
+    }
+
+    #[test]
+    fn collect_waiting_marks_letters_read_and_renders_reply() {
+        let mut book = LetterBook::new();
+        let c = find_correspondent("aodh").unwrap();
+        book.post(c, "the oats", t(0));
+        let now = t(c.delay_hours);
+        let read = book.collect_waiting(now, Season::Spring);
+        assert_eq!(read.len(), 1);
+        let letter = &read[0];
+        assert!(letter.body.contains("Aodh"));
+        assert!(letter.body.contains("the oats"));
+        // Second call returns nothing — the letter is now marked read.
+        assert!(book.collect_waiting(now, Season::Spring).is_empty());
+        assert!(book.letters[0].read);
+    }
+
+    #[test]
+    fn collect_waiting_leaves_in_transit_untouched() {
+        let mut book = LetterBook::new();
+        let peadar = find_correspondent("peadar").unwrap();
+        let aodh = find_correspondent("aodh").unwrap();
+        book.post(peadar, "", t(0)); // 900h — still in transit
+        book.post(aodh, "", t(0)); // 30h — will arrive first
+
+        let read = book.collect_waiting(t(30), Season::Spring);
+        assert_eq!(read.len(), 1);
+        assert_eq!(read[0].correspondent.id, "aodh");
+        assert!(!book.letters[0].read);
+        assert_eq!(book.in_transit(t(30)).len(), 1);
+    }
+
+    #[test]
+    fn reply_selection_is_deterministic() {
+        let c = find_correspondent("maire").unwrap();
+        let a = render_reply_body(c, "news", 7, Season::Autumn);
+        let b = render_reply_body(c, "news", 7, Season::Autumn);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn letter_book_serialises_round_trip() {
+        let mut book = LetterBook::new();
+        let c = find_correspondent("gerald").unwrap();
+        book.post(c, "the bishop's visit", t(0));
+        book.post(c, "", t(5));
+        let _ = book.collect_waiting(t(c.delay_hours + 10), Season::Summer);
+
+        let json = serde_json::to_string(&book).unwrap();
+        let restored: LetterBook = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, book);
+    }
+}

--- a/parish/crates/parish-world/src/lib.rs
+++ b/parish/crates/parish-world/src/lib.rs
@@ -4,6 +4,7 @@ pub mod description;
 pub mod encounter;
 pub mod geo;
 pub mod graph;
+pub mod letters;
 pub mod movement;
 pub mod transport;
 pub mod weather;
@@ -26,6 +27,7 @@ use std::path::Path;
 use parish_types::{ConversationLog, EventBus, GameClock, GossipNetwork, ParishError};
 
 use graph::{LocationData, WorldGraph};
+use letters::LetterBook;
 use weather::WeatherEngine;
 
 /// Maximum number of entries kept in the backend text log, matching the
@@ -75,6 +77,8 @@ pub struct WorldState {
     /// changed (NPCs moved, clock advanced, weather shifted) while the
     /// intent was being parsed.  See issue #283.
     pub tick_generation: u64,
+    /// The player's letter-book — posted letters and pending replies.
+    pub letter_book: LetterBook,
 }
 
 impl WorldState {
@@ -120,6 +124,7 @@ impl WorldState {
             conversation_log: ConversationLog::new(),
             player_name: None,
             tick_generation: 0,
+            letter_book: LetterBook::new(),
         }
     }
 
@@ -169,6 +174,7 @@ impl WorldState {
             conversation_log: ConversationLog::new(),
             player_name: None,
             tick_generation: 0,
+            letter_book: LetterBook::new(),
         })
     }
 
@@ -231,6 +237,7 @@ impl WorldState {
             conversation_log: ConversationLog::new(),
             player_name: None,
             tick_generation: 0,
+            letter_book: LetterBook::new(),
         })
     }
 

--- a/parish/testing/fixtures/play_letters.txt
+++ b/parish/testing/fixtures/play_letters.txt
@@ -1,0 +1,70 @@
+# Letter Writing Play-Test (idea #19)
+# ====================================
+# Walks a player through the full letter-writing loop:
+#   1. Try to post from outside the Letter Office — refused.
+#   2. Walk to the Letter Office, list correspondents.
+#   3. Post three letters with varying delays (14h / 30h / 60h).
+#   4. Leave the office; /mail reports status from outside.
+#   5. Wait out the delays; watch each reply land in order.
+#   6. Return to the office and collect the replies.
+#   7. Post the long-range Boston letter; show it stays in transit.
+
+# ── 1. Baseline: try /post from the starting square ─────────────────
+/status
+/mail
+/post aodh the oats
+# (expected: refused, "come back to The Letter Office…")
+
+# ── 2. Walk to the Letter Office and list recipients ────────────────
+go to the letter office
+/status
+/post
+# (expected: correspondents list)
+
+# ── 3. Post three letters with a spread of delays ───────────────────
+/post brown the disputed boundary
+/post aodh the hay is in
+/post maire all the parish news
+/mail
+# (expected: 3 letters in transit, ETA ~ brown.delay_hours - 10m)
+
+# ── 4. Leave the office; /mail from outside ─────────────────────────
+go to the crossroads
+/mail
+# (expected: still in transit, no waiting mail to fetch from outside)
+
+# ── 5. Wait past the first reply (Brown, 14h) ───────────────────────
+/speed fastest
+/wait 900
+/mail
+# (expected: 1 letter waiting at the office; 2 in transit)
+
+# ── 6. Go and collect it ────────────────────────────────────────────
+go to the letter office
+/mail
+# (expected: full reply body from Mr. Brown printed)
+
+# Confirm the same letter is not re-delivered on a second check.
+/mail
+# (expected: only 2 in-transit status, no body re-printed)
+
+# ── 7. Wait past Aodh (30h total) then Máire (60h) ──────────────────
+/wait 1200
+/mail
+# (expected: Aodh's reply body printed; Máire still in transit)
+
+/wait 2000
+/mail
+# (expected: Máire's reply body printed; nothing else in transit)
+
+# ── 8. Post the long-haul Boston letter — stays in transit ──────────
+/post peadar the farm, the weather, who is living and who is not
+/mail
+# (expected: 1 letter in transit, ETA ~ 900h)
+
+# A short wait doesn't bring Boston any closer.
+/wait 240
+/mail
+
+/status
+/time


### PR DESCRIPTION
## Summary

Implements idea **#19 "Letter Writing"** from
[`docs/design/game-ideas-brainstorm.md`](../blob/main/docs/design/game-ideas-brainstorm.md) — the Letter Office has existed as a location since the world was first expanded (PR #208), but there has never been anything to *do* there. This PR gives the player a reason to step inside.

The player can now **post letters** to a fixed roster of correspondents outside the parish, wait out the delivery delay, and return to the Letter Office to collect hand-written replies. Different destinations have different latencies — a same-day rider to Athlone, two days to Dublin, **thirty-seven days to Boston via Liverpool packet** — so the feature quietly establishes a sense of scale beyond the village edge.

Replies are drawn from deterministic, season-aware tables (no LLM required), which keeps the feature working offline, in the simulator provider, and under snapshot restore.

## What this changes

- `crates/parish-world/src/letters.rs` — new module with `Correspondent`, `Letter`, `LetterBook`, and a seasonal `reply_bank`. Selection is deterministic on `(correspondent, letter_id, season)` so play-tests are reproducible and snapshots round-trip bit-identically.
- `WorldState` gains a `letter_book: LetterBook` field; `GameSnapshot` captures and restores it (serde `default`, so old saves load cleanly).
- Two new slash commands, wired through the shared `handle_command` so Tauri / web / CLI behave identically:
  - `/post` — bare form lists correspondents and their delays.
  - `/post <id> [topic]` — writes a letter; must be at **The Letter Office**; advances the clock by ten minutes. The optional `topic` is woven into the reply body.
  - `/mail` — reports letters in transit (with ETA) and, when at the Letter Office, renders every arrived reply in full and marks them read.
- Feature-gated on `letters` via `is_disabled` — default-on, kill-switchable with `/flag disable letters`, per the CLAUDE.md rule #6 convention.

## Correspondents (demo roster)

| id | Name | Relationship | Round-trip |
| --- | --- | --- | --- |
| `brown` | Mr. Brown | Attorney in Athlone | **14 h** |
| `gerald` | Father Gerald | Priest in Tuam | 22 h |
| `aodh` | Aodh | Cousin in Galway | 30 h |
| `maire` | Máire | Sister in Dublin | 2 days |
| `peadar` | Uncle Peadar | Emigrant in Boston | **37 days** |

Each correspondent has 3 seasonal reply paragraphs (except Father Gerald and Uncle Peadar, where tone is season-invariant). Prose is deliberately plain and period-consistent — no quest-giver pleasantries.

## Tests

Eight new unit tests in `crates/parish-world/src/letters.rs`, all green:

- `find_correspondent_is_case_insensitive`
- `post_schedules_reply_at_delay`
- `post_ids_are_monotonic`
- `letter_waiting_vs_in_transit_by_time`
- `collect_waiting_marks_letters_read_and_renders_reply`
- `collect_waiting_leaves_in_transit_untouched`
- `reply_selection_is_deterministic`
- `letter_book_serialises_round_trip`

Full workspace (`cargo test --workspace --exclude parish-tauri`) passes. Clippy clean. `cargo fmt --check` clean.

## Play-test

`parish --script testing/fixtures/play_letters.txt` drives a player through the full loop. Highlights from the JSON-lines output, pretty-printed:

```
[02] /post aodh the oats                            @Kilteevan Village  (Morning)
    You've no pen nor paper to hand. Come back to The Letter Office to post a letter.

[05] /post                                          @The Letter Office  (Morning)
    Correspondents — post to one of these with `/post <id> [topic]`:
      /post maire   Máire (your sister, in Dublin) — round trip about 2 days
      /post aodh    Aodh (your cousin, in Galway) — round trip about 30 hours
      /post brown   Mr. Brown (the attorney, in Athlone) — round trip about 14 hours
      /post gerald  Father Gerald (the priest, in Tuam) — round trip about 22 hours
      /post peadar  Uncle Peadar (your uncle, emigrated to Boston) — round trip about 37 days

[06] /post brown the disputed boundary              @The Letter Office  (Morning)
    Letter #1 to Mr. Brown (the attorney, in Athlone). You write of the disputed boundary.
    The postmaster takes the letter with a nod; Athlone is only half a day's ride.
    Expect a reply in about 14 hours.

[09] /mail                                          @The Letter Office  (Morning)
    3 letter(s) still in transit (next reply in about 13 hour(s)).
    No letters waiting at the office yet.

[11] /mail                                          @The Crossroads  (Morning)
    3 letter(s) still in transit (next reply in about 13 hour(s)).
    No letters waiting at the office yet.

[13] /wait 900                                      @The Crossroads  (Midnight)
    Waited 900 minutes. Now 23:45 Midnight.

[14] /mail                                          @The Crossroads  (Midnight)
    2 letter(s) still in transit (next reply in about 14 hour(s)).
    1 letter(s) waiting at The Letter Office. Call in to collect them.

[16] /mail                                          @The Letter Office  (Midnight)
    2 letter(s) still in transit (next reply in about 14 hour(s)).
    The postmaster thumbs through the bag and hands you 1 letter(s).

    From Mr. Brown (the attorney, in Athlone):
    Sir, — Touching the matter of the disputed boundary: the surveyor's report
    favours your interest. Await my full opinion by next post. Yours, E. Brown.
    You wrote of the disputed boundary, and I've turned the matter over more
    than once.

    — Mr. Brown

[17] /mail                                          @The Letter Office  (Midnight)
    2 letter(s) still in transit (next reply in about 14 hour(s)).
    No letters waiting at the office yet.

[19] /mail                                          @The Letter Office  (Night)
    1 letter(s) still in transit (next reply in about 24 hour(s)).
    The postmaster thumbs through the bag and hands you 1 letter(s).

    From Aodh (your cousin, in Galway):
    Brigid's girl was married Shrovetide. A quiet match, but a good one.
    You wrote of the hay is in, and I've turned the matter over more than once.

    — Aodh

[21] /mail                                          @The Letter Office  (Dawn)
    The postmaster thumbs through the bag and hands you 1 letter(s).

    From Máire (your sister, in Dublin):
    Dublin is all smoke and bluster this spring, but the crocus is up along the
    canal and I think of home. You wrote of all the parish news, and I've
    turned the matter over more than once.

    — Máire

[22] /post peadar the farm, the weather, who is living and who is not  @The Letter Office  (Dawn)
    Letter #4 to Uncle Peadar (your uncle, emigrated to Boston). You write of
    the farm, the weather, who is living and who is not.
    You hand the letter over for the Liverpool packet; it'll be weeks before
    Boston sees it.
    Expect a reply in about 900 hours.

[23] /mail                                          @The Letter Office  (Dawn)
    1 letter(s) still in transit (next reply in about 899 hour(s)).
    No letters waiting at the office yet.
```

What the log demonstrates:

- **Refusal outside the office** is a concrete narrative beat, not just an error message.
- **ETAs from anywhere** — at step `[14]`, standing at the Crossroads, the player learns mail is waiting without being at the office. You can finish what you're doing and swing by.
- **In-order arrivals** — Brown (14 h), then Aodh (30 h), then Máire (60 h). The Boston letter stays in transit through the rest of the script and will keep doing so for five weeks of game time.
- **Idempotent pickup** — step `[17]` confirms a re-check after reading returns nothing; no duplicate-delivery bug.
- **Seasonal voice** — Máire's reply opens with "Dublin is all smoke and bluster *this spring*"; the same letter id posted in autumn would get "the evenings are drawing in and the cough is back in my chest".
- **Topic threading** — the player's arbitrary `topic` string is echoed back inside the reply, turning flat templates into something that feels answered.

## Test plan

- [x] `cargo test --workspace --exclude parish-tauri` — all green, 8 new letter tests
- [x] `cargo clippy --workspace --exclude parish-tauri --all-targets` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `parish --script testing/fixtures/play_letters.txt` — full walkthrough ends with correct final state (letters read, Boston in transit, 895 h ETA at end)
- [ ] Desktop / web parity: commands go through the shared `handle_command`, so they should work in Tauri and the Axum server unchanged — smoke-test both in-browser before merge.

https://claude.ai/code/session_01SbZAYZjVnFysinNDPM3coX