### PR TITLE
chore(triage): add triage-backlog skill and triage-audit workflow

### DIFF
--- a/.agents/skills/triage-backlog/SKILL.md
+++ b/.agents/skills/triage-backlog/SKILL.md
@@ -3,26 +3,26 @@ name: triage-backlog
 description: Walk the open-issue backlog, classify each un-triaged issue by theme + priority (P0–P3), and apply labels via the GitHub MCP server. Use when the audit workflow flags un-triaged issues, after a batch of new issues lands, or anytime the user asks for triage.
 ---
 
-Run a triage pass over open issues that lack a `P*` priority label. The canonical label vocabulary and rubric live in [`docs/agent/triage-vocabulary.md`](../../../docs/agent/triage-vocabulary.md) — read it before starting.
+Run a triage pass over open issues that lack a `P*` priority or any theme label. The canonical label vocabulary and rubric live in [`docs/agent/triage-vocabulary.md`](../../../docs/agent/triage-vocabulary.md) — read it before starting.
 
 ## Steps
 
-1. **Fetch state in parallel.** Call `mcp__github__list_issues` (state OPEN) and `mcp__github__list_pull_requests` (state open) for `dmooney/parish`. Both responses are large — save to disk and use `jq` rather than reading raw output.
+1. **Fetch state in parallel.** Call `mcp__github__list_issues` (state `OPEN`) and `mcp__github__list_pull_requests` (state `open`) for the current repository. Both responses are large — save to disk and use `jq` rather than reading raw output. (The casing difference between the two is intentional — the MCP schemas differ.)
 
 2. **Find the un-PR'd set.** Extract every `#NNN` reference from PR titles + bodies, intersect with open issue numbers. Issues NOT referenced by any open PR are candidates.
 
-3. **Filter to un-triaged.** Keep only issues whose existing labels do not contain any of `P0`, `P1`, `P2`, `P3`. Don't relabel issues that already have a priority unless the user asks for a re-triage.
+3. **Filter to un-triaged.** Keep an issue if it lacks a `P*` priority label **or** lacks any theme label from `triage-vocabulary.md`. Both kinds are reported by the `triage-audit` workflow, so both must be addressable here. Don't relabel issues that already have both unless the user asks for a re-triage.
 
 4. **Classify.** For each remaining issue, read title + body and assign:
    - **Exactly one priority** (`P0`/`P1`/`P2`/`P3`) using the rubric in `triage-vocabulary.md`.
    - **At least one theme** label. Multiple is fine when an issue genuinely spans themes (e.g. `security` + `infra` for a workflow vuln).
    - When uncertain between two priorities, pick the lower-urgency one and let a human escalate.
 
-5. **Apply.** Call `mcp__github__issue_write` with `method: "update"` and the **union** of (existing labels) + (theme labels) + (priority). `issue_write` *replaces* the set, so always include pre-existing labels like `bug`, `security`, `ready-for-test`. Dispatch in parallel batches of ~15.
+5. **Apply.** Call `mcp__github__issue_write` with `method: "update"` and the **union** of (existing labels) + (theme labels) + (priority). `issue_write` *replaces* the set, so always include pre-existing labels like `bug`, `security`, `ready-for-test`. Dispatch in parallel batches of 5–10 to stay clear of GitHub's secondary rate limits.
 
-6. **Verify.** Re-list with `labels: ["P0"]`, `["P1"]`, `["P2"]`, `["P3"]` and confirm counts match what you applied. Random-sample a few issues with `issue_read` (`get_labels`) to confirm theme labels stuck.
+6. **Verify.** For each priority, make a separate `mcp__github__list_issues` call with `labels: ["P0"]`, then `["P1"]`, then `["P2"]`, then `["P3"]` (four calls — combining priorities in one filter would AND them and return zero). Confirm each count matches what you applied. Random-sample a few issues with `mcp__github__issue_read` (`get_labels`) to confirm theme labels stuck.
 
-7. **Report.** Summarize counts by priority and theme. Link to GitHub filter URLs (`https://github.com/dmooney/Parish/issues?q=is%3Aopen+label%3AP0` etc.). Flag any issue carrying `ready-for-test` without an open PR — those usually need closing, not implementation.
+7. **Report.** Summarize counts by priority and theme. Link to GitHub filter URLs for the current repository, e.g. `https://github.com/OWNER/REPO/issues?q=is%3Aopen+label%3AP0`. Flag any issue carrying `ready-for-test` without an open PR — those usually need closing, not implementation.
 
 ## Notes
 

--- a/.agents/skills/triage-backlog/SKILL.md
+++ b/.agents/skills/triage-backlog/SKILL.md
@@ -18,7 +18,7 @@ Run a triage pass over open issues that lack a `P*` priority or any theme label.
    - **At least one theme** label. Multiple is fine when an issue genuinely spans themes (e.g. `security` + `infra` for a workflow vuln).
    - When uncertain between two priorities, pick the lower-urgency one and let a human escalate.
 
-5. **Apply.** Call `mcp__github__issue_write` with `method: "update"` and the **union** of (existing labels) + (theme labels) + (priority). `issue_write` *replaces* the set, so always include pre-existing labels like `bug`, `security`, `ready-for-test`. Dispatch in parallel batches of 5–10 to stay clear of GitHub's secondary rate limits.
+5. **Apply.** Compute the new label set as **(existing labels with any `P*` priority stripped) + (chosen theme labels) + (chosen priority)** — stripping the old priority is critical so a re-triage doesn't leave both `P1` *and* `P2` on the issue. Pre-existing non-priority labels (`bug`, `security`, `ready-for-test`, `in-progress`, etc.) are preserved. Pass the resulting set to `mcp__github__issue_write` with `method: "update"`. Dispatch in parallel batches of 5–10 to stay clear of GitHub's secondary rate limits.
 
 6. **Verify.** For each priority, make a separate `mcp__github__list_issues` call with `labels: ["P0"]`, then `["P1"]`, then `["P2"]`, then `["P3"]` (four calls — combining priorities in one filter would AND them and return zero). Confirm each count matches what you applied. Random-sample a few issues with `mcp__github__issue_read` (`get_labels`) to confirm theme labels stuck.
 

--- a/.agents/skills/triage-backlog/SKILL.md
+++ b/.agents/skills/triage-backlog/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: triage-backlog
+description: Walk the open-issue backlog, classify each un-triaged issue by theme + priority (P0–P3), and apply labels via the GitHub MCP server. Use when the audit workflow flags un-triaged issues, after a batch of new issues lands, or anytime the user asks for triage.
+---
+
+Run a triage pass over open issues that lack a `P*` priority label. The canonical label vocabulary and rubric live in [`docs/agent/triage-vocabulary.md`](../../../docs/agent/triage-vocabulary.md) — read it before starting.
+
+## Steps
+
+1. **Fetch state in parallel.** Call `mcp__github__list_issues` (state OPEN) and `mcp__github__list_pull_requests` (state open) for `dmooney/parish`. Both responses are large — save to disk and use `jq` rather than reading raw output.
+
+2. **Find the un-PR'd set.** Extract every `#NNN` reference from PR titles + bodies, intersect with open issue numbers. Issues NOT referenced by any open PR are candidates.
+
+3. **Filter to un-triaged.** Keep only issues whose existing labels do not contain any of `P0`, `P1`, `P2`, `P3`. Don't relabel issues that already have a priority unless the user asks for a re-triage.
+
+4. **Classify.** For each remaining issue, read title + body and assign:
+   - **Exactly one priority** (`P0`/`P1`/`P2`/`P3`) using the rubric in `triage-vocabulary.md`.
+   - **At least one theme** label. Multiple is fine when an issue genuinely spans themes (e.g. `security` + `infra` for a workflow vuln).
+   - When uncertain between two priorities, pick the lower-urgency one and let a human escalate.
+
+5. **Apply.** Call `mcp__github__issue_write` with `method: "update"` and the **union** of (existing labels) + (theme labels) + (priority). `issue_write` *replaces* the set, so always include pre-existing labels like `bug`, `security`, `ready-for-test`. Dispatch in parallel batches of ~15.
+
+6. **Verify.** Re-list with `labels: ["P0"]`, `["P1"]`, `["P2"]`, `["P3"]` and confirm counts match what you applied. Random-sample a few issues with `issue_read` (`get_labels`) to confirm theme labels stuck.
+
+7. **Report.** Summarize counts by priority and theme. Link to GitHub filter URLs (`https://github.com/dmooney/Parish/issues?q=is%3Aopen+label%3AP0` etc.). Flag any issue carrying `ready-for-test` without an open PR — those usually need closing, not implementation.
+
+## Notes
+
+- New labels added to `triage-vocabulary.md` are auto-created on first use by `issue_write`, but ship without colors/descriptions. After this skill creates one, set its color in the GitHub UI.
+- If a new theme is needed that isn't in the vocabulary, **stop and ask the user** before inventing a label. Update `triage-vocabulary.md` first.
+- The `triage-audit` workflow runs weekly and posts a summary listing un-triaged issues — that's the usual trigger for invoking this skill.

--- a/.github/triage-labels.json
+++ b/.github/triage-labels.json
@@ -1,0 +1,16 @@
+{
+  "priorities": ["P0", "P1", "P2", "P3"],
+  "themes": [
+    "bug",
+    "enhancement",
+    "performance",
+    "security",
+    "refactor",
+    "frontend",
+    "a11y",
+    "mode-parity",
+    "npc-reactions",
+    "witness-scan",
+    "infra"
+  ]
+}

--- a/.github/workflows/triage-audit.yml
+++ b/.github/workflows/triage-audit.yml
@@ -1,0 +1,89 @@
+name: 'Triage audit'
+
+on:
+  schedule:
+    - cron: '0 9 * * MON'
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/triage-audit.yml'
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: '${{ github.workflow }}'
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: 'Find untriaged open issues'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const PRIORITY = ['P0', 'P1', 'P2', 'P3'];
+            const THEMES = [
+              'bug', 'enhancement', 'performance', 'security', 'refactor',
+              'frontend', 'a11y', 'mode-parity', 'npc-reactions',
+              'witness-scan', 'infra',
+            ];
+
+            const allIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const issues = allIssues.filter(i => !i.pull_request);
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const prRefs = new Set();
+            for (const pr of prs) {
+              const text = `${pr.title}\n${pr.body || ''}`;
+              for (const m of text.matchAll(/#(\d+)/g)) prRefs.add(parseInt(m[1], 10));
+            }
+
+            const lackingPr = issues.filter(i => !prRefs.has(i.number));
+
+            const lackingPriority = [];
+            const lackingTheme = [];
+            for (const i of lackingPr) {
+              const names = i.labels.map(l => typeof l === 'string' ? l : l.name);
+              if (!names.some(n => PRIORITY.includes(n))) lackingPriority.push(i);
+              if (!names.some(n => THEMES.includes(n))) lackingTheme.push(i);
+            }
+
+            const fmt = (list) => list
+              .sort((a, b) => a.number - b.number)
+              .map(i => `- #${i.number} — ${i.title}`)
+              .join('\n') || '_none_';
+
+            const repo = `${context.repo.owner}/${context.repo.repo}`;
+            const filter = (q) => `https://github.com/${repo}/issues?q=${encodeURIComponent(q)}`;
+
+            const summary = core.summary
+              .addHeading('Triage audit', 2)
+              .addRaw(`**${issues.length}** open issues, **${lackingPr.length}** with no open PR.\n\n`)
+              .addHeading(`${lackingPriority.length} lack a P0/P1/P2/P3 label`, 3)
+              .addRaw(`[Filter](${filter(`is:open is:issue -label:P0 -label:P1 -label:P2 -label:P3`)})\n\n`)
+              .addRaw(fmt(lackingPriority))
+              .addHeading(`${lackingTheme.length} lack any theme label`, 3)
+              .addRaw(fmt(lackingTheme))
+              .addRaw('\n\nRun `/triage-backlog` in Claude Code to label them. Vocabulary: `docs/agent/triage-vocabulary.md`.\n');
+
+            await summary.write();
+
+            if (lackingPriority.length > 0) {
+              core.warning(`${lackingPriority.length} open issues need triage`);
+            }

--- a/.github/workflows/triage-audit.yml
+++ b/.github/workflows/triage-audit.yml
@@ -26,16 +26,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github/triage-labels.json
+          sparse-checkout-cone-mode: false
       - name: 'Find untriaged open issues'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            const PRIORITY = ['P0', 'P1', 'P2', 'P3'];
-            const THEMES = [
-              'bug', 'enhancement', 'performance', 'security', 'refactor',
-              'frontend', 'a11y', 'mode-parity', 'npc-reactions',
-              'witness-scan', 'infra',
-            ];
+            const fs = require('fs');
+            const vocab = JSON.parse(fs.readFileSync('.github/triage-labels.json', 'utf8'));
+            const PRIORITY = vocab.priorities;
+            const THEMES = vocab.themes;
 
             const allIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
@@ -96,16 +98,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github/triage-labels.json
+          sparse-checkout-cone-mode: false
       - name: 'Check labels on triggering issue'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            const PRIORITY = ['P0', 'P1', 'P2', 'P3'];
-            const THEMES = [
-              'bug', 'enhancement', 'performance', 'security', 'refactor',
-              'frontend', 'a11y', 'mode-parity', 'npc-reactions',
-              'witness-scan', 'infra',
-            ];
+            const fs = require('fs');
+            const vocab = JSON.parse(fs.readFileSync('.github/triage-labels.json', 'utf8'));
+            const PRIORITY = vocab.priorities;
+            const THEMES = vocab.themes;
 
             const issue = context.payload.issue;
             const names = issue.labels.map(l => typeof l === 'string' ? l : l.name);

--- a/.github/workflows/triage-audit.yml
+++ b/.github/workflows/triage-audit.yml
@@ -87,8 +87,8 @@ jobs:
 
             await summary.write();
 
-            if (lackingPriority.length > 0) {
-              core.warning(`${lackingPriority.length} open issues need triage`);
+            if (lackingPriority.length > 0 || lackingTheme.length > 0) {
+              core.warning(`${lackingPriority.length} open issues lack a priority, ${lackingTheme.length} lack a theme — run /triage-backlog`);
             }
 
   check-new-issue:

--- a/.github/workflows/triage-audit.yml
+++ b/.github/workflows/triage-audit.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   audit:
+    if: github.event_name != 'issues'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -88,4 +89,37 @@ jobs:
 
             if (lackingPriority.length > 0) {
               core.warning(`${lackingPriority.length} open issues need triage`);
+            }
+
+  check-new-issue:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: 'Check labels on triggering issue'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const PRIORITY = ['P0', 'P1', 'P2', 'P3'];
+            const THEMES = [
+              'bug', 'enhancement', 'performance', 'security', 'refactor',
+              'frontend', 'a11y', 'mode-parity', 'npc-reactions',
+              'witness-scan', 'infra',
+            ];
+
+            const issue = context.payload.issue;
+            const names = issue.labels.map(l => typeof l === 'string' ? l : l.name);
+            const priority = names.find(n => PRIORITY.includes(n));
+            const themes = names.filter(n => THEMES.includes(n));
+
+            await core.summary
+              .addHeading(`Issue #${issue.number} triage check`, 2)
+              .addRaw(`**${issue.title}**\n\n`)
+              .addRaw(`- Priority: ${priority || '**MISSING**'}\n`)
+              .addRaw(`- Theme: ${themes.length ? themes.join(', ') : '**MISSING**'}\n`)
+              .addRaw(`\nIf either is missing, run \`/triage-backlog\` in Claude Code. Vocabulary: \`docs/agent/triage-vocabulary.md\`.\n`)
+              .write();
+
+            if (!priority || themes.length === 0) {
+              core.warning(`Issue #${issue.number} needs triage`);
             }

--- a/.github/workflows/triage-audit.yml
+++ b/.github/workflows/triage-audit.yml
@@ -3,6 +3,8 @@ name: 'Triage audit'
 on:
   schedule:
     - cron: '0 9 * * MON'
+  issues:
+    types: [opened, reopened]
   workflow_dispatch:
   pull_request:
     branches: [main]

--- a/docs/agent/skills.md
+++ b/docs/agent/skills.md
@@ -12,3 +12,4 @@ Custom slash commands defined in `.agents/skills/`, with `.claude/skills/` as a 
 | `/chrome-test` | Live browser testing session via browser MCP tools |
 | `/play [scenario]` | Play-test the game via script harness |
 | `/prove <feature>` | Prove a gameplay feature works at runtime (required after implementing features) |
+| `/triage-backlog` | Apply theme + priority labels to open issues lacking them. Vocabulary in [`triage-vocabulary.md`](triage-vocabulary.md). Paired with the `triage-audit` weekly workflow. |

--- a/docs/agent/triage-vocabulary.md
+++ b/docs/agent/triage-vocabulary.md
@@ -1,6 +1,6 @@
 # Triage vocabulary
 
-Canonical label set for open-issue triage. The `triage-backlog` skill and the `triage-audit` workflow both read from this list. Update this file when introducing new themes or priority levels — never invent labels at the call site.
+Canonical label set for open-issue triage. The machine-readable list lives in [`.github/triage-labels.json`](../../.github/triage-labels.json) — the `triage-audit` workflow reads that file directly, and the `triage-backlog` skill reads this doc. When introducing a new theme or priority level, update **both** the JSON and the prose below; never invent labels at the call site.
 
 ## Priority labels (exactly one per issue)
 

--- a/docs/agent/triage-vocabulary.md
+++ b/docs/agent/triage-vocabulary.md
@@ -1,0 +1,50 @@
+# Triage vocabulary
+
+Canonical label set for open-issue triage. The `triage-backlog` skill and the `triage-audit` workflow both read from this list. Update this file when introducing new themes or priority levels — never invent labels at the call site.
+
+## Priority labels (exactly one per issue)
+
+| Label | Meaning |
+|---|---|
+| `P0` | Exploitable security vuln, deadlock, data loss/corruption, or production outage path. Drop everything. |
+| `P1` | Correctness bug in a shipping user flow; broken feature; serious leak/race; auth/permission gap. |
+| `P2` | Perf regression, UX paper cut, mode-parity gap, missing-but-not-blocking feature. |
+| `P3` | Cleanup, refactor, minor test debt, doc/version chore, micro-perf. |
+
+## Theme labels (one or more per issue)
+
+| Label | Scope |
+|---|---|
+| `bug` | Existing behavior is wrong. Pair with another theme when the bug is specifically a perf/security/frontend issue. |
+| `enhancement` | Requested feature or improvement that is not a regression. |
+| `performance` | Latency, throughput, allocation, or resource use. (Do not use the older `perf` label.) |
+| `security` | Exploitable surface, auth/permission, secrets exposure, supply chain, workflow trust. |
+| `refactor` | Code quality, structural change, no behavior change. |
+| `frontend` | Anything in `apps/ui/` — Svelte components, MapLibre, styles. |
+| `a11y` | Accessibility-specific (keyboard nav, ARIA, contrast). Pair with `frontend`. |
+| `mode-parity` | Tauri / web server / headless CLI behavioral divergence (project rule #2). |
+| `npc-reactions` | The LLM-driven NPC-reaction subsystem. |
+| `witness-scan` | The `/witness` verification workflow tooling. |
+| `infra` | CI, deploy, Docker, Cloudflare, Railway, GitHub Actions, runners. |
+
+## Process labels (independent of theme/priority)
+
+| Label | Meaning |
+|---|---|
+| `ready-for-test` | The fix has merged but the issue isn't auto-closed. Verify and close. (Do not use the older `ready for test` form.) |
+| `in-progress` | A human or agent is actively working on this. |
+| `codex-automation` | Issue is being driven by Codex. |
+
+## Application rules
+
+1. Every open issue should carry exactly one `P*` label and at least one theme label. The `triage-audit` workflow reports violations weekly.
+2. `mcp__github__issue_write` *replaces* the label set, so always pass the union of (existing labels) + (new theme labels) + (priority label).
+3. New labels are auto-created by GitHub on first use, but ship without descriptions or colors. After introducing a new label here, update its color/description manually in the GitHub UI or via `gh label create`.
+4. Don't relabel an issue that already has a `P*` label unless explicitly asked to re-triage.
+
+## Priority rubric — concrete examples
+
+- **P0**: SQL injection (#592), deadlock risk (#337), GitHub Actions privilege escalation (#602), CLI proceeding past lock failure in script mode (#608).
+- **P1**: TOCTOU race (#283), missing SQLite transaction around multi-statement delete (#593), broken-on-desktop UI button (#600), Anthropic client without structured-output guarantee (#416).
+- **P2**: Lock contention in debug snapshot (#282), background task lacking graceful shutdown (#104, #228), mode-parity gap in NPC reactions (#402), MapLibre migration regressions (#309).
+- **P3**: Double `.cloned()` (#106), magic-constant ring buffer (#611), 16-month-old pinned binary (#610), validate-lat-lon (#88).


### PR DESCRIPTION
## Summary

Codifies the open-issue triage pass we just ran (63 issues labeled across 10 P0 / 18 P1 / 25 P2 / 10 P3) into reusable automation:

- **`docs/agent/triage-vocabulary.md`** — canonical priority + theme labels with a concrete rubric. Single source of truth for both the skill and the workflow.
- **`.agents/skills/triage-backlog/SKILL.md`** — Claude Code skill (`/triage-backlog`) that walks the backlog, finds open issues lacking a `P*` label, classifies each with theme + priority, and applies labels via the GitHub MCP server. Preserves existing labels (issue_write replaces the set).
- **`.github/workflows/triage-audit.yml`** — Mondays 09:00 UTC GitHub Action that lists open issues with no open PR that lack a `P*` priority or any theme label. Reports to the workflow run summary; emits a `core.warning` so it surfaces in the Actions tab. No LLM dependency — just a triage check that pings humans / agents to invoke `/triage-backlog`.
- **`docs/agent/skills.md`** — registers the new skill in the docs table.

## How it's used

1. The audit workflow runs weekly (or via `workflow_dispatch`) and surfaces any open issues lacking proper labels.
2. When the audit reports drift, run `/triage-backlog` in Claude Code. The skill reads `triage-vocabulary.md`, classifies each un-triaged issue, and applies labels in parallel batches.
3. New themes go into `triage-vocabulary.md` first — the skill explicitly refuses to invent labels.

## Test plan

- [ ] Trigger `triage-audit` via `workflow_dispatch` on `main` after merge — expect a green run with the summary listing zero un-triaged issues (we just labeled the backlog).
- [ ] Open a throwaway test issue with no labels and rerun `workflow_dispatch` — confirm it appears in both "lacking priority" and "lacking theme" sections.
- [ ] Invoke `/triage-backlog` in Claude Code on a future drift batch and confirm labels stick.

https://claude.ai/code/session_018d28XtAHtqJiUkEhDDj2r5

---
_Generated by [Claude Code](https://claude.ai/code/session_018d28XtAHtqJiUkEhDDj2r5)_