### PR TITLE
docs: list inference rate limiting in features

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -247,7 +247,7 @@ Provider config is resolved by `resolve_config` in `crates/parish-config/src/pro
 ### Rate Limiting
 - Outbound request throttling per provider client, gating every LLM call before it leaves the process (`crates/parish-inference/src/rate_limit.rs`)
 - Token-bucket / GCRA quota via the `governor` crate — sustained `per_minute` rate plus a `burst` capacity
-- Per-category overrides under `[engine.inference.rate_limits.*]` in `parish.toml` (`default`, `dialogue`, `simulation`, `intent`, `reaction`), resolved by `RateLimitConfig::for_category` (`crates/parish-config/src/engine.rs`)
+- Per-category overrides under `[engine.inference.rate_limits.*]` in `parish.toml` (`dialogue`, `simulation`, `intent`, `reaction`), resolved by `RateLimitConfig::for_category`; plus a `default` limit for the base client (`crates/parish-config/src/engine.rs`)
 - Off by default — omitting the config (or setting `per_minute = 0`) leaves clients unthrottled, preserving existing behavior
 - Both blocking (`acquire`) and non-blocking (`try_acquire`) entry points so callers can either queue or shed load
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -244,6 +244,13 @@ Provider config is resolved by `resolve_config` in `crates/parish-config/src/pro
 - Logs prompt, response, model, timing, streaming flag, and error status
 - Viewable in the Debug Panel's Inference tab
 
+### Rate Limiting
+- Outbound request throttling per provider client, gating every LLM call before it leaves the process (`crates/parish-inference/src/rate_limit.rs`)
+- Token-bucket / GCRA quota via the `governor` crate — sustained `per_minute` rate plus a `burst` capacity
+- Per-category overrides under `[engine.inference.rate_limits.*]` in `parish.toml` (`default`, `dialogue`, `simulation`, `intent`, `reaction`), resolved by `RateLimitConfig::for_category` (`crates/parish-config/src/engine.rs`)
+- Off by default — omitting the config (or setting `per_minute = 0`) leaves clients unthrottled, preserving existing behavior
+- Both blocking (`acquire`) and non-blocking (`try_acquire`) entry points so callers can either queue or shed load
+
 ---
 
 ## GUI (Tauri 2 + Svelte 5)


### PR DESCRIPTION
## Summary
- Add a `### Rate Limiting` subsection to `## LLM / Inference` in `docs/features.md`, slotted between Inference Logging and the section terminator so it sits with the other inference control/observability features.
- Documents the already-shipping token-bucket limiter in `crates/parish-inference/src/rate_limit.rs` and the `[engine.inference.rate_limits.*]` schema in `crates/parish-config/src/engine.rs` (per-category `default` / `dialogue` / `simulation` / `intent` / `reaction` overrides, off by default).
- Doc-only — no code, config, or behavior changes.

## Test plan
- [x] `git diff docs/features.md` — verify the only hunk is the new subsection inserted between Inference Logging and the `---` separator
- [ ] Render `docs/features.md` in a Markdown previewer and confirm heading level / bullet style matches surrounding subsections
- [ ] Confirm no other section was accidentally added (`grep -n '^## ' docs/features.md` should be unchanged in count)

https://claude.ai/code/session_013grYLNEFH392cxHjwxbeBR

---
_Generated by [Claude Code](https://claude.ai/code/session_013grYLNEFH392cxHjwxbeBR)_