### PR TITLE
ci(railway-watchdog): move to self-hosted macOS runner (#554)

### DIFF
--- a/.github/workflows/railway-watchdog.yml
+++ b/.github/workflows/railway-watchdog.yml
@@ -35,9 +35,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Railway CLI and jq
+      - name: Install railway, gh, and jq
         run: |
-          command -v railway >/dev/null || brew install railwayapp/railway/railway
+          command -v railway >/dev/null || brew install railway
+          command -v gh >/dev/null      || brew install gh
           command -v jq >/dev/null      || brew install jq
 
       - name: Run watchdog

--- a/.github/workflows/railway-watchdog.yml
+++ b/.github/workflows/railway-watchdog.yml
@@ -26,16 +26,19 @@ permissions:
 jobs:
   watchdog:
     name: Check Railway deployment status
-    runs-on: ubuntu-latest
+    # Runs on the self-hosted [macOS, ARM64] runner `parish-mac-arm64`,
+    # matching ci.yml and audit.yml. GitHub-hosted runners are disabled
+    # on this account; see #554.
+    runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Railway CLI
+      - name: Install Railway CLI and jq
         run: |
-          curl -fsSL https://railway.com/install.sh | sh
-          echo "$HOME/.railway/bin" >> "$GITHUB_PATH"
+          command -v railway >/dev/null || brew install railwayapp/railway/railway
+          command -v jq >/dev/null      || brew install jq
 
       - name: Run watchdog
         env:


### PR DESCRIPTION
## Summary

Followup to #565 — the watchdog workflow I just merged still targeted `ubuntu-latest`, which GitHub rejects on this account's current billing state. #554 already migrated CI + audit to the self-hosted `[self-hosted, macOS, ARM64]` runner; this brings the watchdog in line.

- `runs-on: [self-hosted, macOS, ARM64]` — matches `ci.yml` and `audit.yml` post-#554.
- Swapped the Railway CLI install from `curl install.sh | sh` to `brew install railway`, mirroring the macOS convention. Both `railway` and `jq` are gated on `command -v` so the step is a no-op on a warm runner.

## Test plan

- [x] Syntax check (`bash -n deploy/railway-watchdog.sh` — unchanged)
- [x] Confirmed `brew install railway` is the canonical macOS install (formula `railway`, currently installed locally)
- [ ] After merge, `gh workflow run "Railway deployment watchdog" --ref main` and watch it complete green (secret `RAILWAY_TOKEN` is already set from #565)

🤖 Generated with [Claude Code](https://claude.com/claude-code)