### PR TITLE
fix(ui): clear pending travel reset timer on overlap + unmount (#349)

### DIFF
--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -24,7 +24,7 @@
 	import { savePickerVisible } from '../stores/save';
 	import { palette } from '../stores/theme';
 	import { tiles } from '../stores/tiles';
-	import { startTravel } from '../stores/travel';
+	import { startTravel, cancelTravel } from '../stores/travel';
 	import {
 		getWorldSnapshot,
 		getMap,
@@ -176,6 +176,9 @@
 	onDestroy(() => {
 		mountCleanup?.();
 		mobileMediaCleanup?.();
+		// Cancel any pending travel auto-clear so it doesn't fire
+		// against a destroyed tree (#349).
+		cancelTravel();
 		// In browser mode, also tear down the shared WebSocket and any
 		// pending reconnect timer so navigation away doesn't leave an
 		// orphan socket or a zombie reconnect queued.

--- a/apps/ui/src/stores/travel.ts
+++ b/apps/ui/src/stores/travel.ts
@@ -28,9 +28,30 @@ export const travelState = writable<TravelState | null>(null);
 /** Whether a travel animation is currently playing. */
 export const isTraveling = derived(travelState, ($t) => $t !== null);
 
+/** Outstanding auto-clear timer for the active travel animation.
+ *
+ * #349: each call to startTravel must cancel the prior reset timer.
+ * Without this, two travels that overlap (server emitting nested
+ * location-entry events before the first animation finishes) leave
+ * the earlier setTimeout running. When that earlier timer fires it
+ * clears travelState mid-animation of the *newer* travel, freezing
+ * the path-following dot in MapController.
+ *
+ * Exposed at module scope so the cleanup runs even when startTravel
+ * is invoked from outside any component lifecycle.
+ */
+let travelResetTimer: ReturnType<typeof setTimeout> | null = null;
+
 /** Starts a travel animation from a TravelStartPayload. */
 export function startTravel(payload: TravelStartPayload): void {
 	if (payload.waypoints.length < 2) return;
+
+	// Cancel any pending auto-clear from a prior travel so it can't
+	// fire after we've installed the new state (#349).
+	if (travelResetTimer !== null) {
+		clearTimeout(travelResetTimer);
+		travelResetTimer = null;
+	}
 
 	const raw = payload.duration_minutes * MS_PER_GAME_MINUTE;
 	const animationMs = Math.max(MIN_ANIMATION_MS, Math.min(MAX_ANIMATION_MS, raw));
@@ -44,9 +65,25 @@ export function startTravel(payload: TravelStartPayload): void {
 	});
 
 	// Auto-clear when animation completes
-	setTimeout(() => {
+	travelResetTimer = setTimeout(() => {
 		travelState.set(null);
+		travelResetTimer = null;
 	}, animationMs);
+}
+
+/** Cancels any pending auto-clear timer and clears travel state.
+ *
+ * Called by the host component on unmount (#349) so a stale timer
+ * doesn't keep the travel store referencing payload data after the
+ * UI is gone, and doesn't fire travelState.set(null) into a destroyed
+ * tree.
+ */
+export function cancelTravel(): void {
+	if (travelResetTimer !== null) {
+		clearTimeout(travelResetTimer);
+		travelResetTimer = null;
+	}
+	travelState.set(null);
 }
 
 /**

--- a/apps/ui/src/stores/travel.ts
+++ b/apps/ui/src/stores/travel.ts
@@ -42,16 +42,27 @@ export const isTraveling = derived(travelState, ($t) => $t !== null);
  */
 let travelResetTimer: ReturnType<typeof setTimeout> | null = null;
 
+/** Cancels any outstanding auto-clear timer for the travel animation.
+ *
+ * Shared by `startTravel` (so a new travel can't be torn down by the
+ * prior timer) and `cancelTravel` (unmount path). Extracted per a
+ * code-review nit on #583 to avoid duplicating the null-and-clear
+ * dance at every call site.
+ */
+function clearPendingTravelReset(): void {
+	if (travelResetTimer !== null) {
+		clearTimeout(travelResetTimer);
+		travelResetTimer = null;
+	}
+}
+
 /** Starts a travel animation from a TravelStartPayload. */
 export function startTravel(payload: TravelStartPayload): void {
 	if (payload.waypoints.length < 2) return;
 
 	// Cancel any pending auto-clear from a prior travel so it can't
 	// fire after we've installed the new state (#349).
-	if (travelResetTimer !== null) {
-		clearTimeout(travelResetTimer);
-		travelResetTimer = null;
-	}
+	clearPendingTravelReset();
 
 	const raw = payload.duration_minutes * MS_PER_GAME_MINUTE;
 	const animationMs = Math.max(MIN_ANIMATION_MS, Math.min(MAX_ANIMATION_MS, raw));
@@ -79,10 +90,7 @@ export function startTravel(payload: TravelStartPayload): void {
  * tree.
  */
 export function cancelTravel(): void {
-	if (travelResetTimer !== null) {
-		clearTimeout(travelResetTimer);
-		travelResetTimer = null;
-	}
+	clearPendingTravelReset();
 	travelState.set(null);
 }
 


### PR DESCRIPTION
## Summary

**Closes #349** — \`startTravel()\` in [stores/travel.ts](apps/ui/src/stores/travel.ts) called \`setTimeout(...)\` without storing the handle. If two travels overlapped (server emits a nested location-entry event before the first animation finishes), the earlier timer still ran and cleared the newly-started travel mid-animation, freezing the path-following dot in MapController. The timer also kept firing past component unmount.

## Fix

- Track the handle at module scope (\`travelResetTimer\`).
- Clear it at the top of every \`startTravel()\` call so an in-flight reset can't fire against the new state.
- Export a new \`cancelTravel()\` helper that clears both the timer and \`travelState\`. The host \`+page.svelte\` calls it on \`onDestroy\`, and it's available for any future explicit-abort flow.

## Test plan

- [x] \`vite build\` — clean
- [x] \`vitest run src/stores\` — 14 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)