### PR TITLE
fix(ci): use RAILWAY_API_TOKEN for the watchdog (account tokens)

### DIFF
--- a/.github/workflows/railway-watchdog.yml
+++ b/.github/workflows/railway-watchdog.yml
@@ -39,6 +39,11 @@ jobs:
 
       - name: Run watchdog
         env:
+          # Railway CLI reads RAILWAY_API_TOKEN for account/team tokens (which
+          # `railway link --project <name>` needs) and RAILWAY_TOKEN for
+          # project-scoped tokens. Pass the same secret to both so either
+          # token type works without changing this workflow.
+          RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./deploy/railway-watchdog.sh

--- a/.github/workflows/railway-watchdog.yml
+++ b/.github/workflows/railway-watchdog.yml
@@ -39,11 +39,14 @@ jobs:
 
       - name: Run watchdog
         env:
-          # Railway CLI reads RAILWAY_API_TOKEN for account/team tokens (which
-          # `railway link --project <name>` needs) and RAILWAY_TOKEN for
-          # project-scoped tokens. Pass the same secret to both so either
-          # token type works without changing this workflow.
+          # Account/team tokens go in RAILWAY_API_TOKEN; project-scoped
+          # tokens go in RAILWAY_TOKEN. We only set RAILWAY_API_TOKEN here:
+          # `railway link --project <name>` needs cross-project access, and
+          # if both env vars are set the CLI picks RAILWAY_TOKEN first and
+          # rejects an account token there with "Unauthorized".
+          # The GH secret name is RAILWAY_TOKEN for legacy reasons; the
+          # secret value itself is an account token from
+          # railway.com/account/tokens.
           RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./deploy/railway-watchdog.sh

--- a/deploy/railway-watchdog.sh
+++ b/deploy/railway-watchdog.sh
@@ -7,7 +7,7 @@
 # On SUCCESS: closes any open issues labeled `railway-failure` (the next green
 # deploy self-heals old notifications).
 #
-# Requires: railway CLI, gh CLI, jq, RAILWAY_TOKEN env, GH_TOKEN env.
+# Requires: railway CLI, gh CLI, jq, RAILWAY_API_TOKEN env, GH_TOKEN env.
 # Intended to run from .github/workflows/railway-watchdog.yml on a schedule.
 
 set -euo pipefail
@@ -28,7 +28,7 @@ require jq
 # In CI both tokens are mandatory. Locally we fall back to whatever the
 # `railway` and `gh` CLIs already have cached so an operator can dry-run.
 if [ "${CI:-}" = "true" ]; then
-  : "${RAILWAY_TOKEN:?RAILWAY_TOKEN must be set in CI}"
+  : "${RAILWAY_API_TOKEN:?RAILWAY_API_TOKEN must be set in CI}"
   : "${GH_TOKEN:?GH_TOKEN must be set in CI}"
 fi
 


### PR DESCRIPTION
## Summary

The Railway deployment watchdog has been failing for some time with `Unauthorized. Please check that your RAILWAY_TOKEN is valid…`. Refreshing the secret with a new account token from https://railway.com/account/tokens didn't fix it.

Verified the actual cause locally with Railway CLI 4.42.1:

| Env var passed | `railway whoami` result |
|---|---|
| `RAILWAY_TOKEN` (account token value) | `Unauthorized.` ❌ |
| `RAILWAY_API_TOKEN` (same value) | `Logged in as David Mooney` ✅ |

The Railway CLI splits token types by env var: project-scoped tokens go in `RAILWAY_TOKEN`, account/team tokens go in `RAILWAY_API_TOKEN`. The watchdog needs cross-project access (`railway link --project Rundale`), which only account tokens grant. The earlier attempt (`8aa5b39`) tried to pass the same secret to both env vars — but when both are set, the CLI picks `RAILWAY_TOKEN` first and rejects an account token there, so the workflow stayed broken.

## Changes

- `railway-watchdog.yml`: drop `RAILWAY_TOKEN: …`, keep only `RAILWAY_API_TOKEN: ${{ secrets.RAILWAY_TOKEN }}`. The GH secret name stays `RAILWAY_TOKEN` for legacy reasons; the value is an account token.
- `deploy/railway-watchdog.sh`: update the CI-mode guard and header comment from `RAILWAY_TOKEN` to `RAILWAY_API_TOKEN`.

## Test plan

- [x] `railway whoami` locally with the new account token in `RAILWAY_API_TOKEN`: succeeds
- [x] `railway link --project Rundale --environment production --service Parish` locally: succeeds
- [x] `gh workflow run railway-watchdog.yml --ref fix/railway-watchdog-account-token` against this branch: ✅ Run watchdog step passes (run [24915871247](https://github.com/dmooney/Parish/actions/runs/24915871247))

🤖 Generated with [Claude Code](https://claude.com/claude-code)