### PR TITLE
fix(ui): roll back optimistic reaction on IPC failure (#353)

### DIFF
--- a/apps/ui/src/components/ChatPanel.svelte
+++ b/apps/ui/src/components/ChatPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { tick } from 'svelte';
-	import { textLog, streamingActive, loadingPhrase, loadingColor, addReaction, messageHints, worldState, nameHints } from '../stores/game';
+	import { textLog, streamingActive, loadingPhrase, loadingColor, addReaction, removeReaction, messageHints, worldState, nameHints, pushErrorLog, formatIpcError } from '../stores/game';
 	import type { TextLogEntry } from '$lib/types';
 	import { REACTION_PALETTE } from '$lib/reactions';
 	import { reactToMessage } from '$lib/ipc';
@@ -138,9 +138,18 @@
 		if (!entry.id) return;
 		// Optimistic UI update
 		addReaction(entry.id, emoji, 'player');
-		// Send to backend
+		// Send to backend; roll back the optimistic reaction on failure
+		// (#353) so the UI never shows a "saved" state that the server
+		// never received. Swallowing the error caused persistent data
+		// loss on reload/branch-switch because the reaction never
+		// reached a snapshot.
+		const messageId = entry.id;
 		const snippet = entry.content.slice(0, 80);
-		reactToMessage(entry.source, snippet, emoji).catch(() => {});
+		reactToMessage(entry.source, snippet, emoji).catch((err) => {
+			console.warn('reactToMessage failed:', err);
+			removeReaction(messageId, emoji, 'player');
+			pushErrorLog(`Could not record reaction ${emoji}: ${formatIpcError(err)}`);
+		});
 		// Close picker
 		hoveredMessageId = null;
 	}

--- a/apps/ui/src/stores/game.ts
+++ b/apps/ui/src/stores/game.ts
@@ -100,3 +100,22 @@ export function addReaction(messageId: string, emoji: string, source: string): v
 		});
 	});
 }
+
+/** Removes a matching reaction from a message in the text log.
+ *
+ * Used to roll back an optimistic `addReaction` when the backend rejects
+ * the IPC (#353). Matches on (emoji, source) so a player clicking 😊
+ * while an NPC's 😊 already exists doesn't accidentally strip the NPC's
+ * reaction on rollback.
+ */
+export function removeReaction(messageId: string, emoji: string, source: string): void {
+	textLog.update((log) => {
+		return log.map((entry) => {
+			if (entry.id !== messageId) return entry;
+			const reactions = (entry.reactions ?? []).filter(
+				(r) => !(r.emoji === emoji && r.source === source)
+			);
+			return { ...entry, reactions };
+		});
+	});
+}


### PR DESCRIPTION
## Summary

**Closes #353** — \`handleReaction()\` in [ChatPanel.svelte](apps/ui/src/components/ChatPanel.svelte) optimistically called \`addReaction()\` then fired \`reactToMessage()\` with \`.catch(() => {})\`, silently swallowing any IPC failure. A network drop, backend error, or WebSocket reconnect left the emoji showing on the message but never recorded on the server. On reload or branch switch the reaction silently disappeared — persistent data loss with no user-visible signal.

## Fix

- Added \`removeReaction(messageId, emoji, source)\` in [stores/game.ts](apps/ui/src/stores/game.ts). Matches on both emoji AND source so rollback doesn't accidentally strip an NPC's matching emoji when a player's optimistic reaction fails.
- In \`ChatPanel.handleReaction\`, the \`.catch()\` now \`console.warn\`s the error, calls \`removeReaction\` to revert the optimistic update, and appends an error-log line via \`pushErrorLog\` / \`formatIpcError\` so the user knows why their click didn't stick.

## Test plan

- [x] \`vite build\` — clean
- [x] \`vitest run src/components/ChatPanel.test.ts\` — 24 pass (all existing tests unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)