### PR TITLE
fix(ui): FullMapOverlay fits bounds when mapData arrives late (#351)

### DIFF
--- a/apps/ui/src/components/FullMapOverlay.svelte
+++ b/apps/ui/src/components/FullMapOverlay.svelte
@@ -77,11 +77,31 @@
 		};
 	});
 
-	// Push map data changes into the controller.
+	// Tracks whether we've fit the camera to the parish bounds at least
+	// once. The initial fitBounds call inside onMount runs synchronously
+	// against whatever $mapData was at that moment — if the overlay is
+	// opened before mapData has populated (fast 'M' keypress before the
+	// initial fetch resolves, or after `/new` while world state is
+	// rebuilding), the map stays on MapController's hard-coded default
+	// center until the user pans manually. (#351)
+	let hasFitOnce = false;
+
+	// Push map data changes into the controller. The first time mapData
+	// becomes non-empty after mount, also fit bounds so a delayed first
+	// load doesn't leave the user staring at the default Kiltoom view.
 	$effect(() => {
 		if (!mounted || !controller) return;
 		const m = $mapData;
-		if (m) controller.updateMap(m);
+		if (m) {
+			controller.updateMap(m);
+			if (!hasFitOnce && m.locations.length > 0) {
+				controller.fitBounds(
+					m.locations.map((l) => ({ lat: l.lat, lon: l.lon })),
+					60
+				);
+				hasFitOnce = true;
+			}
+		}
 	});
 
 	// Drive travel animation from the shared travel store.


### PR DESCRIPTION
## Summary

**Closes #351** — the eager \`fitBounds\` call in [FullMapOverlay.svelte](apps/ui/src/components/FullMapOverlay.svelte)'s \`onMount\` ran synchronously against whatever \`$mapData\` was at that moment. If the overlay was opened before mapData had populated (fast 'M' keypress before the initial fetch resolves, or after \`/new\` while world state is rebuilding), the camera stayed on \`MapController\`'s hard-coded default Kiltoom coordinates until the user panned manually.

## Fix

Track a \`hasFitOnce\` flag and call \`fitBounds\` inside the existing mapData \`$effect\` the first time \`$mapData\` becomes non-empty post-mount. The eager fit in \`onMount\` stays as the happy path so a normal open with already-loaded data still snaps to the parish bounds without an extra tick.

## Test plan

- [x] \`vite build\` — clean
- Manual: open the overlay before initial fetch resolves → camera now snaps to parish bounds the moment the data arrives instead of remaining on default coords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)