### PR TITLE
ci: run GitHub Actions workflows locally with act

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,46 @@
+# act configuration — run GitHub Actions locally against this repo.
+#
+# See docs/agent/act-local.md for full usage. Quick reference:
+#   just act-list             # list jobs across all workflows
+#   just act-audit            # run cargo-audit (fastest smoke test)
+#   just act-fmt              # run the rust-quality-gate job
+#   just act-ci               # run all of ci.yml
+#   just act-job JOB=<name>   # run one job by id
+#
+# Why these defaults:
+#
+# -P ubuntu-latest=... catthehacker:full — our CI installs apt packages,
+#   Node 22, Rust toolchains, and Playwright browser deps. The default
+#   medium image is missing half of that; the "full" image (~60GB) is the
+#   only one that actually mirrors GitHub's ubuntu-latest runner.
+#
+# --container-architecture linux/amd64 — force amd64 emulation on Apple
+#   Silicon. The catthehacker images ship amd64 only, and several actions
+#   (dtolnay/rust-toolchain, actions/setup-node) refuse to run under arm64
+#   emulation without this flag set explicitly.
+#
+# --artifact-server-path — actions/upload-artifact@v4 requires a real
+#   artifact endpoint (unlike v3, it won't no-op under act). Point it at
+#   a local directory; uploaded artifacts (Playwright reports, etc.) land
+#   there and can be inspected after the run. Path is gitignored.
+#
+# --reuse — keep containers between runs so Rust target/ and npm node_modules
+#   survive. Massive speedup; first run is still slow while images pull and
+#   deps install, but subsequent runs are near-instant on unchanged code.
+#   Clean up occasionally with: docker rm -f $(docker ps -aq --filter name=act-)
+#
+# --action-offline-mode — skip re-fetching action source when already cached.
+#   Drop this flag (or use `just act-refresh`) if you need to pick up a new
+#   version of a third-party action.
+#
+# --env-file /dev/null — do NOT auto-load the repo's `.env` into the runner.
+#   act's default is to read `.env`, which drifts from GitHub's clean env and
+#   causes tests that assume unset vars (e.g. PARISH_PROVIDER) to fail under
+#   act while passing on real CI. Workflow `env:` blocks are still honored.
+
+-P ubuntu-latest=catthehacker/ubuntu:full-latest
+--container-architecture linux/amd64
+--artifact-server-path /tmp/act-artifacts
+--reuse
+--action-offline-mode
+--env-file /dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,10 @@ logs/
 apps/ui/dist/
 claude/*
 .worktrees
+
+# act (local GitHub Actions runner) — secrets file and artifact outputs.
+# Artifact output lives at /tmp/act-artifacts (set in .actrc) — outside
+# the repo, but guard against stray relative-path writes just in case.
+# See .secrets.example and docs/agent/act-local.md.
+.secrets
+act-artifacts/

--- a/.secrets.example
+++ b/.secrets.example
@@ -1,0 +1,16 @@
+# Template for act secrets. Copy to .secrets (which is gitignored) and fill
+# in real values as needed. act reads .secrets automatically.
+#
+#   cp .secrets.example .secrets
+#
+# The current workflows (ci.yml, audit.yml) don't consume any secrets
+# beyond GITHUB_TOKEN, which is only needed if a workflow step calls the
+# GitHub API (e.g. to post PR comments, upload release assets, or fetch
+# private actions). For the jobs we run locally today, leaving it blank
+# is fine — act injects a stub token automatically.
+#
+# If you later add a workflow that needs a real token (e.g. to push to
+# ghcr.io or annotate PRs), generate a fine-scoped PAT and paste it here.
+# Never commit the resulting .secrets file.
+
+GITHUB_TOKEN=

--- a/crates/parish-persistence/src/journal.rs
+++ b/crates/parish-persistence/src/journal.rs
@@ -404,6 +404,7 @@ mod tests {
         // Regression: #344 — a corrupted journal row with a negative
         // `minutes` must not move the clock backward.
         let mut world = parish_world::WorldState::new();
+        world.clock.pause();
         let mut npcs = parish_npc::manager::NpcManager::new();
         let time_before = world.clock.now();
         let events = vec![WorldEvent::ClockAdvanced { minutes: -60 }];
@@ -416,6 +417,7 @@ mod tests {
         // Regression: #344 — a value beyond the one-week sanity bound is
         // treated as corrupted and skipped, leaving the clock alone.
         let mut world = parish_world::WorldState::new();
+        world.clock.pause();
         let mut npcs = parish_npc::manager::NpcManager::new();
         let time_before = world.clock.now();
         let events = vec![WorldEvent::ClockAdvanced {
@@ -429,6 +431,7 @@ mod tests {
     fn test_replay_rejects_zero_clock_advance() {
         // Zero is treated the same as negative — not a valid mutation.
         let mut world = parish_world::WorldState::new();
+        world.clock.pause();
         let mut npcs = parish_npc::manager::NpcManager::new();
         let time_before = world.clock.now();
         let events = vec![WorldEvent::ClockAdvanced { minutes: 0 }];
@@ -479,6 +482,7 @@ mod tests {
         // Legacy rows (minutes = None) behave as before — no clock change
         // from PlayerMoved alone.
         let mut world = parish_world::WorldState::new();
+        world.clock.pause();
         let mut npcs = parish_npc::manager::NpcManager::new();
         let time_before = world.clock.now();
         let events = vec![WorldEvent::PlayerMoved {
@@ -509,6 +513,7 @@ mod tests {
     fn test_replay_player_moved_rejects_out_of_range_minutes() {
         // Guard #344's bounds when minutes arrive via PlayerMoved too.
         let mut world = parish_world::WorldState::new();
+        world.clock.pause();
         let mut npcs = parish_npc::manager::NpcManager::new();
         let time_before = world.clock.now();
         let events = vec![

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -2220,7 +2220,8 @@ pub(crate) mod tests {
         let state = test_app_state();
 
         let (start_loc, start_time) = {
-            let world = state.world.lock().await;
+            let mut world = state.world.lock().await;
+            world.clock.pause();
             (world.player_location, world.clock.now())
         };
 

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -10,5 +10,6 @@ Quick reference for AI agents (Claude Code, Codex, etc.) and human contributors 
 | Tokio / SQLite / Ollama gotchas | [gotchas.md](gotchas.md) |
 | Git workflow & engineering standards | [git-workflow.md](git-workflow.md) |
 | Claude Code skills (`/check`, `/prove`, ...) | [skills.md](skills.md) |
+| Running CI locally with `act` | [act-local.md](act-local.md) |
 
 The root `CLAUDE.md` and `AGENTS.md` are slim indexes — start there if you're new, then come here for the details.

--- a/docs/agent/act-local.md
+++ b/docs/agent/act-local.md
@@ -1,0 +1,124 @@
+# Running CI locally with `act`
+
+[`nektos/act`](https://github.com/nektos/act) runs our GitHub Actions
+workflows inside Docker against the working tree, so the same jobs that gate
+PRs can be exercised locally — no pushed branch, no billed minutes. Every
+job in `ci.yml` and `audit.yml` is runnable this way, including Playwright
+e2e.
+
+This doc is the source of truth for the setup; `.actrc` and the `act-*`
+recipes in `justfile` point back here.
+
+## One-time setup
+
+Everything that isn't checked in needs to happen once on your Mac.
+
+```sh
+# 1. Make sure Docker Desktop is running.
+#    act talks to the local Docker daemon; no daemon, no runs.
+
+# 2. Install act.
+brew install act
+
+# 3. Pull the full runner image (~60GB). This is the only image that
+#    mirrors GitHub's ubuntu-latest closely enough for our workflows —
+#    the medium image is missing apt, Node, and most of the toolchain
+#    that setup-node and dtolnay/rust-toolchain expect to find.
+docker pull catthehacker/ubuntu:full-latest
+
+# 4. (Optional) Seed a secrets file for future workflows that need one.
+#    Current workflows don't, so you can skip this until you add one.
+cp .secrets.example .secrets
+```
+
+Verify:
+
+```sh
+act --version
+just act-list
+```
+
+`just act-list` should print every job in every workflow without touching
+Docker. If that works, act is wired up correctly.
+
+## Day-to-day usage
+
+All of these are defined in `justfile`:
+
+| Command | What it runs |
+|---|---|
+| `just act-list` | Enumerate all jobs (fast, no Docker execution) |
+| `just act-audit` | `audit.yml` cargo-audit job — fastest smoke test |
+| `just act-fmt` | `ci.yml` rust-quality-gate (fmt + clippy + tests) |
+| `just act-harness` | `ci.yml` game-harness fixture sweep |
+| `just act-ui` | `ci.yml` ui-quality (svelte-check + vitest + build) |
+| `just act-e2e` | `ci.yml` ui-e2e (Playwright) |
+| `just act-ci` | All of `ci.yml` — matches what PRs see |
+| `just act-job JOB=<id>` | Run a specific job by id from `act-list` |
+| `just act-pr` | Simulate the `pull_request` event |
+| `just act-refresh` | Re-fetch third-party actions after a version bump |
+| `just act-clean` | Tear down cached containers + artifact output |
+
+## Configuration
+
+`.actrc` sets shared flags for every `act` invocation. The key ones:
+
+- **`-P ubuntu-latest=catthehacker/ubuntu:full-latest`** — full image
+  (~60GB). Needed because our workflows `apt-get install` Tauri/WebKit
+  dev headers, and the medium image doesn't ship apt.
+- **`--container-architecture linux/amd64`** — forces amd64 emulation on
+  Apple Silicon. Some actions (notably `dtolnay/rust-toolchain` and
+  `actions/setup-node`) won't run under Rosetta without it set explicitly.
+- **`--artifact-server-path /tmp/act-artifacts`** — `upload-artifact@v4`
+  requires a real endpoint (unlike v3, it won't no-op). The ui-e2e job
+  uploads its `playwright-report/` here after runs.
+- **`--reuse`** — keeps containers between runs so `target/` and
+  `node_modules/` survive. First run is slow; subsequent runs are fast.
+- **`--action-offline-mode`** — skips re-fetching cached action source.
+  Use `just act-refresh` after bumping an action version.
+
+Edit `.actrc` if you need to deviate; per-command overrides also work
+(e.g. `act -P ubuntu-latest=catthehacker/ubuntu:medium-latest ...`).
+
+## Caveats and gotchas
+
+**First run is slow.** The full image pull is ~60GB compressed. Rust
+builds inside the container start cold — `Swatinem/rust-cache` caches
+to `~/.cache` inside the container, and `--reuse` keeps that around,
+but the very first `cargo build` in the `ui-e2e` job will take several
+minutes. Budget 30–60 minutes for the first full `just act-ci`.
+
+**Apple Silicon emulation tax.** amd64 under Rosetta runs roughly 2–3×
+slower than the same job on GitHub's x86 runners. Expect `just act-ci`
+to take meaningfully longer end-to-end than a pushed PR.
+
+**Disk usage grows.** Every `--reuse` container keeps its own `target/`
+and `node_modules/`. After a couple weeks of daily use you may see
+20–40GB of cached data in Docker. `just act-clean` drops it all.
+
+**Scheduled jobs.** `audit.yml` runs on a cron in prod. act can
+simulate the `schedule` event with `act schedule`, but `just act-audit`
+runs it directly by job id, which is what you want day to day.
+
+**`GITHUB_TOKEN` is a stub.** act injects a dummy token automatically.
+If you ever add a workflow that genuinely needs to call the GitHub API
+(post PR comments, push to ghcr.io), put a real fine-scoped PAT in
+`.secrets` — never commit it.
+
+**Don't use act as your only gate.** act faithfully reproduces a lot,
+but not everything: GitHub-side concurrency groups, branch protections,
+required-check status, and `permissions:` enforcement are server-side
+concerns that only get exercised on a real push. act is for tightening
+the inner loop, not replacing the PR check.
+
+## Upgrading the runner image
+
+When GitHub's `ubuntu-latest` upgrades (currently 24.04), pull the new
+`catthehacker/ubuntu:full-latest` — it tracks upstream:
+
+```sh
+docker pull catthehacker/ubuntu:full-latest
+just act-clean   # drop cached containers built on the old image
+```
+
+No `.actrc` change needed; the tag is already `:full-latest`.

--- a/justfile
+++ b/justfile
@@ -266,6 +266,68 @@ audit:
 update:
     cargo update
 
+# ─── Local CI (act) ──────────────────────────────────────────────────────────
+#
+# Run GitHub Actions workflows locally via nektos/act against Docker. Shared
+# flags live in .actrc; see docs/agent/act-local.md for setup + caveats.
+# First run pulls a ~60GB image and primes caches — grab a coffee.
+
+# List every job across every workflow (use these ids with `just act-job`)
+act-list:
+    act -l
+
+# Run the full CI workflow (ci.yml) — all five jobs, matches what PRs see
+act-ci:
+    act -W .github/workflows/ci.yml
+
+# Run just the fmt/clippy/tests job — fastest signal on a Rust change
+act-fmt:
+    act -W .github/workflows/ci.yml -j rust-quality-gate
+
+# Run the full game harness fixture sweep
+act-harness:
+    act -W .github/workflows/ci.yml -j game-harness
+
+# Run UI unit tests (svelte-check + vitest + build)
+act-ui:
+    act -W .github/workflows/ci.yml -j ui-quality
+
+# Run Playwright e2e job — slowest, uploads playwright-report as an artifact
+# to /tmp/act-artifacts after the run.
+act-e2e:
+    act -W .github/workflows/ci.yml -j ui-e2e
+
+# Run security audit workflow — cheapest, good for smoke-testing that act
+# itself is configured correctly.
+act-audit:
+    act -W .github/workflows/audit.yml
+
+# Run an arbitrary job by id: `just act-job JOB=rust-multi-channel`
+act-job JOB:
+    act -j {{JOB}}
+
+# Simulate the pull_request event (some jobs gate on event type)
+act-pr:
+    act pull_request
+
+# Force-refresh third-party actions (drops --action-offline-mode). Use after
+# bumping an action version in a workflow.
+act-refresh:
+    act --action-offline-mode=false
+
+# Tear down cached act containers. Run when things get weird or before a
+# clean-slate verification.
+act-clean:
+    #!/usr/bin/env bash
+    containers=$(docker ps -aq --filter name=act-)
+    if [ -n "$containers" ]; then
+        docker rm -f $containers
+        echo "Removed act containers."
+    else
+        echo "No act containers to remove."
+    fi
+    rm -rf /tmp/act-artifacts
+
 # ─── Ollama ──────────────────────────────────────────────────────────────────
 
 # Start the Ollama server in the background


### PR DESCRIPTION
## Summary

- Adds [nektos/act](https://github.com/nektos/act) wiring so every job in `ci.yml` and `audit.yml` — fmt, clippy, tests, game harness, UI unit, Playwright e2e, and cargo-audit — can be exercised locally against Docker without pushing a branch or burning CI minutes.
- Pins `.actrc` defaults that matter on a Mac: full catthehacker runner image (~60GB, the only variant with apt + setup-node + Tauri headers), forced amd64 under Rosetta, `--reuse` for cache persistence, `--artifact-server-path` for `upload-artifact@v4`, and `--env-file /dev/null` so the repo's `.env` cannot leak into tests that assume the clean env GitHub runners have.
- Exposes day-to-day usage through `just act-*` recipes (`act-list`, `act-audit`, `act-fmt`, `act-harness`, `act-ui`, `act-e2e`, `act-ci`, `act-job JOB=…`, `act-pr`, `act-refresh`, `act-clean`).
- Fixes 6 pre-existing latent tests (`parish-persistence::journal` × 5, `parish-server::routes` × 1) that snapshot `world.clock.now()`, run an operation that should leave the clock untouched, and assert exact equality. `GameClock` derives from wall-clock × 36, so ~28ms of real-time drift between the two reads advances the game clock by a full second and breaks the assertion. Native Mac was fast enough to hide it; amd64 emulation under Rosetta surfaced it. Fix: pause the clock before the snapshot — the assertion now tests intent (\"replay did not advance the clock\") rather than \"replay was fast enough.\"

## Why this is worth merging

- **Faster inner loop.** `just act-fmt` on warm caches runs the full Rust quality gate in ~3.5 min; no push, no branch noise, no billed minutes.
- **Faithful reproduction.** The `--env-file /dev/null` default makes the container env match GitHub's runner; without it, local `.env` silently diverges from CI.
- **Two latent flakes retired.** The wall-clock-sensitive tests were bombs waiting for a slow runner; they'd have eventually bitten a contributor on a busy laptop or a noisy CI host regardless of act.

## What reviewers should know

- First run of `just act-audit` or `just act-fmt` is slow (image pull + rustup + cargo install cargo-audit + cold apt). Budget ~15 min first time; subsequent runs are fast with `--reuse`.
- `just act-audit` will currently **fail** on `main` — not because act is broken, but because there's a real open RUSTSEC finding (`rustls-webpki` vuln, plus `serde_yml` and `rand` 0.9.2 unsound warnings). That's a dependency bump, out of scope for this PR but worth a follow-up.
- `just act-ci` and `just act-e2e` were not run during setup (30–60 min each); they're wired the same way as the cheaper recipes and should Just Work, but first-run time is significant.

## Test plan

- [x] `act --version` → 0.2.87
- [x] `docker pull catthehacker/ubuntu:full-latest` (host default arch pull; act re-pulls amd64 on first invocation)
- [x] `just act-list` enumerates 6 jobs across both workflows
- [x] `just act-audit` runs end-to-end; fails on a legitimate cargo-audit finding (act wiring verified correct)
- [x] `just act-fmt` runs end-to-end; fmt + clippy + `cargo test --workspace --all-targets` all green
- [x] All 21 `parish-persistence::journal::tests` pass natively; both previously-failing clock tests pass under amd64 emulation after the `clock.pause()` fix
- [ ] `just act-ci` (not run this session — long first run)
- [ ] `just act-e2e` (not run this session — long first run)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)