### PR TITLE
fix(ui): quick-travel chip preserves draft input (#354)

### DIFF
--- a/apps/ui/src/components/InputField.svelte
+++ b/apps/ui/src/components/InputField.svelte
@@ -474,6 +474,13 @@
 		// can't recover it) is worse than forcing the user to either
 		// send or clear their draft first. Surface a clear reminder and
 		// bail out.
+		//
+		// codex P2 on #573: isEditorEmpty() reads the cached editorText,
+		// which can be stale when the DOM was modified programmatically
+		// (e.g. insertNpcMention drops in chips without firing input
+		// events that re-sync). Pull a fresh plain-text view first so a
+		// non-empty draft can't sneak past this guard.
+		syncEditorText();
 		if (!isEditorEmpty()) {
 			pushErrorLog(
 				`Send or clear the draft in the input before travelling to ${locationName}.`

--- a/apps/ui/src/components/InputField.svelte
+++ b/apps/ui/src/components/InputField.svelte
@@ -468,8 +468,19 @@
 
 	async function quickTravel(locationName: string) {
 		if ($streamingActive) return;
+		// #354: if the player is mid-composition, don't clobber their
+		// draft. The quick-travel chip is an explicit nav action, but
+		// losing work silently (and without saving to history so ArrowUp
+		// can't recover it) is worse than forcing the user to either
+		// send or clear their draft first. Surface a clear reminder and
+		// bail out.
+		if (!isEditorEmpty()) {
+			pushErrorLog(
+				`Send or clear the draft in the input before travelling to ${locationName}.`
+			);
+			return;
+		}
 		selectedNpcRealNames = [];
-		clearEditor();
 		try {
 			await submitInput(`go to ${locationName}`);
 		} catch (err) {


### PR DESCRIPTION
## Summary

**Closes #354** — \`quickTravel()\` in [InputField.svelte](apps/ui/src/components/InputField.svelte) called \`clearEditor()\` unconditionally and then \`submitInput('go to X')\`. A player mid-composition who accidentally hit a travel chip lost their text with no confirmation, and since \`saveHistory()\` wasn't called here either, ArrowUp couldn't recover the draft.

## Fix

If the editor isn't empty, refuse to travel and surface a clear error (\`Send or clear the draft in the input before travelling to X.\`). The explicit nav action is declined rather than quietly destroying user work; the player can either hit Send first or clear the draft manually and retry.

## Test plan

- [x] \`vite build\` — clean
- Manual: typing a message and then clicking any "Go To" chip now shows the error log line instead of silently losing the draft. Clicking the chip with an empty editor still travels normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)