### PR TITLE
fix(ui): dispose mountCleanup if setupMount resolves after unmount (#348)

### DIFF
--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -155,9 +155,23 @@
 
 	let mountCleanup: (() => void) | null = null;
 	let mobileMediaCleanup: (() => void) | null = null;
+	// Disposed-before-mount-resolves flag for #348. setupMount is async
+	// and onMount kicks it off in a detached IIFE, so a fast unmount
+	// (HMR, navigate-away during initial fetch) can fire onDestroy
+	// before mountCleanup is even assigned. Without this flag the
+	// cleanup is silently dropped and every listener / timer
+	// setupMount registers leaks indefinitely. We flip cancelled in
+	// onDestroy and run cleanup() at the moment setupMount resolves
+	// if the flag is set.
+	let cancelled = false;
 	onMount(() => {
 		(async () => {
-			mountCleanup = await setupMount();
+			const cleanup = await setupMount();
+			if (cancelled) {
+				cleanup();
+			} else {
+				mountCleanup = cleanup;
+			}
 		})();
 		// Track the narrow-viewport media query live so a user who
 		// resizes from mobile to desktop while focailOpen is true
@@ -174,6 +188,7 @@
 		}
 	});
 	onDestroy(() => {
+		cancelled = true;
 		mountCleanup?.();
 		mobileMediaCleanup?.();
 		// In browser mode, also tear down the shared WebSocket and any


### PR DESCRIPTION
## Summary

**Closes #348** — \`onMount\` in [+page.svelte](apps/ui/src/routes/+page.svelte) fired a detached async IIFE that assigned \`mountCleanup\` only after \`setupMount()\` resolved. If the component was destroyed before that resolved (HMR, navigate-away during initial fetch, fast tab switch), \`onDestroy\` saw \`mountCleanup === null\` and returned silently. Meanwhile \`setupMount\` eventually finished and registered window listeners + the auto-pause tracker timer + every WebSocket / Tauri event listener — all permanently leaked. Every HMR cycle in dev re-leaks them.

## Fix

Add a \`cancelled\` flag flipped by \`onDestroy\`. The async IIFE checks it when \`setupMount\` resolves: if true, cleanup runs immediately and \`mountCleanup\` stays \`null\`; otherwise the cleanup is stashed for the normal \`onDestroy\` path. Net: zero leak window regardless of whether unmount races mount.

## Test plan

- [x] \`vite build\` — clean
- No browser-observable behavior change in the happy path; the fix only kicks in when unmount races a still-pending \`setupMount\`, which doesn't reproduce reliably in a single-shot smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)