### PR TITLE
fix: align Dockerfile Rust version with CI

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -10,7 +10,7 @@ COPY apps/ui/ ./
 RUN npm run build
 
 # ── Stage 2: build Rust binary ────────────────────────────────────────────────
-FROM rust:1.88-slim-bookworm AS builder
+FROM rust:1.95-slim-bookworm AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config libssl-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -10,7 +10,7 @@ COPY apps/ui/ ./
 RUN npm run build
 
 # ── Stage 2: build Rust binary ────────────────────────────────────────────────
-FROM rust:1.95-slim-bookworm AS builder
+FROM rust:1.95.0-slim-bookworm AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config libssl-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes #695.

Aligns the Dockerfile Rust toolchain version with CI (`dtolnay/rust-toolchain@1.95.0` → `rust:1.95-slim-bookworm`), so a green CI run guarantees a working deploy image.

**Commands run:** read-only (version bump only, cargo build unchanged)