### PR TITLE
security: parish.toml gitignore + Tauri react_to_message injection guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ act-artifacts/
 
 .gemini/
 gha-creds-*.json
+
+# Local configuration — may contain API keys (Gemini, Ollama, etc.)
+# See parish.example.toml for the expected structure.
+parish.toml

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -1906,6 +1906,10 @@ async fn do_branch_log_text(state: &Arc<AppState>) -> Result<String, String> {
 
 // ── Reaction commands ──────────────────────────────────────────────────────
 
+fn is_snippet_injection_char(c: char) -> bool {
+    c == '"' || c == '\\' || c == '\u{2028}' || c == '\u{2029}' || c.is_control()
+}
+
 /// Player reacts to an NPC message with an emoji.
 #[tauri::command]
 pub async fn react_to_message(
@@ -1917,6 +1921,11 @@ pub async fn react_to_message(
     // Validate emoji is in the palette
     if reactions::reaction_description(&emoji).is_none() {
         return Err("Unknown reaction emoji.".to_string());
+    }
+
+    // Reject snippets that could inject content into NPC system prompts (#687).
+    if message_snippet.chars().any(is_snippet_injection_char) {
+        return Err("Message snippet contains disallowed characters.".to_string());
     }
 
     let mut npc_manager = state.npc_manager.lock().await;

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -1906,10 +1906,6 @@ async fn do_branch_log_text(state: &Arc<AppState>) -> Result<String, String> {
 
 // ── Reaction commands ──────────────────────────────────────────────────────
 
-fn is_snippet_injection_char(c: char) -> bool {
-    c == '"' || c == '\\' || c == '\u{2028}' || c == '\u{2029}' || c.is_control()
-}
-
 /// Player reacts to an NPC message with an emoji.
 #[tauri::command]
 pub async fn react_to_message(
@@ -1918,6 +1914,10 @@ pub async fn react_to_message(
     emoji: String,
     state: tauri::State<'_, Arc<AppState>>,
 ) -> Result<(), String> {
+    fn is_snippet_injection_char(c: char) -> bool {
+        c == '"' || c == '\\' || c == '\u{2028}' || c == '\u{2029}' || c.is_control()
+    }
+
     // Validate emoji is in the palette
     if reactions::reaction_description(&emoji).is_none() {
         return Err("Unknown reaction emoji.".to_string());


### PR DESCRIPTION
Fixes #688, fixes #687.

- **#688** — Add `parish.toml` to `.gitignore`. The file may contain LLM API keys and must never be committed. `parish.example.toml` already exists as the template.
- **#687** — Add `is_snippet_injection_char` guard to the Tauri `react_to_message` command, matching the identical validation already in the web server path. Without this, a crafted snippet could inject control characters / Unicode line-separators into NPC system prompts via the Tauri backend.

**Commands run:** `just check`