### PR TITLE
fix(infra): cleanup Cloudflare tunnel + DNS on PR close

### DIFF
--- a/.github/workflows/cloudflare-cleanup.yml
+++ b/.github/workflows/cloudflare-cleanup.yml
@@ -1,0 +1,130 @@
+name: Cloudflare PR cleanup
+
+# Deletes the per-PR Cloudflare Named Tunnel and DNS CNAME record that
+# deploy/entrypoint.sh creates when a PR preview environment spins up.
+# Without this, every closed PR leaves an orphaned tunnel + CNAME in the
+# Cloudflare account (issue #428).
+#
+# Required repository secrets (already used by Railway PR envs):
+#   CF_API_TOKEN   – Cloudflare API token with Tunnel:Edit + Zone DNS:Edit
+#   CF_ACCOUNT_ID  – Cloudflare account ID
+#   CF_ZONE_ID     – Zone ID for the preview domain
+#   PREVIEW_DOMAIN – e.g. "preview.rundale.dev"
+#
+# Design notes:
+#   - Runs on ubuntu-latest (no self-hosted runner needed — pure API calls).
+#   - `continue-on-error: true` on each deletion step so a missing tunnel or
+#     DNS record (e.g. PR closed before Railway ever created the env) does not
+#     fail the workflow and spam notifications.
+#   - Tunnel deletion uses DELETE with force_delete=true so cloudflared
+#     connections that haven't drained yet are killed immediately; otherwise
+#     the API returns 409 until the last connector disconnects.
+#   - We delete the DNS record *before* the tunnel so there's no window where
+#     the CNAME points at a tunnel that no longer exists.
+
+on:
+  pull_request:
+    types: [closed]
+
+concurrency:
+  # One cleanup run per PR; if somehow two fire (e.g. rapid reopen/close),
+  # let the second cancel the first — both do the same idempotent work.
+  group: cf-cleanup-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: Delete tunnel + DNS for PR ${{ github.event.pull_request.number }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Only run when the required secrets are present.  PRs from external
+    # contributors on public forks won't have access to secrets, and the
+    # Railway preview env would never have been created anyway.
+    # Note: GitHub does not allow direct secret comparison in `if:`; we use
+    # an env var set from the secret — empty string evaluates falsy.
+    if: ${{ env.CF_API_TOKEN != '' }}
+    env:
+      CF_API: https://api.cloudflare.com/client/v4
+      CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+      CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+      CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+      PREVIEW_DOMAIN: ${{ secrets.PREVIEW_DOMAIN }}
+      PR_NUM: ${{ github.event.pull_request.number }}
+
+    steps:
+      - name: Resolve tunnel ID for parish-pr-${{ github.event.pull_request.number }}
+        id: resolve
+        # Exit 0 even if the tunnel was never created (no env → no tunnel).
+        # tunnel_id output is empty string in that case; later steps skip.
+        run: |
+          TUNNEL_NAME="parish-pr-${PR_NUM}"
+          echo "Resolving tunnel '${TUNNEL_NAME}' …"
+
+          TUNNEL_ID="$(curl -fsSL \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "${CF_API}/accounts/${CF_ACCOUNT_ID}/cfd_tunnel?name=${TUNNEL_NAME}&is_deleted=false" \
+            | jq -r '.result[0].id // empty')"
+
+          if [[ -z "$TUNNEL_ID" ]]; then
+            echo "No active tunnel found for ${TUNNEL_NAME} — nothing to clean up."
+          else
+            echo "Found tunnel: ${TUNNEL_ID}"
+          fi
+
+          echo "tunnel_id=${TUNNEL_ID}" >> "$GITHUB_OUTPUT"
+          echo "tunnel_name=${TUNNEL_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Delete DNS CNAME record (pr-${{ github.event.pull_request.number }}.${{ env.PREVIEW_DOMAIN }})
+        # Delete DNS first so there's no window where the CNAME resolves to a
+        # deleted tunnel.  Safe to run even when no tunnel existed.
+        continue-on-error: true
+        run: |
+          HOSTNAME="pr-${PR_NUM}.${PREVIEW_DOMAIN}"
+          echo "Looking up DNS record for ${HOSTNAME} …"
+
+          DNS_ID="$(curl -fsSL \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "${CF_API}/zones/${CF_ZONE_ID}/dns_records?name=${HOSTNAME}&type=CNAME" \
+            | jq -r '.result[0].id // empty')"
+
+          if [[ -z "$DNS_ID" ]]; then
+            echo "No CNAME record found for ${HOSTNAME} — skipping."
+            exit 0
+          fi
+
+          echo "Deleting DNS record ${DNS_ID} (${HOSTNAME}) …"
+          curl -fsSL -X DELETE \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "${CF_API}/zones/${CF_ZONE_ID}/dns_records/${DNS_ID}" \
+            | jq -e '.success' > /dev/null
+          echo "DNS record deleted."
+
+      - name: Delete Cloudflare tunnel (${{ steps.resolve.outputs.tunnel_name }})
+        if: steps.resolve.outputs.tunnel_id != ''
+        continue-on-error: true
+        run: |
+          TUNNEL_ID="${{ steps.resolve.outputs.tunnel_id }}"
+          TUNNEL_NAME="${{ steps.resolve.outputs.tunnel_name }}"
+          echo "Deleting tunnel ${TUNNEL_NAME} (${TUNNEL_ID}) …"
+
+          # force_delete=true terminates any lingering cloudflared connectors
+          # instead of returning 409 while they're still connected.
+          curl -fsSL -X DELETE \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "${CF_API}/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${TUNNEL_ID}?force_delete=true" \
+            | jq -e '.success' > /dev/null
+          echo "Tunnel deleted."
+
+      - name: Summary
+        if: always()
+        run: |
+          PR_LABEL="PR #${PR_NUM}"
+          TUNNEL_ID="${{ steps.resolve.outputs.tunnel_id }}"
+          if [[ -z "$TUNNEL_ID" ]]; then
+            echo "${PR_LABEL}: no Cloudflare tunnel was found (environment may never have been provisioned)."
+          else
+            echo "${PR_LABEL}: cleanup complete — tunnel parish-pr-${PR_NUM} and its DNS record have been removed."
+          fi


### PR DESCRIPTION
## Summary

Fixes #428.

`deploy/entrypoint.sh` (added in #253) creates a per-PR Named Tunnel and DNS CNAME record for Railway preview environments but never cleaned them up on PR close. Over time this accumulates orphaned tunnels and DNS entries in the Cloudflare account, each counting against tunnel limits.

## What this adds

`.github/workflows/cloudflare-cleanup.yml` — triggers on `pull_request: types: [closed]` and:

1. **Resolves** the `parish-pr-<N>` tunnel via the CF API (exits cleanly if the tunnel never existed — e.g. PR closed before Railway provisioned an environment).
2. **Deletes the DNS CNAME first** (`pr-<N>.<PREVIEW_DOMAIN>`) so there is no window where the record points at a deleted tunnel.
3. **Deletes the tunnel** with `force_delete=true` to kill any lingering cloudflared connectors rather than getting a 409 while they drain.
4. **Summary step** reports outcome either way.

## Design choices

- `continue-on-error: true` on both deletion steps — a missing resource (never-provisioned PR) is not an error.
- Runs on `ubuntu-latest` (no self-hosted runner needed — pure Cloudflare API calls via `curl` + `jq`).
- Uses the same four secrets already set on Railway PR envs: `CF_API_TOKEN`, `CF_ACCOUNT_ID`, `CF_ZONE_ID`, `PREVIEW_DOMAIN`.
- Job skips entirely when `CF_API_TOKEN` is empty (external forks, pre-secret-setup).
- Concurrency key `cf-cleanup-pr-<N>` with `cancel-in-progress: true` — safe if a PR is rapidly reopened then closed again.

## Test plan

- [ ] Confirm workflow appears on the Actions tab after merge
- [ ] Open a test PR, confirm Railway creates `pr-<N>.preview.rundale.dev`
- [ ] Close the PR, confirm the workflow runs and the tunnel + DNS record are gone in the Cloudflare dashboard
- [ ] Close a PR that never had a Railway env (e.g. draft closed immediately) — confirm workflow exits cleanly with "no tunnel found" summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)