### PR TITLE
fix: safe numeric casts in weather engine and geo-tool pipeline

### DIFF
--- a/crates/parish-core/src/debug_snapshot.rs
+++ b/crates/parish-core/src/debug_snapshot.rs
@@ -123,7 +123,7 @@ pub struct WeatherDebug {
     /// Minimum duration before a transition is allowed (game-hours).
     pub min_duration_hours: f64,
     /// Game-hour cursor of the last transition evaluation, if any.
-    pub last_check_hour: Option<u32>,
+    pub last_check_hour: Option<i64>,
 }
 
 /// World graph summary for debug display.

--- a/crates/parish-geo-tool/src/connections.rs
+++ b/crates/parish-geo-tool/src/connections.rs
@@ -319,7 +319,7 @@ fn ensure_connectivity(features: &[GeoFeature], connections: &mut Vec<GeneratedC
 
         debug!(
             "bridging components: {} <-> {} ({}m)",
-            features[best_pair.0].name, features[best_pair.1].name, best_dist as u32
+            features[best_pair.0].name, features[best_pair.1].name, best_dist as u64
         );
 
         connections.push(GeneratedConnection {

--- a/crates/parish-geo-tool/src/pipeline.rs
+++ b/crates/parish-geo-tool/src/pipeline.rs
@@ -196,8 +196,11 @@ fn build_locations(
         std::collections::HashMap::new();
 
     for conn in connections {
-        let from_id = LocationId(conn.from_idx as u32 + id_offset);
-        let to_id = LocationId(conn.to_idx as u32 + id_offset);
+        let from_id = LocationId(
+            u32::try_from(conn.from_idx).expect("feature index fits in u32") + id_offset,
+        );
+        let to_id =
+            LocationId(u32::try_from(conn.to_idx).expect("feature index fits in u32") + id_offset);
 
         // Forward connection
         conn_map.entry(conn.from_idx).or_default().push(Connection {
@@ -218,7 +221,7 @@ fn build_locations(
         .iter()
         .enumerate()
         .map(|(idx, feature)| {
-            let id = LocationId(idx as u32 + id_offset);
+            let id = LocationId(u32::try_from(idx).expect("feature index fits in u32") + id_offset);
             let (description_template, description_source) = generate_description(feature);
             let mythological_significance = generate_mythological_significance(feature);
             let connections = conn_map.remove(&idx).unwrap_or_default();

--- a/crates/parish-world/src/weather.rs
+++ b/crates/parish-world/src/weather.rs
@@ -96,7 +96,7 @@ pub struct WeatherEngine {
     /// Minimum duration in game-hours before a transition is allowed.
     min_duration_hours: f64,
     /// Game-hour of the last transition check (to avoid multiple checks per hour).
-    last_check_hour: Option<u32>,
+    last_check_hour: Option<i64>,
     /// Ring buffer of recent weather transitions: (timestamp, new_weather).
     history: VecDeque<(DateTime<Utc>, Weather)>,
 }
@@ -142,7 +142,7 @@ impl WeatherEngine {
     }
 
     /// Returns the game-hour of the last transition check, or `None` if unchecked.
-    pub fn last_check_hour(&self) -> Option<u32> {
+    pub fn last_check_hour(&self) -> Option<i64> {
         self.last_check_hour
     }
 
@@ -160,7 +160,7 @@ impl WeatherEngine {
         season: Season,
         rng: &mut impl Rng,
     ) -> Option<Weather> {
-        let current_hour = now.timestamp() as u32 / 3600;
+        let current_hour = now.timestamp() / 3600;
 
         // Only check once per game-hour
         if self.last_check_hour == Some(current_hour) {


### PR DESCRIPTION
Fixes #679, fixes #689.

**weather.rs** — `last_check_hour` was cast `as u32` from an `i64` Unix timestamp. For game dates in 1820 the timestamp is a large negative number; `as u32` wraps silently, producing a nonsense hour value and breaking the once-per-hour dedup guard that prevents redundant weather transitions. Changed field/accessor to `Option<i64>` and removed the cast.

**geo-tool pipeline.rs** — three `usize as u32` index casts replaced with `u32::try_from().expect()` so an impossibly large feature list panics loudly rather than silently aliasing IDs.

**connections.rs** — debug-log distance cast from `as u32` (truncates on large floats) to `as u64`.

**Commands run:** `just check`