### PR TITLE
fix(ui): Focail panel no longer double-renders on desktop (#355)

### DIFF
--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -15,6 +15,11 @@
 
 	/** Which mobile-only panel is open (if any). Desktop ignores this. */
 	let mobilePanel = $state<'none' | 'map' | 'sidebar'>('none');
+	/** True on narrow viewports (<=768px). Desktop ignores focailOpen; on
+	 * mobile the chat column becomes the Focail panel when that store
+	 * is true. Fix for #355: without this gate both columns render the
+	 * same Sidebar side-by-side on desktop. */
+	let isMobile = $state(false);
 	import { debugVisible, debugSnapshot, debugDockLeft } from '../stores/debug';
 	import { savePickerVisible } from '../stores/save';
 	import { palette } from '../stores/theme';
@@ -149,13 +154,28 @@
 	}
 
 	let mountCleanup: (() => void) | null = null;
+	let mobileMediaCleanup: (() => void) | null = null;
 	onMount(() => {
 		(async () => {
 			mountCleanup = await setupMount();
 		})();
+		// Track the narrow-viewport media query live so a user who
+		// resizes from mobile to desktop while focailOpen is true
+		// doesn't end up with two Sidebars stacked in the chat column
+		// and the right column (#355).
+		if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+			const mq = window.matchMedia('(max-width: 768px)');
+			isMobile = mq.matches;
+			const onChange = (e: MediaQueryListEvent) => {
+				isMobile = e.matches;
+			};
+			mq.addEventListener('change', onChange);
+			mobileMediaCleanup = () => mq.removeEventListener('change', onChange);
+		}
 	});
 	onDestroy(() => {
 		mountCleanup?.();
+		mobileMediaCleanup?.();
 		// In browser mode, also tear down the shared WebSocket and any
 		// pending reconnect timer so navigation away doesn't leave an
 		// orphan socket or a zombie reconnect queued.
@@ -597,7 +617,7 @@
 
 	<div class="main-area">
 		<div class="chat-col" class:mobile-hidden={mobilePanel !== 'none'}>
-			{#if $focailOpen}
+			{#if $focailOpen && isMobile}
 				<Sidebar onclose={() => focailOpen.set(false)} />
 			{:else}
 				<ChatPanel />


### PR DESCRIPTION
## Summary

**Closes #355** — on desktop (>768px) both the chat column and the right column are visible at the same time. When \`focailOpen\` was true, the chat column replaced \`ChatPanel\`+\`InputField\` with \`<Sidebar onclose=…>\`, and the right column was still rendering \`<Sidebar />\`. The user saw the same Irish-words hint list side-by-side in two columns and lost access to the chat input entirely — toggling \`/irish\` on a wide viewport effectively broke the game.

## Fix

Gate the chat-column swap on an \`isMobile\` \`$state\` backed by a \`matchMedia('(max-width: 768px)')\` listener. A \`change\` listener keeps \`isMobile\` live so a user who resizes from mobile to desktop with \`focailOpen\` still true recovers cleanly — the panel reverts to the right-column sidebar without a reload.

## Test plan — verified in the web version

- [x] Desktop (1400x900): click Language Hints → only the right-col sidebar shows Focail, chat-col keeps \`ChatPanel\` + \`InputField\` with the text entry usable. Screenshot attached.
- [x] Mobile (375x812): click Language Hints → chat-col becomes the full-width Focail panel with a close button (existing mobile UX preserved).
- [x] \`vite build\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)