### PR TITLE
docs: track three deferred follow-ups from harness-engineering plan

### DIFF
--- a/docs/adr/020-npc-tool-use.md
+++ b/docs/adr/020-npc-tool-use.md
@@ -1,0 +1,91 @@
+# ADR-020: NPC Function-Calling / Tool-Use Output
+
+> Back to [ADR Index](README.md) | [Docs Index](../index.md)
+
+## Status
+
+Proposed (2026-04-26). No implementation yet.
+
+## Context
+
+Tier 1 NPC dialogue today is rendered as **prose followed by a `---` separator and a JSON sidecar** (see [ADR-008 Structured JSON LLM Output](008-structured-json-llm-output.md), [ADR-019 JSON Structured Output for NPC Dialogue](019-json-structured-output-for-npc-dialogue.md)). The system prompt at `mods/rundale/prompts/tier1_system.txt` instructs the model to emit:
+
+```
+<dialogue text>
+---
+{
+  "action": "...",
+  "mood": "...",
+  "internal_thought": "...",
+  "irish_words": [...]
+}
+```
+
+This works, but has two costs that show up in the harness:
+
+1. **Parse fragility.** The separator-based protocol depends on the model behaving. We've already shipped one fix for this — see commit `1b3c5bc refactor: replace separator-based LLM parsing with JSON structured output (#472)`. The post-fix parser is robust, but every new field (e.g. tier-2 `mood_changes` arrays, `relationship_changes`) costs prompt-engineering effort to keep the model emitting the right shape across providers.
+2. **Action enumeration drift.** `"action"` is a freeform string in the schema; the engine's enum (`speak | move | trade | work | rest | observe`) is *implied* by the prompt. The model can emit an action the engine doesn't know how to handle, and we discover it at runtime.
+
+Most modern provider APIs (Anthropic, OpenAI, Google) expose **structured tool-calling**: the client declares a JSON schema for each tool, the provider validates the model's call against the schema, and the response is a guaranteed-typed structured object instead of free text. This eliminates both costs above.
+
+Two complications:
+
+- **Local Ollama doesn't reliably support tool-calling** for the model sizes we target (14B, 9B). [ADR-005 Ollama Local Inference](005-ollama-local-inference.md) commits us to a local-first option. Any decision must keep the offline path viable.
+- **Streaming.** Today Tier 1 streams the prose to the client token-by-token (see `parish-server/src/ws.rs`, `parish-inference/src/utf8_stream.rs`); the JSON sidecar is parsed at the end. Tool-calling typically returns a single structured response, defeating the streaming UX.
+
+## Decision
+
+**Deferred.** Capture the trade-offs here and come back to it after one of the following:
+
+- The harness gains [LLM quality evals](../plans/llm-quality-evals.md) (separate plan) — once we can quantitatively measure prose vs tool-call output quality, the choice is no longer guesswork.
+- A local model gains reliable tool-calling at 9B parameters or below.
+- The JSON-sidecar schema grows by another two fields (signal that prompt-engineering cost is exceeding tool-call benefit).
+
+When we revisit, the candidate decision is:
+
+> **Cloud Tier 1 dialogue uses provider-native tool-calling; local Ollama Tier 1 keeps the JSON-sidecar protocol as a fallback. Tier 2 / Tier 3 unconditionally use tool-calling on cloud providers since they don't stream and have a simpler schema.**
+
+## Consequences
+
+### If accepted (when we revisit)
+
+**Easier:**
+
+- Schema validation moves from prompt engineering to API contract — the engine's action enum becomes the tool's `action` enum, and the provider rejects bad calls before we see them.
+- Adding a field is a code change, not a prompt-tweak iteration.
+- LLM quality evals can rubric on tool-args validity directly (no JSON-extraction step).
+
+**Harder:**
+
+- **Two code paths per tier.** Cloud Tier 1 uses tool-calling; local Tier 1 uses the existing protocol. Mode parity (AGENTS.md §2) requires both to produce the same `Tier1Response` struct. Likely materializes as a `Tier1ResponseAdapter` trait with `CloudToolCallAdapter` and `JsonSidecarAdapter` impls.
+- **Streaming UX.** Need to design how a tool-call response surfaces dialogue tokens to the client. Options: (a) keep dialogue as a streamed prose field on the tool's argument (token-stream within structured args is supported by Anthropic/OpenAI), (b) accept non-streaming Tier 1 on cloud and rely on cloud latency being low enough.
+- **Prompt rewrite.** `tier1_system.txt` must teach the cloud path to call the tool *and* the local path to emit the sidecar. Prompt-template branching, gated on provider category from `parish-config`'s provider routing.
+
+### If rejected
+
+We keep the current protocol and accept the two costs above. The escape hatch is to invest more in the JSON-sidecar parser robustness.
+
+## Alternatives Considered
+
+### A. Adopt tool-calling everywhere immediately, drop local-Ollama Tier 1
+
+Cleanest code path. Violates [ADR-005 Ollama Local Inference](005-ollama-local-inference.md). Rejected.
+
+### B. Build a Rust-side JSON-schema validator that retries on bad output
+
+Strictly an improvement to the current protocol. Cheaper than tool-calling, but doesn't address the action-enum-drift problem (still need a closed enum in the prompt and runtime enforcement). Could ship in parallel as a defensive measure regardless of this ADR's outcome.
+
+### C. Move all of Tier 1 to a single cloud provider, drop local
+
+Out of scope — that's a product decision, not an output-format one.
+
+## Related
+
+- [ADR-005 Ollama Local Inference](005-ollama-local-inference.md) — local-first commitment that constrains this decision.
+- [ADR-008 Structured JSON LLM Output](008-structured-json-llm-output.md) — current output protocol.
+- [ADR-013 Cloud LLM for Player Dialogue](013-cloud-llm-dialogue.md) — provider routing this decision would key off.
+- [ADR-017 Per-Category Inference Providers](017-per-category-inference-providers.md) — the category split (Dialogue / Simulation / Intent / Reaction) maps onto where tool-calling is and isn't viable.
+- [ADR-019 JSON Structured Output for NPC Dialogue](019-json-structured-output-for-npc-dialogue.md) — recent reinforcement of the current protocol.
+- [LLM Quality Evals Plan](../plans/llm-quality-evals.md) — measurement framework that should land before this decision, so the trade-off is data-driven.
+- [docs/design/npc-system.md](../design/npc-system.md) — current NPC pipeline this would change.
+- `mods/rundale/prompts/tier1_system.txt` — the prompt to refactor.

--- a/docs/adr/021-npc-memory-retrieval.md
+++ b/docs/adr/021-npc-memory-retrieval.md
@@ -1,0 +1,82 @@
+# ADR-021: Embedding-Based NPC Memory Retrieval
+
+> Back to [ADR Index](README.md) | [Docs Index](../index.md)
+
+## Status
+
+Proposed (2026-04-26). No implementation yet.
+
+## Context
+
+NPCs in Rundale carry two memory stores today (see [docs/design/npc-system.md](../design/npc-system.md) and `crates/parish-npc/src/memory.rs`):
+
+1. **Short-term** — a 20-entry ring buffer of recent observations and conversations.
+2. **Long-term** — accumulating entries with no eviction beyond manual pruning.
+
+When the engine constructs a Tier 1 prompt, it injects **all** long-term memories (or a recency-truncated slice) into the context. As an NPC's life progresses across many in-game days, this approach has predictable failures:
+
+- **Context pressure.** Long-term memory grows without bound; eventually it exceeds the model's context window or becomes the dominant chunk of every prompt, crowding out the system prompt and scene context.
+- **Recency bias.** Truncating to the most recent N entries throws away exactly the kind of memory that makes an NPC feel alive — "remember when you helped me with the harvest last spring" gets evicted long before "you said hello yesterday."
+- **No relevance signal.** A player asking about the priest in St. Brigid's Church doesn't need every memory in the NPC's life — they need memories about the priest, the church, and the player's prior interactions on related topics.
+
+The standard fix is **embedding-based retrieval**: store each memory as a vector, embed the prompt context, retrieve the top-K most relevant memories per turn. This works well in production agent systems but adds infrastructure: an embedding model, a vector store, an embedding step on every memory write, and a retrieval step on every prompt build.
+
+## Decision
+
+**Deferred.** Two prerequisites should land before we commit:
+
+1. **A reliable lightweight embedding option.** The local-first commitment from [ADR-005 Ollama Local Inference](005-ollama-local-inference.md) means we need an embedding model that ships with Ollama (or equivalent local runtime) and produces useful 256–768 dim vectors at acceptable latency. Today, the candidate is `nomic-embed-text` or `mxbai-embed-large` via Ollama — the local-quality bar should be measured before we rely on it.
+2. **Quality measurement.** Without [LLM quality evals](../plans/llm-quality-evals.md), we cannot tell whether retrieval *improves* dialogue quality vs. simply changing it. The eval suite should land first so the retrieval rollout can be evaluated.
+
+When we revisit, the candidate decision is:
+
+> **Long-term memory entries are stored both as plaintext (the existing `Memory` struct) and as an embedding vector. At Tier 1 prompt-build time, the engine embeds the scene context (player input + location + speakers) and selects the top-K (K ≈ 6) memories by cosine similarity, falling back to recency if the embedding store is unavailable. Short-term memory is unchanged. Vector storage piggy-backs on `parish-persistence`'s SQLite — likely [`sqlite-vss`](https://github.com/asg017/sqlite-vss) or an in-process kNN over a `BLOB` column.**
+
+## Consequences
+
+### If accepted (when we revisit)
+
+**Easier:**
+
+- NPCs can carry a long, plausible life-history without exploding the prompt.
+- Scenes feel more grounded — the right memory surfaces at the right moment without prompt-engineering hacks.
+- Eval suite can rubric on "did the relevant past event surface" with a held-out test corpus.
+
+**Harder:**
+
+- **New dependency surface.** Either a vector-search SQLite extension (`sqlite-vss` adds platform-specific binaries that complicate Tauri packaging) or an in-process kNN (works but slower above a few thousand memories per NPC).
+- **Embedding-time cost.** Every memory write becomes a model call. Tier 4 → Tier 1 promotion already runs an inflate step; embedding gets bundled there.
+- **Provider routing.** Embedding category needs to be added to the per-category provider config from [ADR-017](017-per-category-inference-providers.md). Cloud-vs-local choice for embeddings is its own knob.
+- **Migration.** Existing save files have memories without vectors; either lazily embed on first read or backfill on load.
+- **Eval guarantee.** A bad retrieval (irrelevant memory floated to top) can produce *worse* dialogue than no retrieval — the eval suite must catch this.
+
+### If rejected
+
+Stay with the recency-truncation approach. Accept that long-lived NPCs won't carry deep memory. Mitigations available without retrieval:
+
+- Per-NPC manual memory curation (a human picks the "core" memories that always go in).
+- LLM-assisted compaction — periodically summarize old memories into a single "biographical summary" entry.
+
+## Alternatives Considered
+
+### A. LLM-assisted summarization instead of retrieval
+
+Periodically run a Tier 2/3 simulation step that compacts the bottom-N memories into a single summary entry. Cheaper infrastructure, no embeddings, no vector store. Loses fidelity — the summary becomes the only history, and the original moments are gone. Could ship in parallel as a complement to retrieval.
+
+### B. Tag-based retrieval (no embeddings)
+
+Tag each memory at write-time with topics (NPC names, locations, themes) and retrieve by tag-match. Cheap and explainable. Requires the writer (the engine, on each Tier 1/2 turn) to assign tags — that's another LLM call or a hand-coded heuristic. The heuristic loses the semantic match that's the whole point of embeddings.
+
+### C. Cloud-only embeddings, drop local-Ollama support for long-lived NPCs
+
+Cleanest code, violates [ADR-005](005-ollama-local-inference.md). Rejected.
+
+## Related
+
+- [ADR-002 Cognitive LOD Tiers](002-cognitive-lod-tiers.md) — the tier system this would slot into.
+- [ADR-003 SQLite WAL Persistence](003-sqlite-wal-persistence.md) — likely host for the vector store.
+- [ADR-005 Ollama Local Inference](005-ollama-local-inference.md) — local-first commitment that constrains the embedding-model choice.
+- [ADR-017 Per-Category Inference Providers](017-per-category-inference-providers.md) — needs a new category for embedding.
+- [docs/design/npc-system.md](../design/npc-system.md) — current memory model. The "Consider embedding-based retrieval" sentence there is the seed for this ADR.
+- [LLM Quality Evals Plan](../plans/llm-quality-evals.md) — measurement framework that should land before this decision.
+- `crates/parish-npc/src/memory.rs` — the module to extend.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,9 @@ This directory contains Architecture Decision Records (ADRs) for the Rundale gam
 | [016](016-tauri-svelte-gui.md) | Replace egui with Tauri 2 + Svelte GUI | Accepted | 2026-03-24 |
 | [017](017-per-category-inference-providers.md) | Per-Category Inference Providers | Accepted | 2026-03-23 |
 | [018](018-npc-intelligence-dimensions.md) | NPC Multidimensional Intelligence | Accepted | 2026-03-25 |
+| [019](019-json-structured-output-for-npc-dialogue.md) | JSON Structured Output for NPC Dialogue | Accepted | 2026-04-22 |
+| [020](020-npc-tool-use.md) | NPC Function-Calling / Tool-Use Output | Proposed | 2026-04-26 |
+| [021](021-npc-memory-retrieval.md) | Embedding-Based NPC Memory Retrieval | Proposed | 2026-04-26 |
 
 ## ADR Template
 

--- a/docs/plans/llm-quality-evals.md
+++ b/docs/plans/llm-quality-evals.md
@@ -1,0 +1,105 @@
+# LLM Quality Evals Plan
+
+> Back to [Docs Index](../index.md) | Sibling: [Promptfoo Pentest Plan](promptfoo-pentest-plan.md)
+
+## Goal
+
+Continuous, **quantitative** quality regression sensors over Tier 1 / Tier 2 NPC output — independent of, and complementary to, the existing pentest plan. The pentest plan red-teams for security; this plan tracks output *quality* over model swaps, prompt edits, and gameplay changes.
+
+This is the deferred LLM-as-judge piece from Phase 3 of the harness-engineering plan ([PR #538](https://github.com/dmooney/Parish/pull/538)). When that PR lands, Phase 3 introduces capture-on-green snapshot baselines + structural rubrics in `crates/parish-cli/tests/eval_baselines.rs`; those are computational sensors. This plan adds the inferential sensors the article calls out as the hardest piece of the Behaviour harness.
+
+## Status
+
+Proposed. No code yet. Once accepted, lands as a small standalone PR with a `just eval-quality` recipe and a starter rubric.
+
+## Scope
+
+### In scope
+
+- **Tier 1 dialogue** (`mods/rundale/prompts/tier1_*.txt`) — judge dialogue against rubrics like:
+  - "Sounds plausibly 1820 rural Ireland (no anachronistic words, idioms, or concepts)."
+  - "Mood / relationship cues from the prompt are reflected in the reply."
+  - "NPC stays in character (occupation, age, personality) across multiple turns."
+  - "JSON sidecar is well-formed and the `action` field is a valid enum value."
+- **Tier 2 simulation** (`mods/rundale/prompts/tier2_system.txt`) — JSON validity, mood enum validity, summary plausibility.
+- **Intent parsing** (the `parse_intent` LLM call in `parish-input`) — exact-match accuracy on a curated corpus of player utterances.
+- A **`just eval-quality`** recipe and a **`/eval-quality`** skill (sister to `/rubric`) to run the suite ad-hoc.
+- A leaderboard JSON in `testing/evals/quality/leaderboard.json` capturing each (model, prompt-template-version, rubric) → score, so model swaps and prompt edits are visible.
+
+### Out of scope
+
+- Pentest / red-teaming — covered by [`promptfoo-pentest-plan.md`](promptfoo-pentest-plan.md).
+- Function-calling output format change — see [ADR-020 NPC Tool Use](../adr/020-npc-tool-use.md). Once accepted, this plan's rubrics will move from "JSON is well-formed" to "tool call args validate against schema."
+- Long-term-memory retrieval quality — see [ADR-021 NPC Memory Retrieval](../adr/021-npc-memory-retrieval.md). When that ships, the corpus will need scenarios that exercise recall.
+
+## Approach
+
+Promptfoo is already on the table for the pentest plan; reuse it. The two suites live side-by-side:
+
+```
+testing/evals/
+├── baselines/                # Phase 3 — structural snapshots (already shipped)
+│   ├── test_movement_errors.json
+│   ├── test_walkthrough.json
+│   └── test_all_locations.json
+├── pentest/                  # promptfoo-pentest-plan.md
+│   └── …
+└── quality/                  # this plan
+    ├── tier1.yaml            # Promptfoo config: prompts × providers × rubrics
+    ├── tier2.yaml
+    ├── intent.yaml
+    ├── corpus/               # Curated player utterances + reference outputs
+    │   ├── tier1-dialogue.jsonl
+    │   ├── tier2-summary.jsonl
+    │   └── intent-classification.jsonl
+    └── leaderboard.json      # Append-only scoreboard
+```
+
+### Rubric judge
+
+Use a frontier model (e.g. Claude Sonnet 4.6) as the judge by default. Rubrics live in YAML next to the prompts; each rubric is a single-line judge prompt plus a numeric threshold. Failures emit a one-line summary plus the offending sample in the run artifact.
+
+### Determinism + reproducibility
+
+- **Fixed seed on the model under test** when supported. When not (most cloud providers), run N=5 and report mean ± stdev.
+- **Provider/model recorded** in every leaderboard row so a regression can be attributed.
+- **Prompt template version** = git short-SHA of the prompt file.
+
+## Plan
+
+### Phase A — Wiring (1 PR, ~half a day)
+
+1. `testing/evals/quality/` directory + `tier1.yaml` with a 10-sample corpus and one rubric ("plausible 1820 voice").
+2. `just eval-quality` recipe that runs Promptfoo against `tier1.yaml`, writes a row into `leaderboard.json`, and exits non-zero if the rubric score drops below baseline.
+3. CI job `quality-evals` (optional — may stay manual until cost is understood; if added, gate on a small fixed corpus only).
+4. `.agents/skills/eval-quality/SKILL.md` mirroring `/rubric` but for inferential checks.
+
+### Phase B — Coverage (incremental)
+
+Add `tier2.yaml`, `intent.yaml`, expand corpus, add rubrics as you find recurring quality issues. Each rubric should answer "is there a kind of regression I keep catching by re-reading the JSON output myself?" and turn it into a judge prompt.
+
+### Phase C — Leaderboard tooling
+
+A small CLI (`scripts/eval-leaderboard.py` or extend `parish-cli`) that prints the leaderboard sorted by score, filters by model/prompt version, and diffs any two runs. Useful for prompt iteration.
+
+## Critical files
+
+- New: `testing/evals/quality/tier1.yaml`, `corpus/`, `leaderboard.json`
+- New: `.agents/skills/eval-quality/SKILL.md`
+- Edit: `justfile` (add `eval-quality` recipe)
+- Edit (after [PR #538](https://github.com/dmooney/Parish/pull/538) lands): `crates/parish-cli/tests/eval_baselines.rs` (cross-reference in module doc)
+- Reference: `mods/rundale/prompts/tier1_system.txt`, `tier1_context.txt`, `tier2_system.txt`
+
+## Verification
+
+- `just eval-quality` — runs to completion in under a minute against the local provider; non-zero exit on rubric regression.
+- Smoke: deliberately introduce an anachronism in `tier1_system.txt` ("smartphone"); rerun; confirm the rubric flags it and the leaderboard records the drop.
+- `just check-doc-paths` — every path cited above exists by the time the plan ships.
+
+## Related
+
+- [ADR-008 Structured JSON LLM Output](../adr/008-structured-json-llm-output.md) — current output format the rubrics validate against.
+- [ADR-018 NPC Multidimensional Intelligence](../adr/018-npc-intelligence-dimensions.md) — characterisation rubrics will lean on this.
+- [ADR-020 NPC Tool Use](../adr/020-npc-tool-use.md) — if accepted, rubrics shift from JSON-shape to tool-args-shape.
+- [Promptfoo Pentest Plan](promptfoo-pentest-plan.md) — sibling effort; share the harness wiring but keep corpora separate.
+- `crates/parish-cli/tests/eval_baselines.rs` — Phase 3 structural sensors this plan complements.

--- a/docs/requirements/roadmap.md
+++ b/docs/requirements/roadmap.md
@@ -200,6 +200,15 @@
 - [x] Frontend component tests (Vitest + @testing-library/svelte, 22 tests)
 - [ ] Screenshot replacement via `WebviewWindow::capture_image()`
 
+## Phase 9 — Gameplay-AI Quality
+
+> Tracks the deferred items from the harness-engineering plan. These are
+> design-stage; each links to a plan or ADR before any code lands.
+
+- [ ] LLM-as-judge eval suite over Tier 1 / Tier 2 / Intent prompts → [Plan](../plans/llm-quality-evals.md)
+- [ ] Function-calling / tool-use output for NPC dialogue → [ADR-020](../adr/020-npc-tool-use.md)
+- [ ] Embedding-based long-term NPC memory retrieval → [ADR-021](../adr/021-npc-memory-retrieval.md)
+
 ## Open Questions
 
 > [Detailed analysis](../plans/open-questions.md) — **All resolved.**


### PR DESCRIPTION
## Summary

Captures the three deferred items from the harness-engineering plan in [PR #538](https://github.com/dmooney/Parish/pull/538) so they don't get lost. No code; design-stage tracking only.

PR #538's plan explicitly listed these as out of scope (the article is about *coding-agent* harnesses, not gameplay-AI), but they're real follow-ups worth tracking. The right home for each, per Parish conventions, is `docs/plans/` (actionable rollout) or `docs/adr/` (architectural decision needing discussion):

- **`docs/plans/llm-quality-evals.md`** — sibling to the existing `promptfoo-pentest-plan.md`. The pentest plan red-teams for security; this plan is the **quality** complement: Promptfoo-based LLM-as-judge over Tier 1 / Tier 2 / Intent prompts. Three-phase rollout, corpus layout, reproducibility controls, leaderboard tooling. Complements (doesn't replace) the structural rubrics shipping in PR #538's `eval_baselines.rs`.
- **`docs/adr/020-npc-tool-use.md`** — Proposed. Move NPC dialogue from prose+JSON to provider-native function-calling on cloud, with the Ollama JSON-sidecar protocol kept as a local fallback. Decision deferred until quality evals (above) are in place and a 9B-class local model with reliable tool-calling exists.
- **`docs/adr/021-npc-memory-retrieval.md`** — Proposed. Embedding-based retrieval over long-term NPC memory vs. today's recency-truncation. Decision deferred pending a usable local embedding model and the quality eval suite.
- **`docs/adr/README.md`** — index updated. Added ADR-019 (was missing from the index) plus the two new Proposed ADRs.
- **`docs/requirements/roadmap.md`** — new "Phase 9 — Gameplay-AI Quality" section with one-line bullets pointing at the plan and the two ADRs.

Sandboxing was the fourth deferred item; intentionally not tracked — Parish has no agent-RCE surface, so it remains a non-issue.

## Why a separate PR

PR #538 is the *coding-agent* harness. This PR is the gameplay-AI follow-up paper trail. Different scopes, different reviewers, different merge timelines — keeping them separate is per `AGENTS.md` "one logical change per commit" and the conventional-commit guidance.

## Test plan

- [x] `just witness-scan` — clean (5 changed files, no placeholder markers)
- [x] `cargo fmt --check` — clean (no Rust touched)
- [x] Manual: every relative link in the new files points at an existing file (or is a forward reference to PR #538's `eval_baselines.rs`, marked as such)
- [x] Manual: ADR template (Status / Context / Decision / Consequences / Alternatives / Related) followed for both new ADRs

https://claude.ai/code/session_013SeweeZo5NRtWctNMSkEK1

---
_Generated by [Claude Code](https://claude.ai/code/session_013SeweeZo5NRtWctNMSkEK1)_