### PR TITLE
fix(npc): distinguish panic vs cancellation in reaction watcher tasks

### DIFF
--- a/parish/crates/parish-cli/src/headless.rs
+++ b/parish/crates/parish-cli/src/headless.rs
@@ -1348,8 +1348,21 @@ async fn emit_headless_npc_reactions(app: &mut App, player_input: &str) {
 
     // Collect results as tasks finish, then persist + print each reaction.
     while let Some(result) = join_set.join_next().await {
-        let Ok((npc_name, Some(emoji))) = result else {
-            continue;
+        let (npc_name, emoji) = match result {
+            Ok((name, Some(emoji))) => (name, emoji),
+            Ok((_, None)) => continue,
+            Err(e) if e.is_panic() => {
+                tracing::error!(error = %e, "npc reaction task panicked");
+                continue;
+            }
+            Err(e) if e.is_cancelled() => {
+                tracing::debug!("npc reaction task cancelled (shutdown)");
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "npc reaction task ended unexpectedly");
+                continue;
+            }
         };
 
         // Persist to reaction_log so NPC memory is maintained (#403).

--- a/parish/crates/parish-server/src/routes.rs
+++ b/parish/crates/parish-server/src/routes.rs
@@ -1517,8 +1517,6 @@ fn emit_npc_reactions(
     let player_msg_id = player_msg_id.to_string();
     let player_input = player_input.to_string();
 
-    // #651 — await the task handle and surface any panic to the log so errors
-    // are never silently swallowed.
     let handle = tokio::spawn(async move {
         let (npcs_here, llm_enabled, reaction_client, reaction_model) = {
             let npc_manager = state.npc_manager.lock().await;
@@ -1585,8 +1583,21 @@ fn emit_npc_reactions(
 
         // Collect results as tasks finish, then persist + emit each reaction.
         while let Some(result) = join_set.join_next().await {
-            let Ok((npc_name, Some(emoji))) = result else {
-                continue;
+            let (npc_name, emoji) = match result {
+                Ok((name, Some(emoji))) => (name, emoji),
+                Ok((_, None)) => continue,
+                Err(e) if e.is_panic() => {
+                    tracing::error!(error = %e, "npc reaction task panicked");
+                    continue;
+                }
+                Err(e) if e.is_cancelled() => {
+                    tracing::debug!("npc reaction task cancelled (shutdown)");
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "npc reaction task ended unexpectedly");
+                    continue;
+                }
             };
 
             // Persist to reaction_log so NPC memory is maintained (#403).
@@ -1612,12 +1623,20 @@ fn emit_npc_reactions(
         }
     });
 
-    // Spawn a lightweight watcher that logs any panic from the reaction batch
-    // (#651). This keeps emit_npc_reactions non-blocking while ensuring panics
-    // are visible in the tracing output rather than silently swallowed.
+    // Watcher: keeps emit_npc_reactions non-blocking while making panics visible
+    // and quietly absorbing the cancellation seen during runtime shutdown.
     tokio::spawn(async move {
-        if let Err(e) = handle.await {
-            tracing::error!(error = %e, "emit_npc_reactions task panicked");
+        match handle.await {
+            Ok(_) => {}
+            Err(e) if e.is_panic() => {
+                tracing::error!(error = %e, "emit_npc_reactions task panicked");
+            }
+            Err(e) if e.is_cancelled() => {
+                tracing::debug!("emit_npc_reactions task cancelled (shutdown)");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "emit_npc_reactions task ended unexpectedly");
+            }
         }
     });
 }

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -1973,8 +1973,6 @@ fn emit_npc_reactions(
     let player_msg_id = player_msg_id.to_string();
     let player_input = player_input.to_string();
 
-    // #651 — await the task handle and surface any panic to the log so errors
-    // are never silently swallowed.
     let handle = tokio::spawn(async move {
         let (npcs_here, llm_enabled, reaction_client, reaction_model) = {
             let npc_manager = state.npc_manager.lock().await;
@@ -2041,8 +2039,21 @@ fn emit_npc_reactions(
 
         // Collect results as tasks finish, then persist + emit each reaction.
         while let Some(result) = join_set.join_next().await {
-            let Ok((npc_name, Some(emoji))) = result else {
-                continue;
+            let (npc_name, emoji) = match result {
+                Ok((name, Some(emoji))) => (name, emoji),
+                Ok((_, None)) => continue,
+                Err(e) if e.is_panic() => {
+                    tracing::error!(error = %e, "npc reaction task panicked");
+                    continue;
+                }
+                Err(e) if e.is_cancelled() => {
+                    tracing::debug!("npc reaction task cancelled (shutdown)");
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "npc reaction task ended unexpectedly");
+                    continue;
+                }
             };
 
             // Persist to reaction_log so NPC memory is maintained (#403).
@@ -2068,12 +2079,20 @@ fn emit_npc_reactions(
         }
     });
 
-    // Spawn a lightweight watcher that logs any panic from the reaction batch
-    // (#651). This keeps emit_npc_reactions non-blocking while ensuring panics
-    // are visible in the tracing output rather than silently swallowed.
+    // Watcher: keeps emit_npc_reactions non-blocking while making panics visible
+    // and quietly absorbing the cancellation seen during runtime shutdown.
     tokio::spawn(async move {
-        if let Err(e) = handle.await {
-            tracing::error!(error = %e, "emit_npc_reactions task panicked");
+        match handle.await {
+            Ok(_) => {}
+            Err(e) if e.is_panic() => {
+                tracing::error!(error = %e, "emit_npc_reactions task panicked");
+            }
+            Err(e) if e.is_cancelled() => {
+                tracing::debug!("emit_npc_reactions task cancelled (shutdown)");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "emit_npc_reactions task ended unexpectedly");
+            }
         }
     });
 }


### PR DESCRIPTION
## Summary

- Polish from a Gemini review that didn't land in #661: refine the
  `emit_npc_reactions` watcher and inner `JoinSet` handling to use
  `JoinError::is_panic()` / `is_cancelled()` instead of treating every
  `Err` as a panic.
- Without this, runtime shutdown turns the cancellation of in-flight
  reaction batches into a `tracing::error!`. After this:
  - **panic** → `tracing::error!` (real bug)
  - **cancelled** → `tracing::debug!` (normal at shutdown / abort)
  - **other** → `tracing::warn!` (unexpected, but not a panic)
- Applied across all three modes for parity: `parish-server` (`routes.rs`),
  `parish-tauri` (`commands.rs`), and `parish-cli` (`headless.rs`).
  Headless has no outer watcher (the function is awaited inline), so only
  the inner `JoinSet` arm changes there.

## Test plan

- [x] `just check` (fmt + clippy `-D warnings` + workspace tests) passes locally
- [ ] CI green