### PR TITLE
fix: wire travel encounters into game loop

### DIFF
--- a/crates/parish-core/src/game_session.rs
+++ b/crates/parish-core/src/game_session.rs
@@ -183,12 +183,12 @@ pub fn apply_movement(
             });
 
             // En-route encounter (fires ~20% of traversals, see encounter.rs)
-            if let Some(ref text) = encounter_msg {
+            if let Some(text) = encounter_msg {
                 world.log(text.clone());
                 messages.push(GameMessage {
                     source: "system",
                     subtype: Some("encounter"),
-                    text: text.clone(),
+                    text,
                 });
             }
 

--- a/crates/parish-core/src/game_session.rs
+++ b/crates/parish-core/src/game_session.rs
@@ -24,6 +24,7 @@ use crate::npc::manager::{NpcManager, TierTransition};
 use crate::npc::reactions::{NpcReaction, ReactionTemplates, generate_arrival_reactions};
 use crate::npc::{Npc, NpcId};
 use crate::world::description::{format_exits, render_description};
+use crate::world::encounter::check_encounter;
 use crate::world::movement::{MovementResult, resolve_movement};
 use crate::world::time::TimeOfDay;
 use crate::world::transport::TransportMode;
@@ -147,6 +148,11 @@ pub fn apply_movement(
                     });
             }
 
+            // Check for a travel encounter now that the clock has advanced.
+            let encounter_msg =
+                check_encounter(world.clock.time_of_day(), dice::DiceRoll::roll().value())
+                    .map(|ev| ev.description);
+
             // Reassign NPC cognitive tiers
             let tier_transitions = npc_manager.assign_tiers(world, &[]);
 
@@ -175,6 +181,16 @@ pub fn apply_movement(
                 subtype: None,
                 text: narration,
             });
+
+            // En-route encounter (fires ~20% of traversals, see encounter.rs)
+            if let Some(ref text) = encounter_msg {
+                world.log(text.clone());
+                messages.push(GameMessage {
+                    source: "system",
+                    subtype: Some("encounter"),
+                    text: text.clone(),
+                });
+            }
 
             // Arrival description + exits
             world.log(look_text.clone());


### PR DESCRIPTION
Fixes #719.

`check_encounter` was defined in `parish-world` and fully unit-tested but had no production callers — en-route encounters never fired during gameplay.

This wires it into the `MovementResult::Arrived` arm of `apply_movement` (the shared movement pipeline used by all three backends). The call happens after the clock advances so the time-of-day probability modifier reflects the post-travel time. Uses `DiceRoll::roll()` matching the existing randomness pattern in this file.

Encounter text is logged to `world.log()` and emitted as a `GameMessage { subtype: Some("encounter") }` so Tauri, web, and CLI surfaces all receive it.

**Commands run:** `just check`