### PR TITLE
fix(a11y): make SavePicker branch button keyboard-accessible

### DIFF
--- a/parish/apps/ui/src/components/SavePicker.svelte
+++ b/parish/apps/ui/src/components/SavePicker.svelte
@@ -438,12 +438,12 @@
 						</div>
 					{/each}
 
-					<div class="ledger-row new-ledger" on:click={handleForkLedger} role="button" tabindex="0" on:keydown={(e) => { if (!e.repeat && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); handleForkLedger(); } }}>
+					<div class="ledger-row new-ledger" on:click={() => { if (!loading) handleForkLedger(); }} role="button" tabindex="0" aria-disabled={loading} on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); if (!loading && !e.repeat) handleForkLedger(); } }}>
 						<span class="file-number">+</span>
 						<span class="file-name">Fork New Ledger</span>
 					</div>
 
-					<div class="ledger-row new-ledger" on:click={handleNewGame} role="button" tabindex="0" on:keydown={(e) => { if (!e.repeat && (e.key === 'Enter' || e.key === ' ')) { e.preventDefault(); handleNewGame(); } }}>
+					<div class="ledger-row new-ledger" on:click={() => { if (!loading) handleNewGame(); }} role="button" tabindex="0" aria-disabled={loading} on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); if (!loading && !e.repeat) handleNewGame(); } }}>
 						<span class="file-number">+</span>
 						<span class="file-name">New Game</span>
 					</div>
@@ -711,10 +711,12 @@
 		margin-bottom: 4px;
 		z-index: 5;
 	}
-	.dag-node:hover .node-branch-btn {
+	.dag-node:hover .node-branch-btn,
+	.dag-node:focus-within .node-branch-btn {
 		display: block;
 	}
-	.node-branch-btn:hover {
+	.node-branch-btn:hover,
+	.node-branch-btn:focus-visible {
 		color: var(--color-accent);
 		border-color: var(--color-accent);
 	}
@@ -888,6 +890,14 @@
 	.new-ledger {
 		border-bottom: none;
 		cursor: pointer;
+	}
+	.new-ledger:focus-visible {
+		outline: 2px solid var(--color-accent);
+		outline-offset: -2px;
+	}
+	.new-ledger[aria-disabled='true'] {
+		opacity: 0.5;
+		cursor: default;
 	}
 
 	.loading-msg {


### PR DESCRIPTION
## Summary

- **"Branch From Here" button now reachable by keyboard.** It was `display: none` by default and only shown on `:hover`, making it invisible to keyboard-only users. Added `:focus-within` so it appears when any child element (e.g. the node body button) has focus, letting users Tab to it.
- **"Fork New Ledger" / "New Game" guarded during loading.** These `role="button"` divs previously allowed re-clicks while an async operation was in flight. Added `aria-disabled` and JS guards to prevent double-submission.
- **Focus-visible styles added** to the new-ledger action rows and the branch button for clear keyboard navigation feedback.

## Accessibility improvements

| Element | Before | After |
|---------|--------|-------|
| "Branch From Here" btn | Hidden from keyboard users (hover-only) | Visible via `:focus-within` on parent node |
| "Fork New Ledger" / "New Game" | Clickable during loading, no disabled state | Guarded with `aria-disabled`, visual opacity change |
| New-ledger rows | No focus indicator | `:focus-visible` outline ring |
| Branch button | No focus style | `:focus-visible` accent highlight |

## Test plan

- [ ] Open the Ledger (F5), tab through DAG nodes — "Branch From Here" should appear when a node body has focus
- [ ] Tab to "Branch From Here" and activate with Enter — branching flow should start
- [ ] In Ledgers view, tab to "Fork New Ledger" / "New Game" — focus ring should be visible
- [ ] Trigger a load, verify "Fork New Ledger" / "New Game" become visually dimmed and unclickable

https://claude.ai/code/session_01Jre1azr8jS5zg2UZYTKqeZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jre1azr8jS5zg2UZYTKqeZ)_