### PR TITLE
fix: resolve build/config bugs #511, #512, #518

### DIFF
--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
 	plugins: [sveltekit(), svelteTesting()],
 	clearScreen: false,
 	server: {
-		port: parseInt(process.env.PARISH_DEV_PORT || '5173'),
+		port: parseInt(process.env.PARISH_DEV_PORT || '5173', 10) || 5173,
 		strictPort: true,
 		fs: {
 			allow: ['.']

--- a/crates/parish-inference/src/anthropic_client.rs
+++ b/crates/parish-inference/src/anthropic_client.rs
@@ -177,7 +177,8 @@ impl AnthropicClient {
         let url = format!("{}/v1/messages", self.base_url);
         let req = self.apply_headers(self.client.post(&url).json(body));
         req.send()
-            .await?
+            .await
+            .map_err(|e| ParishError::Inference(e.to_string()))?
             .error_for_status()
             .map_err(|e| ParishError::Inference(e.to_string()))
     }

--- a/crates/parish-inference/src/openai_client.rs
+++ b/crates/parish-inference/src/openai_client.rs
@@ -377,7 +377,8 @@ impl OpenAiClient {
         req = self.apply_auth_headers(req);
 
         req.send()
-            .await?
+            .await
+            .map_err(|e| ParishError::Inference(e.to_string()))?
             .error_for_status()
             .map_err(|e| ParishError::Inference(e.to_string()))
     }

--- a/justfile
+++ b/justfile
@@ -98,6 +98,7 @@ run:
     PORT=5173
     while ss -tln 2>/dev/null | grep -q ":$PORT " || lsof -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1; do
         PORT=$((PORT + 1))
+        if [ "$PORT" -gt 5200 ]; then echo "No free port found in range 5173-5200" >&2; exit 1; fi
     done
     export PARISH_DEV_PORT=$PORT
     if [ "$PORT" -eq 5173 ]; then


### PR DESCRIPTION
## Summary

- **#511** — Add explicit radix (`10`) and `|| 5173` NaN fallback to `parseInt` in `apps/ui/vite.config.ts`, preventing opaque Vite errors when `PARISH_DEV_PORT` is non-numeric.
- **#512** — Cap the justfile port-scan loop at port 5200 so it exits with a clear error instead of spinning indefinitely.
- **#518** — Map transport errors in `AnthropicClient::send_request` (and `OpenAiClient::send_request`) to `ParishError::Inference` instead of `ParishError::Network`, so callers see a consistent error variant for all inference call failures.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p parish-inference -- -D warnings` — clean
- [x] `cargo test -p parish-inference` — 197 tests pass (174 unit + 23 integration)
- [ ] Verify `just run` picks a free port and errors clearly if 5173–5200 are all busy
- [ ] Set `PARISH_DEV_PORT=abc` and confirm Vite falls back to 5173

https://claude.ai/code/session_01Y5fQpF4mJ1Z9qPMXB5XQfH