### PR TITLE
fix(ui): add regression tests for MapLibre icons, travel highlighting, and glow (#309)

### DIFF
--- a/apps/ui/src/lib/map/style.test.ts
+++ b/apps/ui/src/lib/map/style.test.ts
@@ -109,6 +109,22 @@ describe('buildStyle', () => {
 		expect(icons?.type).toBe('symbol');
 	});
 
+	// ── Regression #1: location icons (issue #309) ──────────────────────────────
+	// The location-circles symbol layer must use the 'icon-image' expression that
+	// resolves to 'icon-<name>' — matching the keys registerLocationIcons() uses
+	// when it calls map.addImage('icon-<name>', …) in the controller.
+	it('location-circles icon-image expression matches the icon-<name> convention', () => {
+		const style = buildStyle('full', THEME, osm());
+		const icons = style.layers.find((l) => l.id === 'location-circles');
+		expect(icons).toBeDefined();
+		expect(icons?.type).toBe('symbol');
+		const layout = (icons as { layout: Record<string, unknown> }).layout;
+		expect(layout['icon-image']).toEqual(['concat', 'icon-', ['get', 'icon']]);
+	});
+
+	// ── Regression #2: travel edge highlighting (issue #309) ────────────────────
+	// The edges-solid layer must honour the traversing property for both line-color
+	// (accent vs border) and line-width (wider when traversing).
 	it('adds traversing-edge highlight styling to solid edges', () => {
 		const style = buildStyle('full', THEME, osm());
 		const solid = style.layers.find((l) => l.id === 'edges-solid');
@@ -118,6 +134,40 @@ describe('buildStyle', () => {
 			['get', 'traversing'],
 			THEME.accent,
 			THEME.border
+		]);
+		// Traversing edges should also be more opaque than normal ones.
+		const opacity = (solid as { paint: { 'line-opacity': unknown } }).paint['line-opacity'];
+		expect(opacity).toEqual(['case', ['get', 'traversing'], 1, 0.85]);
+	});
+
+	// ── Regression #3: glow filter for lit/player locations (issue #309) ────────
+	// The location-glow circle layer approximates the old SVG feColorMatrix glow
+	// via circle-blur. Lit locations must get a non-zero blur; plain ones get 0.
+	it('location-glow uses circle-blur to approximate lit/player glow', () => {
+		const style = buildStyle('full', THEME, osm());
+		const glow = style.layers.find((l) => l.id === 'location-glow');
+		expect(glow).toBeDefined();
+		const paint = (glow as { paint: Record<string, unknown> }).paint;
+		// circle-blur must be a case expression that gives non-zero blur to isPlayer
+		// and lit locations while hiding plain ones.
+		const blur = paint['circle-blur'];
+		expect(Array.isArray(blur)).toBe(true);
+		const blurExpr = blur as unknown[];
+		expect(blurExpr[0]).toBe('case');
+		// isPlayer case (index 1-2) and lit case (index 3-4) must have positive blur.
+		expect(typeof blurExpr[2]).toBe('number');
+		expect(blurExpr[2] as number).toBeGreaterThan(0);
+		expect(typeof blurExpr[4]).toBe('number');
+		expect(blurExpr[4] as number).toBeGreaterThan(0);
+		// Default (last value) must be 0 — plain unlit locations have no glow.
+		expect(blurExpr[blurExpr.length - 1]).toBe(0);
+		// Plain locations must have 0 circle-opacity (hidden glow circle).
+		const opacity = paint['circle-opacity'];
+		expect(opacity).toEqual([
+			'case',
+			['any', ['get', 'isPlayer'], ['get', 'lit']],
+			1,
+			0
 		]);
 	});
 });


### PR DESCRIPTION
## Summary

Issue #309 tracked three MapLibre migration regressions:
1. Location icons missing (Phosphor glyphs rendered as plain circles)
2. Travel edge highlighting broken during active travel
3. SVG glow filter dropped for lit/player locations

All three were fixed in main via PR #399 (`fix(ui): restore MapLibre location icons, travel-edge highlight, and lit glow`). This PR adds explicit regression tests that pin the three contracts so they cannot silently regress again.

## Per-regression approach

**Regression 1 — Icons:** The `location-circles` symbol layer must use `['concat', 'icon-', ['get', 'icon']]` as `icon-image`, matching the `icon-<name>` keys that `registerLocationIcons()` passes to `map.addImage()`. A new test verifies this exact expression.

**Regression 2 — Travel highlighting:** The `edges-solid` layer must apply `['case', ['get', 'traversing'], accent, border]` for `line-color` and `['case', ['get', 'traversing'], 1, 0.85]` for `line-opacity`. The existing color test is extended with an opacity assertion.

**Regression 3 — Glow filter:** The `location-glow` circle layer must have a non-zero `circle-blur` for `isPlayer` and `lit` locations, and `circle-opacity: 0` for plain locations (so the glow circle is invisible for unmarked nodes). A new test verifies the `circle-blur` case expression structure and the `circle-opacity` guard.

## Test plan

- [x] `just ui-test` — 185 tests pass (183 pre-existing + 2 new + 1 extended)
- [x] `just check` — fmt + clippy + Rust tests all pass
- [x] New tests are targeted per-regression and will fail if any of the three layer definitions are accidentally reverted

Closes #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)