### PR TITLE
fix: banshee-disabled immortal NPCs and duplicate tick_banshee

### DIFF
--- a/crates/parish-cli/src/headless.rs
+++ b/crates/parish-cli/src/headless.rs
@@ -322,7 +322,8 @@ pub async fn run_headless(
                     let mut rng = rand::thread_rng();
                     crate::npc::tier4::tick_tier4(&mut tier4_refs, season, game_date, &mut rng)
                 };
-                let game_events = app.npc_manager.apply_tier4_events(&events, now);
+                let banshee_on = !app.flags.is_disabled("banshee");
+                let game_events = app.npc_manager.apply_tier4_events(&events, now, banshee_on);
                 for evt in game_events {
                     app.world.event_bus.publish(evt);
                 }

--- a/crates/parish-cli/src/testing.rs
+++ b/crates/parish-cli/src/testing.rs
@@ -416,26 +416,6 @@ impl GameTestHarness {
         self.process_schedule_events(&events);
         self.app.npc_manager.assign_tiers(&self.app.world, &[]);
 
-        // Banshee tick: herald and finalise doomed NPCs.
-        // Default-on; gated by the `banshee` feature flag being explicitly disabled.
-        if !self.app.flags.is_disabled("banshee") {
-            let player_loc = self.app.world.player_location;
-            let report = self.app.npc_manager.tick_banshee(
-                &self.app.world.clock,
-                &self.app.world.graph,
-                &mut self.app.world.text_log,
-                &self.app.world.event_bus,
-                player_loc,
-            );
-            if !report.is_empty() {
-                self.app.debug_event(format!(
-                    "[banshee] {} wail(s), {} death(s)",
-                    report.wails.len(),
-                    report.deaths.len()
-                ));
-            }
-        }
-
         // Propagate gossip between co-located NPCs
         if !self.app.world.gossip_network.is_empty() {
             let groups = self.app.npc_manager.tier2_groups();
@@ -469,7 +449,11 @@ impl GameTestHarness {
                 let mut rng2 = rand::thread_rng();
                 crate::npc::tier4::tick_tier4(&mut tier4_refs, season, game_date, &mut rng2)
             };
-            let game_events = self.app.npc_manager.apply_tier4_events(&t4_events, now);
+            let banshee_on = !self.app.flags.is_disabled("banshee");
+            let game_events = self
+                .app
+                .npc_manager
+                .apply_tier4_events(&t4_events, now, banshee_on);
             for evt in game_events {
                 self.app.world.event_bus.publish(evt);
             }
@@ -572,29 +556,10 @@ impl GameTestHarness {
                 let count = events.len();
                 self.process_schedule_events(&events);
 
-                // Banshee tick: herald and finalise doomed NPCs.
-                let mut banshee_count = 0;
-                if !self.app.flags.is_disabled("banshee") {
-                    let player_loc = self.app.world.player_location;
-                    let report = self.app.npc_manager.tick_banshee(
-                        &self.app.world.clock,
-                        &self.app.world.graph,
-                        &mut self.app.world.text_log,
-                        &self.app.world.event_bus,
-                        player_loc,
-                    );
-                    banshee_count = report.wails.len() + report.deaths.len();
-                }
-
-                let msg = if count == 0 && banshee_count == 0 {
+                let msg = if count == 0 {
                     "No NPC activity.".to_string()
-                } else if banshee_count == 0 {
-                    format!("{} schedule event(s) processed.", count)
                 } else {
-                    format!(
-                        "{} schedule event(s) processed, {} banshee event(s).",
-                        count, banshee_count
-                    )
+                    format!("{} schedule event(s) processed.", count)
                 };
                 self.app.world.log(msg.clone());
                 return ActionResult::SystemCommand { response: msg };

--- a/crates/parish-npc/src/manager.rs
+++ b/crates/parish-npc/src/manager.rs
@@ -811,6 +811,7 @@ impl NpcManager {
         &mut self,
         events: &[crate::tier4::Tier4Event],
         timestamp: DateTime<Utc>,
+        banshee_enabled: bool,
     ) -> Vec<GameEvent> {
         use crate::tier4::Tier4Event;
 
@@ -857,24 +858,33 @@ impl NpcManager {
                     }
                 }
                 Tier4Event::Death { npc_id } => {
-                    // Schedule the doom a game-day ahead so the banshee tick has a
-                    // chance to herald it before the NPC is actually removed.
-                    // If the banshee feature is disabled at tick time, `tick_banshee`
-                    // is simply not called and the NPC will remain alive until a
-                    // future tick removes them — this preserves mode parity without
-                    // requiring the flag check here.
-                    if let Some(npc) = self.npcs.get_mut(npc_id) {
-                        let doom = timestamp
-                            + chrono::Duration::hours(crate::banshee::DOOM_LEAD_TIME_HOURS);
-                        npc.doom = Some(doom);
-                        npc.banshee_heralded = false;
-                        let desc = format!("{} is fated to die.", npc.name);
-                        life_descriptions.push(desc.clone());
-                        game_events.push(GameEvent::LifeEvent {
-                            npc_id: *npc_id,
-                            description: desc,
-                            timestamp,
-                        });
+                    if banshee_enabled {
+                        if let Some(npc) = self.npcs.get_mut(npc_id) {
+                            let doom = timestamp
+                                + chrono::Duration::hours(crate::banshee::DOOM_LEAD_TIME_HOURS);
+                            npc.doom = Some(doom);
+                            npc.banshee_heralded = false;
+                            let desc = format!("{} is fated to die.", npc.name);
+                            life_descriptions.push(desc.clone());
+                            game_events.push(GameEvent::LifeEvent {
+                                npc_id: *npc_id,
+                                description: desc,
+                                timestamp,
+                            });
+                        }
+                    } else {
+                        let name = self.npcs.get(npc_id).map(|n| n.name.clone());
+                        if let Some(name) = name {
+                            let desc = format!("{} has passed away.", name);
+                            life_descriptions.push(desc.clone());
+                            game_events.push(GameEvent::LifeEvent {
+                                npc_id: *npc_id,
+                                description: desc,
+                                timestamp,
+                            });
+                        }
+                        self.npcs.remove(npc_id);
+                        self.tier_assignments.remove(npc_id);
                     }
                 }
                 Tier4Event::Birth { parent_ids } => {
@@ -2035,7 +2045,7 @@ mod tests {
             let mut rng = rand::thread_rng();
             tick_tier4(&mut tier4_refs, season, game_date, &mut rng)
         };
-        let game_events = mgr.apply_tier4_events(&events, now);
+        let game_events = mgr.apply_tier4_events(&events, now, true);
         for evt in game_events {
             world.event_bus.publish(evt);
         }
@@ -2324,7 +2334,7 @@ mod tests {
 
         let now = Utc.with_ymd_and_hms(1820, 6, 15, 14, 0, 0).unwrap();
         let events = vec![Tier4Event::Death { npc_id: NpcId(42) }];
-        let game_events = mgr.apply_tier4_events(&events, now);
+        let game_events = mgr.apply_tier4_events(&events, now, true);
 
         assert!(
             mgr.get(NpcId(42)).is_some(),
@@ -2335,6 +2345,23 @@ mod tests {
         assert_eq!(
             doom - now,
             chrono::Duration::hours(crate::banshee::DOOM_LEAD_TIME_HOURS)
+        );
+        assert!(!game_events.is_empty(), "should still emit a life event");
+    }
+
+    #[test]
+    fn tier4_death_immediate_when_banshee_disabled() {
+        use crate::tier4::Tier4Event;
+        let mut mgr = NpcManager::new();
+        mgr.add_npc(make_test_npc(42, 2));
+
+        let now = Utc.with_ymd_and_hms(1820, 6, 15, 14, 0, 0).unwrap();
+        let events = vec![Tier4Event::Death { npc_id: NpcId(42) }];
+        let game_events = mgr.apply_tier4_events(&events, now, false);
+
+        assert!(
+            mgr.get(NpcId(42)).is_none(),
+            "NPC should be removed immediately when banshee is disabled"
         );
         assert!(!game_events.is_empty(), "should still emit a life event");
     }

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -1151,7 +1151,7 @@ pub fn run() {
                                         &mut rng,
                                     )
                                 };
-                                let game_events = npc_mgr.apply_tier4_events(&events, now);
+                                let game_events = npc_mgr.apply_tier4_events(&events, now, banshee_enabled);
                                 // Collect per-event descriptions before publishing.
                                 let life_descriptions: Vec<String> = game_events
                                     .iter()


### PR DESCRIPTION
## Summary

- **#514**: When the `banshee` feature flag was disabled, `Tier4Event::Death` scheduled a doom timestamp but `tick_banshee` (the only code that processes doom) was never called — making doomed NPCs immortal. `apply_tier4_events` now takes a `banshee_enabled` parameter and falls back to immediate NPC removal when the flag is off.
- **#508**: The test harness called `tick_banshee` redundantly — once inside `advance_time()` or the `/tick` handler, then again in `execute()`'s post-action tick. Removed the duplicate calls from `advance_time()` and the `/tick` handler so each action triggers exactly one banshee check via `execute()`.

## Changes

- `crates/parish-npc/src/manager.rs`: Added `banshee_enabled: bool` param to `apply_tier4_events`; Death handler branches on it (doom scheduling vs immediate removal). Added `tier4_death_immediate_when_banshee_disabled` test.
- `crates/parish-cli/src/testing.rs`: Removed `tick_banshee` from `advance_time()` and `/tick` handler; all callers pass `banshee_on` to `apply_tier4_events`.
- `crates/parish-cli/src/headless.rs`: Pass `banshee_on` to `apply_tier4_events`.
- `crates/parish-tauri/src/lib.rs`: Pass `banshee_enabled` to `apply_tier4_events`.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — all pass (including new `tier4_death_immediate_when_banshee_disabled`)
- [x] `cargo run -- --script testing/fixtures/test_walkthrough.txt` — JSON output correct

https://claude.ai/code/session_01UWN31GShfUyDpDVWnqZXqb

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWN31GShfUyDpDVWnqZXqb)_