### PR TITLE
fix(editor): destroy MapLibre instance when location deselects (#409)

### DIFF
--- a/apps/ui/src/components/editor/LocationDetail.svelte
+++ b/apps/ui/src/components/editor/LocationDetail.svelte
@@ -295,9 +295,22 @@
 		};
 	});
 
-	$: if (mapContainer && !map) {
+	// Tear the MapLibre instance down the moment the selected location
+	// clears (#409). The `{#if loc}` wrapper below unmounts the map-frame
+	// div, but Svelte's `bind:this` does not always reset `mapContainer`
+	// to `undefined` in time for the mapContainer-based watch below to
+	// fire — so we couple the cleanup to `loc` directly. Without this,
+	// each deselect leaks a WebGL context (MapLibre allocates one per
+	// Map instance) and after a few navigations the browser aborts
+	// further WebGL contexts.
+	$: if (!loc && map) {
+		destroyMap();
+	}
+	$: if (loc && mapContainer && !map) {
 		void ensureMap();
 	}
+	// Defensive secondary cleanup for any case where the div is
+	// unmounted without `loc` flipping (e.g. future refactors).
 	$: if (!mapContainer && map) {
 		destroyMap();
 	}


### PR DESCRIPTION
## Summary

**Closes #409** — LocationDetail creates its MapLibre map inside an \`{#if loc}\` block. The pre-existing reactive cleanup was tied to \`mapContainer\` going undefined, but Svelte's \`bind:this\` doesn't always reset the bound variable before reactive statements run. Each deselect leaks a \`maplibregl.Map\` instance (and with it a WebGL context, allocated per Map). After a handful of select/deselect cycles the browser starts aborting further WebGL contexts, and the editor map goes blank.

## Fix

Add a reactive statement tied directly to \`loc\` becoming \`null\` so \`destroyMap()\` runs deterministically on deselect, independent of how Svelte schedules the \`bind:this\` teardown. The existing \`mapContainer\`-based guard is retained as defensive secondary cleanup for any future path that unmounts the div without clearing \`loc\`.

## Test plan

- [x] \`vite build\` — clean
- [x] No backend changes; pure UI fix to [LocationDetail.svelte](apps/ui/src/components/editor/LocationDetail.svelte)

Manual verification on the live editor (select / deselect / select another location) will be part of test coverage for this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)