### PR TITLE
[codex] fix: add HSTS security header

### DIFF
--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -25,7 +25,8 @@ use std::time::Duration;
 use axum::Router;
 use axum::extract::ConnectInfo;
 use axum::http::header::{
-    CONTENT_SECURITY_POLICY, REFERRER_POLICY, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS,
+    CONTENT_SECURITY_POLICY, REFERRER_POLICY, STRICT_TRANSPORT_SECURITY, X_CONTENT_TYPE_OPTIONS,
+    X_FRAME_OPTIONS,
 };
 use axum::http::{HeaderValue, Request, StatusCode};
 use axum::middleware as axum_mw;
@@ -401,6 +402,10 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
                  base-uri 'self'; \
                  form-action 'self'",
             ),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static("max-age=31536000; includeSubDomains"),
         ))
         .layer(SetResponseHeaderLayer::overriding(
             X_FRAME_OPTIONS,

--- a/crates/parish-server/tests/security_headers.rs
+++ b/crates/parish-server/tests/security_headers.rs
@@ -6,7 +6,8 @@
 /// required headers without needing a live TCP port.
 use axum::Router;
 use axum::http::header::{
-    CONTENT_SECURITY_POLICY, REFERRER_POLICY, X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS,
+    CONTENT_SECURITY_POLICY, REFERRER_POLICY, STRICT_TRANSPORT_SECURITY, X_CONTENT_TYPE_OPTIONS,
+    X_FRAME_OPTIONS,
 };
 use axum::http::{HeaderValue, Request, StatusCode};
 use axum::routing::get;
@@ -30,6 +31,10 @@ fn security_header_router() -> Router {
                  base-uri 'self'; \
                  form-action 'self'",
             ),
+        ))
+        .layer(SetResponseHeaderLayer::overriding(
+            STRICT_TRANSPORT_SECURITY,
+            HeaderValue::from_static("max-age=31536000; includeSubDomains"),
         ))
         .layer(SetResponseHeaderLayer::overriding(
             X_FRAME_OPTIONS,
@@ -71,6 +76,21 @@ async fn response_has_content_security_policy_header() {
         csp_str.contains("frame-ancestors 'none'"),
         "CSP must include frame-ancestors 'none'; got: {csp_str}"
     );
+}
+
+#[tokio::test]
+async fn response_has_strict_transport_security_header() {
+    let app = security_header_router();
+    let req = Request::builder()
+        .uri("/ping")
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let hsts = resp
+        .headers()
+        .get(STRICT_TRANSPORT_SECURITY)
+        .expect("Strict-Transport-Security header must be present");
+    assert_eq!(hsts, "max-age=31536000; includeSubDomains");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #517.

## Summary

- Adds a `Strict-Transport-Security` response header to the server security hardening stack.
- Uses `max-age=31536000; includeSubDomains` for defense in depth behind HTTPS deployments.
- Adds a security-header integration assertion so HSTS coverage stays in the header regression suite.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p parish-server --test security_headers`
- `cargo test -p parish-server`
- `cargo clippy --workspace -- -D warnings`
- `cargo run -p parish -- --script testing/fixtures/test_walkthrough.txt`

## Notes

- `cargo test --workspace` still hits the existing sandbox-only `wiremock` localhost bind failure in `parish-core` `async_llm_integration` tests.
