### PR TITLE
fix(ui): connect editor form labels to inputs for a11y

### DIFF
--- a/.agents/ux-review.md
+++ b/.agents/ux-review.md
@@ -1,0 +1,1 @@
+# UX Review Journal

--- a/parish/apps/ui/src/components/editor/LocationDetail.svelte
+++ b/parish/apps/ui/src/components/editor/LocationDetail.svelte
@@ -397,8 +397,9 @@
 			<section class="section">
 				<h4 class="section-label">Identity</h4>
 				<div class="field-row">
-					<label class="field-label">Name</label>
+					<label class="field-label" for="loc-name">Name</label>
 					<input
+						id="loc-name"
 						class="field-input"
 						type="text"
 						value={loc.name}
@@ -406,16 +407,18 @@
 					/>
 				</div>
 				<div class="field-row">
-					<label class="field-label">Indoor</label>
+					<label class="field-label" for="loc-indoor">Indoor</label>
 					<input
+						id="loc-indoor"
 						type="checkbox"
 						checked={loc.indoor}
 						on:change={(e) => handleFieldChange('indoor', e.currentTarget.checked)}
 					/>
 				</div>
 				<div class="field-row">
-					<label class="field-label">Public</label>
+					<label class="field-label" for="loc-public">Public</label>
 					<input
+						id="loc-public"
 						type="checkbox"
 						checked={loc.public}
 						on:change={(e) => handleFieldChange('public', e.currentTarget.checked)}
@@ -426,8 +429,9 @@
 			<section class="section">
 				<h4 class="section-label">Coordinates</h4>
 				<div class="field-row">
-					<label class="field-label">Geo kind</label>
+					<label class="field-label" for="loc-geo-kind">Geo kind</label>
 					<select
+						id="loc-geo-kind"
 						class="field-input"
 						value={loc.geo_kind ?? 'fictional'}
 						on:change={(e) => handleFieldChange('geo_kind', e.currentTarget.value as GeoKind)}
@@ -438,8 +442,9 @@
 					</select>
 				</div>
 				<div class="field-row">
-					<label class="field-label">Mode</label>
+					<label class="field-label" for="loc-coord-mode">Mode</label>
 					<select
+						id="loc-coord-mode"
 						class="field-input"
 						value={loc.relative_to ? 'relative' : 'absolute'}
 						on:change={(e) => setCoordinateMode(e.currentTarget.value as 'absolute' | 'relative')}
@@ -450,8 +455,9 @@
 				</div>
 				{#if loc.relative_to}
 					<div class="field-row">
-						<label class="field-label">Anchor</label>
+						<label class="field-label" for="loc-anchor">Anchor</label>
 						<select
+							id="loc-anchor"
 							class="field-input"
 							value={loc.relative_to.anchor}
 							on:change={(e) => applyRelativeField('anchor', e.currentTarget.value)}
@@ -462,16 +468,18 @@
 						</select>
 					</div>
 					<div class="field-row">
-						<label class="field-label">dNorth m</label>
+						<label class="field-label" for="loc-dnorth">dNorth m</label>
 						<input
+							id="loc-dnorth"
 							class="field-input short"
 							type="number"
 							step="1"
 							value={loc.relative_to.dnorth_m}
 							on:change={(e) => applyRelativeField('dnorth_m', e.currentTarget.value)}
 						/>
-						<label class="field-label">dEast m</label>
+						<label class="field-label" for="loc-deast">dEast m</label>
 						<input
+							id="loc-deast"
 							class="field-input short"
 							type="number"
 							step="1"
@@ -481,16 +489,18 @@
 					</div>
 				{:else}
 					<div class="field-row">
-						<label class="field-label">Lat</label>
+						<label class="field-label" for="loc-lat">Lat</label>
 						<input
+							id="loc-lat"
 							class="field-input short"
 							type="number"
 							step="0.00001"
 							value={loc.lat}
 							on:change={(e) => handleFieldChange('lat', parseFloat(e.currentTarget.value))}
 						/>
-						<label class="field-label">Lon</label>
+						<label class="field-label" for="loc-lon">Lon</label>
 						<input
+							id="loc-lon"
 							class="field-input short"
 							type="number"
 							step="0.00001"
@@ -500,8 +510,9 @@
 					</div>
 				{/if}
 				<div class="field-row">
-					<label class="field-label">Geo source</label>
+					<label class="field-label" for="loc-geo-source">Geo source</label>
 					<input
+						id="loc-geo-source"
 						class="field-input"
 						type="text"
 						value={loc.geo_source ?? ''}
@@ -531,6 +542,7 @@
 				<h4 class="section-label">Description Template</h4>
 				<textarea
 					class="field-textarea tall"
+					aria-label="Description template"
 					value={loc.description_template}
 					on:change={(e) => handleFieldChange('description_template', e.currentTarget.value)}
 				></textarea>
@@ -551,6 +563,7 @@
 				<h4 class="section-label">Mythological Significance</h4>
 				<textarea
 					class="field-textarea"
+					aria-label="Mythological significance"
 					value={loc.mythological_significance ?? ''}
 					placeholder="Fairy fort, holy well, cursed ground…"
 					on:change={(e) =>

--- a/parish/apps/ui/src/components/editor/NpcDetail.svelte
+++ b/parish/apps/ui/src/components/editor/NpcDetail.svelte
@@ -84,8 +84,9 @@
 			<section class="section">
 				<h4 class="section-label">Identity</h4>
 				<div class="field-row">
-					<label class="field-label">Name</label>
+					<label class="field-label" for="npc-name">Name</label>
 					<input
+						id="npc-name"
 						class="field-input"
 						type="text"
 						value={npc.name}
@@ -93,8 +94,9 @@
 					/>
 				</div>
 				<div class="field-row">
-					<label class="field-label">Age</label>
+					<label class="field-label" for="npc-age">Age</label>
 					<input
+						id="npc-age"
 						class="field-input short"
 						type="number"
 						value={npc.age}
@@ -102,8 +104,9 @@
 					/>
 				</div>
 				<div class="field-row">
-					<label class="field-label">Occupation</label>
+					<label class="field-label" for="npc-occupation">Occupation</label>
 					<input
+						id="npc-occupation"
 						class="field-input"
 						type="text"
 						value={npc.occupation}
@@ -111,8 +114,9 @@
 					/>
 				</div>
 				<div class="field-row">
-					<label class="field-label">Mood</label>
+					<label class="field-label" for="npc-mood">Mood</label>
 					<input
+						id="npc-mood"
 						class="field-input"
 						type="text"
 						value={npc.mood}
@@ -120,8 +124,9 @@
 					/>
 				</div>
 				<div class="field-row">
-					<label class="field-label">Brief Description</label>
+					<label class="field-label" for="npc-brief-desc">Brief Description</label>
 					<input
+						id="npc-brief-desc"
 						class="field-input"
 						type="text"
 						value={npc.brief_description ?? ''}
@@ -133,8 +138,9 @@
 					/>
 				</div>
 				<div class="field-row">
-					<label class="field-label">Personality</label>
+					<label class="field-label" for="npc-personality">Personality</label>
 					<textarea
+						id="npc-personality"
 						class="field-textarea"
 						value={npc.personality}
 						on:change={(e) => handleFieldChange('personality', e.currentTarget.value)}
@@ -146,8 +152,9 @@
 			<section class="section">
 				<h4 class="section-label">Home & Workplace</h4>
 				<div class="field-row">
-					<label class="field-label">Home</label>
+					<label class="field-label" for="npc-home">Home</label>
 					<select
+						id="npc-home"
 						class="field-select"
 						value={npc.home}
 						on:change={(e) => handleFieldChange('home', parseInt(e.currentTarget.value))}
@@ -158,8 +165,9 @@
 					</select>
 				</div>
 				<div class="field-row">
-					<label class="field-label">Workplace</label>
+					<label class="field-label" for="npc-workplace">Workplace</label>
 					<select
+						id="npc-workplace"
 						class="field-select"
 						value={npc.workplace ?? -1}
 						on:change={(e) => {
@@ -181,8 +189,9 @@
 					<h4 class="section-label">Intelligence</h4>
 					{#each intelligenceDimensions as dim}
 						<div class="field-row">
-							<label class="field-label">{dim.label}</label>
+							<label class="field-label" for="npc-intel-{dim.key}">{dim.label}</label>
 							<input
+								id="npc-intel-{dim.key}"
 								class="field-range"
 								type="range"
 								min="1"


### PR DESCRIPTION
## Summary

- **Connect all `<label>` elements to their `<input>`/`<select>`/`<textarea>` siblings** via `for`/`id` attributes in both `LocationDetail.svelte` and `NpcDetail.svelte`
- **Add `aria-label`** to two standalone textareas (Description Template, Mythological Significance) that lack wrapping `<label>` elements
- 20 form fields fixed across both editor components

## 💡 What

The editor forms used `<label class="field-label">` elements that were visually adjacent to inputs but not programmatically associated — missing `for`/`id` attribute pairs.

## 🎯 Why

Screen readers cannot announce which label belongs to which input without `for`/`id` association. Users navigating the Location or NPC editor with assistive technology would hear unlabeled form controls, making the editor unusable. This also means clicking a label now correctly focuses its input — a small UX win for all users.

## ♿ Accessibility

- **WCAG 2.1 SC 1.3.1 (Info and Relationships):** Labels are now programmatically associated with their controls
- **WCAG 2.1 SC 4.1.2 (Name, Role, Value):** All form controls now have accessible names
- Verified with `svelte-check`: 0 errors, no new warnings

## Test plan

- [ ] Open the editor, select a location — verify all fields are labeled (inspect with browser a11y tree or screen reader)
- [ ] Click a label text (e.g. "Name", "Indoor") — verify the corresponding input receives focus
- [ ] Select an NPC — verify same label-input association works for NPC fields
- [ ] Verify intelligence range sliders announce their dimension label
- [ ] Run `npx svelte-check` — 0 errors

https://claude.ai/code/session_01P3M4xa2HFjm7T3haocAKTs

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3M4xa2HFjm7T3haocAKTs)_