### PR TITLE
fix: rich-text indentation + witness-scan unreachable! false positive

### DIFF
--- a/apps/ui/.prettierrc
+++ b/apps/ui/.prettierrc
@@ -1,0 +1,5 @@
+{
+	"useTabs": true,
+	"singleQuote": true,
+	"trailingComma": "all"
+}

--- a/apps/ui/src/lib/rich-text.test.ts
+++ b/apps/ui/src/lib/rich-text.test.ts
@@ -1,128 +1,128 @@
-import { describe, it, expect } from "vitest";
-import { segmentText, type RichSegment } from "./rich-text";
+import { describe, it, expect } from 'vitest';
+import { segmentText, type RichSegment } from './rich-text';
 
-describe("segmentText", () => {
-  it("returns plain segment for empty hints", () => {
-    expect(segmentText("Hello world", [], [], "")).toEqual([
-      { text: "Hello world", kind: "plain" },
-    ]);
-  });
+describe('segmentText', () => {
+	it('returns plain segment for empty hints', () => {
+		expect(segmentText('Hello world', [], [], '')).toEqual([
+			{ text: 'Hello world', kind: 'plain' },
+		]);
+	});
 
-  it("returns empty array for empty content", () => {
-    expect(segmentText("", ["féile"], [], "")).toEqual([]);
-  });
+	it('returns empty array for empty content', () => {
+		expect(segmentText('', ['féile'], [], '')).toEqual([]);
+	});
 
-  it("highlights Irish words", () => {
-    const result = segmentText("He said fáilte warmly", ["fáilte"], [], "");
-    expect(result).toEqual([
-      { text: "He said ", kind: "plain" },
-      { text: "fáilte", kind: "irish" },
-      { text: " warmly", kind: "plain" },
-    ]);
-  });
+	it('highlights Irish words', () => {
+		const result = segmentText('He said fáilte warmly', ['fáilte'], [], '');
+		expect(result).toEqual([
+			{ text: 'He said ', kind: 'plain' },
+			{ text: 'fáilte', kind: 'irish' },
+			{ text: ' warmly', kind: 'plain' },
+		]);
+	});
 
-  it("highlights NPC names", () => {
-    const result = segmentText("Seán walked home", [], ["Seán"], "");
-    expect(result).toEqual([
-      { text: "Seán", kind: "name" },
-      { text: " walked home", kind: "plain" },
-    ]);
-  });
+	it('highlights NPC names', () => {
+		const result = segmentText('Seán walked home', [], ['Seán'], '');
+		expect(result).toEqual([
+			{ text: 'Seán', kind: 'name' },
+			{ text: ' walked home', kind: 'plain' },
+		]);
+	});
 
-  it("highlights location name", () => {
-    const result = segmentText("Welcome to Kilteevan", [], [], "Kilteevan");
-    expect(result).toEqual([
-      { text: "Welcome to ", kind: "plain" },
-      { text: "Kilteevan", kind: "location" },
-    ]);
-  });
+	it('highlights location name', () => {
+		const result = segmentText('Welcome to Kilteevan', [], [], 'Kilteevan');
+		expect(result).toEqual([
+			{ text: 'Welcome to ', kind: 'plain' },
+			{ text: 'Kilteevan', kind: 'location' },
+		]);
+	});
 
-  it("irish priority beats name on overlap", () => {
-    const result = segmentText(
-      "The word féile is nice",
-      ["féile"],
-      ["féile"],
-      "",
-    );
-    expect(result).toEqual([
-      { text: "The word ", kind: "plain" },
-      { text: "féile", kind: "irish" },
-      { text: " is nice", kind: "plain" },
-    ]);
-  });
+	it('irish priority beats name on overlap', () => {
+		const result = segmentText(
+			'The word féile is nice',
+			['féile'],
+			['féile'],
+			'',
+		);
+		expect(result).toEqual([
+			{ text: 'The word ', kind: 'plain' },
+			{ text: 'féile', kind: 'irish' },
+			{ text: ' is nice', kind: 'plain' },
+		]);
+	});
 
-  it("handles multiple words in a single category", () => {
-    const result = segmentText(
-      "A cáca and bainne please",
-      ["cáca", "bainne"],
-      [],
-      "",
-    );
-    expect(result).toEqual([
-      { text: "A ", kind: "plain" },
-      { text: "cáca", kind: "irish" },
-      { text: " and ", kind: "plain" },
-      { text: "bainne", kind: "irish" },
-      { text: " please", kind: "plain" },
-    ]);
-  });
+	it('handles multiple words in a single category', () => {
+		const result = segmentText(
+			'A cáca and bainne please',
+			['cáca', 'bainne'],
+			[],
+			'',
+		);
+		expect(result).toEqual([
+			{ text: 'A ', kind: 'plain' },
+			{ text: 'cáca', kind: 'irish' },
+			{ text: ' and ', kind: 'plain' },
+			{ text: 'bainne', kind: 'irish' },
+			{ text: ' please', kind: 'plain' },
+		]);
+	});
 
-  it("is case-insensitive", () => {
-    const result = segmentText("FÁILTE to you", ["fáilte"], [], "");
-    expect(result).toEqual([
-      { text: "FÁILTE", kind: "irish" },
-      { text: " to you", kind: "plain" },
-    ]);
-  });
+	it('is case-insensitive', () => {
+		const result = segmentText('FÁILTE to you', ['fáilte'], [], '');
+		expect(result).toEqual([
+			{ text: 'FÁILTE', kind: 'irish' },
+			{ text: ' to you', kind: 'plain' },
+		]);
+	});
 
-  it("does not match partial words", () => {
-    const result = segmentText("unfailing effort", ["fail"], [], "");
-    expect(result).toEqual([{ text: "unfailing effort", kind: "plain" }]);
-  });
+	it('does not match partial words', () => {
+		const result = segmentText('unfailing effort', ['fail'], [], '');
+		expect(result).toEqual([{ text: 'unfailing effort', kind: 'plain' }]);
+	});
 
-  it("handles regex-special characters in words", () => {
-    const result = segmentText("Price is $5.00 today", ["$5.00"], [], "");
-    expect(result).toEqual([
-      { text: "Price is ", kind: "plain" },
-      { text: "$5.00", kind: "irish" },
-      { text: " today", kind: "plain" },
-    ]);
-  });
+	it('handles regex-special characters in words', () => {
+		const result = segmentText('Price is $5.00 today', ['$5.00'], [], '');
+		expect(result).toEqual([
+			{ text: 'Price is ', kind: 'plain' },
+			{ text: '$5.00', kind: 'irish' },
+			{ text: ' today', kind: 'plain' },
+		]);
+	});
 
-  it("filters empty strings from word lists", () => {
-    const result = segmentText("A féile day", ["", "féile", ""], [], "");
-    expect(result).toEqual([
-      { text: "A ", kind: "plain" },
-      { text: "féile", kind: "irish" },
-      { text: " day", kind: "plain" },
-    ]);
-  });
+	it('filters empty strings from word lists', () => {
+		const result = segmentText('A féile day', ['', 'féile', ''], [], '');
+		expect(result).toEqual([
+			{ text: 'A ', kind: 'plain' },
+			{ text: 'féile', kind: 'irish' },
+			{ text: ' day', kind: 'plain' },
+		]);
+	});
 
-  it("higher-priority match wins even when a lower-priority match starts earlier", () => {
-    // "An Cailín" is registered as a name (lower priority) starting at col 4;
-    // "Cailín" is registered as an irish word (higher priority) starting at col 7.
-    // Both matches overlap.  Per the docstring, priority resolves overlaps:
-    // the irish "Cailín" should win even though the name "An Cailín" starts first.
-    const result = segmentText(
-      "Say An Cailín please",
-      ["Cailín"],
-      ["An Cailín"],
-      "",
-    );
-    expect(result.some((s) => s.kind === "irish" && s.text === "Cailín")).toBe(
-      true,
-    );
-    expect(result.every((s) => s.kind !== "name")).toBe(true);
-  });
+	it('higher-priority match wins even when a lower-priority match starts earlier', () => {
+		// 'An Cailín' is registered as a name (lower priority) starting at col 4;
+		// 'Cailín' is registered as an irish word (higher priority) starting at col 7.
+		// Both matches overlap.  Per the docstring, priority resolves overlaps:
+		// the irish 'Cailín' should win even though the name 'An Cailín' starts first.
+		const result = segmentText(
+			'Say An Cailín please',
+			['Cailín'],
+			['An Cailín'],
+			'',
+		);
+		expect(result.some((s) => s.kind === 'irish' && s.text === 'Cailín')).toBe(
+			true,
+		);
+		expect(result.every((s) => s.kind !== 'name')).toBe(true);
+	});
 
-  it("longest match wins when words overlap", () => {
-    const result = segmentText(
-      "The An Cailín spoke",
-      ["An Cailín", "An"],
-      [],
-      "",
-    );
-    const kinds = result.map((s) => `${s.kind}:${s.text}`);
-    expect(kinds).toContain("irish:An Cailín");
-  });
+	it('longest match wins when words overlap', () => {
+		const result = segmentText(
+			'The An Cailín spoke',
+			['An Cailín', 'An'],
+			[],
+			'',
+		);
+		const kinds = result.map((s) => `${s.kind}:${s.text}`);
+		expect(kinds).toContain('irish:An Cailín');
+	});
 });

--- a/apps/ui/src/lib/rich-text.ts
+++ b/apps/ui/src/lib/rich-text.ts
@@ -19,6 +19,15 @@ interface MatchRange {
 	kind: SegmentKind;
 }
 
+// Priority table (module-level constant): higher number = higher priority.
+// Hoisted out of segmentText so it is not reallocated on every call.
+const KIND_PRIORITY: Record<SegmentKind, number> = {
+	irish: 3,
+	location: 2,
+	name: 1,
+	plain: 0,
+};
+
 /**
  * Splits `content` into segments annotated with a semantic kind.
  *
@@ -65,14 +74,6 @@ export function segmentText(
 
 	if (ranges.length === 0) return [{ text: content, kind: 'plain' }];
 
-	// Priority table: higher number = higher priority.
-	const kindPriority: Record<SegmentKind, number> = {
-		irish: 3,
-		location: 2,
-		name: 1,
-		plain: 0,
-	};
-
 	// Resolve overlaps by priority first (highest wins), then by start position
 	// for equal-priority matches (earlier wins).  This matches the docstring
 	// contract: "Overlapping matches are resolved by priority; for equal-priority
@@ -81,12 +82,13 @@ export function segmentText(
 	// Algorithm:
 	//   1. Sort by priority descending, then by start position ascending.
 	//   2. Greedily accept ranges that don't overlap any already-accepted range.
-	//      Because we visit highest-priority ranges first, a high-priority range
-	//      that starts later will be accepted before a lower-priority range that
-	//      started earlier — exactly the behaviour the docstring promises.
+	//      Because we visit in priority-DESC order, a higher-priority range is
+	//      always accepted before a lower-priority one, regardless of position.
+	//      Among equal-priority matches the start-ASC sub-sort ensures the
+	//      earlier range is visited (and accepted) first.
 	//   3. Re-sort accepted ranges by start position for segment construction.
 	ranges.sort(
-		(a, b) => kindPriority[b.kind] - kindPriority[a.kind] || a.start - b.start,
+		(a, b) => KIND_PRIORITY[b.kind] - KIND_PRIORITY[a.kind] || a.start - b.start,
 	);
 
 	const resolved: MatchRange[] = [];

--- a/apps/ui/src/lib/rich-text.ts
+++ b/apps/ui/src/lib/rich-text.ts
@@ -6,17 +6,17 @@
  * and location names without requiring any backend markup.
  */
 
-export type SegmentKind = "plain" | "irish" | "name" | "location";
+export type SegmentKind = 'plain' | 'irish' | 'name' | 'location';
 
 export interface RichSegment {
-  text: string;
-  kind: SegmentKind;
+	text: string;
+	kind: SegmentKind;
 }
 
 interface MatchRange {
-  start: number;
-  end: number;
-  kind: SegmentKind;
+	start: number;
+	end: number;
+	kind: SegmentKind;
 }
 
 /**
@@ -27,93 +27,92 @@ interface MatchRange {
  * the earlier one wins. Matching is case-insensitive and word-boundary aware.
  */
 export function segmentText(
-  content: string,
-  irishWords: string[],
-  nameWords: string[],
-  locationName: string,
+	content: string,
+	irishWords: string[],
+	nameWords: string[],
+	locationName: string,
 ): RichSegment[] {
-  if (!content) return [];
+	if (!content) return [];
 
-  const ranges: MatchRange[] = [];
+	const ranges: MatchRange[] = [];
 
-  // Single alternation regex per category instead of one regex per word.
-  // Reduces regex compilations from O(words) to O(1) and content scans
-  // from O(words) to O(1) per category.
-  const addMatches = (words: string[], kind: SegmentKind) => {
-    const filtered = words.map((w) => w.trim()).filter(Boolean);
-    if (filtered.length === 0) return;
-    // Sort longest-first so alternation matches greedily
-    filtered.sort((a, b) => b.length - a.length);
-    const alt = filtered
-      .map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
-      .join("|");
-    const re = new RegExp(
-      `(?<![\\w\\u00C0-\\u024F])(?:${alt})(?![\\w\\u00C0-\\u024F])`,
-      "gi",
-    );
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(content)) !== null) {
-      ranges.push({ start: m.index, end: m.index + m[0].length, kind });
-    }
-  };
+	// Single alternation regex per category instead of one regex per word.
+	// Reduces regex compilations from O(words) to O(1) and content scans
+	// from O(words) to O(1) per category.
+	const addMatches = (words: string[], kind: SegmentKind) => {
+		const filtered = words.map((w) => w.trim()).filter(Boolean);
+		if (filtered.length === 0) return;
+		// Sort longest-first so alternation matches greedily
+		filtered.sort((a, b) => b.length - a.length);
+		const alt = filtered
+			.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+			.join('|');
+		const re = new RegExp(
+			`(?<![\\w\\u00C0-\\u024F])(?:${alt})(?![\\w\\u00C0-\\u024F])`,
+			'gi',
+		);
+		let m: RegExpExecArray | null;
+		while ((m = re.exec(content)) !== null) {
+			ranges.push({ start: m.index, end: m.index + m[0].length, kind });
+		}
+	};
 
-  // Add in reverse priority order (lower priority first) so higher-priority
-  // matches can overwrite during conflict resolution below.
-  addMatches(nameWords, "name");
-  if (locationName) addMatches([locationName], "location");
-  addMatches(irishWords, "irish");
+	// Add in reverse priority order (lower priority first) so higher-priority
+	// matches can overwrite during conflict resolution below.
+	addMatches(nameWords, 'name');
+	if (locationName) addMatches([locationName], 'location');
+	addMatches(irishWords, 'irish');
 
-  if (ranges.length === 0) return [{ text: content, kind: "plain" }];
+	if (ranges.length === 0) return [{ text: content, kind: 'plain' }];
 
-  // Priority table: higher number = higher priority.
-  const kindPriority: Record<SegmentKind, number> = {
-    irish: 3,
-    location: 2,
-    name: 1,
-    plain: 0,
-  };
+	// Priority table: higher number = higher priority.
+	const kindPriority: Record<SegmentKind, number> = {
+		irish: 3,
+		location: 2,
+		name: 1,
+		plain: 0,
+	};
 
-  // Resolve overlaps by priority first (highest wins), then by start position
-  // for equal-priority matches (earlier wins).  This matches the docstring
-  // contract: "Overlapping matches are resolved by priority; for equal-priority
-  // matches the earlier one wins."
-  //
-  // Algorithm:
-  //   1. Sort by priority descending, then by start position ascending.
-  //   2. Greedily accept ranges that don't overlap any already-accepted range.
-  //      Because we visit highest-priority ranges first, a high-priority range
-  //      that starts later will be accepted before a lower-priority range that
-  //      started earlier — exactly the behaviour the docstring promises.
-  //   3. Re-sort accepted ranges by start position for segment construction.
-  ranges.sort(
-    (a, b) =>
-      kindPriority[b.kind] - kindPriority[a.kind] || a.start - b.start,
-  );
+	// Resolve overlaps by priority first (highest wins), then by start position
+	// for equal-priority matches (earlier wins).  This matches the docstring
+	// contract: "Overlapping matches are resolved by priority; for equal-priority
+	// matches the earlier one wins."
+	//
+	// Algorithm:
+	//   1. Sort by priority descending, then by start position ascending.
+	//   2. Greedily accept ranges that don't overlap any already-accepted range.
+	//      Because we visit highest-priority ranges first, a high-priority range
+	//      that starts later will be accepted before a lower-priority range that
+	//      started earlier — exactly the behaviour the docstring promises.
+	//   3. Re-sort accepted ranges by start position for segment construction.
+	ranges.sort(
+		(a, b) => kindPriority[b.kind] - kindPriority[a.kind] || a.start - b.start,
+	);
 
-  const resolved: MatchRange[] = [];
-  for (const r of ranges) {
-    // Reject if this range overlaps any already-accepted range.
-    const overlaps = resolved.some((a) => r.start < a.end && r.end > a.start);
-    if (overlaps) continue;
-    resolved.push(r);
-  }
+	const resolved: MatchRange[] = [];
+	for (const r of ranges) {
+		// Reject if this range overlaps any already-accepted range.
+		const overlaps = resolved.some((a) => r.start < a.end && r.end > a.start);
+		if (overlaps) continue;
+		resolved.push(r);
+	}
 
-  // Re-sort by start position for left-to-right segment construction.
-  resolved.sort((a, b) => a.start - b.start);
+	// Re-sort by start position for left-to-right segment construction.
+	resolved.sort((a, b) => a.start - b.start);
 
-  // Build segment array
-  const segments: RichSegment[] = [];
-  let pos = 0;
-  for (const r of resolved) {
-    if (r.start > pos) {
-      segments.push({ text: content.slice(pos, r.start), kind: "plain" });
-    }
-    segments.push({ text: content.slice(r.start, r.end), kind: r.kind });
-    pos = r.end;
-  }
-  if (pos < content.length) {
-    segments.push({ text: content.slice(pos), kind: "plain" });
-  }
+	// Build segment array
+	const segments: RichSegment[] = [];
+	let pos = 0;
+	for (const r of resolved) {
+		if (r.start > pos) {
+			segments.push({ text: content.slice(pos, r.start), kind: 'plain' });
+		}
+		segments.push({ text: content.slice(r.start, r.end), kind: r.kind });
+		pos = r.end;
+	}
+	if (pos < content.length) {
+		segments.push({ text: content.slice(pos), kind: 'plain' });
+	}
 
-  return segments;
+	return segments;
 }

--- a/justfile
+++ b/justfile
@@ -259,7 +259,7 @@ witness-scan:
         -e 'return nil\s*//\s*placeholder' \
         -e 'todo!\(' \
         -e 'unimplemented!\(' \
-        -e 'unreachable!\(' \
+        -e 'unreachable!\(\s*\)' \
         -e 'panic!\("[Nn]ot implemented' \
         -e 'panic!\("[Tt]odo' \
         -- "$f" && found=1 || true


### PR DESCRIPTION
## Summary

- Re-indents `apps/ui/src/lib/rich-text.ts` and `apps/ui/src/lib/rich-text.test.ts` from 2-space/double-quoted back to project-standard tab/single-quote (code-style.md §Frontend). Also adds `apps/ui/.prettierrc` with `useTabs: true` + `singleQuote: true` so `npx prettier --check` enforces this going forward.
- Tightens the `witness-scan` grep from `unreachable!\(` (which flags all `unreachable!` calls) to `unreachable!\(\s*\)` (which only flags bare argumentless `unreachable!()` placeholder calls, allowing legitimate `unreachable!("validated above")` usage).

## Test plan

- [x] `npx prettier --check apps/ui/src/lib/rich-text.ts apps/ui/src/lib/rich-text.test.ts` — passes
- [x] `just witness-scan` — passes (no false positives)
- [x] `just check` — passes (fmt-check + clippy + tests + witness-scan)

Fixes #652, fixes #653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)