### PR TITLE
fix: banshee-disabled immortal NPCs and double tick in harness

### DIFF
--- a/crates/parish-cli/src/headless.rs
+++ b/crates/parish-cli/src/headless.rs
@@ -322,7 +322,8 @@ pub async fn run_headless(
                     let mut rng = rand::thread_rng();
                     crate::npc::tier4::tick_tier4(&mut tier4_refs, season, game_date, &mut rng)
                 };
-                let game_events = app.npc_manager.apply_tier4_events(&events, now);
+                let banshee_on = !app.flags.is_disabled("banshee");
+                let game_events = app.npc_manager.apply_tier4_events(&events, now, banshee_on);
                 for evt in game_events {
                     app.world.event_bus.publish(evt);
                 }

--- a/crates/parish-cli/src/testing.rs
+++ b/crates/parish-cli/src/testing.rs
@@ -469,7 +469,11 @@ impl GameTestHarness {
                 let mut rng2 = rand::thread_rng();
                 crate::npc::tier4::tick_tier4(&mut tier4_refs, season, game_date, &mut rng2)
             };
-            let game_events = self.app.npc_manager.apply_tier4_events(&t4_events, now);
+            let banshee_on = !self.app.flags.is_disabled("banshee");
+            let game_events = self
+                .app
+                .npc_manager
+                .apply_tier4_events(&t4_events, now, banshee_on);
             for evt in game_events {
                 self.app.world.event_bus.publish(evt);
             }
@@ -572,29 +576,13 @@ impl GameTestHarness {
                 let count = events.len();
                 self.process_schedule_events(&events);
 
-                // Banshee tick: herald and finalise doomed NPCs.
-                let mut banshee_count = 0;
-                if !self.app.flags.is_disabled("banshee") {
-                    let player_loc = self.app.world.player_location;
-                    let report = self.app.npc_manager.tick_banshee(
-                        &self.app.world.clock,
-                        &self.app.world.graph,
-                        &mut self.app.world.text_log,
-                        &self.app.world.event_bus,
-                        player_loc,
-                    );
-                    banshee_count = report.wails.len() + report.deaths.len();
-                }
+                // Banshee tick is handled by the post-action block in execute(),
+                // so we don't call it here to avoid processing doomed NPCs twice.
 
-                let msg = if count == 0 && banshee_count == 0 {
+                let msg = if count == 0 {
                     "No NPC activity.".to_string()
-                } else if banshee_count == 0 {
-                    format!("{} schedule event(s) processed.", count)
                 } else {
-                    format!(
-                        "{} schedule event(s) processed, {} banshee event(s).",
-                        count, banshee_count
-                    )
+                    format!("{} schedule event(s) processed.", count)
                 };
                 self.app.world.log(msg.clone());
                 return ActionResult::SystemCommand { response: msg };

--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -1447,7 +1447,7 @@ mod tests {
 
         // Apply an Illness event — should populate ring buffer
         let events = vec![Tier4Event::Illness { npc_id }];
-        mgr.apply_tier4_events(&events, Utc::now());
+        mgr.apply_tier4_events(&events, Utc::now(), true);
 
         let summary = build_tier_summary(&mgr);
         assert_eq!(summary.tier4_recent_events.len(), 1);

--- a/crates/parish-npc/src/manager.rs
+++ b/crates/parish-npc/src/manager.rs
@@ -811,6 +811,7 @@ impl NpcManager {
         &mut self,
         events: &[crate::tier4::Tier4Event],
         timestamp: DateTime<Utc>,
+        banshee_enabled: bool,
     ) -> Vec<GameEvent> {
         use crate::tier4::Tier4Event;
 
@@ -857,24 +858,35 @@ impl NpcManager {
                     }
                 }
                 Tier4Event::Death { npc_id } => {
-                    // Schedule the doom a game-day ahead so the banshee tick has a
-                    // chance to herald it before the NPC is actually removed.
-                    // If the banshee feature is disabled at tick time, `tick_banshee`
-                    // is simply not called and the NPC will remain alive until a
-                    // future tick removes them — this preserves mode parity without
-                    // requiring the flag check here.
-                    if let Some(npc) = self.npcs.get_mut(npc_id) {
-                        let doom = timestamp
-                            + chrono::Duration::hours(crate::banshee::DOOM_LEAD_TIME_HOURS);
-                        npc.doom = Some(doom);
-                        npc.banshee_heralded = false;
-                        let desc = format!("{} is fated to die.", npc.name);
-                        life_descriptions.push(desc.clone());
-                        game_events.push(GameEvent::LifeEvent {
-                            npc_id: *npc_id,
-                            description: desc,
-                            timestamp,
-                        });
+                    if banshee_enabled {
+                        // Schedule the doom a game-day ahead so the banshee tick
+                        // has a chance to herald it before the NPC is removed.
+                        if let Some(npc) = self.npcs.get_mut(npc_id) {
+                            let doom = timestamp
+                                + chrono::Duration::hours(crate::banshee::DOOM_LEAD_TIME_HOURS);
+                            npc.doom = Some(doom);
+                            npc.banshee_heralded = false;
+                            let desc = format!("{} is fated to die.", npc.name);
+                            life_descriptions.push(desc.clone());
+                            game_events.push(GameEvent::LifeEvent {
+                                npc_id: *npc_id,
+                                description: desc,
+                                timestamp,
+                            });
+                        }
+                    } else {
+                        // Banshee disabled — immediate removal (pre-banshee behavior).
+                        if let Some(npc) = self.npcs.get(npc_id) {
+                            let desc = format!("{} has passed away.", npc.name);
+                            life_descriptions.push(desc.clone());
+                            game_events.push(GameEvent::LifeEvent {
+                                npc_id: *npc_id,
+                                description: desc,
+                                timestamp,
+                            });
+                        }
+                        self.npcs.remove(npc_id);
+                        self.tier_assignments.remove(npc_id);
                     }
                 }
                 Tier4Event::Birth { parent_ids } => {
@@ -2035,7 +2047,7 @@ mod tests {
             let mut rng = rand::thread_rng();
             tick_tier4(&mut tier4_refs, season, game_date, &mut rng)
         };
-        let game_events = mgr.apply_tier4_events(&events, now);
+        let game_events = mgr.apply_tier4_events(&events, now, true);
         for evt in game_events {
             world.event_bus.publish(evt);
         }
@@ -2324,7 +2336,7 @@ mod tests {
 
         let now = Utc.with_ymd_and_hms(1820, 6, 15, 14, 0, 0).unwrap();
         let events = vec![Tier4Event::Death { npc_id: NpcId(42) }];
-        let game_events = mgr.apply_tier4_events(&events, now);
+        let game_events = mgr.apply_tier4_events(&events, now, true);
 
         assert!(
             mgr.get(NpcId(42)).is_some(),
@@ -2335,6 +2347,23 @@ mod tests {
         assert_eq!(
             doom - now,
             chrono::Duration::hours(crate::banshee::DOOM_LEAD_TIME_HOURS)
+        );
+        assert!(!game_events.is_empty(), "should still emit a life event");
+    }
+
+    #[test]
+    fn tier4_death_with_banshee_disabled_removes_npc_immediately() {
+        use crate::tier4::Tier4Event;
+        let mut mgr = NpcManager::new();
+        mgr.add_npc(make_test_npc(42, 2));
+
+        let now = Utc.with_ymd_and_hms(1820, 6, 15, 14, 0, 0).unwrap();
+        let events = vec![Tier4Event::Death { npc_id: NpcId(42) }];
+        let game_events = mgr.apply_tier4_events(&events, now, false);
+
+        assert!(
+            mgr.get(NpcId(42)).is_none(),
+            "NPC should be removed immediately when banshee is disabled"
         );
         assert!(!game_events.is_empty(), "should still emit a life event");
     }

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -1151,7 +1151,7 @@ pub fn run() {
                                         &mut rng,
                                     )
                                 };
-                                let game_events = npc_mgr.apply_tier4_events(&events, now);
+                                let game_events = npc_mgr.apply_tier4_events(&events, now, banshee_enabled);
                                 // Collect per-event descriptions before publishing.
                                 let life_descriptions: Vec<String> = game_events
                                     .iter()


### PR DESCRIPTION
## Summary

- **#514**: When the `banshee` feature flag was disabled, `Tier4Event::Death` scheduled a doom timestamp that no code path ever processed (`tick_banshee` is gated behind the flag), leaving doomed NPCs alive forever. Now `apply_tier4_events` accepts a `banshee_enabled` flag — when on, doom is scheduled for the herald; when off, the NPC is removed immediately (pre-banshee behavior).
- **#508**: The `/tick` command handler in `testing.rs` called `tick_banshee` directly, but `execute()` already runs a post-action banshee tick after every command returns. A single `/tick` was processing doomed NPCs twice. Removed the redundant call from the `/tick` handler.

## Changes

| File | What |
|------|------|
| `crates/parish-npc/src/manager.rs` | `apply_tier4_events` gains `banshee_enabled: bool`; Death handler branches on it |
| `crates/parish-cli/src/testing.rs` | Pass flag to `apply_tier4_events`; remove duplicate `tick_banshee` from `/tick` handler |
| `crates/parish-cli/src/headless.rs` | Pass flag to `apply_tier4_events` |
| `crates/parish-tauri/src/lib.rs` | Pass flag to `apply_tier4_events` |
| `crates/parish-core/src/debug_snapshot.rs` | Pass `true` to test caller |

## Test plan

- [x] New unit test `tier4_death_with_banshee_disabled_removes_npc_immediately` verifies immediate removal
- [x] Existing test `tier4_death_now_schedules_doom_rather_than_removing` still passes (banshee-on path)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — all pass
- [x] Game harness walkthrough passes

Fixes #514, fixes #508

https://claude.ai/code/session_01SedrhcCrFaGBLcpvSoHmcN