### PR TITLE
⚡ Bolt: O(1) HashMap lookups in find_eligible_couples

### DIFF
--- a/parish/crates/parish-npc/src/tier4.rs
+++ b/parish/crates/parish-npc/src/tier4.rs
@@ -285,6 +285,10 @@ fn find_trade_partner(npcs: &[&mut Npc], merchant: &Npc) -> Option<NpcId> {
 /// - Both are healthy (not ill)
 /// - At least one is aged 18-45
 fn find_eligible_couples(npcs: &[&mut Npc]) -> Vec<(NpcId, NpcId)> {
+    // O(n) index so partner lookups below are O(1) instead of O(n).
+    let npc_index: std::collections::HashMap<NpcId, (bool, u8)> =
+        npcs.iter().map(|n| (n.id, (n.is_ill, n.age))).collect();
+
     let mut couples = Vec::new();
     let mut seen = std::collections::HashSet::new();
 
@@ -296,33 +300,23 @@ fn find_eligible_couples(npcs: &[&mut Npc]) -> Vec<(NpcId, NpcId)> {
             if rel.kind != RelationshipKind::Romantic {
                 continue;
             }
-            // Canonical pair ordering to avoid duplicates
             let pair = if npc.id.0 < partner_id.0 {
                 (npc.id, *partner_id)
             } else {
                 (*partner_id, npc.id)
             };
-            if seen.contains(&pair) {
-                continue;
-            }
-            seen.insert(pair);
-
-            // Check partner health
-            let partner_healthy = npcs
-                .iter()
-                .find(|n| n.id == *partner_id)
-                .is_some_and(|p| !p.is_ill);
-            if !partner_healthy {
+            if !seen.insert(pair) {
                 continue;
             }
 
-            // At least one must be of childbearing age (18-45)
+            let Some(&(partner_ill, partner_age)) = npc_index.get(partner_id) else {
+                continue;
+            };
+            if partner_ill {
+                continue;
+            }
+
             let npc_eligible = (18..=45).contains(&npc.age);
-            let partner_age = npcs
-                .iter()
-                .find(|n| n.id == *partner_id)
-                .map(|p| p.age)
-                .unwrap_or(0);
             let partner_eligible = (18..=45).contains(&partner_age);
 
             if npc_eligible || partner_eligible {

--- a/parish/crates/parish-npc/src/tier4.rs
+++ b/parish/crates/parish-npc/src/tier4.rs
@@ -300,6 +300,7 @@ fn find_eligible_couples(npcs: &[&mut Npc]) -> Vec<(NpcId, NpcId)> {
             if rel.kind != RelationshipKind::Romantic {
                 continue;
             }
+            // Canonical pair ordering to avoid duplicates
             let pair = if npc.id.0 < partner_id.0 {
                 (npc.id, *partner_id)
             } else {
@@ -316,6 +317,7 @@ fn find_eligible_couples(npcs: &[&mut Npc]) -> Vec<(NpcId, NpcId)> {
                 continue;
             }
 
+            // At least one must be of childbearing age (18-45)
             let npc_eligible = (18..=45).contains(&npc.age);
             let partner_eligible = (18..=45).contains(&partner_age);
 


### PR DESCRIPTION
## 💡 What

Replaces two O(n) linear scans per romantic relationship in `find_eligible_couples` (tier4.rs) with O(1) HashMap lookups via a pre-built `NpcId → (is_ill, age)` index.

Also folds the `seen.contains()` + `seen.insert()` double-lookup into a single `HashSet::insert()` call.

## 🎯 Why

For each NPC with romantic relationships, the old code performed **two full linear scans** through the entire NPC slice to check the partner's health and age. With N NPCs and R relationships per NPC, the function was **O(N × R × N)** — effectively O(N³) in the worst case where every NPC has relationships.

As the NPC population grows over a long game session, this becomes increasingly expensive during the seasonal tier-4 tick.

## 📊 Impact

| Metric | Before | After |
|--------|--------|-------|
| Partner lookup cost | O(N) linear scan × 2 | O(1) HashMap get × 2 |
| Overall complexity | O(N × R × N) | O(N × R + N) |
| HashSet dedup | 2 lookups (contains + insert) | 1 lookup (insert returns bool) |

For a parish with 100 NPCs where 30 have romantic relationships, this eliminates ~60 linear scans (up to 6,000 comparisons) per seasonal tick, replacing them with ~60 hash lookups.

## 🔬 Measurement

All 18 tier4 tests pass, including the deterministic seed test confirming identical event output. Full test suite (104 tests across 7 non-Tauri crates) passes clean. Clippy and fmt clean.

```
cargo test -p parish-npc -- tier4        # 18 passed
cargo clippy -p parish-npc -- -D warnings  # 0 warnings
```

https://claude.ai/code/session_01BgSe2YgDGVzw1SYFzA8jmG

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgSe2YgDGVzw1SYFzA8jmG)_