### PR TITLE
fix(editor): restore Mythological Significance + Aliases sections (#411)

### DIFF
--- a/apps/ui/src/components/editor/LocationDetail.svelte
+++ b/apps/ui/src/components/editor/LocationDetail.svelte
@@ -470,6 +470,31 @@
 					<p class="empty-note">None</p>
 				{/if}
 			</section>
+
+			<section class="section">
+				<h4 class="section-label">Mythological Significance</h4>
+				<textarea
+					class="field-textarea"
+					value={loc.mythological_significance ?? ''}
+					placeholder="Fairy fort, holy well, cursed ground…"
+					on:change={(e) =>
+						handleFieldChange(
+							'mythological_significance',
+							e.currentTarget.value.trim() === '' ? null : e.currentTarget.value
+						)}
+				></textarea>
+			</section>
+
+			{#if loc.aliases && loc.aliases.length > 0}
+				<section class="section">
+					<h4 class="section-label">Aliases</h4>
+					<div class="alias-list">
+						{#each loc.aliases as alias}
+							<span class="alias-tag">{alias}</span>
+						{/each}
+					</div>
+				</section>
+			{/if}
 		</div>
 	{:else}
 		<div class="empty-state">
@@ -636,6 +661,22 @@
 		border-radius: 3px;
 		background: color-mix(in srgb, var(--color-accent) 12%, transparent);
 		color: var(--color-accent);
+	}
+
+	.alias-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.2rem;
+	}
+
+	.alias-tag {
+		display: inline-block;
+		font-size: 0.7rem;
+		padding: 0.1rem 0.35rem;
+		border-radius: 3px;
+		background: color-mix(in srgb, var(--color-muted) 18%, transparent);
+		color: var(--color-muted);
+		font-style: italic;
 	}
 
 	.empty-state {

--- a/apps/ui/src/components/editor/LocationDetail.svelte
+++ b/apps/ui/src/components/editor/LocationDetail.svelte
@@ -485,16 +485,18 @@
 				></textarea>
 			</section>
 
-			{#if loc.aliases && loc.aliases.length > 0}
-				<section class="section">
-					<h4 class="section-label">Aliases</h4>
+			<section class="section">
+				<h4 class="section-label">Aliases</h4>
+				{#if loc.aliases && loc.aliases.length > 0}
 					<div class="alias-list">
 						{#each loc.aliases as alias}
 							<span class="alias-tag">{alias}</span>
 						{/each}
 					</div>
-				</section>
-			{/if}
+				{:else}
+					<p class="empty-note">None</p>
+				{/if}
+			</section>
 		</div>
 	{:else}
 		<div class="empty-state">


### PR DESCRIPTION
## Summary

**Closes #411** — the map-editing overhaul in PR #398 silently dropped two sections that had been present in the original Parish Designer layout (#263):

- **Mythological Significance** — an editable textarea wired to the location's \`mythological_significance\` field. Authors use this to annotate fairy forts, holy wells, cursed ground, etc. The field still round-trips through save/load, but was no longer reachable from the UI.
- **Aliases** — a read-only display of the location's \`aliases\` array (e.g. \`"holy well"\`, \`"the well"\`, \`"well"\` for The Holy Well). Same strings the fuzzy name matcher uses; invisible meant authors couldn't debug why their synonym-matching wasn't behaving.

## Changes

[LocationDetail.svelte](apps/ui/src/components/editor/LocationDetail.svelte) now restores both sections below \`Associated NPCs\`, matching the pre-#398 layout order. The Mythological Significance textarea writes \`null\` on empty input so the JSON round-trips as \`Option<String>\` cleanly. Small CSS additions for \`.alias-list\` / \`.alias-tag\` mirror the existing \`.assoc-npc\` chip pattern.

## Test plan

Verified end-to-end in the web version of Parish (\`cargo run -p parish -- --web 3001\`, cookie-backed session, Designer modal):

- [x] Loaded \`mods/rundale\`, navigated to Locations tab, selected **The Holy Well**.
- [x] Section labels in order: Map Designer · Identity · Coordinates · Connections · Description Template · Associated NPCs · **Mythological Significance** · **Aliases**.
- [x] Textarea populated with the expected St. Tíobán's Well prose.
- [x] Alias chips render: \`holy well\`, \`the well\`, \`well\`.
- [x] Edited the mythological textarea → \`POST /api/editor-update-locations\` returned 200 and the new value is reflected in the snapshot.
- [x] \`cargo build -p parish-server\` — clean (no backend changes).
- [x] \`vite build\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)