### PR TITLE
ops: add railway deployment watchdog (#562)

### DIFF
--- a/.github/workflows/railway-watchdog.yml
+++ b/.github/workflows/railway-watchdog.yml
@@ -1,0 +1,44 @@
+name: Railway deployment watchdog
+
+# Polls Railway every 10 minutes and opens a GitHub issue when the Parish
+# service has a FAILED/CRASHED deployment. See #562 for design notes and
+# roadmap toward Claude-driven auto-fix (v2).
+
+on:
+  schedule:
+    # Every 10 minutes. Cheap: one Railway API call + one gh search.
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+  # Re-run immediately after a push to main so a just-shipped fix closes
+  # stale issues as soon as the next deploy turns green, without waiting
+  # up to 10 minutes for the next cron tick.
+  push:
+    branches: [main]
+
+concurrency:
+  group: railway-watchdog
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  watchdog:
+    name: Check Railway deployment status
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Railway CLI
+        run: |
+          curl -fsSL https://railway.com/install.sh | sh
+          echo "$HOME/.railway/bin" >> "$GITHUB_PATH"
+
+      - name: Run watchdog
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./deploy/railway-watchdog.sh

--- a/deploy/railway-watchdog.sh
+++ b/deploy/railway-watchdog.sh
@@ -81,13 +81,19 @@ if [ -n "$existing" ]; then
   exit 0
 fi
 
-# Pull build-log tail. Surface only the lines an operator would read first:
-# explicit error markers plus the final 30 lines for context.
+# Pick the log stream that actually contains the failure. FAILED is a build
+# failure; CRASHED means the container started and exited at runtime, so the
+# diagnostic signal is in deploy logs, not build logs.
+case "$status" in
+  CRASHED) log_flag="--deployment"; log_kind="deploy" ;;
+  *)       log_flag="--build";      log_kind="build"  ;;
+esac
+
 log_tmp=$(mktemp)
 trap 'rm -f "$log_tmp"' EXIT
-if ! railway logs --build --service "$SERVICE" --environment "$ENVIRONMENT" \
+if ! railway logs "$log_flag" --service "$SERVICE" --environment "$ENVIRONMENT" \
     "$deployment_id" -n "$LOG_LINES" >"$log_tmp" 2>&1; then
-  echo "(warning: failed to fetch build logs)" >&2
+  echo "(warning: failed to fetch $log_kind logs)" >&2
 fi
 
 error_excerpt=$(grep -iE 'error|failed|cannot|panic|exit code' "$log_tmp" | tail -n 30 || true)
@@ -102,13 +108,13 @@ Automated report from \`.github/workflows/railway-watchdog.yml\` — see #562.
 - **Status:** \`$status\`
 - **Detected:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-### Error lines from build log
+### Error lines from $log_kind log
 
 \`\`\`
 ${error_excerpt:-(no explicit error markers found — see tail below)}
 \`\`\`
 
-### Last $LOG_LINES lines of build log (tail)
+### Last $LOG_LINES lines of $log_kind log (tail)
 
 \`\`\`
 ${tail_excerpt:-(log fetch failed)}

--- a/deploy/railway-watchdog.sh
+++ b/deploy/railway-watchdog.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Railway deployment watchdog — see issue #562.
+#
+# Queries Railway for the latest deployment status of SERVICE in ENVIRONMENT.
+# On FAILED/CRASHED: opens a GitHub issue with build-log excerpt (idempotent
+# per deployment ID — re-running with the same failed deployment is a no-op).
+# On SUCCESS: closes any open issues labeled `railway-failure` (the next green
+# deploy self-heals old notifications).
+#
+# Requires: railway CLI, gh CLI, jq, RAILWAY_TOKEN env, GH_TOKEN env.
+# Intended to run from .github/workflows/railway-watchdog.yml on a schedule.
+
+set -euo pipefail
+
+SERVICE="${RAILWAY_SERVICE:-Parish}"
+ENVIRONMENT="${RAILWAY_ENVIRONMENT:-production}"
+PROJECT="${RAILWAY_PROJECT:-Rundale}"
+LABEL="railway-failure"
+LOG_LINES="${RAILWAY_LOG_LINES:-120}"
+
+require() {
+  command -v "$1" >/dev/null || { echo "missing dependency: $1" >&2; exit 2; }
+}
+require railway
+require gh
+require jq
+
+# In CI both tokens are mandatory. Locally we fall back to whatever the
+# `railway` and `gh` CLIs already have cached so an operator can dry-run.
+if [ "${CI:-}" = "true" ]; then
+  : "${RAILWAY_TOKEN:?RAILWAY_TOKEN must be set in CI}"
+  : "${GH_TOKEN:?GH_TOKEN must be set in CI}"
+fi
+
+# Resolve and link the project/env so subsequent --service calls work. `link`
+# writes to the current directory, which on Actions runners is scratch space.
+railway link --project "$PROJECT" --environment "$ENVIRONMENT" --service "$SERVICE" >/dev/null
+
+status_json=$(railway service status --service "$SERVICE" --environment "$ENVIRONMENT" --json)
+deployment_id=$(jq -r '.deploymentId // empty' <<<"$status_json")
+status=$(jq -r '.status // "UNKNOWN"' <<<"$status_json")
+
+echo "service=$SERVICE env=$ENVIRONMENT deployment=$deployment_id status=$status"
+
+case "$status" in
+  FAILED|CRASHED)
+    : # proceed to ensure-issue-exists below
+    ;;
+  SUCCESS)
+    # Close every stale railway-failure issue. The current deploy is green,
+    # so any older failure report is by definition resolved.
+    mapfile -t stale < <(gh issue list --label "$LABEL" --state open --json number --jq '.[].number')
+    for n in "${stale[@]:-}"; do
+      [ -z "$n" ] && continue
+      gh issue close "$n" --comment "Auto-closed: latest Parish deployment \`$deployment_id\` is SUCCESS."
+      echo "closed stale issue #$n"
+    done
+    exit 0
+    ;;
+  BUILDING|DEPLOYING|QUEUED|INITIALIZING|REMOVING)
+    echo "transient state, skipping"
+    exit 0
+    ;;
+  *)
+    echo "unhandled status '$status', skipping" >&2
+    exit 0
+    ;;
+esac
+
+if [ -z "$deployment_id" ]; then
+  echo "no deploymentId in status payload; cannot dedupe" >&2
+  exit 1
+fi
+
+# Idempotence: one issue per deployment ID. `gh issue list --search` matches
+# on title+body, so the ID in the title is enough.
+existing=$(gh issue list --label "$LABEL" --state open \
+  --search "$deployment_id in:title" --json number --jq '.[0].number // empty')
+if [ -n "$existing" ]; then
+  echo "issue #$existing already tracks deployment $deployment_id"
+  exit 0
+fi
+
+# Pull build-log tail. Surface only the lines an operator would read first:
+# explicit error markers plus the final 30 lines for context.
+log_tmp=$(mktemp)
+trap 'rm -f "$log_tmp"' EXIT
+if ! railway logs --build --service "$SERVICE" --environment "$ENVIRONMENT" \
+    "$deployment_id" -n "$LOG_LINES" >"$log_tmp" 2>&1; then
+  echo "(warning: failed to fetch build logs)" >&2
+fi
+
+error_excerpt=$(grep -iE 'error|failed|cannot|panic|exit code' "$log_tmp" | tail -n 30 || true)
+tail_excerpt=$(tail -n 30 "$log_tmp" || true)
+
+title="railway: deployment $deployment_id $status"
+body=$(cat <<EOF
+Automated report from \`.github/workflows/railway-watchdog.yml\` — see #562.
+
+- **Service:** \`$SERVICE\` (\`$ENVIRONMENT\`)
+- **Deployment:** \`$deployment_id\`
+- **Status:** \`$status\`
+- **Detected:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+### Error lines from build log
+
+\`\`\`
+${error_excerpt:-(no explicit error markers found — see tail below)}
+\`\`\`
+
+### Last $LOG_LINES lines of build log (tail)
+
+\`\`\`
+${tail_excerpt:-(log fetch failed)}
+\`\`\`
+
+---
+
+**Next steps:** inspect the log excerpt above, push a fix or revert the offending commit, and the next green deploy will auto-close this issue.
+EOF
+)
+
+issue_url=$(gh issue create \
+  --title "$title" \
+  --label "$LABEL,bug,requires-human" \
+  --body "$body")
+echo "opened $issue_url"

--- a/docs/development/railway-watchdog.md
+++ b/docs/development/railway-watchdog.md
@@ -1,0 +1,58 @@
+# Railway deployment watchdog
+
+The production Parish web service deploys to Railway via [`deploy/Dockerfile`](../../deploy/Dockerfile) (config in [`railway.toml`](../../railway.toml)). When a deployment fails, the service stays broken silently until someone notices. The **watchdog** is an automated check that turns a silent failure into a labeled GitHub issue.
+
+Scope is deliberately small. It **detects and notifies** today; it does not auto-fix. Auto-fix is the v2 goal tracked in [#562](https://github.com/dmooney/Parish/issues/562).
+
+## How it works
+
+- [`.github/workflows/railway-watchdog.yml`](../../.github/workflows/railway-watchdog.yml) runs every 10 minutes (and on push to `main`).
+- It shells out to [`deploy/railway-watchdog.sh`](../../deploy/railway-watchdog.sh), which:
+  1. Queries `railway service status --json` for the latest deployment.
+  2. On `FAILED`/`CRASHED`: searches for an open issue whose title contains the deployment ID. If none exists, opens one labeled `railway-failure,bug,requires-human` with a tail of the build log.
+  3. On `SUCCESS`: closes every open issue carrying the `railway-failure` label (the next green deploy self-heals stale notifications).
+  4. On transient states (`BUILDING`, `DEPLOYING`, etc.): exits 0.
+
+Idempotence is enforced by the deployment ID in the issue title — repeated runs against the same failed deployment are no-ops.
+
+## Setup
+
+One-time, per repo:
+
+1. **Create a Railway API token** scoped to read the Parish service and project.
+   - Railway dashboard → Account Settings → Tokens → *Create Token*.
+   - Give it a label like `github-watchdog`.
+2. **Store it as a GitHub Actions secret.**
+   ```sh
+   gh secret set RAILWAY_TOKEN --body "<token>"
+   ```
+3. The `railway-failure` label already exists. If it's been deleted, recreate it:
+   ```sh
+   gh label create railway-failure --color B60205 \
+     --description "Auto-filed by railway-watchdog workflow — a Railway deployment failed"
+   ```
+
+That's the whole install. The workflow's `GITHUB_TOKEN` is provided automatically by Actions.
+
+## Running locally
+
+Useful for tuning the log excerpt or testing label behavior before landing changes:
+
+```sh
+export RAILWAY_TOKEN=...   # same token Actions uses
+export GH_TOKEN=$(gh auth token)
+./deploy/railway-watchdog.sh
+```
+
+Override the service or project by setting `RAILWAY_SERVICE`, `RAILWAY_ENVIRONMENT`, or `RAILWAY_PROJECT`.
+
+## Roadmap — toward v2 (Claude-driven auto-fix)
+
+The watchdog is step one of [#562](https://github.com/dmooney/Parish/issues/562). Once notification is reliable, the intended next moves:
+
+- **Diagnose:** extend the script to attach a short Claude-authored summary of the log excerpt (not a fix — just a diagnosis).
+- **Fix draft:** on well-understood failure patterns (workspace-manifest errors, missing files referenced by `COPY`, lockfile/toolchain mismatches), spawn a Claude agent to open a fix PR against `main`.
+- **Gate:** never auto-merge without the existing codex `+1` gate the team already uses for `codex-automation` PRs.
+- **Loop-breaker:** cap auto-retries per 24h; escalate with `requires-human` once the cap is hit.
+
+Each increment is independently useful — ship them one at a time rather than as a big-bang rewrite.


### PR DESCRIPTION
## Summary

Step one of #562 — detection, not auto-fix. Today a broken Railway deployment stays broken silently; this PR turns it into a labeled GitHub issue within ~10 minutes.

- `.github/workflows/railway-watchdog.yml` polls Railway every 10 min (and on push to `main`).
- `deploy/railway-watchdog.sh` queries `railway service status --json`; on `FAILED`/`CRASHED` it opens a `railway-failure,bug,requires-human` issue with a build-log excerpt, idempotent per deployment ID. On `SUCCESS` it auto-closes stale `railway-failure` issues.
- `docs/development/railway-watchdog.md` covers `RAILWAY_TOKEN` setup and the v2 roadmap (Claude-driven diagnosis → fix PR, gated by the existing codex `+1` review convention).

Design rationale lives in #562. Deliberately narrow scope: no auto-merge, no auto-fix, no access to `main` beyond what `GITHUB_TOKEN` already grants.

## Setup required after merge

1. Create a Railway API token (dashboard → Account Settings → Tokens).
2. `gh secret set RAILWAY_TOKEN --body "<token>"`.

The `railway-failure` label is already created.

## Test plan

- [x] Syntax check: `bash -n deploy/railway-watchdog.sh`
- [x] Local dry-run against current (BUILDING) deployment — exits 0 with `transient state, skipping`
- [x] Verified `gh issue list --search "<id> in:title"` returns `none` for a fresh deployment id (dedupe works)
- [x] Verified `railway logs --build ... <id>` surfaces the expected error on the original broken deployment (log-fetch path works)
- [ ] After merge, set `RAILWAY_TOKEN` secret and trigger `workflow_dispatch` to confirm end-to-end against production state

🤖 Generated with [Claude Code](https://claude.com/claude-code)