### PR TITLE
perf: avoid holding all 5 locks during debug snapshot construction

### DIFF
--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -107,31 +107,52 @@ pub async fn get_debug_snapshot(
     Extension(session_id): Extension<SessionId>,
     State(global): State<Arc<GlobalState>>,
 ) -> impl IntoResponse {
-    let world = state.world.lock().await;
-    let npc_manager = state.npc_manager.lock().await;
-    // Peek inference_queue presence *before* taking config so we honor the
-    // canonical `npc_manager → inference_queue → config` order enforced by
-    // handle_npc_conversation and run_idle_banter (#483). Taking
-    // inference_queue after config here would be the opposite order and
-    // create a latent deadlock with those handlers.
+    // Snapshot each piece of state with a brief, non-overlapping lock window.
+    // This avoids holding all 5+ locks simultaneously (#105, #282), which
+    // caused latency spikes on all concurrent game operations and created
+    // a latent deadlock risk if lock ordering ever drifted.
+    //
+    // Lock order respected throughout: world → npc_manager → inference_queue
+    // → config → debug_events → game_events → inference_log (#483).
+
+    // 1. Peek inference_queue presence first to honour canonical order (#483).
     let has_inference_queue = state.inference_queue.lock().await.is_some();
-    let config = state.config.lock().await;
-    let events = state.debug_events.lock().await;
-    let game_events = state.game_events.lock().await;
+
+    // 2. Clone the fields we need from config — drop the lock immediately.
+    let (provider_name, model_name, base_url, cloud_provider, cloud_model, improv_enabled) = {
+        let config = state.config.lock().await;
+        (
+            config.provider_name.clone(),
+            config.model_name.clone(),
+            config.base_url.clone(),
+            config.cloud_provider_name.clone(),
+            config.cloud_model_name.clone(),
+            config.improv_enabled,
+        )
+    };
+
+    // 3. Clone debug_events ring buffer — drop the lock immediately.
+    let events_snapshot: std::collections::VecDeque<parish_core::debug_snapshot::DebugEvent> =
+        state.debug_events.lock().await.iter().cloned().collect();
+
+    // 4. Clone game_events ring buffer — drop the lock immediately.
+    let game_events_snapshot: std::collections::VecDeque<parish_core::world::events::GameEvent> =
+        state.game_events.lock().await.iter().cloned().collect();
+
+    // 5. Clone inference log — drop the lock immediately.
     let raw_call_log: Vec<parish_core::debug_snapshot::InferenceLogEntry> =
         state.inference_log.lock().await.iter().cloned().collect();
 
-    // Build a full inference debug block (used internally; base_url included
-    // for accurate `has_queue` / `reaction_req_id` etc.).
+    // Build a full inference debug block from the cloned data (no locks held).
     let inference = InferenceDebug {
-        provider_name: config.provider_name.clone(),
-        model_name: config.model_name.clone(),
-        base_url: config.base_url.clone(),
-        cloud_provider: config.cloud_provider_name.clone(),
-        cloud_model: config.cloud_model_name.clone(),
+        provider_name,
+        model_name,
+        base_url,
+        cloud_provider,
+        cloud_model,
         has_queue: has_inference_queue,
         reaction_req_id: parish_core::game_session::reaction_req_id_peek(),
-        improv_enabled: config.improv_enabled,
+        improv_enabled,
         call_log: raw_call_log.clone(),
     };
     let linked = global.sessions.google_account_for_session(&session_id.0);
@@ -143,15 +164,22 @@ pub async fn get_debug_snapshot(
         session_id: Some(session_id.0.clone()),
     };
 
+    // 6. Acquire world and npc_manager (in canonical order) only for the
+    // duration of the pure-read snapshot build, then release immediately.
+    let world = state.world.lock().await;
+    let npc_manager = state.npc_manager.lock().await;
+
     // Build the full snapshot then redact the inference section (#333).
     let mut snapshot = debug_snapshot::build_debug_snapshot(
         &world,
         &npc_manager,
-        &events,
-        &game_events,
+        &events_snapshot,
+        &game_events_snapshot,
         &inference,
         &auth,
     );
+    drop(npc_manager);
+    drop(world);
 
     // Replace call_log entries with redacted forms (no prompt/response text,
     // no system_prompt, no base_url).

--- a/crates/parish-server/tests/isolation.rs
+++ b/crates/parish-server/tests/isolation.rs
@@ -270,6 +270,170 @@ async fn second_ws_upgrade_same_email_is_409() {
     assert_eq!(status, StatusCode::CONFLICT);
 }
 
+// ── #105 / #282 — Debug snapshot acquires locks sequentially, not all at once ─
+//
+// Before the fix, `get_debug_snapshot` (and the Tauri debug tick) held all 5+
+// mutexes simultaneously while building the snapshot.  The fix snapshots each
+// lock's data in a brief, non-overlapping window so only `world` and
+// `npc_manager` are held during the actual `build_debug_snapshot` call.
+//
+// This test exercises the corrected lock pattern against a live `AppState` to
+// confirm that concurrent snapshot + state-mutation tasks do not deadlock and
+// both produce sensible output.
+
+/// Concurrent snapshot builds and state reads must not deadlock (#105, #282).
+///
+/// Spawns multiple tasks that simultaneously:
+/// - read the debug_events / game_events / inference_log (snapshot path)
+/// - acquire world + npc_manager (the dominant locks in `build_debug_snapshot`)
+///
+/// If any task blocks forever the test times out; if the data is coherent
+/// each snapshot's `world` fields must be non-empty.
+#[tokio::test]
+async fn debug_snapshot_no_deadlock_with_concurrent_readers() {
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    use parish_core::debug_snapshot::{
+        AuthDebug, DebugEvent, InferenceDebug, build_debug_snapshot,
+    };
+    use parish_core::npc::manager::NpcManager;
+    use parish_core::world::events::GameEvent;
+    use parish_core::world::transport::TransportConfig;
+    use parish_core::world::{LocationId, WorldState};
+    use parish_server::state::{GameConfig, UiConfigSnapshot, build_app_state};
+
+    let data_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../mods/rundale");
+    let world = WorldState::from_parish_file(&data_dir.join("world.json"), LocationId(15)).unwrap();
+    let npc_manager = NpcManager::new();
+    let ui_config = UiConfigSnapshot {
+        hints_label: "test".to_string(),
+        default_accent: "#000".to_string(),
+        splash_text: String::new(),
+        active_tile_source: String::new(),
+        tile_sources: Vec::new(),
+    };
+    let theme_palette = parish_core::game_mod::default_theme_palette();
+    let saves_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../saves");
+
+    let state = Arc::new(build_app_state(
+        world,
+        npc_manager,
+        None,
+        GameConfig {
+            provider_name: "test".to_string(),
+            base_url: String::new(),
+            api_key: None,
+            model_name: "test-model".to_string(),
+            cloud_provider_name: None,
+            cloud_model_name: None,
+            cloud_api_key: None,
+            cloud_base_url: None,
+            improv_enabled: false,
+            max_follow_up_turns: 2,
+            idle_banter_after_secs: 25,
+            auto_pause_after_secs: 60,
+            category_provider: [None, None, None, None],
+            category_model: [None, None, None, None],
+            category_api_key: [None, None, None, None],
+            category_base_url: [None, None, None, None],
+            flags: parish_core::config::FeatureFlags::default(),
+            category_rate_limit: [None, None, None, None],
+            active_tile_source: String::new(),
+            tile_sources: Vec::new(),
+            reveal_unexplored_locations: false,
+        },
+        None,
+        TransportConfig::default(),
+        ui_config,
+        theme_palette,
+        saves_dir,
+        data_dir.clone(),
+        None,
+        data_dir.join("parish-flags.json"),
+    ));
+
+    // Pre-populate debug_events so the snapshot has something to copy.
+    {
+        let mut events = state.debug_events.lock().await;
+        events.push_back(DebugEvent {
+            timestamp: "08:00 1820-03-20".to_string(),
+            category: "system".to_string(),
+            message: "test event".to_string(),
+        });
+    }
+
+    // Spawn 8 concurrent tasks that each execute the fixed snapshot pattern.
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let state = Arc::clone(&state);
+        handles.push(tokio::spawn(async move {
+            // Replicate the fixed lock acquisition sequence from get_debug_snapshot.
+            let has_inference_queue = state.inference_queue.lock().await.is_some();
+            let (provider_name, model_name, base_url, improv_enabled) = {
+                let config = state.config.lock().await;
+                (
+                    config.provider_name.clone(),
+                    config.model_name.clone(),
+                    config.base_url.clone(),
+                    config.improv_enabled,
+                )
+            };
+            let events_snap: VecDeque<DebugEvent> =
+                state.debug_events.lock().await.iter().cloned().collect();
+            let game_events_snap: VecDeque<GameEvent> =
+                state.game_events.lock().await.iter().cloned().collect();
+            let call_log: Vec<parish_core::debug_snapshot::InferenceLogEntry> =
+                state.inference_log.lock().await.iter().cloned().collect();
+
+            let inference = InferenceDebug {
+                provider_name,
+                model_name,
+                base_url,
+                cloud_provider: None,
+                cloud_model: None,
+                has_queue: has_inference_queue,
+                reaction_req_id: 0,
+                improv_enabled,
+                call_log,
+            };
+
+            // Acquire world + npc_manager last, build snapshot, release.
+            let world = state.world.lock().await;
+            let npc_manager = state.npc_manager.lock().await;
+            let snapshot = build_debug_snapshot(
+                &world,
+                &npc_manager,
+                &events_snap,
+                &game_events_snap,
+                &inference,
+                &AuthDebug::disabled(),
+            );
+            drop(npc_manager);
+            drop(world);
+
+            snapshot
+        }));
+    }
+
+    // All tasks must complete without deadlock.
+    let mut snapshots = Vec::new();
+    for handle in handles {
+        snapshots.push(handle.await.expect("task panicked"));
+    }
+
+    assert_eq!(snapshots.len(), 8, "all 8 snapshot tasks must complete");
+    for snap in &snapshots {
+        // The snapshot must reference a valid world clock.
+        assert!(
+            snap.clock.game_time.contains("08:00"),
+            "clock should start at 08:00"
+        );
+        // The pre-populated debug event must be present.
+        assert_eq!(snap.events.len(), 1, "one debug event must be present");
+    }
+}
+
 // ── #335 — Branch name validation ────────────────────────────────────────────
 
 /// A branch name of 65 characters must be rejected with 400.

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -1482,18 +1482,59 @@ pub fn run() {
                         crate::commands::tick_inactivity(&state_idle, &handle_idle).await;
                     }
                 });
-                // Debug tick: emit debug snapshot every 2 seconds
+                // Debug tick: emit debug snapshot every 2 seconds.
+                //
+                // Snapshot each piece of state with a brief, non-overlapping
+                // lock window to avoid holding all 5+ locks simultaneously
+                // (#105, #282). Lock order: world → npc_manager →
+                // inference_queue → config → debug_events → game_events →
+                // inference_log (#483).
                 let state_debug = Arc::clone(&state_setup);
                 let handle_debug = handle.clone();
                 tokio::spawn(async move {
                     loop {
                         tokio::time::sleep(Duration::from_secs(2)).await;
-                        let world = state_debug.world.lock().await;
-                        let npc_manager = state_debug.npc_manager.lock().await;
-                        let debug_events = state_debug.debug_events.lock().await;
-                        let game_events = state_debug.game_events.lock().await;
-                        let config = state_debug.config.lock().await;
 
+                        // 1. Peek inference_queue presence first (#483).
+                        let has_inference_queue =
+                            state_debug.inference_queue.lock().await.is_some();
+
+                        // 2. Clone config fields — drop the lock immediately.
+                        let (provider_name, model_name, base_url, cloud_provider, cloud_model, improv_enabled) = {
+                            let config = state_debug.config.lock().await;
+                            (
+                                config.provider_name.clone(),
+                                config.model_name.clone(),
+                                config.base_url.clone(),
+                                config.cloud_provider_name.clone(),
+                                config.cloud_model_name.clone(),
+                                config.improv_enabled,
+                            )
+                        };
+
+                        // 3. Clone debug_events ring buffer — drop immediately.
+                        let debug_events_snapshot: std::collections::VecDeque<
+                            parish_core::debug_snapshot::DebugEvent,
+                        > = state_debug
+                            .debug_events
+                            .lock()
+                            .await
+                            .iter()
+                            .cloned()
+                            .collect();
+
+                        // 4. Clone game_events ring buffer — drop immediately.
+                        let game_events_snapshot: std::collections::VecDeque<
+                            parish_core::world::events::GameEvent,
+                        > = state_debug
+                            .game_events
+                            .lock()
+                            .await
+                            .iter()
+                            .cloned()
+                            .collect();
+
+                        // 5. Clone inference log — drop immediately.
                         let call_log: Vec<parish_core::debug_snapshot::InferenceLogEntry> =
                             state_debug
                                 .inference_log
@@ -1503,26 +1544,34 @@ pub fn run() {
                                 .cloned()
                                 .collect();
 
+                        // Build InferenceDebug from cloned data (no locks held).
                         let inference = InferenceDebug {
-                            provider_name: config.provider_name.clone(),
-                            model_name: config.model_name.clone(),
-                            base_url: config.base_url.clone(),
-                            cloud_provider: config.cloud_provider_name.clone(),
-                            cloud_model: config.cloud_model_name.clone(),
-                            has_queue: state_debug.inference_queue.lock().await.is_some(),
+                            provider_name,
+                            model_name,
+                            base_url,
+                            cloud_provider,
+                            cloud_model,
+                            has_queue: has_inference_queue,
                             reaction_req_id: parish_core::game_session::reaction_req_id_peek(),
-                            improv_enabled: config.improv_enabled,
+                            improv_enabled,
                             call_log,
                         };
 
+                        // 6. Acquire world and npc_manager (canonical order)
+                        // only for the pure-read snapshot build, then release.
+                        let world = state_debug.world.lock().await;
+                        let npc_manager = state_debug.npc_manager.lock().await;
                         let snapshot = parish_core::debug_snapshot::build_debug_snapshot(
                             &world,
                             &npc_manager,
-                            &debug_events,
-                            &game_events,
+                            &debug_events_snapshot,
+                            &game_events_snapshot,
                             &inference,
                             &parish_core::debug_snapshot::AuthDebug::disabled(),
                         );
+                        drop(npc_manager);
+                        drop(world);
+
                         let _ = handle_debug.emit(events::EVENT_DEBUG_UPDATE, snapshot);
                     }
                 });


### PR DESCRIPTION
## Summary

Fixes #105, fixes #282.

Both the Tauri debug tick (every 2 s) and the web server `get_debug_snapshot` route were acquiring `world`, `npc_manager`, `inference_queue`, `config`, `debug_events`, `game_events`, and `inference_log` and then holding 5 of those simultaneously while `build_debug_snapshot` ran. This caused:

- Latency spikes on all concurrent game operations (every handler that needs any of these locks had to wait)
- A latent deadlock risk if lock ordering ever drifted from the canonical sequence documented in `AppState` (#483)

## Design choice — Option A (minimal change)

Snapshot each lock's data in a brief, non-overlapping window, then acquire only `world` + `npc_manager` (in canonical order) for the pure-read `build_debug_snapshot` call and drop them immediately afterwards.

Lock order is preserved throughout:
```
world → npc_manager → inference_queue → config → debug_events → game_events → inference_log
```

No new abstractions, no type changes, no impact on callers of `build_debug_snapshot`.

## Files changed

- `crates/parish-server/src/routes.rs` — `get_debug_snapshot` handler (fixes #282)
- `crates/parish-tauri/src/lib.rs` — debug tick task (fixes #105)
- `crates/parish-server/tests/isolation.rs` — regression test: 8 concurrent snapshot tasks must complete without deadlock and produce coherent output

## Commands run

```
just check   # fmt + clippy + all tests — clean
cargo test -p parish-server --test isolation   # 10/10 pass, including new test
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)