### PR TITLE
fix: banshee flag disabled leaves NPCs immortal + double tick

### DIFF
--- a/crates/parish-cli/src/headless.rs
+++ b/crates/parish-cli/src/headless.rs
@@ -322,7 +322,8 @@ pub async fn run_headless(
                     let mut rng = rand::thread_rng();
                     crate::npc::tier4::tick_tier4(&mut tier4_refs, season, game_date, &mut rng)
                 };
-                let game_events = app.npc_manager.apply_tier4_events(&events, now);
+                let banshee_on = !app.flags.is_disabled("banshee");
+                let game_events = app.npc_manager.apply_tier4_events(&events, now, banshee_on);
                 for evt in game_events {
                     app.world.event_bus.publish(evt);
                 }

--- a/crates/parish-cli/src/testing.rs
+++ b/crates/parish-cli/src/testing.rs
@@ -416,26 +416,6 @@ impl GameTestHarness {
         self.process_schedule_events(&events);
         self.app.npc_manager.assign_tiers(&self.app.world, &[]);
 
-        // Banshee tick: herald and finalise doomed NPCs.
-        // Default-on; gated by the `banshee` feature flag being explicitly disabled.
-        if !self.app.flags.is_disabled("banshee") {
-            let player_loc = self.app.world.player_location;
-            let report = self.app.npc_manager.tick_banshee(
-                &self.app.world.clock,
-                &self.app.world.graph,
-                &mut self.app.world.text_log,
-                &self.app.world.event_bus,
-                player_loc,
-            );
-            if !report.is_empty() {
-                self.app.debug_event(format!(
-                    "[banshee] {} wail(s), {} death(s)",
-                    report.wails.len(),
-                    report.deaths.len()
-                ));
-            }
-        }
-
         // Propagate gossip between co-located NPCs
         if !self.app.world.gossip_network.is_empty() {
             let groups = self.app.npc_manager.tier2_groups();
@@ -469,7 +449,11 @@ impl GameTestHarness {
                 let mut rng2 = rand::thread_rng();
                 crate::npc::tier4::tick_tier4(&mut tier4_refs, season, game_date, &mut rng2)
             };
-            let game_events = self.app.npc_manager.apply_tier4_events(&t4_events, now);
+            let banshee_on = !self.app.flags.is_disabled("banshee");
+            let game_events = self
+                .app
+                .npc_manager
+                .apply_tier4_events(&t4_events, now, banshee_on);
             for evt in game_events {
                 self.app.world.event_bus.publish(evt);
             }
@@ -572,29 +556,10 @@ impl GameTestHarness {
                 let count = events.len();
                 self.process_schedule_events(&events);
 
-                // Banshee tick: herald and finalise doomed NPCs.
-                let mut banshee_count = 0;
-                if !self.app.flags.is_disabled("banshee") {
-                    let player_loc = self.app.world.player_location;
-                    let report = self.app.npc_manager.tick_banshee(
-                        &self.app.world.clock,
-                        &self.app.world.graph,
-                        &mut self.app.world.text_log,
-                        &self.app.world.event_bus,
-                        player_loc,
-                    );
-                    banshee_count = report.wails.len() + report.deaths.len();
-                }
-
-                let msg = if count == 0 && banshee_count == 0 {
+                let msg = if count == 0 {
                     "No NPC activity.".to_string()
-                } else if banshee_count == 0 {
-                    format!("{} schedule event(s) processed.", count)
                 } else {
-                    format!(
-                        "{} schedule event(s) processed, {} banshee event(s).",
-                        count, banshee_count
-                    )
+                    format!("{} schedule event(s) processed.", count)
                 };
                 self.app.world.log(msg.clone());
                 return ActionResult::SystemCommand { response: msg };

--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -1447,7 +1447,7 @@ mod tests {
 
         // Apply an Illness event — should populate ring buffer
         let events = vec![Tier4Event::Illness { npc_id }];
-        mgr.apply_tier4_events(&events, Utc::now());
+        mgr.apply_tier4_events(&events, Utc::now(), true);
 
         let summary = build_tier_summary(&mgr);
         assert_eq!(summary.tier4_recent_events.len(), 1);

--- a/crates/parish-npc/src/manager.rs
+++ b/crates/parish-npc/src/manager.rs
@@ -806,11 +806,15 @@ impl NpcManager {
 
     /// Applies the results of a Tier 4 tick to NPC state.
     ///
+    /// When `banshee_enabled` is false, death events remove the NPC
+    /// immediately instead of scheduling doom for the banshee herald.
+    ///
     /// Returns a list of `GameEvent`s to publish on the event bus.
     pub fn apply_tier4_events(
         &mut self,
         events: &[crate::tier4::Tier4Event],
         timestamp: DateTime<Utc>,
+        banshee_enabled: bool,
     ) -> Vec<GameEvent> {
         use crate::tier4::Tier4Event;
 
@@ -857,24 +861,32 @@ impl NpcManager {
                     }
                 }
                 Tier4Event::Death { npc_id } => {
-                    // Schedule the doom a game-day ahead so the banshee tick has a
-                    // chance to herald it before the NPC is actually removed.
-                    // If the banshee feature is disabled at tick time, `tick_banshee`
-                    // is simply not called and the NPC will remain alive until a
-                    // future tick removes them — this preserves mode parity without
-                    // requiring the flag check here.
-                    if let Some(npc) = self.npcs.get_mut(npc_id) {
-                        let doom = timestamp
-                            + chrono::Duration::hours(crate::banshee::DOOM_LEAD_TIME_HOURS);
-                        npc.doom = Some(doom);
-                        npc.banshee_heralded = false;
-                        let desc = format!("{} is fated to die.", npc.name);
-                        life_descriptions.push(desc.clone());
-                        game_events.push(GameEvent::LifeEvent {
-                            npc_id: *npc_id,
-                            description: desc,
-                            timestamp,
-                        });
+                    if banshee_enabled {
+                        if let Some(npc) = self.npcs.get_mut(npc_id) {
+                            let doom = timestamp
+                                + chrono::Duration::hours(crate::banshee::DOOM_LEAD_TIME_HOURS);
+                            npc.doom = Some(doom);
+                            npc.banshee_heralded = false;
+                            let desc = format!("{} is fated to die.", npc.name);
+                            life_descriptions.push(desc.clone());
+                            game_events.push(GameEvent::LifeEvent {
+                                npc_id: *npc_id,
+                                description: desc,
+                                timestamp,
+                            });
+                        }
+                    } else {
+                        if let Some(npc) = self.npcs.get(npc_id) {
+                            let desc = format!("{} has died.", npc.name);
+                            life_descriptions.push(desc.clone());
+                            game_events.push(GameEvent::LifeEvent {
+                                npc_id: *npc_id,
+                                description: desc,
+                                timestamp,
+                            });
+                        }
+                        self.npcs.remove(npc_id);
+                        self.tier_assignments.remove(npc_id);
                     }
                 }
                 Tier4Event::Birth { parent_ids } => {
@@ -2035,7 +2047,7 @@ mod tests {
             let mut rng = rand::thread_rng();
             tick_tier4(&mut tier4_refs, season, game_date, &mut rng)
         };
-        let game_events = mgr.apply_tier4_events(&events, now);
+        let game_events = mgr.apply_tier4_events(&events, now, true);
         for evt in game_events {
             world.event_bus.publish(evt);
         }
@@ -2324,7 +2336,7 @@ mod tests {
 
         let now = Utc.with_ymd_and_hms(1820, 6, 15, 14, 0, 0).unwrap();
         let events = vec![Tier4Event::Death { npc_id: NpcId(42) }];
-        let game_events = mgr.apply_tier4_events(&events, now);
+        let game_events = mgr.apply_tier4_events(&events, now, true);
 
         assert!(
             mgr.get(NpcId(42)).is_some(),
@@ -2335,6 +2347,23 @@ mod tests {
         assert_eq!(
             doom - now,
             chrono::Duration::hours(crate::banshee::DOOM_LEAD_TIME_HOURS)
+        );
+        assert!(!game_events.is_empty(), "should still emit a life event");
+    }
+
+    #[test]
+    fn tier4_death_removes_immediately_when_banshee_disabled() {
+        use crate::tier4::Tier4Event;
+        let mut mgr = NpcManager::new();
+        mgr.add_npc(make_test_npc(42, 2));
+
+        let now = Utc.with_ymd_and_hms(1820, 6, 15, 14, 0, 0).unwrap();
+        let events = vec![Tier4Event::Death { npc_id: NpcId(42) }];
+        let game_events = mgr.apply_tier4_events(&events, now, false);
+
+        assert!(
+            mgr.get(NpcId(42)).is_none(),
+            "NPC should be removed immediately when banshee is disabled"
         );
         assert!(!game_events.is_empty(), "should still emit a life event");
     }

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -1151,7 +1151,7 @@ pub fn run() {
                                         &mut rng,
                                     )
                                 };
-                                let game_events = npc_mgr.apply_tier4_events(&events, now);
+                                let game_events = npc_mgr.apply_tier4_events(&events, now, banshee_enabled);
                                 // Collect per-event descriptions before publishing.
                                 let life_descriptions: Vec<String> = game_events
                                     .iter()


### PR DESCRIPTION
## Summary

Fixes two related banshee tick bugs:

- **#514**: When the `banshee` feature flag was disabled, `Tier4Event::Death` scheduled a doom timestamp but `tick_banshee` (the only code that processes doom) was never called — doomed NPCs lived forever. Now `apply_tier4_events` accepts a `banshee_enabled` flag: when false, NPCs are removed immediately (pre-banshee behaviour); when true, doom is scheduled for the banshee herald as before.

- **#508**: In `testing.rs`, `tick_banshee` was called redundantly in `advance_time()` and the `/tick` command handler, then again by `execute()` after every action. Removed the duplicate calls so `execute()` is the single call site.

## Changes

- `crates/parish-npc/src/manager.rs` — added `banshee_enabled: bool` param to `apply_tier4_events`; `Death` handler does immediate removal when false; added test `tier4_death_removes_immediately_when_banshee_disabled`
- `crates/parish-cli/src/testing.rs` — removed `tick_banshee` from `advance_time()` and `/tick` handler; `execute()` remains the single call site
- `crates/parish-cli/src/headless.rs` — pass `banshee_on` to `apply_tier4_events`
- `crates/parish-tauri/src/lib.rs` — pass `banshee_enabled` to `apply_tier4_events`
- `crates/parish-core/src/debug_snapshot.rs` — pass `true` to `apply_tier4_events` in test

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — all pass (including new `tier4_death_removes_immediately_when_banshee_disabled`)
- [x] Game harness walkthrough — JSON output correct

https://claude.ai/code/session_01T4opu5WF4f6SKBu3nGkbCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4opu5WF4f6SKBu3nGkbCN)_