### PR TITLE
refactor: drop time-of-day and weather palette tinting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,7 +3017,6 @@ name = "parish-palette"
 version = "0.1.0"
 dependencies = [
  "parish-config",
- "parish-types",
 ]
 
 [[package]]

--- a/crates/parish-cli/src/config.rs
+++ b/crates/parish-cli/src/config.rs
@@ -13,8 +13,8 @@
 pub use parish_core::config::{
     CliCloudOverrides, CliOverrides, CloudConfig, CognitiveTierConfig, EncounterConfig,
     EngineConfig, FeatureFlags, InferenceCategory, InferenceConfig, NpcConfig, PaletteConfig,
-    PersistenceConfig, Provider, ProviderConfig, RelationshipLabelConfig, SeasonTintConfig,
-    SpeedConfig, WeatherTintConfig, WorldConfig, resolve_cloud_config, resolve_config,
+    PersistenceConfig, Provider, ProviderConfig, RelationshipLabelConfig, SpeedConfig, WorldConfig,
+    resolve_cloud_config, resolve_config,
 };
 
 use crate::error::ParishError;

--- a/crates/parish-config/src/engine.rs
+++ b/crates/parish-config/src/engine.rs
@@ -58,7 +58,7 @@ pub struct EngineConfig {
     /// NPC memory, cognition, and relationship tuning.
     #[serde(default)]
     pub npc: NpcConfig,
-    /// Color palette tints and contrast.
+    /// Color palette contrast configuration.
     #[serde(default)]
     pub palette: PaletteConfig,
     /// World graph tuning.
@@ -565,7 +565,7 @@ fn default_reaction_max_reactions() -> usize {
 // Palette
 // ---------------------------------------------------------------------------
 
-/// Color palette tinting and contrast configuration.
+/// Color palette contrast configuration.
 #[derive(Debug, Deserialize, Clone)]
 pub struct PaletteConfig {
     /// Minimum luminance contrast between foreground and background.
@@ -574,12 +574,6 @@ pub struct PaletteConfig {
     /// Minimum luminance contrast between muted text and background.
     #[serde(default = "default_min_muted_bg_contrast")]
     pub min_muted_bg_contrast: f32,
-    /// Season color tint multipliers.
-    #[serde(default)]
-    pub season_tints: SeasonTintConfig,
-    /// Weather color tint multipliers.
-    #[serde(default)]
-    pub weather_tints: WeatherTintConfig,
 }
 
 impl Default for PaletteConfig {
@@ -587,8 +581,6 @@ impl Default for PaletteConfig {
         Self {
             min_fg_bg_contrast: 80.0,
             min_muted_bg_contrast: 45.0,
-            season_tints: SeasonTintConfig::default(),
-            weather_tints: WeatherTintConfig::default(),
         }
     }
 }
@@ -598,109 +590,6 @@ fn default_min_fg_bg_contrast() -> f32 {
 }
 fn default_min_muted_bg_contrast() -> f32 {
     45.0
-}
-
-/// Season tint multipliers: `[r_mult, g_mult, b_mult, desaturation]`.
-#[derive(Debug, Deserialize, Clone)]
-pub struct SeasonTintConfig {
-    /// Spring tint.
-    #[serde(default = "default_spring_tint")]
-    pub spring: [f32; 4],
-    /// Summer tint.
-    #[serde(default = "default_summer_tint")]
-    pub summer: [f32; 4],
-    /// Autumn tint.
-    #[serde(default = "default_autumn_tint")]
-    pub autumn: [f32; 4],
-    /// Winter tint.
-    #[serde(default = "default_winter_tint")]
-    pub winter: [f32; 4],
-}
-
-impl Default for SeasonTintConfig {
-    fn default() -> Self {
-        Self {
-            spring: [0.98, 1.02, 0.98, 0.0],
-            summer: [1.03, 1.01, 0.97, 0.0],
-            autumn: [1.06, 1.00, 0.92, 0.0],
-            winter: [0.94, 0.96, 1.04, 0.08],
-        }
-    }
-}
-
-fn default_spring_tint() -> [f32; 4] {
-    [0.98, 1.02, 0.98, 0.0]
-}
-fn default_summer_tint() -> [f32; 4] {
-    [1.03, 1.01, 0.97, 0.0]
-}
-fn default_autumn_tint() -> [f32; 4] {
-    [1.06, 1.00, 0.92, 0.0]
-}
-fn default_winter_tint() -> [f32; 4] {
-    [0.94, 0.96, 1.04, 0.08]
-}
-
-/// Weather tint multipliers: `[r_mult, g_mult, b_mult, desaturation, brightness, contrast_reduction]`.
-#[derive(Debug, Deserialize, Clone)]
-pub struct WeatherTintConfig {
-    /// Clear weather (identity).
-    #[serde(default = "default_clear_tint")]
-    pub clear: [f32; 6],
-    /// Partly cloudy weather.
-    #[serde(default = "default_partly_cloudy_tint")]
-    pub partly_cloudy: [f32; 6],
-    /// Overcast weather.
-    #[serde(default = "default_overcast_tint")]
-    pub overcast: [f32; 6],
-    /// Light rain weather.
-    #[serde(default = "default_light_rain_tint")]
-    pub light_rain: [f32; 6],
-    /// Heavy rain weather.
-    #[serde(default = "default_heavy_rain_tint")]
-    pub heavy_rain: [f32; 6],
-    /// Fog weather.
-    #[serde(default = "default_fog_tint")]
-    pub fog: [f32; 6],
-    /// Storm weather.
-    #[serde(default = "default_storm_tint")]
-    pub storm: [f32; 6],
-}
-
-impl Default for WeatherTintConfig {
-    fn default() -> Self {
-        Self {
-            clear: [1.0, 1.0, 1.0, 0.0, 1.0, 0.0],
-            partly_cloudy: [0.97, 0.97, 0.98, 0.08, 0.96, 0.0],
-            overcast: [0.95, 0.95, 0.97, 0.15, 0.92, 0.0],
-            light_rain: [0.90, 0.92, 0.96, 0.15, 0.88, 0.0],
-            heavy_rain: [0.85, 0.87, 0.93, 0.25, 0.80, 0.0],
-            fog: [0.97, 0.97, 0.98, 0.35, 0.95, 0.15],
-            storm: [0.80, 0.82, 0.85, 0.30, 0.75, 0.0],
-        }
-    }
-}
-
-fn default_clear_tint() -> [f32; 6] {
-    [1.0, 1.0, 1.0, 0.0, 1.0, 0.0]
-}
-fn default_partly_cloudy_tint() -> [f32; 6] {
-    [0.97, 0.97, 0.98, 0.08, 0.96, 0.0]
-}
-fn default_overcast_tint() -> [f32; 6] {
-    [0.95, 0.95, 0.97, 0.15, 0.92, 0.0]
-}
-fn default_light_rain_tint() -> [f32; 6] {
-    [0.90, 0.92, 0.96, 0.15, 0.88, 0.0]
-}
-fn default_heavy_rain_tint() -> [f32; 6] {
-    [0.85, 0.87, 0.93, 0.25, 0.80, 0.0]
-}
-fn default_fog_tint() -> [f32; 6] {
-    [0.97, 0.97, 0.98, 0.35, 0.95, 0.15]
-}
-fn default_storm_tint() -> [f32; 6] {
-    [0.80, 0.82, 0.85, 0.30, 0.75, 0.0]
 }
 
 // ---------------------------------------------------------------------------
@@ -990,8 +879,7 @@ memory_capacity = 30
     fn test_palette_config_defaults() {
         let cfg = PaletteConfig::default();
         assert!((cfg.min_fg_bg_contrast - 80.0).abs() < f32::EPSILON);
-        assert_eq!(cfg.season_tints.spring, [0.98, 1.02, 0.98, 0.0]);
-        assert_eq!(cfg.weather_tints.clear, [1.0, 1.0, 1.0, 0.0, 1.0, 0.0]);
+        assert!((cfg.min_muted_bg_contrast - 45.0).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/crates/parish-palette/Cargo.toml
+++ b/crates/parish-palette/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 edition = "2024"
 license = "GPL-3.0-only"
 publish = false
-description = "Backend-agnostic time-of-day, season, and weather color interpolation for Parish"
+description = "Backend-agnostic time-of-day color interpolation for Parish"
 
 [dependencies]
-parish-types = { path = "../parish-types" }
 parish-config = { path = "../parish-config" }

--- a/crates/parish-palette/README.md
+++ b/crates/parish-palette/README.md
@@ -1,12 +1,12 @@
 # parish-palette
 
-Backend-agnostic time-of-day, season, and weather color interpolation for the Parish engine.
+Backend-agnostic time-of-day color interpolation for the Parish engine.
 
-Provides smooth RGB palette computation that interpolates between time-of-day keyframes and applies seasonal and weather tinting. UI renderers (Tauri, web server, headless logging) consume `RawPalette` values from this crate.
+Provides smooth RGB palette computation that interpolates between time-of-day keyframes and enforces a minimum foreground/background contrast floor. UI renderers (Tauri, web server, headless logging) consume `RawPalette` values from this crate.
 
 ## Why a sibling crate
 
-The palette logic is presentation-layer infrastructure shared by every UI surface. It depends only on `parish-types` (for `Season`/`Weather`) and `parish-config` (for `PaletteConfig`), and has no game-state dependencies. Keeping it as a sibling crate (rather than a module of `parish-world`) signals that it is *not* world state — it's a derived view of world state used by renderers.
+The palette logic is presentation-layer infrastructure shared by every UI surface. It depends only on `parish-config` (for `PaletteConfig`), and has no game-state dependencies. Keeping it as a sibling crate (rather than a module of `parish-world`) signals that it is *not* world state — it's a derived view of world state used by renderers.
 
 ## Pipeline
 

--- a/crates/parish-palette/src/lib.rs
+++ b/crates/parish-palette/src/lib.rs
@@ -1,11 +1,11 @@
 //! Smooth color palette interpolation engine.
 //!
 //! Provides backend-agnostic RGB palette computation that smoothly
-//! interpolates between time-of-day keyframes and applies seasonal
-//! and weather tinting. UI renderers consume [`RawPalette`] values from this module.
+//! interpolates between time-of-day keyframes and enforces a minimum
+//! foreground/background contrast floor. UI renderers consume
+//! [`RawPalette`] values from this module.
 
 use parish_config::PaletteConfig;
-use parish_types::{Season, Weather};
 
 /// A backend-agnostic RGB color.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -225,115 +225,9 @@ fn interpolated_palette(hour: u32, minute: u32) -> RawPalette {
     KEYFRAMES[0].palette
 }
 
-/// Season tint parameters from config: (r_mult, g_mult, b_mult, desaturation).
-fn season_tint_with_config(season: Season, config: &PaletteConfig) -> (f32, f32, f32, f32) {
-    let t = match season {
-        Season::Spring => config.season_tints.spring,
-        Season::Summer => config.season_tints.summer,
-        Season::Autumn => config.season_tints.autumn,
-        Season::Winter => config.season_tints.winter,
-    };
-    (t[0], t[1], t[2], t[3])
-}
-
-/// Season tint parameters: (r_mult, g_mult, b_mult, desaturation).
-///
-/// Used in tests via [`apply_season_tint`]; runtime code uses [`season_tint_with_config`].
-#[cfg(test)]
-fn season_tint(season: Season) -> (f32, f32, f32, f32) {
-    season_tint_with_config(season, &PaletteConfig::default())
-}
-
-/// Weather tint parameters from config: (r_mult, g_mult, b_mult, desaturation, brightness, contrast_reduction).
-fn weather_tint_with_config(
-    weather: Weather,
-    config: &PaletteConfig,
-) -> (f32, f32, f32, f32, f32, f32) {
-    let t = match weather {
-        Weather::Clear => config.weather_tints.clear,
-        Weather::PartlyCloudy => config.weather_tints.partly_cloudy,
-        Weather::Overcast => config.weather_tints.overcast,
-        Weather::LightRain => config.weather_tints.light_rain,
-        Weather::HeavyRain => config.weather_tints.heavy_rain,
-        Weather::Fog => config.weather_tints.fog,
-        Weather::Storm => config.weather_tints.storm,
-    };
-    (t[0], t[1], t[2], t[3], t[4], t[5])
-}
-
-/// Weather tint parameters: (r_mult, g_mult, b_mult, desaturation, brightness, contrast_reduction).
-///
-/// Kept for tests; runtime code uses [`weather_tint_with_config`].
-#[cfg(test)]
-#[allow(dead_code)] // available for future test use
-fn weather_tint(weather: Weather) -> (f32, f32, f32, f32, f32, f32) {
-    weather_tint_with_config(weather, &PaletteConfig::default())
-}
-
 /// Computes the luminance of an RGB color (ITU-R BT.601).
 fn luminance(c: RawColor) -> f32 {
     0.299 * c.r as f32 + 0.587 * c.g as f32 + 0.114 * c.b as f32
-}
-
-/// Applies a multiplicative tint, desaturation, and brightness to a single color.
-fn tint_color(
-    c: RawColor,
-    r_mult: f32,
-    g_mult: f32,
-    b_mult: f32,
-    desat: f32,
-    bright: f32,
-) -> RawColor {
-    let lum = luminance(c);
-
-    // Desaturate: blend toward gray (luminance)
-    let r = c.r as f32 + (lum - c.r as f32) * desat;
-    let g = c.g as f32 + (lum - c.g as f32) * desat;
-    let b = c.b as f32 + (lum - c.b as f32) * desat;
-
-    // Apply color multiplier and brightness
-    let r = (r * r_mult * bright).round().clamp(0.0, 255.0) as u8;
-    let g = (g * g_mult * bright).round().clamp(0.0, 255.0) as u8;
-    let b = (b * b_mult * bright).round().clamp(0.0, 255.0) as u8;
-
-    RawColor::new(r, g, b)
-}
-
-/// Applies season tinting to all palette colors.
-#[cfg(test)]
-fn apply_season_tint(palette: &mut RawPalette, season: Season) {
-    let (rm, gm, bm, desat) = season_tint(season);
-    palette.bg = tint_color(palette.bg, rm, gm, bm, desat, 1.0);
-    palette.fg = tint_color(palette.fg, rm, gm, bm, desat, 1.0);
-    palette.accent = tint_color(palette.accent, rm, gm, bm, desat, 1.0);
-    palette.panel_bg = tint_color(palette.panel_bg, rm, gm, bm, desat, 1.0);
-    palette.input_bg = tint_color(palette.input_bg, rm, gm, bm, desat, 1.0);
-    palette.border = tint_color(palette.border, rm, gm, bm, desat, 1.0);
-    palette.muted = tint_color(palette.muted, rm, gm, bm, desat, 1.0);
-}
-
-/// Applies weather tinting to all palette colors.
-///
-/// For fog, also reduces contrast by blending fg toward bg.
-///
-/// Kept for tests; runtime code uses [`compute_palette_with_config`].
-#[cfg(test)]
-#[allow(dead_code)] // available for future test use
-fn apply_weather_tint(palette: &mut RawPalette, weather: Weather) {
-    let (rm, gm, bm, desat, bright, contrast_reduction) = weather_tint(weather);
-    palette.bg = tint_color(palette.bg, rm, gm, bm, desat, bright);
-    palette.fg = tint_color(palette.fg, rm, gm, bm, desat, bright);
-    palette.accent = tint_color(palette.accent, rm, gm, bm, desat, bright);
-    palette.panel_bg = tint_color(palette.panel_bg, rm, gm, bm, desat, bright);
-    palette.input_bg = tint_color(palette.input_bg, rm, gm, bm, desat, bright);
-    palette.border = tint_color(palette.border, rm, gm, bm, desat, bright);
-    palette.muted = tint_color(palette.muted, rm, gm, bm, desat, bright);
-
-    // Fog contrast reduction: blend fg toward bg
-    if contrast_reduction > 0.0 {
-        palette.fg = lerp_color(palette.fg, palette.bg, contrast_reduction);
-        palette.muted = lerp_color(palette.muted, palette.bg, contrast_reduction * 0.5);
-    }
 }
 
 /// Minimum luminance difference between fg and bg to ensure readability.
@@ -402,55 +296,23 @@ fn ensure_contrast(palette: &mut RawPalette) {
     ensure_contrast_with_config(palette, &PaletteConfig::default());
 }
 
-/// Computes the fully interpolated and tinted palette using the provided [`PaletteConfig`].
+/// Computes the interpolated palette using the provided [`PaletteConfig`].
 ///
-/// Same pipeline as [`compute_palette`] but reads tint multipliers and contrast
-/// thresholds from `config` instead of hardcoded defaults.
-pub fn compute_palette_with_config(
-    hour: u32,
-    minute: u32,
-    season: Season,
-    weather: Weather,
-    config: &PaletteConfig,
-) -> RawPalette {
+/// Same pipeline as [`compute_palette`] but reads contrast thresholds from
+/// `config` instead of hardcoded defaults.
+pub fn compute_palette_with_config(hour: u32, minute: u32, config: &PaletteConfig) -> RawPalette {
     let mut palette = interpolated_palette(hour, minute);
-
-    let (rm, gm, bm, desat) = season_tint_with_config(season, config);
-    palette.bg = tint_color(palette.bg, rm, gm, bm, desat, 1.0);
-    palette.fg = tint_color(palette.fg, rm, gm, bm, desat, 1.0);
-    palette.accent = tint_color(palette.accent, rm, gm, bm, desat, 1.0);
-    palette.panel_bg = tint_color(palette.panel_bg, rm, gm, bm, desat, 1.0);
-    palette.input_bg = tint_color(palette.input_bg, rm, gm, bm, desat, 1.0);
-    palette.border = tint_color(palette.border, rm, gm, bm, desat, 1.0);
-    palette.muted = tint_color(palette.muted, rm, gm, bm, desat, 1.0);
-
-    let (rm, gm, bm, desat, bright, contrast_reduction) = weather_tint_with_config(weather, config);
-    palette.bg = tint_color(palette.bg, rm, gm, bm, desat, bright);
-    palette.fg = tint_color(palette.fg, rm, gm, bm, desat, bright);
-    palette.accent = tint_color(palette.accent, rm, gm, bm, desat, bright);
-    palette.panel_bg = tint_color(palette.panel_bg, rm, gm, bm, desat, bright);
-    palette.input_bg = tint_color(palette.input_bg, rm, gm, bm, desat, bright);
-    palette.border = tint_color(palette.border, rm, gm, bm, desat, bright);
-    palette.muted = tint_color(palette.muted, rm, gm, bm, desat, bright);
-
-    if contrast_reduction > 0.0 {
-        palette.fg = lerp_color(palette.fg, palette.bg, contrast_reduction);
-        palette.muted = lerp_color(palette.muted, palette.bg, contrast_reduction * 0.5);
-    }
-
     ensure_contrast_with_config(&mut palette, config);
     palette
 }
 
-/// Computes the fully interpolated and tinted palette for the given time, season, and weather.
+/// Computes the interpolated palette for the given time of day.
 ///
 /// This is the main entry point for UI renderers.
 /// 1. Smoothly interpolates between time-of-day keyframe palettes
-/// 2. Applies seasonal color tinting
-/// 3. Applies weather color tinting
-/// 4. Enforces minimum contrast between text and background
-pub fn compute_palette(hour: u32, minute: u32, season: Season, weather: Weather) -> RawPalette {
-    compute_palette_with_config(hour, minute, season, weather, &PaletteConfig::default())
+/// 2. Enforces minimum contrast between text and background
+pub fn compute_palette(hour: u32, minute: u32) -> RawPalette {
+    compute_palette_with_config(hour, minute, &PaletteConfig::default())
 }
 
 #[cfg(test)]
@@ -548,86 +410,17 @@ mod tests {
     }
 
     #[test]
-    fn test_season_clear_compute() {
-        // With Clear weather and Spring season, compute_palette should still produce valid colors
-        let p = compute_palette(12, 0, Season::Spring, Weather::Clear);
+    fn test_compute_palette_produces_valid_colors() {
+        let p = compute_palette(12, 0);
         assert_ne!(p.bg, RawColor::new(0, 0, 0));
     }
 
     #[test]
-    fn test_weather_clear_is_near_identity() {
-        // Clear weather should barely change the palette (only season effect)
-        let base = interpolated_palette(12, 0);
-        let tinted = compute_palette(12, 0, Season::Summer, Weather::Clear);
-        // Summer tint is subtle, bg should be close
-        let diff_r = (base.bg.r as i16 - tinted.bg.r as i16).unsigned_abs();
-        let diff_g = (base.bg.g as i16 - tinted.bg.g as i16).unsigned_abs();
-        assert!(
-            diff_r < 20,
-            "Summer tint should be subtle, got diff_r={diff_r}"
-        );
-        assert!(
-            diff_g < 20,
-            "Summer tint should be subtle, got diff_g={diff_g}"
-        );
-    }
-
-    #[test]
-    fn test_winter_is_bluer() {
-        let base = interpolated_palette(12, 0);
-        let mut winter = base;
-        apply_season_tint(&mut winter, Season::Winter);
-        // Winter blue channel should be >= base (blue multiplier is 1.04)
-        assert!(winter.bg.b >= base.bg.b, "Winter should tint bluer");
-    }
-
-    #[test]
-    fn test_storm_is_darker() {
-        let base = interpolated_palette(12, 0);
-        let stormy = compute_palette(12, 0, Season::Summer, Weather::Storm);
-        let base_lum = luminance(base.bg);
-        let storm_lum = luminance(stormy.bg);
-        assert!(
-            storm_lum < base_lum,
-            "Storm should darken: base_lum={base_lum}, storm_lum={storm_lum}"
-        );
-    }
-
-    #[test]
-    fn test_fog_reduces_contrast() {
-        let clear = compute_palette(12, 0, Season::Summer, Weather::Clear);
-        let foggy = compute_palette(12, 0, Season::Summer, Weather::Fog);
-        let clear_contrast = (luminance(clear.fg) - luminance(clear.bg)).abs();
-        let fog_contrast = (luminance(foggy.fg) - luminance(foggy.bg)).abs();
-        assert!(
-            fog_contrast < clear_contrast,
-            "Fog should reduce contrast: clear={clear_contrast}, fog={fog_contrast}"
-        );
-    }
-
-    #[test]
-    fn test_all_combinations_valid() {
-        let seasons = [
-            Season::Spring,
-            Season::Summer,
-            Season::Autumn,
-            Season::Winter,
-        ];
-        let weathers = [
-            Weather::Clear,
-            Weather::PartlyCloudy,
-            Weather::Overcast,
-            Weather::LightRain,
-            Weather::HeavyRain,
-            Weather::Fog,
-            Weather::Storm,
-        ];
-        for season in &seasons {
-            for weather in &weathers {
-                for hour in [0, 6, 12, 18, 23] {
-                    let _p = compute_palette(hour, 0, *season, *weather);
-                    // No panics, channels are within u8 range by construction
-                }
+    fn test_compute_palette_all_hours_valid() {
+        for hour in [0, 6, 12, 18, 23] {
+            for minute in [0, 15, 30, 45] {
+                let _p = compute_palette(hour, minute);
+                // No panics, channels are within u8 range by construction
             }
         }
     }
@@ -682,7 +475,7 @@ mod tests {
         // Verify contrast floor holds for every 15-minute slot across the full day
         for hour in 0..24 {
             for minute in [0, 15, 30, 45] {
-                let p = compute_palette(hour, minute, Season::Spring, Weather::Clear);
+                let p = compute_palette(hour, minute);
                 let contrast = (luminance(p.fg) - luminance(p.bg)).abs();
                 assert!(
                     contrast >= MIN_FG_BG_CONTRAST - 1.0,
@@ -719,59 +512,5 @@ mod tests {
     fn test_luminance() {
         assert!((luminance(RawColor::new(255, 255, 255)) - 255.0).abs() < 0.01);
         assert!((luminance(RawColor::new(0, 0, 0))).abs() < 0.01);
-    }
-
-    #[test]
-    fn test_tint_color_identity() {
-        let c = RawColor::new(100, 150, 200);
-        let tinted = tint_color(c, 1.0, 1.0, 1.0, 0.0, 1.0);
-        assert_eq!(tinted, c);
-    }
-
-    #[test]
-    fn test_autumn_is_warmer() {
-        let base = interpolated_palette(12, 0);
-        let mut autumn = base;
-        apply_season_tint(&mut autumn, Season::Autumn);
-        // Autumn red multiplier is 1.06, should increase red
-        assert!(autumn.bg.r >= base.bg.r, "Autumn should tint warmer/redder");
-    }
-
-    #[test]
-    fn test_palette_new_variants() {
-        let base = interpolated_palette(12, 0);
-        let base_lum = luminance(base.bg);
-
-        // PartlyCloudy should be slightly darker than Clear
-        let partly_cloudy = compute_palette(12, 0, Season::Summer, Weather::PartlyCloudy);
-        let pc_lum = luminance(partly_cloudy.bg);
-        assert!(
-            pc_lum < base_lum,
-            "PartlyCloudy should be slightly darker than base: pc={pc_lum}, base={base_lum}"
-        );
-
-        // LightRain should be darker than PartlyCloudy
-        let light_rain = compute_palette(12, 0, Season::Summer, Weather::LightRain);
-        let lr_lum = luminance(light_rain.bg);
-        assert!(
-            lr_lum < pc_lum,
-            "LightRain should be darker than PartlyCloudy: lr={lr_lum}, pc={pc_lum}"
-        );
-
-        // HeavyRain should be darker than LightRain
-        let heavy_rain = compute_palette(12, 0, Season::Summer, Weather::HeavyRain);
-        let hr_lum = luminance(heavy_rain.bg);
-        assert!(
-            hr_lum < lr_lum,
-            "HeavyRain should be darker than LightRain: hr={hr_lum}, lr={lr_lum}"
-        );
-
-        // Storm should be darkest
-        let storm = compute_palette(12, 0, Season::Summer, Weather::Storm);
-        let st_lum = luminance(storm.bg);
-        assert!(
-            st_lum < hr_lum,
-            "Storm should be darker than HeavyRain: st={st_lum}, hr={hr_lum}"
-        );
     }
 }

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -79,18 +79,13 @@ pub async fn get_npcs_here(Extension(state): Extension<Arc<AppState>>) -> Json<V
     Json(parish_core::ipc::build_npcs_here(&world, &npc_manager))
 }
 
-/// `GET /api/theme` — returns the current time-of-day palette (weather + season tinted).
+/// `GET /api/theme` — returns the current time-of-day palette.
 pub async fn get_theme(Extension(state): Extension<Arc<AppState>>) -> Json<ThemePalette> {
     use chrono::Timelike;
     use parish_palette::compute_palette;
     let world = state.world.lock().await;
     let now = world.clock.now();
-    let raw = compute_palette(
-        now.hour(),
-        now.minute(),
-        world.clock.season(),
-        world.weather,
-    );
+    let raw = compute_palette(now.hour(), now.minute());
     Json(ThemePalette::from(raw))
 }
 

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -168,19 +168,14 @@ pub async fn get_npcs_here(state: tauri::State<'_, Arc<AppState>>) -> Result<Vec
     Ok(parish_core::ipc::build_npcs_here(&world, &npc_manager))
 }
 
-/// Returns the current time-of-day palette (weather + season tinted) as CSS hex colours.
+/// Returns the current time-of-day palette as CSS hex colours.
 #[tauri::command]
 pub async fn get_theme(state: tauri::State<'_, Arc<AppState>>) -> Result<ThemePalette, String> {
     use chrono::Timelike;
     use parish_palette::compute_palette;
     let world = state.world.lock().await;
     let now = world.clock.now();
-    let raw = compute_palette(
-        now.hour(),
-        now.minute(),
-        world.clock.season(),
-        world.weather,
-    );
+    let raw = compute_palette(now.hour(), now.minute());
     Ok(ThemePalette::from(raw))
 }
 

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -976,17 +976,12 @@ pub fn run() {
                                 &state_tick.pronunciations,
                             );
                             let _ = handle_tick.emit(events::EVENT_WORLD_UPDATE, snapshot);
-                            // Emit current time-of-day palette (weather + season tinted)
+                            // Emit current time-of-day palette
                             {
                                 use chrono::Timelike;
                                 use parish_palette::compute_palette;
                                 let now = world.clock.now();
-                                let raw = compute_palette(
-                                    now.hour(),
-                                    now.minute(),
-                                    world.clock.season(),
-                                    world.weather,
-                                );
+                                let raw = compute_palette(now.hour(), now.minute());
                                 if last_palette != Some(raw) {
                                     let _ = handle_tick.emit(
                                         events::EVENT_THEME_UPDATE,

--- a/crates/parish-types/src/ids.rs
+++ b/crates/parish-types/src/ids.rs
@@ -13,7 +13,7 @@ use crate::ParishError;
 
 /// Current weather conditions in the game world.
 ///
-/// Affects color palette tinting and location description templates.
+/// Affects location description templates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Weather {
     Clear,

--- a/docs/adr/018-engine-config-extraction.md
+++ b/docs/adr/018-engine-config-extraction.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-After the engine/game-data separation (ADR/PR #119), game content lives in the mod system (`mods/rundale/`). However, ~60 engine-level numeric constants (inference timeouts, game speed factors, encounter probabilities, NPC memory/cognition tuning, palette tinting) remained hardcoded, requiring recompilation to tune.
+After the engine/game-data separation (ADR/PR #119), game content lives in the mod system (`mods/rundale/`). However, ~50 engine-level numeric constants (inference timeouts, game speed factors, encounter probabilities, NPC memory/cognition tuning, palette contrast thresholds) remained hardcoded, requiring recompilation to tune.
 
 ## Decision
 
@@ -18,7 +18,7 @@ Extract engine tuning parameters into an `[engine]` section of `parish.toml` via
 - **Game speed**: 5 speed presets (Slow through Ludicrous)
 - **Encounters**: 7 per-time-of-day probability thresholds
 - **NPC**: Memory capacity, separator holdback, context count, 4 truncation lengths, cognitive tier distances, tier 2 tick interval, 5 relationship label thresholds
-- **Palette**: 2 contrast thresholds, 4 season tints, 5 weather tints
+- **Palette**: 2 contrast thresholds
 - **World**: Fuzzy name-matching threshold (Jaro-Winkler similarity)
 - **Persistence**: Journal compaction threshold (reserved, not yet wired)
 

--- a/docs/design/designer-editor.md
+++ b/docs/design/designer-editor.md
@@ -4,7 +4,7 @@
 
 Parish (Rundale) is a text adventure set in 1820s rural Ireland with a rich body
 of authored game content: locations, NPCs, schedules, relationships, festivals,
-encounters, anachronisms, pronunciations, palette tints, loading screens, engine
+encounters, anachronisms, pronunciations, loading screens, engine
 tuning, and a branching SQLite save format. Today **none of it has a GUI editor**.
 Designers must hand-edit JSON/TOML files, rely on deserialization errors to flag
 mistakes, and restart the game to see changes. There is no save inspector, no

--- a/docs/design/gui-design.md
+++ b/docs/design/gui-design.md
@@ -93,7 +93,7 @@ Two collapsible sections:
 
 ## Color System
 
-The GUI uses time-of-day palettes with season and weather tinting, computed by the shared `src/world/palette.rs` engine. The 7 defined palettes cover the major times of day:
+The GUI uses time-of-day palettes computed by the shared `crates/parish-palette` engine. The 7 defined palettes cover the major times of day:
 
 | Time | Background | Text | Accent |
 |------|-----------|------|--------|
@@ -105,7 +105,7 @@ The GUI uses time-of-day palettes with season and weather tinting, computed by t
 | Night | `(20,25,40)` near-black | `(180,180,190)` silver | `(100,110,140)` blue-grey |
 | Midnight | `(10,12,20)` darkest | `(150,150,165)` muted | `(70,75,100)` dark blue |
 
-Palettes are selected by `compute_palette()` (from `src/world/palette.rs`) and season/weather tinting is applied on top. See [Weather System](weather-system.md) for tint parameters.
+Palettes are selected by `compute_palette()` (from `crates/parish-palette`), which interpolates between the 7 keyframes and enforces a minimum foreground/background contrast floor.
 
 ## Input Processing
 

--- a/docs/design/map-evolution.md
+++ b/docs/design/map-evolution.md
@@ -77,7 +77,7 @@ Enrich the map with contextual info:
 The map should feel different at different times, like the rest of the game:
 
 - **Ambient lighting**: At night, the map darkens. Only locations with "lights" (pub, church, houses) glow. The countryside between locations is dark.
-- **Weather overlay**: Rain could add a subtle texture or blue tint. Fog could reduce visibility radius on the minimap.
+- **Weather overlay**: Rain could add a subtle texture. Fog could reduce visibility radius on the minimap.
 - **Shadow direction**: Cast subtle shadows from nodes based on sun position (morning = shadows west, evening = shadows east). Pure flavor.
 
 ### 7. Animated Travel

--- a/docs/design/overview.md
+++ b/docs/design/overview.md
@@ -260,7 +260,7 @@ Beyond provider settings, `parish.toml` supports an `[engine]` section for runti
 | `[engine.npc]` | Memory capacity, holdback, truncation limits |
 | `[engine.npc.cognitive_tiers]` | Tier distance thresholds, Tier 2 tick interval |
 | `[engine.npc.relationship_labels]` | Relationship strength label thresholds |
-| `[engine.palette]` | Contrast thresholds, season/weather tints |
+| `[engine.palette]` | Contrast thresholds |
 
 Config structs live in `crates/parish-core/src/config/engine.rs`.
 

--- a/docs/design/visual-effects-system.md
+++ b/docs/design/visual-effects-system.md
@@ -115,7 +115,7 @@ animation. CSS `mix-blend-mode: screen` over the chat panel for the text inversi
 Vertical streaks descend across the chat panel — short, thin, semi-transparent lines with
 slight `blur` and a `linear-gradient` body that fades out at the bottom. They drift at
 slightly different speeds and horizontal positions, created with `nth-child` offset delays.
-Heavy rain has more streaks, faster, with a subtle blue tint. Light rain is sparse and slow.
+Heavy rain has more streaks, faster. Light rain is sparse and slow.
 
 **Implementation:**
 `<div class="rain-layer">` containing 20–40 `<span class="raindrop">` elements.
@@ -420,8 +420,8 @@ A `prefers-reduced-motion` media query wraps all `@keyframes` animations. When
 `prefers-reduced-motion: reduce` is active:
 
 - All animated effects are disabled.
-- Static versions replace animated ones where meaningful (e.g., a static rain tint
-  instead of falling streaks; a static amber corner glow instead of pulsing candles).
+- Static versions replace animated ones where meaningful (e.g., a static rain
+  overlay instead of falling streaks; a static amber corner glow instead of pulsing candles).
 - The Fairy simply doesn't visit.
 
 A player-facing toggle ("Effects: On / Minimal / Off") will be surfaced in a future

--- a/docs/design/weather-system.md
+++ b/docs/design/weather-system.md
@@ -2,19 +2,21 @@
 
 > Parent: [Architecture Overview](overview.md) | [Docs Index](../index.md)
 
-Weather is a simulation driver, not just visual dressing. Weather state is part of world state and affects NPC context prompts, location descriptions, and color palettes.
+Weather is a simulation driver. Weather state is part of world state and affects NPC context prompts, location descriptions, and encounter patterns. It does **not** affect the UI palette — the time-of-day palette is independent of weather.
 
 ## Weather Enum
 
-The `Weather` enum in `src/world/mod.rs` defines five conditions:
+The `Weather` enum in `crates/parish-types/src/ids.rs` defines seven conditions:
 
-| Variant      | Description                               |
-|--------------|-------------------------------------------|
-| `Clear`      | Default — no palette modification         |
-| `Overcast`   | Slightly darker and desaturated           |
-| `Rain`       | Darker with a blue-gray tint              |
-| `Fog`        | Washed out, low contrast                  |
-| `Storm`      | Much darker and heavily desaturated       |
+| Variant         | Description           |
+|-----------------|-----------------------|
+| `Clear`         | Sunny / no cover      |
+| `PartlyCloudy`  | Mixed sun and cloud   |
+| `Overcast`      | Heavy cloud cover     |
+| `LightRain`     | Drizzle / light rain  |
+| `HeavyRain`     | Sustained rain        |
+| `Fog`           | Low visibility        |
+| `Storm`         | Wind, thunder, gale   |
 
 ## Effects on Simulation
 
@@ -27,35 +29,6 @@ The `Weather` enum in `src/world/mod.rs` defines five conditions:
 | **Overcast**      | Muted mood, reduced outdoor activity                          |
 | **Storms**        | Disruptive, affects travel and NPC schedules                  |
 
-## Palette Tinting
-
-Weather modifies the base time-of-day color palette via multiplicative tinting in `src/world/palette.rs`. The tinting system applies three layers:
-
-1. **Time-of-day interpolation** — smooth linear interpolation between 7 keyframe palettes based on exact hour and minute
-2. **Season tinting** — subtle color shifts (Winter: cooler/bluer, Summer: warmer, Autumn: amber, Spring: greener)
-3. **Weather tinting** — brightness, desaturation, and color temperature adjustments
-
-### Weather Tint Parameters
-
-| Weather   | RGB Multiplier         | Desaturation | Brightness | Contrast Reduction |
-|-----------|------------------------|-------------|------------|-------------------|
-| Clear     | (1.0, 1.0, 1.0)       | 0%          | 100%       | 0%                |
-| Overcast  | (0.95, 0.95, 0.97)    | 15%         | 92%        | 0%                |
-| Rain      | (0.88, 0.90, 0.95)    | 20%         | 85%        | 0%                |
-| Fog       | (0.97, 0.97, 0.98)    | 35%         | 95%        | 15%               |
-| Storm     | (0.80, 0.82, 0.85)    | 30%         | 75%        | 0%                |
-
-### Season Tint Parameters
-
-| Season  | RGB Multiplier         | Desaturation |
-|---------|------------------------|-------------|
-| Spring  | (0.98, 1.02, 0.98)    | 0%          |
-| Summer  | (1.03, 1.01, 0.97)    | 0%          |
-| Autumn  | (1.06, 1.00, 0.92)    | 0%          |
-| Winter  | (0.94, 0.96, 1.04)    | 8%          |
-
-The GUI consumes `RawPalette` from the engine.
-
 ## Related
 
 - [GUI Design](gui-design.md) — GUI color theming
@@ -64,7 +37,6 @@ The GUI consumes `RawPalette` from the engine.
 
 ## Source Modules
 
-- [`src/world/mod.rs`](../../src/world/mod.rs) — `Weather` enum definition
-- [`src/world/palette.rs`](../../src/world/palette.rs) — Smooth interpolation engine, season/weather tinting
-- [`src/world/palette.rs`](../../src/world/palette.rs) — Palette engine, season/weather tinting
-- [`src/npc/`](../../src/npc/) — Weather-aware NPC behavior
+- [`crates/parish-types/src/ids.rs`](../../crates/parish-types/src/ids.rs) — `Weather` enum definition
+- [`crates/parish-palette/src/lib.rs`](../../crates/parish-palette/src/lib.rs) — Time-of-day palette interpolation (no weather input)
+- [`crates/parish-npc/`](../../crates/parish-npc/) — Weather-aware NPC behavior

--- a/docs/features.md
+++ b/docs/features.md
@@ -28,7 +28,6 @@ Parish is a text-based adventure game set in 1820s rural Ireland, powered by LLM
 ### Weather System
 - **Seven weather states:** Clear, PartlyCloudy, Overcast, LightRain, HeavyRain, Fog, Storm (`crates/parish-types/src/ids.rs`)
 - Weather transition engine runs in the simulation tick path
-- Weather affects UI palette tinting (desaturation, brightness, color temperature)
 - Weather state available to NPC dialogue context
 
 ### Festivals
@@ -279,8 +278,6 @@ Provider config is resolved by `resolve_config` in `crates/parish-config/src/pro
 
 ### Theme System
 - Time-of-day color theming with smooth RGB gradient interpolation
-- Season-aware palette tinting
-- Weather-variant tinting
 - CSS custom properties driven by Rust theme-tick events
 - Mod-configurable accent color
 

--- a/docs/plans/phase-5b-weather-state-machine.md
+++ b/docs/plans/phase-5b-weather-state-machine.md
@@ -2,7 +2,7 @@
 
 > Parent: [Phase 5](phase-5-full-lod-scale.md) | [Roadmap](../requirements/roadmap.md) | [Docs Index](../index.md)
 >
-> **Status: Complete**
+> **Status: Complete** — *palette-tinting tasks below have since been reverted; weather no longer affects the UI palette.*
 >
 > **Depends on:** Phase 5A (event bus for `WeatherChanged` events)
 > **Depended on by:** 5D (weather context in Tier 3 prompts), 5E (weather drives Tier 4 rules)

--- a/docs/requirements/roadmap.md
+++ b/docs/requirements/roadmap.md
@@ -96,7 +96,6 @@
 - [x] `WeatherEngine` with seasonal transition probabilities
 - [x] Weather affects NPC schedules (seek shelter in rain)
 - [x] Weather context in Tier 2 prompts
-- [x] Palette tinting for new weather variants
 - [x] Publish `WeatherChanged` events via event bus
 
 ### Phase 5C — NPC Long-Term Memory & Gossip

--- a/docs/reviews/chrome-testing-session.md
+++ b/docs/reviews/chrome-testing-session.md
@@ -79,7 +79,7 @@ every page load.
 | Debug: Events tab | Pass | Empty (no debug events stored in web mode) |
 | Debug: Inference tab | Pass | Not deeply tested |
 | WebSocket reconnect | Not tested | Would need to kill/restart server mid-session |
-| Theme/palette updates | Pass | Time-of-day tinting updated as clock advanced |
+| Theme/palette updates | Pass | Time-of-day palette updated as clock advanced |
 | Multiple NPC conversations | Pass | Talked to Fr. Tierney and Tommy O'Brien |
 
 ## Observations

--- a/parish.example.toml
+++ b/parish.example.toml
@@ -101,19 +101,6 @@ strained = -0.7
 min_fg_bg_contrast = 80.0
 min_muted_bg_contrast = 45.0
 
-[engine.palette.season_tints]
-spring = [0.98, 1.02, 0.98, 0.0]   # [r_mult, g_mult, b_mult, desaturation]
-summer = [1.03, 1.01, 0.97, 0.0]
-autumn = [1.06, 1.00, 0.92, 0.0]
-winter = [0.94, 0.96, 1.04, 0.08]
-
-[engine.palette.weather_tints]
-clear = [1.0, 1.0, 1.0, 0.0, 1.0, 0.0]       # [r, g, b, desat, brightness, contrast_reduction]
-overcast = [0.95, 0.95, 0.97, 0.15, 0.92, 0.0]
-rain = [0.88, 0.90, 0.95, 0.20, 0.85, 0.0]
-fog = [0.97, 0.97, 0.98, 0.35, 0.95, 0.15]
-storm = [0.80, 0.82, 0.85, 0.30, 0.75, 0.0]
-
 [engine.world]
 fuzzy_threshold = 0.82          # Jaro-Winkler similarity for fuzzy location matching (0.0–1.0)
 


### PR DESCRIPTION
## Summary

The season/weather palette tinting feature is dropped. After this PR, the UI palette depends solely on time-of-day; weather and season still drive simulation, encounter patterns, and location descriptions, but no longer modulate UI colours.

- **`parish-palette`** — drop `season_tint*`, `weather_tint*`, `tint_color`, `apply_*_tint`, and the fog contrast-reduction step. `compute_palette` / `compute_palette_with_config` lose their `Season` / `Weather` parameters; keyframe interpolation and the contrast floor stay.
- **`parish-config`** — trim `PaletteConfig` to its two contrast thresholds; delete `SeasonTintConfig`, `WeatherTintConfig`, and their nine default-fns.
- **`parish-cli` / `parish-tauri` / `parish-server`** — drop the now-unused re-exports and update the three `compute_palette` call sites.
- **`parish.example.toml`** — remove the `[engine.palette.season_tints]` and `[engine.palette.weather_tints]` tables.
- **Docs** — scrub tinting references from `features.md`, `weather-system.md`, `gui-design.md`, `overview.md`, ADR 018, the roadmap, `visual-effects-system.md`, `designer-editor.md`, `map-evolution.md`, `chrome-testing-session.md`, and the `parish-palette` README. Mark the phase-5b palette-tinting tasks as superseded rather than rewriting the historical plan.

22 files changed, +61 / −496.

## Test plan

- [x] `cargo build --workspace --exclude parish-tauri` (Tauri excluded — its `gdk-3.0` system dep is unavailable in this sandbox; CI builds it)
- [x] `cargo test --workspace --exclude parish-tauri` — all suites green
- [x] `cargo clippy --workspace --exclude parish-tauri --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `rg -in "tint" crates/ docs/ parish.example.toml` — no real hits remain (only the historical phase-5b plan body and a `setInterval`-substring false positive in `+page.svelte`)
- [ ] Verify in CI that `parish-tauri` compiles with the trimmed `compute_palette(hour, minute)` call sites
- [ ] Smoke test: run `just run-headless`, advance the clock, confirm the palette still varies with time-of-day and no longer reacts to weather/season changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDK5fG67sCvYneDMfSDYkW)_