### PR TITLE
fix(railway-watchdog): install CLI via npm, not curl (#562)

### DIFF
--- a/.github/workflows/railway-watchdog.yml
+++ b/.github/workflows/railway-watchdog.yml
@@ -33,9 +33,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Railway CLI
-        run: |
-          curl -fsSL https://railway.com/install.sh | sh
-          echo "$HOME/.railway/bin" >> "$GITHUB_PATH"
+        # railway.com/install.sh is now behind a Cloudflare bot challenge
+        # (curl gets a 403). The npm package is the supported alternative
+        # and Node is preinstalled on ubuntu-latest, so this is a one-liner.
+        run: npm install --global @railway/cli
 
       - name: Run watchdog
         env:


### PR DESCRIPTION
## Summary

The watchdog has been failing every scheduled run with `missing dependency: railway`. Root cause: `curl https://railway.com/install.sh` is now blocked by Cloudflare's bot challenge — `curl` gets back HTTP 403 (`Sec-CH-UA-*` headers in the response confirm it's the JS-challenge gate), so the install no-ops and the next step's `command -v railway` check trips.

Fix: install via the official npm package instead. Node is preinstalled on `ubuntu-latest`, so this is a one-liner with no PATH manipulation.

## Repro

```sh
$ curl -sI https://railway.com/install.sh | head -3
HTTP/2 403
date: Sat, 25 Apr 2026 16:01:46 GMT
content-type: text/html; charset=UTF-8
```

Latest broken run: https://github.com/dmooney/Parish/actions/runs/24934804505 — fails inside `Install Railway CLI` with `curl: (22) The requested URL returned error: 403`.

## Test plan

- [x] Confirmed `npm view @railway/cli version` returns 4.42.1 (current, matches the homebrew formula)
- [ ] After merge, `gh workflow run "Railway deployment watchdog" --ref main` and watch one full run to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)