### PR TITLE
fix: surface panics in NPC reaction tasks; remove dead WS guard check

### DIFF
--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -1487,7 +1487,9 @@ fn emit_npc_reactions(
     let player_msg_id = player_msg_id.to_string();
     let player_input = player_input.to_string();
 
-    tokio::spawn(async move {
+    // #651 — await the task handle and surface any panic to the log so errors
+    // are never silently swallowed.
+    let handle = tokio::spawn(async move {
         let (npcs_here, llm_enabled, reaction_client, reaction_model) = {
             let npc_manager = state.npc_manager.lock().await;
             let config = state.config.lock().await;
@@ -1577,6 +1579,15 @@ fn emit_npc_reactions(
                     source: capitalize_first(&npc_name),
                 },
             );
+        }
+    });
+
+    // Spawn a lightweight watcher that logs any panic from the reaction batch
+    // (#651). This keeps emit_npc_reactions non-blocking while ensuring panics
+    // are visible in the tracing output rather than silently swallowed.
+    tokio::spawn(async move {
+        if let Err(e) = handle.await {
+            tracing::error!(error = %e, "emit_npc_reactions task panicked");
         }
     });
 }

--- a/crates/parish-server/src/ws.rs
+++ b/crates/parish-server/src/ws.rs
@@ -46,16 +46,13 @@ impl Drop for ActiveWsGuard {
             set.remove(&self.email);
         } else if let Ok(handle) = tokio::runtime::Handle::try_current() {
             // #499 — only spawn cleanup if the Tokio runtime is still alive.
+            // #656 — drop the handle immediately (fire-and-forget); is_finished()
+            // on a freshly-spawned task is always false and was dead code.
             let state = Arc::clone(&self.state);
             let email = self.email.clone();
-            if handle
-                .spawn(async move {
-                    state.active_ws.lock().await.remove(&email);
-                })
-                .is_finished()
-            {
-                tracing::warn!(user = %self.email, "ActiveWsGuard: async cleanup task completed immediately or failed");
-            }
+            let _handle = handle.spawn(async move {
+                state.active_ws.lock().await.remove(&email);
+            });
         } else {
             tracing::warn!(user = %self.email, "ActiveWsGuard: no Tokio runtime — email slot leaked (benign at shutdown)");
         }

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -1958,7 +1958,9 @@ fn emit_npc_reactions(
     let player_msg_id = player_msg_id.to_string();
     let player_input = player_input.to_string();
 
-    tokio::spawn(async move {
+    // #651 — await the task handle and surface any panic to the log so errors
+    // are never silently swallowed.
+    let handle = tokio::spawn(async move {
         let (npcs_here, llm_enabled, reaction_client, reaction_model) = {
             let npc_manager = state.npc_manager.lock().await;
             let config = state.config.lock().await;
@@ -2048,6 +2050,15 @@ fn emit_npc_reactions(
                     source: capitalize_first(&npc_name),
                 },
             );
+        }
+    });
+
+    // Spawn a lightweight watcher that logs any panic from the reaction batch
+    // (#651). This keeps emit_npc_reactions non-blocking while ensuring panics
+    // are visible in the tracing output rather than silently swallowed.
+    tokio::spawn(async move {
+        if let Err(e) = handle.await {
+            tracing::error!(error = %e, "emit_npc_reactions task panicked");
         }
     });
 }


### PR DESCRIPTION
## Summary

- **#651** (`fix`): `emit_npc_reactions` spawned a detached `tokio::spawn` whose `JoinHandle` was immediately dropped, meaning any panic inside the outer task was silently swallowed. Now a lightweight watcher task awaits the handle and logs panics via `tracing::error!`. Applied to both `parish-server` (`routes.rs`) and `parish-tauri` (`commands.rs`) for mode parity.

- **#656** (`chore`): `ActiveWsGuard::Drop` called `is_finished()` on a freshly-spawned `JoinHandle` from within a synchronous `Drop` body — the async task never gets a chance to poll before `Drop` returns, so `is_finished()` is always `false` and the warning log was dead code. Removed the check; the handle is now dropped immediately (fire-and-forget), which was already the intent.

## Test plan

- [x] `just check` — fmt + clippy + 289 tests all pass (148 unit + 29 integration + 74 headless script + 10 persistence + 28 world graph)
- [x] No new `#[allow]` introduced
- [x] Both changes applied across server and Tauri code paths for mode parity

Fixes #651, fixes #656.