### PR TITLE
fix(persistence): acquire SaveFileLock at startup + surface CLI failures (#425, #426)

### DIFF
--- a/crates/parish-cli/src/headless.rs
+++ b/crates/parish-cli/src/headless.rs
@@ -166,7 +166,23 @@ pub async fn run_headless(
     app.save_file_path = Some(db_path.clone());
 
     // Acquire advisory lock so other instances know this save is in use.
+    // If try_acquire returns None the file is already locked by another
+    // instance; make that visible instead of silently continuing to write
+    // into the same database (#426). The server and Tauri backends fail
+    // closed on the same condition; the CLI is interactive so we warn
+    // and proceed, giving the user a chance to cancel with ^C.
     app.save_lock = crate::persistence::SaveFileLock::try_acquire(&db_path);
+    if app.save_lock.is_none() {
+        eprintln!(
+            "Warning: save file {} is locked by another Parish instance; \
+             opening anyway — concurrent writes may corrupt it.",
+            db_path.display()
+        );
+        tracing::warn!(
+            path = %db_path.display(),
+            "SaveFileLock::try_acquire returned None on startup — save file in use by another instance",
+        );
+    }
 
     match crate::persistence::Database::open(&db_path) {
         Ok(db) => {
@@ -830,6 +846,17 @@ async fn handle_headless_load(app: &mut App, name: &str) {
             }
             // Release old lock and acquire lock on the new save file.
             app.save_lock = crate::persistence::SaveFileLock::try_acquire(&new_path);
+            if app.save_lock.is_none() {
+                eprintln!(
+                    "Warning: save file {} is locked by another Parish instance; \
+                     opening anyway — concurrent writes may corrupt it.",
+                    new_path.display()
+                );
+                tracing::warn!(
+                    path = %new_path.display(),
+                    "SaveFileLock::try_acquire returned None during save-switch — save file in use by another instance",
+                );
+            }
 
             match crate::persistence::Database::open(&new_path) {
                 Ok(new_db) => {

--- a/crates/parish-server/src/session.rs
+++ b/crates/parish-server/src/session.rs
@@ -421,6 +421,22 @@ async fn restore_session(
         init_inference_queue(&app_state, c.clone()).await;
     }
 
+    // Acquire advisory lock on the restored save file so another server
+    // instance (or a headless CLI) cannot concurrently write to it (#425).
+    // If a peer already holds the lock we log a warning and continue:
+    // refusing to start would leave the user with no session at all, and
+    // per-process ownership makes strict mutual exclusion across
+    // containers out of scope for this handler. The lock is stored on
+    // AppState.save_lock so it lives for the session's lifetime.
+    let locked = parish_core::persistence::SaveFileLock::try_acquire(&db_path);
+    if locked.is_none() {
+        tracing::warn!(
+            path = %db_path.display(),
+            session_id = %session_id,
+            "SaveFileLock::try_acquire returned None on session resume — save file appears in use by another instance",
+        );
+    }
+    *app_state.save_lock.lock().await = locked;
     *app_state.save_path.lock().await = Some(db_path);
     *app_state.current_branch_id.lock().await = Some(branch_id);
     *app_state.current_branch_name.lock().await = Some(branch_name);
@@ -477,6 +493,18 @@ async fn init_session_save(app_state: &Arc<AppState>, session_saves: &Path) -> R
     .await
     .map_err(|e| e.to_string())??;
 
+    // Advisory lock on the freshly-initialised save file so peer
+    // instances don't write to it concurrently (#425). For a just-created
+    // save we expect the lock to always succeed, but we stay defensive:
+    // warn if the lock fails rather than silently proceeding.
+    let locked = parish_core::persistence::SaveFileLock::try_acquire(&save_path);
+    if locked.is_none() {
+        tracing::warn!(
+            path = %save_path.display(),
+            "SaveFileLock::try_acquire returned None on init_session_save — new save file unexpectedly locked",
+        );
+    }
+    *app_state.save_lock.lock().await = locked;
     *app_state.save_path.lock().await = Some(save_path);
     *app_state.current_branch_id.lock().await = Some(branch_id);
     *app_state.current_branch_name.lock().await = Some("main".to_string());


### PR DESCRIPTION
## Summary

Two SaveFileLock coverage gaps introduced in PR #302:

- **Closes #425** — server startup didn't acquire the lock. PR #302 added \`SaveFileLock\` to \`load_branch\` and \`new_save_file\`, but both initial-session paths in [session.rs](crates/parish-server/src/session.rs) (\`create_session\` on resume, \`init_session_save\` on new saves) set \`save_path\` without acquiring the advisory lock. Another instance pointed at the same saves directory could concurrently write to the file.
- **Closes #426** — headless CLI silently swallowed lock failures. \`try_acquire\` returns \`Option\` and the CLI stored \`None\` without any signal to the user, defeating the point of the advisory lock. The server and Tauri backends already fail closed; the CLI was the only silent path.

## Fix

**Server ([session.rs](crates/parish-server/src/session.rs)):** \`SaveFileLock::try_acquire\` on both initial-session paths, storing the result on \`AppState.save_lock\`. Warn (\`tracing::warn\`) rather than refusing to start if the lock fails — a web server refusing to serve because a peer holds the lock is worse UX than a noisy log, and stricter mutual exclusion across containers is out of scope for this handler.

**Headless CLI ([headless.rs](crates/parish-cli/src/headless.rs)):** \`eprintln!\` + \`tracing::warn\` at both the startup and save-switch sites when \`try_acquire\` returns \`None\`, so the user sees the warning instead of unknowingly writing into an already-in-use database. The CLI is interactive, so proceeding-with-warning matches the existing pattern and lets the user Ctrl+C if they want to abort.

## Test plan

- [x] \`cargo build -p parish-server -p parish\` — clean
- [x] \`cargo test --workspace\` — all green, same test counts as main
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)