### PR TITLE
fix(testing): separate /unexplored proof from ephemeral play_prove.txt (#412)

### DIFF
--- a/testing/fixtures/play_prove.txt
+++ b/testing/fixtures/play_prove.txt
@@ -1,8 +1,16 @@
-# Prove: /unexplored slash command toggles reveal mode for map visibility.
-# Goal: verify command responses for status, reveal, and hide.
-
-/unexplored
-/unexplored reveal
-/unexplored
-/unexplored hide
-/unexplored
+# Ephemeral scratch fixture for the /prove skill.
+#
+# The /prove skill rewrites this file on every run (see
+# .claude/skills/prove/SKILL.md). Checking durable test content in
+# here is a mistake — the next /prove run will overwrite it.
+# (#412: PR #397 checked in a /unexplored proof here; that content
+# was moved to prove_unexplored.txt.)
+#
+# Feature-specific proof scripts that should persist across /prove
+# runs live under their own names (e.g. prove_unexplored.txt,
+# play_weather.txt).
+#
+# Keep this stub harmless so `cargo run -- --script testing/fixtures/play_prove.txt`
+# still resolves to something runnable before the first /prove of
+# a fresh working copy.
+/status

--- a/testing/fixtures/prove_unexplored.txt
+++ b/testing/fixtures/prove_unexplored.txt
@@ -1,0 +1,13 @@
+# Prove: /unexplored slash command toggles reveal mode for map visibility.
+# Goal: verify command responses for status, reveal, and hide.
+#
+# Preserved from PR #397 after it mistakenly landed in play_prove.txt
+# (#412). play_prove.txt is the ephemeral scratch slot the /prove skill
+# rewrites on every run; this file is the durable test for the
+# /unexplored feature.
+
+/unexplored
+/unexplored reveal
+/unexplored
+/unexplored hide
+/unexplored


### PR DESCRIPTION
## Summary

**Closes #412** — PR #397 checked durable \`/unexplored\` test content into [testing/fixtures/play_prove.txt](testing/fixtures/play_prove.txt), which is the ephemeral scratch slot the \`/prove\` skill rewrites on every run (see [.claude/skills/prove/SKILL.md](.claude/skills/prove/SKILL.md)). The next \`/prove\` invocation would silently destroy the content.

## Fix

- Move the \`/unexplored\` proof to [testing/fixtures/prove_unexplored.txt](testing/fixtures/prove_unexplored.txt), alongside the other durable named proofs (\`play_weather.txt\`, \`play_frontier.txt\`).
- Reduce \`play_prove.txt\` to a harmless \`/status\` stub + a prominent header comment documenting the file's ephemeral role so future contributors don't repeat the mistake.

## Test plan

- [x] \`cargo run -p parish -- --script testing/fixtures/prove_unexplored.txt\` — emits the four \`/unexplored\` state transitions (hidden → revealed → revealed → hidden → hidden).
- [x] \`cargo run -p parish -- --script testing/fixtures/play_prove.txt\` — emits the \`/status\` summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)