### PR TITLE
fix(persistence): persist NPC deflated_summary across save/load (#338)

### DIFF
--- a/crates/parish-persistence/src/snapshot.rs
+++ b/crates/parish-persistence/src/snapshot.rs
@@ -124,6 +124,17 @@ pub struct NpcSnapshot {
     /// Whether the banshee wail has already been emitted for the current doom.
     #[serde(default)]
     pub banshee_heralded: bool,
+    /// Compressed summary written by `NpcManager::assign_tiers` when the
+    /// NPC demotes from a higher cognitive tier.
+    ///
+    /// Serialized so that an autosave + reload doesn't silently erase
+    /// Phase 5 cognitive-LOD compression history (#338). The previous
+    /// schema had no field for it and [`Self::into_npc`] hard-coded
+    /// `None`, so every save/load cycle dropped the demotion summary
+    /// on the floor. `#[serde(default)]` keeps older save files
+    /// (pre-#338) loadable.
+    #[serde(default)]
+    pub deflated_summary: Option<parish_npc::transitions::NpcSummary>,
 }
 
 impl NpcSnapshot {
@@ -151,6 +162,7 @@ impl NpcSnapshot {
             is_ill: npc.is_ill,
             doom: npc.doom,
             banshee_heralded: npc.banshee_heralded,
+            deflated_summary: npc.deflated_summary.clone(),
         }
     }
 
@@ -178,7 +190,10 @@ impl NpcSnapshot {
             is_ill: self.is_ill,
             doom: self.doom,
             banshee_heralded: self.banshee_heralded,
-            deflated_summary: None,
+            // #338: previously hard-coded to None, erasing the
+            // demotion summary on every save/load cycle. Round-tripped
+            // through NpcSnapshot.deflated_summary now.
+            deflated_summary: self.deflated_summary,
             reaction_log: parish_npc::reactions::ReactionLog::default(),
         }
     }
@@ -426,6 +441,55 @@ mod tests {
         assert_eq!(restored.name, "NPC 1");
         assert_eq!(restored.location, LocationId(2));
         assert_eq!(restored.mood, "calm");
+    }
+
+    /// #338: deflated_summary used to be hard-coded to None on
+    /// into_npc, so every autosave + reload erased the cognitive-LOD
+    /// compression history that NpcManager::assign_tiers wrote on
+    /// demotion. Round-trip it through the snapshot now.
+    #[test]
+    fn test_npc_snapshot_preserves_deflated_summary() {
+        use parish_npc::transitions::NpcSummary;
+
+        let mut npc = make_test_npc(7, 4);
+        let summary = NpcSummary {
+            npc_id: NpcId(7),
+            location: LocationId(4),
+            mood: "wistful".to_string(),
+            recent_activity: vec!["minded the bar".to_string()],
+            key_relationship_changes: vec![],
+        };
+        npc.deflated_summary = Some(summary.clone());
+
+        let snap = NpcSnapshot::from_npc(&npc);
+        // Serialize through JSON to also exercise the (de)serialize
+        // glue, since this is what hits disk in autosaves.
+        let json = serde_json::to_string(&snap).unwrap();
+        let parsed: NpcSnapshot = serde_json::from_str(&json).unwrap();
+        let restored = parsed.into_npc();
+
+        assert_eq!(
+            restored.deflated_summary,
+            Some(summary),
+            "deflated_summary must survive a save→load cycle"
+        );
+    }
+
+    /// Backwards compatibility: a snapshot serialized by the
+    /// pre-#338 schema (no `deflated_summary` field) must still
+    /// deserialize cleanly, defaulting to None.
+    #[test]
+    fn test_npc_snapshot_legacy_blob_without_deflated_summary() {
+        let legacy_json = r#"{
+            "id": 1, "name": "Legacy", "age": 30, "occupation": "Farmer",
+            "personality": "stoic", "location": 1, "mood": "neutral",
+            "home": null, "workplace": null, "schedule": null,
+            "relationships": {}, "memory": {"entries": []},
+            "knowledge": [], "state": "Present"
+        }"#;
+        let parsed: NpcSnapshot =
+            serde_json::from_str(legacy_json).expect("legacy NpcSnapshot must parse");
+        assert!(parsed.deflated_summary.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Closes #338** — \`Npc::deflated_summary\` is the only cognitive context Tier 3 prompts use when \`last_activity\` is \`None\`, written by \`NpcManager::assign_tiers\` when an NPC demotes from a higher tier. [\`NpcSnapshot\`](crates/parish-persistence/src/snapshot.rs) had no field for it and \`into_npc\` hard-coded \`None\`, so every autosave (60s) silently erased the demotion summary and every reload dropped Phase 5 cognitive-LOD history on the floor.

## Fix

Add \`deflated_summary: Option<NpcSummary>\` to \`NpcSnapshot\` with \`#[serde(default)]\` for backwards compatibility, wire through \`from_npc\` / \`into_npc\`.

## Test plan

- [x] \`cargo test -p parish-persistence\` — 96 pass, two new:
  - \`test_npc_snapshot_preserves_deflated_summary\` round-trips a populated \`NpcSummary\` through serde + \`into_npc\` and asserts the full struct survives.
  - \`test_npc_snapshot_legacy_blob_without_deflated_summary\` feeds a pre-#338 JSON blob (no field) and confirms it parses to \`None\`.
- [x] \`cargo test --workspace\` — green
- [x] \`cargo clippy -p parish-persistence --all-targets -- -D warnings\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)