### PR TITLE
perf(editor): suppress map easeTo on unrelated edits (#410)

### DIFF
--- a/apps/ui/src/components/editor/LocationDetail.svelte
+++ b/apps/ui/src/components/editor/LocationDetail.svelte
@@ -145,14 +145,17 @@
 		}
 	}
 
-	// Track the last selection we animated to, so locations-array updates
-	// that don't change the selected location can refresh the GeoJSON
-	// sources without triggering another easeTo animation (#410). Without
-	// this, every keystroke in a text field would dispatch a full camera
-	// pan — persistLocations swaps a new `locations` array into the store,
-	// re-firing the reactive statement below even though the map center
-	// hasn't actually moved.
+	// Track the last selection + coords we animated to, so updates that
+	// don't actually move the camera skip the easeTo animation (#410).
+	// Without this, every keystroke in a text field would dispatch a full
+	// camera pan — persistLocations swaps a new `locations` array into
+	// the store, re-firing the reactive statement below even when the map
+	// center hasn't moved. We key on (selectedId, lat, lon) tuple so that
+	// coordinate-changing actions (drag release, nudge, lat/lon field
+	// edits) *do* recenter — per codex P1 on #559.
 	let lastAnimatedSelectedId: number | null = null;
+	let lastAnimatedLat: number | null = null;
+	let lastAnimatedLon: number | null = null;
 
 	function setMapData(nextLocations: LocationData[], nextSelectedId: number | null, preview?: { id: number; lat: number; lon: number }) {
 		if (!map || !mapLoaded) return;
@@ -165,20 +168,25 @@
 			type: 'FeatureCollection',
 			features: edgeFeatures
 		});
-		// Animate the camera only when the selection changes or a drag
-		// preview is active; unrelated field edits that bumped the
-		// locations array must not cause camera jitter.
-		const selectionChanged = nextSelectedId !== lastAnimatedSelectedId;
-		if (!selectionChanged && !preview) return;
 		const center = getEditorMapCenter(features, nextSelectedId, preview);
 		if (!center) return;
 		const [lon, lat] = center;
+		// Animate only when something that affects the camera position
+		// actually changes: the selection, or the selected marker's
+		// coordinates. Unrelated field edits that bumped the locations
+		// array must not cause camera jitter. Preview frames (drag in
+		// progress) always animate so the camera tracks the cursor.
+		const selectionChanged = nextSelectedId !== lastAnimatedSelectedId;
+		const coordsChanged = lat !== lastAnimatedLat || lon !== lastAnimatedLon;
+		if (!preview && !selectionChanged && !coordsChanged) return;
 		map.easeTo({ center: [lon, lat], duration: 250 });
 		if (!preview) {
 			// Preview frames stream continuously during a drag; don't mark
 			// the selection as "animated" from them or we'd suppress the
 			// final settle-on-release animation.
 			lastAnimatedSelectedId = nextSelectedId;
+			lastAnimatedLat = lat;
+			lastAnimatedLon = lon;
 		}
 	}
 
@@ -186,6 +194,12 @@
 		mapLoaded = false;
 		map?.remove();
 		map = null;
+		// Reset animation memo so a later remount (deselect → reselect
+		// the same item, or component re-mount) still animates the first
+		// setMapData call — codex P2 on #559.
+		lastAnimatedSelectedId = null;
+		lastAnimatedLat = null;
+		lastAnimatedLon = null;
 	}
 
 	function readLocationId(event: { features?: Array<{ properties?: { id?: number | string } }> }): number | null {

--- a/apps/ui/src/components/editor/LocationDetail.svelte
+++ b/apps/ui/src/components/editor/LocationDetail.svelte
@@ -145,6 +145,15 @@
 		}
 	}
 
+	// Track the last selection we animated to, so locations-array updates
+	// that don't change the selected location can refresh the GeoJSON
+	// sources without triggering another easeTo animation (#410). Without
+	// this, every keystroke in a text field would dispatch a full camera
+	// pan — persistLocations swaps a new `locations` array into the store,
+	// re-firing the reactive statement below even though the map center
+	// hasn't actually moved.
+	let lastAnimatedSelectedId: number | null = null;
+
 	function setMapData(nextLocations: LocationData[], nextSelectedId: number | null, preview?: { id: number; lat: number; lon: number }) {
 		if (!map || !mapLoaded) return;
 		const { features, edgeFeatures } = buildEditorMapData(nextLocations, nextSelectedId, preview);
@@ -156,10 +165,21 @@
 			type: 'FeatureCollection',
 			features: edgeFeatures
 		});
+		// Animate the camera only when the selection changes or a drag
+		// preview is active; unrelated field edits that bumped the
+		// locations array must not cause camera jitter.
+		const selectionChanged = nextSelectedId !== lastAnimatedSelectedId;
+		if (!selectionChanged && !preview) return;
 		const center = getEditorMapCenter(features, nextSelectedId, preview);
 		if (!center) return;
 		const [lon, lat] = center;
 		map.easeTo({ center: [lon, lat], duration: 250 });
+		if (!preview) {
+			// Preview frames stream continuously during a drag; don't mark
+			// the selection as "animated" from them or we'd suppress the
+			// final settle-on-release animation.
+			lastAnimatedSelectedId = nextSelectedId;
+		}
 	}
 
 	function destroyMap() {


### PR DESCRIPTION
## Summary

**Closes #410** — the reactive \`$: setMapData(locations, selectedId)\` in [LocationDetail.svelte](apps/ui/src/components/editor/LocationDetail.svelte) fires whenever the \`locations\` array reference changes. \`persistLocations\` rebuilds that array on every field edit (\`{ ...s, locations: normalizedLocations }\`), so every keystroke in Name / Description / any text field kicked off a 250ms \`map.easeTo\` animation. The map jittered continuously during typing.

## Fix

Track the last \`selectedId\` we actually animated to. In \`setMapData\`, always refresh the GeoJSON sources (cheap; keeps markers and edges accurate), but only invoke \`easeTo\` when:

- the selection genuinely changed since the last animated frame, or
- a drag preview is in progress (drag frames still need live camera follow).

Drag preview frames do not update \`lastAnimatedSelectedId\`, so the final settle-on-release animation still runs.

## Test plan

- [x] \`vite build\` — clean
- [x] No backend changes; pure UI fix
- Manual: type into a location's Name or Description textarea → map markers refresh (geojson sources updated) but the camera no longer pans with each keystroke; clicking a different location in the list still animates to the new center.

🤖 Generated with [Claude Code](https://claude.com/claude-code)