### PR TITLE
fix(ui): prevent drag race with click selection in LocationDetail editor

### DIFF
--- a/apps/ui/src/components/editor/LocationDetail.svelte
+++ b/apps/ui/src/components/editor/LocationDetail.svelte
@@ -65,6 +65,20 @@
 		}
 	}
 
+	// Like updateSelectedLocation but targets a specific location ID.
+	// Used by the drag-commit path so that if the reactive `loc`/`selectedId`
+	// changes between mousedown and mouseup (click-to-select race #408), the
+	// dragged location — not the newly-selected one — receives the update.
+	async function updateLocationById(id: number, mutator: (location: LocationData) => LocationData) {
+		if (!$editorSnapshot) return;
+		const nextLocations = $editorSnapshot.locations.map((l) => (l.id === id ? mutator(l) : l));
+		try {
+			await persistLocations(nextLocations);
+		} catch (e) {
+			console.error('Failed to update location:', e);
+		}
+	}
+
 	async function handleFieldChange(field: string, value: unknown) {
 		await updateSelectedLocation((current) => ({ ...current, [field]: value }));
 	}
@@ -302,15 +316,22 @@
 			nextMap.dragPan.disable();
 		});
 		nextMap.on('mousemove', (event) => {
-			if (!dragging || !loc || dragTargetId !== loc.id) return;
+			// Use dragTargetId (set at mousedown) as the authoritative drag ID.
+			// Do NOT use loc.id here: the reactive `loc` may have changed to a
+			// different location if the user also triggered a click-selection
+			// while the drag was in progress (race #408).
+			if (!dragging || dragTargetId === null) return;
 			dragLat = event.lngLat.lat;
 			dragLon = event.lngLat.lng;
 			dragMoved = true;
-			setMapData(locations, selectedId, { id: loc.id, lat: dragLat, lon: dragLon });
+			setMapData(locations, selectedId, { id: dragTargetId, lat: dragLat, lon: dragLon });
 		});
 		nextMap.on('mouseup', async () => {
-			if (dragging && dragMoved && loc && dragTargetId === loc.id) {
-				await updateSelectedLocation((current) =>
+			// Capture dragTargetId before clearing it so the async update
+			// targets the correct location even if `loc` has since changed.
+			const targetId = dragTargetId;
+			if (dragging && dragMoved && targetId !== null) {
+				await updateLocationById(targetId, (current) =>
 					applyDraggedCoordinates(current, locations, dragLat, dragLon)
 				);
 			}

--- a/apps/ui/src/components/editor/LocationDetail.test.ts
+++ b/apps/ui/src/components/editor/LocationDetail.test.ts
@@ -272,4 +272,71 @@ describe('LocationDetail', () => {
 		await mockState.lastMap!.trigger('mouseleave', {}, 'editor-locations');
 		expect(mockState.lastMap!.getCanvas().style.cursor).toBe('');
 	});
+
+	// #408 — mousedown on non-selected location must not initiate drag
+	it('does not start a drag when mousedown fires on a non-selected location', async () => {
+		editorSelectedLocationId.set(1);
+		render(LocationDetail);
+
+		await waitFor(() => {
+			expect(mockState.lastMap).not.toBeNull();
+		});
+
+		const map = mockState.lastMap!;
+
+		// Mousedown on location 2 (not the currently selected location 1)
+		await map.trigger(
+			'mousedown',
+			{ features: [{ properties: { id: 2 } }], originalEvent: { shiftKey: false } },
+			'editor-locations'
+		);
+		// A move should not trigger any update because drag was never started
+		await map.trigger('mousemove', { lngLat: { lat: 53.52, lng: -8.12 } });
+		await map.trigger('mouseup', {});
+
+		expect(mockState.editorUpdateLocationsMock).not.toHaveBeenCalled();
+	});
+
+	// #408 — if selection changes during an active drag, mouseup must update
+	// the originally dragged location, not the newly selected one.
+	it('commits drag to the originally dragged location even if selection changes mid-drag', async () => {
+		editorSelectedLocationId.set(1);
+		render(LocationDetail);
+
+		await waitFor(() => {
+			expect(mockState.lastMap).not.toBeNull();
+		});
+
+		const map = mockState.lastMap!;
+
+		// Start dragging location 1 (the selected one)
+		await map.trigger(
+			'mousedown',
+			{ features: [{ properties: { id: 1 } }], originalEvent: { shiftKey: false } },
+			'editor-locations'
+		);
+		// Move the mouse — drag is in progress
+		await map.trigger('mousemove', { lngLat: { lat: 53.60, lng: -8.20 } });
+
+		// Simulate selection change mid-drag (click race) — location 2 becomes selected
+		editorSelectedLocationId.set(2);
+		await waitFor(() => {}); // let Svelte flush reactivity
+
+		// Release mouse — should commit to location 1 (the dragged one), not location 2
+		await map.trigger('mouseup', {});
+
+		await waitFor(() => {
+			expect(mockState.editorUpdateLocationsMock).toHaveBeenCalledTimes(1);
+		});
+
+		const calls = mockState.editorUpdateLocationsMock.mock.calls as unknown as Array<[unknown]>;
+		const updatedLocations = calls.at(-1)?.[0] as Array<{ id: number; lat: number; lon: number }>;
+		// Location 1 coordinates should be updated
+		const loc1 = updatedLocations.find((l) => l.id === 1);
+		expect(loc1).toBeDefined();
+		expect(loc1!.lat).toBeCloseTo(53.60, 4);
+		// Location 2 should be unchanged
+		const loc2 = updatedLocations.find((l) => l.id === 2);
+		expect(loc2?.lat).toBeCloseTo(53.51, 4);
+	});
 });


### PR DESCRIPTION
## Summary

Fixes #408.

- **Root cause**: the `mousemove` and `mouseup` handlers in the map-based location editor used the reactive `loc.id` variable to track which location was being dragged. If a click-to-select event changed `editorSelectedLocationId` between `mousedown` and `mouseup`, the coordinate update was applied to the newly-selected location instead of the one actually being dragged.
- **Fix**: use `dragTargetId` (set at `mousedown`, cleared at `mouseup`) as the sole authority on which location is being dragged. On `mouseup`, capture `dragTargetId` into a local variable before clearing state, then apply the update via a new `updateLocationById(id, mutator)` helper — this bypasses `loc` entirely so a mid-drag selection change cannot redirect the write.
- The existing `id !== selectedId` guard in `mousedown` is preserved and correct; no drag begins for a non-selected marker.

## Changes

- `apps/ui/src/components/editor/LocationDetail.svelte`: add `updateLocationById`, fix `mousemove` + `mouseup` to use `dragTargetId` rather than `loc.id`
- `apps/ui/src/components/editor/LocationDetail.test.ts`: two new tests covering the fixed race scenarios

## Test plan

- [x] `just ui-test` — 200 tests pass (all pre-existing + 2 new)
- [x] New test: mousedown on non-selected location does not start drag and calls no update
- [x] New test: drag committed after mid-drag selection change updates the dragged location, not the newly-selected one

🤖 Generated with [Claude Code](https://claude.com/claude-code)