### PR TITLE
fix(npc): scrub dead-NPC references on death (#339)

### DIFF
--- a/crates/parish-npc/src/manager.rs
+++ b/crates/parish-npc/src/manager.rs
@@ -191,6 +191,37 @@ impl NpcManager {
         self.npcs.insert(npc.id, npc);
     }
 
+    /// Removes a deceased NPC and scrubs every dangling reference to it
+    /// from the rest of the roster (#339).
+    ///
+    /// A bare `self.npcs.remove(id)` would leave:
+    ///
+    /// - `tier_assignments` still keyed by the dead id (handled by
+    ///   the existing death sites, included here for symmetry).
+    /// - `introduced_npcs` / `npcs_who_know_player_name` still
+    ///   containing the dead id (display-name lookups would still
+    ///   greet the deceased; gossip would still walk them).
+    /// - Every surviving NPC's `relationships` map still pointing
+    ///   at the dead id, leading to dereferences-of-nothing in
+    ///   gossip and tier-2 affinity scans.
+    ///
+    /// Call this from every death-handling path instead of the bare
+    /// `self.npcs.remove(...)`. Returns the removed NPC if it existed,
+    /// matching `HashMap::remove` semantics.
+    pub fn remove_npc(&mut self, id: NpcId) -> Option<Npc> {
+        let removed = self.npcs.remove(&id);
+        self.tier_assignments.remove(&id);
+        self.introduced_npcs.remove(&id);
+        self.npcs_who_know_player_name.remove(&id);
+        // Scrub the dead id from every surviving NPC's relationships.
+        // Cheap: the map is small per NPC, and remove is a no-op when
+        // the key is absent.
+        for npc in self.npcs.values_mut() {
+            npc.relationships.remove(&id);
+        }
+        removed
+    }
+
     /// Returns a reference to an NPC by id.
     pub fn get(&self, id: NpcId) -> Option<&Npc> {
         self.npcs.get(&id)
@@ -885,8 +916,9 @@ impl NpcManager {
                                 timestamp,
                             });
                         }
-                        self.npcs.remove(npc_id);
-                        self.tier_assignments.remove(npc_id);
+                        // Scrub the dead id from introductions, name knowledge,
+                        // and every surviving NPC's relationships map (#339).
+                        self.remove_npc(*npc_id);
                     }
                 }
                 Tier4Event::Birth { parent_ids } => {
@@ -1058,9 +1090,10 @@ impl NpcManager {
             };
 
             if now >= doom {
-                // Doom has arrived — the NPC dies now.
-                self.npcs.remove(&id);
-                self.tier_assignments.remove(&id);
+                // Doom has arrived — the NPC dies now. Use remove_npc
+                // so introductions, name knowledge, and every other
+                // NPC's relationships map all drop the dead id (#339).
+                self.remove_npc(id);
                 let desc = format!("{} has passed away.", name);
                 world_text_log.push(format!(
                     "Word travels before the sun is fully up: {} did not see the morning. \
@@ -2366,6 +2399,62 @@ mod tests {
             "NPC should be removed immediately when banshee is disabled"
         );
         assert!(!game_events.is_empty(), "should still emit a life event");
+    }
+
+    // ── #339 dead-NPC reference cleanup ─────────────────────────────────────
+
+    #[test]
+    fn remove_npc_scrubs_all_references() {
+        use crate::types::Relationship;
+
+        let mut mgr = NpcManager::new();
+        // Three NPCs so we can verify scrubbing across the surviving roster.
+        for id in [10, 20, 30] {
+            mgr.add_npc(make_test_npc(id, 0));
+        }
+        // Tier assignments + introductions + name knowledge for the doomed NPC.
+        mgr.tier_assignments.insert(NpcId(20), CogTier::Tier1);
+        mgr.introduced_npcs.insert(NpcId(20));
+        mgr.npcs_who_know_player_name.insert(NpcId(20));
+
+        // Give the survivors relationships pointing at the doomed NPC.
+        mgr.npcs.get_mut(&NpcId(10)).unwrap().relationships.insert(
+            NpcId(20),
+            Relationship::new(crate::types::RelationshipKind::Neighbor, 0.0),
+        );
+        mgr.npcs.get_mut(&NpcId(30)).unwrap().relationships.insert(
+            NpcId(20),
+            Relationship::new(crate::types::RelationshipKind::Neighbor, 0.0),
+        );
+        // Plus an unrelated relationship that must survive.
+        mgr.npcs.get_mut(&NpcId(10)).unwrap().relationships.insert(
+            NpcId(30),
+            Relationship::new(crate::types::RelationshipKind::Neighbor, 0.0),
+        );
+
+        let removed = mgr.remove_npc(NpcId(20));
+        assert!(removed.is_some(), "remove_npc should return the dead NPC");
+
+        // npcs map: gone
+        assert!(mgr.get(NpcId(20)).is_none());
+        // tier_assignments: gone
+        assert!(!mgr.tier_assignments.contains_key(&NpcId(20)));
+        // introductions: gone
+        assert!(!mgr.introduced_npcs.contains(&NpcId(20)));
+        // name knowledge: gone
+        assert!(!mgr.npcs_who_know_player_name.contains(&NpcId(20)));
+        // Survivors lost their dead-NPC relationships but kept the unrelated ones.
+        let n10 = mgr.get(NpcId(10)).unwrap();
+        assert!(!n10.relationships.contains_key(&NpcId(20)));
+        assert!(n10.relationships.contains_key(&NpcId(30)));
+        let n30 = mgr.get(NpcId(30)).unwrap();
+        assert!(!n30.relationships.contains_key(&NpcId(20)));
+    }
+
+    #[test]
+    fn remove_npc_returns_none_for_missing_id() {
+        let mut mgr = NpcManager::new();
+        assert!(mgr.remove_npc(NpcId(9_999_999)).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Closes #339** — when Tier 4 produced a Death event, \`NpcManager\` called the bare \`self.npcs.remove(id)\` (and \`self.tier_assignments.remove\`). Every other reference to that \`NpcId\` was left behind:

- \`introduced_npcs\` still contained the dead id (display-name lookups still greeted the deceased).
- \`npcs_who_know_player_name\` still contained the dead id.
- \`relationships\` maps on every other NPC still pointed at the dead id (gossip and tier-2 affinity scans dereferenced a vanished \`NpcId\`).

## Fix

New \`NpcManager::remove_npc(id)\` in [manager.rs](crates/parish-npc/src/manager.rs) that atomically:

- removes from \`npcs\`
- removes from \`tier_assignments\`
- removes from \`introduced_npcs\` and \`npcs_who_know_player_name\`
- walks every surviving NPC's \`relationships\` map and drops the dead id

Both death paths (banshee-disabled immediate removal in \`apply_tier4_events\`, and banshee doom arrival in \`tick_banshee\`) now call \`remove_npc\` instead of bare \`HashMap::remove\`.

## Test plan

- [x] \`cargo test -p parish-npc\` — 348 pass, two new:
  - \`remove_npc_scrubs_all_references\` seeds tier/intro/name-knowledge/cross-relationships and asserts every reference is gone after remove_npc, plus that an unrelated relationship survives.
  - \`remove_npc_returns_none_for_missing_id\` matches HashMap::remove semantics.
- [x] \`cargo clippy -p parish-npc --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)