### PR TITLE
fix(a11y): add focus-visible styles to all interactive elements

### DIFF
--- a/apps/ui/src/components/ChatPanel.svelte
+++ b/apps/ui/src/components/ChatPanel.svelte
@@ -478,7 +478,8 @@
 		transition: transform 0.1s, background 0.1s;
 	}
 
-	.reaction-btn:hover {
+	.reaction-btn:hover,
+	.reaction-btn:focus-visible {
 		transform: scale(1.3);
 		background: var(--color-input-bg);
 	}

--- a/apps/ui/src/components/DebugPanel.svelte
+++ b/apps/ui/src/components/DebugPanel.svelte
@@ -593,7 +593,9 @@
 	}
 
 	.debug-dock-toggle:hover,
-	.debug-close:hover {
+	.debug-dock-toggle:focus-visible,
+	.debug-close:hover,
+	.debug-close:focus-visible {
 		color: var(--color-fg);
 		border-color: var(--color-accent);
 	}
@@ -638,7 +640,8 @@
 		letter-spacing: 0.05em;
 	}
 
-	.tab-btn:hover {
+	.tab-btn:hover,
+	.tab-btn:focus-visible {
 		color: var(--color-fg);
 	}
 
@@ -760,7 +763,8 @@
 		margin-bottom: 0.5rem;
 	}
 
-	.back-btn:hover {
+	.back-btn:hover,
+	.back-btn:focus-visible {
 		color: var(--color-fg);
 		border-color: var(--color-accent);
 	}

--- a/apps/ui/src/components/InputField.svelte
+++ b/apps/ui/src/components/InputField.svelte
@@ -1097,7 +1097,8 @@
 		transition: background 0.15s, border-color 0.15s, transform 0.15s, color 0.15s;
 	}
 
-	.npc-chip:hover {
+	.npc-chip:hover,
+	.npc-chip:focus-visible {
 		border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-border));
 		transform: translateY(-1px);
 	}
@@ -1164,7 +1165,8 @@
 		transition: background 0.15s, color 0.15s, border-color 0.15s;
 	}
 
-	.travel-chip:hover:not(:disabled) {
+	.travel-chip:hover:not(:disabled),
+	.travel-chip:focus-visible:not(:disabled) {
 		background: var(--color-accent);
 		color: var(--color-bg);
 		border-color: var(--color-accent);

--- a/apps/ui/src/components/MapPanel.svelte
+++ b/apps/ui/src/components/MapPanel.svelte
@@ -346,7 +346,8 @@
 		border-radius: 3px;
 	}
 
-	.expand-btn:hover {
+	.expand-btn:hover,
+	.expand-btn:focus-visible {
 		color: var(--color-accent);
 		border-color: var(--color-accent);
 		background: var(--color-input-bg);

--- a/apps/ui/src/components/SavePicker.svelte
+++ b/apps/ui/src/components/SavePicker.svelte
@@ -624,7 +624,8 @@
 	.footer-spacer {
 		flex: 1;
 	}
-	.footer-btn:hover {
+	.footer-btn:hover,
+	.footer-btn:focus-visible {
 		color: var(--color-accent);
 		border-color: var(--color-accent);
 	}
@@ -819,7 +820,8 @@
 		text-transform: uppercase;
 		letter-spacing: 0.03em;
 	}
-	.phantom-btn:hover:not(:disabled) {
+	.phantom-btn:hover:not(:disabled),
+	.phantom-btn:focus-visible:not(:disabled) {
 		color: var(--color-accent);
 		border-color: var(--color-accent);
 	}
@@ -906,7 +908,8 @@
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
 	}
-	.action-btn:hover:not(:disabled) {
+	.action-btn:hover:not(:disabled),
+	.action-btn:focus-visible:not(:disabled) {
 		color: var(--color-accent);
 		border-color: var(--color-accent);
 	}

--- a/apps/ui/src/components/StatusBar.svelte
+++ b/apps/ui/src/components/StatusBar.svelte
@@ -186,7 +186,8 @@
 		transition: color 0.2s, border-color 0.2s;
 	}
 
-	.save-toggle:hover {
+	.save-toggle:hover,
+	.save-toggle:focus-visible {
 		color: var(--color-fg);
 		border-color: var(--color-accent);
 	}
@@ -213,7 +214,9 @@
 	}
 
 	.debug-toggle:hover,
-	.designer-link:hover {
+	.debug-toggle:focus-visible,
+	.designer-link:hover,
+	.designer-link:focus-visible {
 		color: var(--color-fg);
 		border-color: var(--color-accent);
 	}

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -744,6 +744,7 @@
 		}
 
 		.mobile-btn:hover,
+		.mobile-btn:focus-visible,
 		.mobile-btn.active {
 			color: var(--color-accent);
 			border-color: var(--color-accent);


### PR DESCRIPTION
## Summary

- Adds `:focus-visible` selectors alongside every `:hover` rule on interactive buttons across 7 UI components
- Fixes keyboard focus rings being invisible because component-scoped `:hover` styles overrode the global `:focus-visible` rule in `app.css`
- Covers StatusBar, MapPanel, ChatPanel, InputField, SavePicker, DebugPanel, and mobile nav toolbar

## ♿ Accessibility

The app defines a global `outline: 2px solid var(--color-accent)` focus ring in `app.css:83`, but every component that styled `:hover` separately was implicitly suppressing the focus indicator for keyboard users. Now all interactive elements show the same visual feedback on keyboard focus as they do on hover — accent-colored border/text highlights, scale transforms on reactions, etc.

**Affected elements:** Ledger/Dbg/Designer toggles, map expand button, reaction picker buttons, NPC mention chips, travel chips, save picker footer/action/phantom buttons, debug panel dock/close/tab/back buttons, mobile nav buttons.

## 💡 Why

Keyboard-only users (and many assistive technology users) had no way to see which button was focused. This is a WCAG 2.1 Level AA requirement (Success Criterion 2.4.7: Focus Visible).

## Test plan

- [ ] Tab through StatusBar buttons (Ledger, Dbg, Designer) — accent border appears on focus
- [ ] Tab to map expand button — accent highlight visible
- [ ] Tab through reaction picker buttons on NPC messages — scale + background on focus
- [ ] Tab through NPC chips and travel chips — border/transform feedback on focus
- [ ] Tab through SavePicker dialog buttons — accent highlights visible
- [ ] Tab through DebugPanel tabs and controls — text/border highlights on focus
- [ ] On mobile viewport, tab through nav toolbar buttons — accent highlight visible

https://claude.ai/code/session_01TwvwMh9ZNCRkaUa4bQb2E4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwvwMh9ZNCRkaUa4bQb2E4)_