### PR TITLE
perf: O(n²) → O(n) NPC relationship hydration

### DIFF
--- a/parish/crates/parish-npc/src/data.rs
+++ b/parish/crates/parish-npc/src/data.rs
@@ -267,7 +267,11 @@ pub fn load_npcs_from_str(json: &str) -> Result<Vec<Npc>, ParishError> {
         }
     }
 
-    // Second pass: ensure bidirectional relationships
+    // Second pass: ensure bidirectional relationships.
+    // Build an index so reciprocal insertion is O(n) instead of O(n²).
+    let id_to_index: HashMap<NpcId, usize> =
+        npcs.iter().enumerate().map(|(i, n)| (n.id, i)).collect();
+
     let mut additions: Vec<(NpcId, NpcId, RelationshipKind, f64)> = Vec::new();
     for npc in &npcs {
         for (target_id, rel) in &npc.relationships {
@@ -275,10 +279,9 @@ pub fn load_npcs_from_str(json: &str) -> Result<Vec<Npc>, ParishError> {
         }
     }
 
-    // Apply reciprocal relationships where missing
     for (from_id, to_id, kind, strength) in additions {
-        if let Some(target_npc) = npcs.iter_mut().find(|n| n.id == to_id) {
-            target_npc
+        if let Some(&idx) = id_to_index.get(&to_id) {
+            npcs[idx]
                 .relationships
                 .entry(from_id)
                 .or_insert_with(|| Relationship::new(kind, strength));

--- a/parish/crates/parish-npc/src/data.rs
+++ b/parish/crates/parish-npc/src/data.rs
@@ -272,7 +272,8 @@ pub fn load_npcs_from_str(json: &str) -> Result<Vec<Npc>, ParishError> {
     let id_to_index: HashMap<NpcId, usize> =
         npcs.iter().enumerate().map(|(i, n)| (n.id, i)).collect();
 
-    let mut additions: Vec<(NpcId, NpcId, RelationshipKind, f64)> = Vec::new();
+    let total_edges: usize = npcs.iter().map(|n| n.relationships.len()).sum();
+    let mut additions: Vec<(NpcId, NpcId, RelationshipKind, f64)> = Vec::with_capacity(total_edges);
     for npc in &npcs {
         for (target_id, rel) in &npc.relationships {
             additions.push((npc.id, *target_id, rel.kind, rel.strength));


### PR DESCRIPTION
## Summary

- **💡 What:** Replace linear `Vec::iter_mut().find()` with a pre-built `HashMap<NpcId, usize>` index during bidirectional relationship hydration in `load_npcs_from_str`.
- **🎯 Why:** The reciprocal-relationship loop scanned the full NPC vec (`O(n)`) for every relationship edge, making the overall pass `O(n × m)` where `n` = NPCs and `m` = total relationship edges. With 23 NPCs and ~100+ edges today, that's thousands of comparisons that grow quadratically as content scales.
- **📊 Impact:** Reduces relationship hydration from `O(n × m)` to `O(n + m)` — each edge now does a single `O(1)` HashMap lookup instead of scanning up to 23 NPCs. The HashMap construction is a one-time `O(n)` cost.
- **🔬 Measurement:** All 14 `data::tests` pass, including `test_bidirectional_relationships` which verifies every relationship has a reciprocal entry. Full `parish-npc` and `parish-core` test suites green. Impact scales with NPC count — most visible when modders add large NPC rosters.

## Change

`crates/parish-npc/src/data.rs` — 7 lines added, 4 removed:
- Build `id_to_index: HashMap<NpcId, usize>` from the NPC vec
- Replace `npcs.iter_mut().find(|n| n.id == to_id)` with `id_to_index.get(&to_id)` + direct index

## Test plan

- [x] `cargo test -p parish-npc` — 48 tests pass
- [x] `cargo test -p parish-core` — all pass
- [x] `cargo clippy -p parish-npc --tests` — clean
- [x] `cargo fmt -- --check` — clean

https://claude.ai/code/session_01E7HaoQZECA3wyQFcFKJi1T

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7HaoQZECA3wyQFcFKJi1T)_