### PR TITLE
feat(server): serve LICENSE, NOTICE, third-party notices over HTTP

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -256,11 +256,11 @@ Full text: `assets/fonts/NotoSansSymbols2-LICENSE.txt` and
   is legally required but it is acknowledged here for transparency.
 - Compiled Tauri bundles (`.app`, `.deb`, `.msi`, `.dmg`) include `LICENSE`,
   `NOTICE`, and this file via `tauri.conf.json` → `bundle.resources`.
-- For the web/hosted build, the source repository is the canonical
-  distribution: GPL-3.0 requires that the corresponding source remain
-  available, which it is at <https://github.com/dmooney/Parish>. Wiring
-  the Axum server to serve `/LICENSE`, `/NOTICE`, and this file from the
-  static bundle is tracked as a follow-up.
+- The hosted web build (Axum server) serves `/LICENSE`, `/NOTICE`, and
+  this file (`/THIRD_PARTY_NOTICES.md`) as public routes alongside the
+  static bundle, so the licence travels with the deployed binary as
+  GPL-3.0 requires. The corresponding source remains available at
+  <https://github.com/dmooney/Parish>.
 - This file must be kept in sync with direct dependencies. Any PR that adds
   a new runtime dependency must update the relevant table above and/or
   regenerate the `.rust.md` / `.ui.md` companions.

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -25,13 +25,13 @@ use std::time::Duration;
 use axum::Router;
 use axum::extract::ConnectInfo;
 use axum::http::header::{
-    CONTENT_SECURITY_POLICY, REFERRER_POLICY, STRICT_TRANSPORT_SECURITY, X_CONTENT_TYPE_OPTIONS,
-    X_FRAME_OPTIONS,
+    CONTENT_SECURITY_POLICY, CONTENT_TYPE, REFERRER_POLICY, STRICT_TRANSPORT_SECURITY,
+    X_CONTENT_TYPE_OPTIONS, X_FRAME_OPTIONS,
 };
 use axum::http::{HeaderValue, Request, StatusCode};
 use axum::middleware as axum_mw;
 use axum::middleware::Next;
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use tower_http::services::ServeDir;
 use tower_http::set_header::SetResponseHeaderLayer;
@@ -71,6 +71,33 @@ pub const CSP_POLICY: &str = "default-src 'self'; \
                               frame-ancestors 'none'; \
                               base-uri 'self'; \
                               form-action 'self'";
+
+// ── GPL-3.0 redistribution: licence files served alongside the hosted web
+//    build.  Tauri bundles ship these via `tauri.conf.json` →
+//    `bundle.resources`; the Axum server embeds them at compile time via
+//    `include_str!` and serves them from the corresponding routes wired up
+//    in `run_server` (mounted *after* `cf_access_guard` so they remain
+//    publicly reachable).
+pub async fn serve_license() -> impl IntoResponse {
+    (
+        [(CONTENT_TYPE, "text/plain; charset=utf-8")],
+        include_str!("../../../LICENSE"),
+    )
+}
+
+pub async fn serve_notice() -> impl IntoResponse {
+    (
+        [(CONTENT_TYPE, "text/plain; charset=utf-8")],
+        include_str!("../../../NOTICE"),
+    )
+}
+
+pub async fn serve_third_party_notices() -> impl IntoResponse {
+    (
+        [(CONTENT_TYPE, "text/markdown; charset=utf-8")],
+        include_str!("../../../THIRD_PARTY_NOTICES.md"),
+    )
+}
 
 /// Global auth-failure counter — exposed via `GET /metrics`.
 static AUTH_FAILURES: AtomicU64 = AtomicU64::new(0);
@@ -445,6 +472,13 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
             Arc::clone(&global),
             middleware::session_middleware,
         ))
+        // ── GPL-3.0 redistribution: legal/licence files mounted *after*
+        //    `cf_access_guard` and `session_middleware` so they remain
+        //    publicly reachable (the licence must travel with the hosted
+        //    binary).  Rate-limit + security-header layers below still apply.
+        .route("/LICENSE", get(serve_license))
+        .route("/NOTICE", get(serve_notice))
+        .route("/THIRD_PARTY_NOTICES.md", get(serve_third_party_notices))
         // ── #381: Global per-IP rate limiter (outside auth guard, throttles floods) ──
         .layer(axum_mw::from_fn_with_state(
             ip_limiter,

--- a/crates/parish-server/tests/legal_routes.rs
+++ b/crates/parish-server/tests/legal_routes.rs
@@ -1,0 +1,155 @@
+/// Integration tests for the GPL-3.0 redistribution routes (`/LICENSE`,
+/// `/NOTICE`, `/THIRD_PARTY_NOTICES.md`).
+///
+/// These tests cover two contracts:
+///
+/// 1. **Content** — each route returns `200 OK`, the right `Content-Type`,
+///    and a non-empty body sourced from the repo-root file via
+///    `include_str!` in `parish_server::serve_*`.
+///
+/// 2. **Bypass** — when wired the way `run_server` wires them (registered
+///    *after* `cf_access_guard` is applied), the routes remain publicly
+///    reachable even with a fail-closed guard in front of the rest of the
+///    app.  This pins down the layer-ordering invariant — Axum's `.layer()`
+///    only wraps routes registered *before* it, so re-ordering would
+///    silently put the licence files behind auth and violate GPL public
+///    availability.
+use axum::Router;
+use axum::body::Body;
+use axum::http::header::CONTENT_TYPE;
+use axum::http::{Request, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::Response;
+use axum::routing::get;
+use parish_server::{serve_license, serve_notice, serve_third_party_notices};
+use tower::ServiceExt;
+
+const BODY_LIMIT: usize = 64 * 1024;
+
+fn legal_router() -> Router {
+    Router::new()
+        .route("/LICENSE", get(serve_license))
+        .route("/NOTICE", get(serve_notice))
+        .route("/THIRD_PARTY_NOTICES.md", get(serve_third_party_notices))
+}
+
+async fn assert_route(path: &str, expected_content_type: &str) {
+    let req = Request::builder()
+        .uri(path)
+        .body(Body::empty())
+        .expect("build request");
+    let resp = legal_router().oneshot(req).await.expect("router responded");
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "GET {path} must return 200 OK",
+    );
+
+    let ct = resp
+        .headers()
+        .get(CONTENT_TYPE)
+        .unwrap_or_else(|| panic!("GET {path} must carry a Content-Type"))
+        .to_str()
+        .unwrap_or_else(|_| panic!("GET {path} Content-Type must be ASCII"));
+    assert_eq!(
+        ct, expected_content_type,
+        "GET {path} Content-Type mismatch",
+    );
+
+    let bytes = axum::body::to_bytes(resp.into_body(), BODY_LIMIT)
+        .await
+        .unwrap_or_else(|e| panic!("GET {path} body read failed: {e}"));
+    assert!(!bytes.is_empty(), "GET {path} body must be non-empty");
+}
+
+#[tokio::test]
+async fn license_route_serves_plain_text() {
+    assert_route("/LICENSE", "text/plain; charset=utf-8").await;
+}
+
+#[tokio::test]
+async fn notice_route_serves_plain_text() {
+    assert_route("/NOTICE", "text/plain; charset=utf-8").await;
+}
+
+#[tokio::test]
+async fn third_party_notices_route_serves_markdown() {
+    assert_route("/THIRD_PARTY_NOTICES.md", "text/markdown; charset=utf-8").await;
+}
+
+#[tokio::test]
+async fn license_body_contains_gpl_marker() {
+    // Sanity-check that the embedded body really is the GPL-3.0 LICENSE
+    // file (not, say, an empty stub) — guards against an `include_str!`
+    // path drift after a future repo move.
+    let req = Request::builder()
+        .uri("/LICENSE")
+        .body(Body::empty())
+        .unwrap();
+    let resp = legal_router().oneshot(req).await.unwrap();
+    let bytes = axum::body::to_bytes(resp.into_body(), BODY_LIMIT)
+        .await
+        .unwrap();
+    let body = std::str::from_utf8(&bytes).expect("LICENSE is UTF-8");
+    assert!(
+        body.contains("GNU GENERAL PUBLIC LICENSE"),
+        "LICENSE body must contain the GPL header; got first 200 bytes: {:?}",
+        &body[..body.len().min(200)],
+    );
+}
+
+/// Stand-in for `cf_access_guard`: rejects every request with `401`.  Used
+/// to prove the layer-ordering invariant — routes mounted *after* this
+/// layer are not wrapped by it and remain reachable.
+async fn always_401(_req: Request<Body>, _next: Next) -> Result<Response, StatusCode> {
+    Err(StatusCode::UNAUTHORIZED)
+}
+
+#[tokio::test]
+async fn legal_routes_bypass_a_fail_closed_guard() {
+    // Mirror `run_server`'s wiring shape:
+    //   - register a "guarded" route
+    //   - apply the always-401 layer
+    //   - register the legal routes *after* the layer
+    //
+    // Then assert that the guarded route is rejected while the legal
+    // routes pass through unscathed.
+    let app = Router::new()
+        .route("/api/health", get(|| async { StatusCode::OK }))
+        .layer(middleware::from_fn(always_401))
+        .route("/LICENSE", get(serve_license))
+        .route("/NOTICE", get(serve_notice))
+        .route("/THIRD_PARTY_NOTICES.md", get(serve_third_party_notices));
+
+    // Guarded route is rejected by the stand-in.
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "guard must reject /api/health (sanity check on the stand-in)",
+    );
+
+    // Legal routes bypass the guard.
+    for path in ["/LICENSE", "/NOTICE", "/THIRD_PARTY_NOTICES.md"] {
+        let resp = app
+            .clone()
+            .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "{path} must bypass the fail-closed guard",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds explicit `GET /LICENSE`, `GET /NOTICE`, and `GET /THIRD_PARTY_NOTICES.md` routes to the Axum web server, embedding the repo-root files at compile time via `include_str!`.
- Reverts the softened "tracked as a follow-up" wording in `THIRD_PARTY_NOTICES.md` (added in [#530](https://github.com/dmooney/Parish/pull/530) after a Codex review caught the false "already serves" claim) to a positive assertion that the server now serves the three files.
- Closes the GPL-3.0 redistribution gap on the hosted web build. Tauri bundles already ship the three files via `tauri.conf.json` → `bundle.resources`; the Axum build did not.

## Why this design

**Compile-time embed (Option 1 from the brief).** `include_str!` keeps the implementation a few lines, sidesteps a runtime fs dependency, and avoids duplicating the files into `apps/ui/static/`. Total binary growth is ~49 KB (LICENSE 35 KB + NOTICE 2 KB + third-party notices 12 KB) — well within the noise.

**Routes mounted *after* `cf_access_guard`.** This is the load-bearing detail. `cf_access_guard` is fail-closed in release mode — without a valid Cloudflare Access JWT it returns 401. In Axum, `.layer(L)` only wraps routes registered *before* it, so registering the legal routes *after* the guard layer lets them bypass auth (which they must, for GPL public availability) while still picking up the rate-limit and security-header layers applied later in the chain. The session middleware is also above the legal routes — they don't need a session cookie.

The new bypass test in `tests/legal_routes.rs` pins down this layer-ordering invariant so a future refactor can't silently put the licence files behind auth.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test -p parish-server --test legal_routes` — 5 tests pass (3 content tests, 1 GPL-marker sanity test, 1 bypass invariant test)
- [x] `just check` — full suite green except `check-doc-paths` (macOS bash 3.2 / `mapfile` issue, reproduces on clean `main`, unrelated)
- [x] `cargo run -p parish -- --web 8123` + `curl -fsS -D - …` against each route — all return `200 OK`, correct `Content-Type`, and `content-length` matching the on-disk file size:
  - `/LICENSE` → `text/plain; charset=utf-8`, 35149 bytes
  - `/NOTICE` → `text/plain; charset=utf-8`, 2193 bytes
  - `/THIRD_PARTY_NOTICES.md` → `text/markdown; charset=utf-8`, 11788 bytes
- [x] Confirmed all five outer security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy) are still applied to the legal routes
- [x] `git diff --stat` confirms only three files changed (no refactor sweep leakage)

## Out of scope

- No generic `/static/*` fallthrough — explicit routes only, per the brief.
- No code generation, no `build.rs`.
- No change to Tauri / desktop wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)