### PR TITLE
fix(infra): cloudflare-cleanup gate + multiarch Dockerfile SHA

### DIFF
--- a/.github/workflows/cloudflare-cleanup.yml
+++ b/.github/workflows/cloudflare-cleanup.yml
@@ -43,9 +43,10 @@ jobs:
     # Only run when the required secrets are present.  PRs from external
     # contributors on public forks won't have access to secrets, and the
     # Railway preview env would never have been created anyway.
-    # Note: GitHub does not allow direct secret comparison in `if:`; we use
-    # an env var set from the secret — empty string evaluates falsy.
-    if: ${{ env.CF_API_TOKEN != '' }}
+    # Note: job-level `env` is not yet populated when the job-level `if` is
+    # evaluated, so `env.CF_API_TOKEN` is always empty there.  The `secrets`
+    # context IS available at job-level `if`, so we check the secret directly.
+    if: ${{ secrets.CF_API_TOKEN != '' }}
     env:
       CF_API: https://api.cloudflare.com/client/v4
       CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -27,19 +27,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Download cloudflared at a pinned version and verify against an inline SHA-256.
-# Cloudflare does not publish per-asset .sha256 files, so we pin the digest here
-# and verify locally. Bump CLOUDFLARED_VERSION and CLOUDFLARED_SHA256 together.
+# Cloudflare does not publish per-asset .sha256 files, so we pin the digests here
+# and verify locally. Bump CLOUDFLARED_VERSION and both SHA256 constants together.
 # TARGETARCH is set automatically by BuildKit (amd64, arm64).
-# The SHA below matches the amd64 binary; for arm64 builds, override via:
-#   docker build --build-arg CLOUDFLARED_SHA256=<arm64-digest> ...
+# Both amd64 and arm64 hashes are pinned inline; the correct one is selected via
+# a shell case statement so multi-arch builds are integrity-checked on every arch.
 ARG TARGETARCH
 ARG CLOUDFLARED_VERSION=2026.3.0
-ARG CLOUDFLARED_SHA256=4a9e50e6d6d798e90fcd01933151a90bf7edd99a0a55c28ad18f2e16263a5c30
 RUN cd /tmp \
  && curl -fsSL \
       "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-${TARGETARCH}" \
       -o cloudflared \
- && echo "${CLOUDFLARED_SHA256}  cloudflared" | sha256sum -c - \
+ && case "${TARGETARCH}" in \
+      amd64) SHA256="4a9e50e6d6d798e90fcd01933151a90bf7edd99a0a55c28ad18f2e16263a5c30" ;; \
+      arm64) SHA256="0755ba4cbab59980e6148367fcf53a8f3ec85a97deefd63c2420cf7850769bee" ;; \
+      *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+    esac \
+ && echo "${SHA256}  cloudflared" | sha256sum -c - \
  && install -m 0755 cloudflared /usr/local/bin/cloudflared \
  && rm cloudflared
 


### PR DESCRIPTION
## Summary

- **#647** — Fixes always-false cleanup gate: job-level `if: ${{ env.CF_API_TOKEN != '' }}` evaluated before `env` was populated, so the Cloudflare cleanup job silently never ran. Changed to `if: ${{ secrets.CF_API_TOKEN != '' }}` (the `secrets` context is available at job-level `if` evaluation time).
- **#648** — Fixes arm64 Dockerfile builds: `CLOUDFLARED_SHA256` was hardcoded to the amd64 digest, so arm64 image builds always failed `sha256sum` verification. Replaced the single `ARG` with an inline `case` statement that selects the correct pinned digest per architecture. The override build-arg is removed — both digests are baked in.

## Changes

- `.github/workflows/cloudflare-cleanup.yml`: `env.CF_API_TOKEN` → `secrets.CF_API_TOKEN` in job-level `if`
- `deploy/Dockerfile`: per-arch SHA-256 selection via shell `case`; amd64 and arm64 both pinned inline for cloudflared 2026.3.0

## Commands run

```
just check   # fmt + clippy + tests — all pass
```

Fixes #647, fixes #648.