### PR TITLE
perf(ui): MapPanel recomputes edge stubs on map move, not every frame (#350)

### DIFF
--- a/apps/ui/src/components/MapPanel.svelte
+++ b/apps/ui/src/components/MapPanel.svelte
@@ -161,28 +161,20 @@
 			}
 		);
 
-		// Re-project stubs whenever the map camera moves or resizes.
-		// We access the underlying map via a move listener added through
-		// the controller's public projectToScreen + a `move` subscription
-		// that we wire directly here — the controller exposes the map as
-		// needed via its side-effects (click/hover), so we attach the
-		// listener through a cast-free hook: we add a `move` callback via
-		// `addMoveListener` below.
-		//
-		// Simplest implementation: poll on a rAF loop while mounted. This
-		// avoids having to surface the raw map reference. Runs cheaply
-		// because it only updates state when values actually change.
-		let rafId: number;
-		const loop = () => {
-			recomputeStubs();
-			rafId = requestAnimationFrame(loop);
-		};
-		rafId = requestAnimationFrame(loop);
+		// Recompute stubs once on mount and then only when the camera
+		// actually moves or the container resizes (#350). The previous
+		// requestAnimationFrame loop ran every frame for the lifetime
+		// of the component — recomputing identical stub geometry over
+		// and over and burning CPU/GPU even when the user wasn't
+		// interacting. The controller now exposes `addMoveListener`
+		// so we can subscribe surgically.
+		recomputeStubs();
+		const unsubscribeMove = controller.addMoveListener(recomputeStubs);
 
 		mounted = true;
 
 		return () => {
-			cancelAnimationFrame(rafId);
+			unsubscribeMove();
 			controller?.destroy();
 			controller = null;
 		};

--- a/apps/ui/src/lib/map/controller.ts
+++ b/apps/ui/src/lib/map/controller.ts
@@ -328,6 +328,24 @@ export class MapController {
 		return { width: canvas.clientWidth, height: canvas.clientHeight };
 	}
 
+	/** Subscribes `fn` to MapLibre `move` and `resize` events.
+	 *
+	 * Returns an unsubscribe function. Used by MapPanel to recompute
+	 * off-screen edge stubs only when the camera actually moves,
+	 * instead of polling on a `requestAnimationFrame` loop at ~60fps
+	 * for the entire mount lifetime (#350). The previous polling
+	 * approach burned CPU/GPU continuously and triggered downstream
+	 * Svelte reactivity churn even when the user wasn't interacting.
+	 */
+	addMoveListener(fn: () => void): () => void {
+		this.map.on('move', fn);
+		this.map.on('resize', fn);
+		return () => {
+			this.map.off('move', fn);
+			this.map.off('resize', fn);
+		};
+	}
+
 	/** Registers a handler called when a location is clicked. */
 	onLocationClick(handler: (info: LocationClickInfo) => void): void {
 		this.clickHandler = handler;


### PR DESCRIPTION
## Summary

**Closes #350** — [MapPanel.svelte](apps/ui/src/components/MapPanel.svelte) was polling \`recomputeStubs()\` inside a \`requestAnimationFrame\` loop for the whole component lifetime — ~60fps of pixel projection over every edge, every neighbor lookup, every \`$state\` reassignment, even when the camera was idle. Constant CPU/GPU load and downstream Svelte reactivity churn for nothing.

## Fix

- New \`MapController.addMoveListener(fn)\` in [controller.ts](apps/ui/src/lib/map/controller.ts): subscribes the callback to MapLibre's \`move\` and \`resize\` events and returns an unsubscribe handle. Cast-free, encapsulated, reusable.
- \`MapPanel\` calls \`recomputeStubs()\` once on mount, then registers the listener for subsequent updates. Cleanup unsubscribes on unmount alongside \`controller.destroy()\`.

## Test plan

- [x] \`vite build\` — clean
- [x] \`vitest run\` — 176 tests pass
- [x] Live verification at 1400×900: parish dots render correctly in the mini-map panel on load (screenshot below); no \`requestAnimationFrame\` loop runs while the user is idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)