### PR TITLE
test: autosave interval constant + regression sensor

### DIFF
--- a/crates/parish-core/src/lib.rs
+++ b/crates/parish-core/src/lib.rs
@@ -15,6 +15,11 @@ pub mod ipc;
 pub mod loading;
 pub mod prompts;
 
+/// How often autosave tasks should snapshot active sessions (seconds).
+/// Used by both the Axum web server and the Tauri desktop backend.
+/// Changing this risks silent data loss on crash — update tests accordingly.
+pub const AUTOSAVE_INTERVAL_SECS: u64 = 60;
+
 // Sub-crate re-exports — preserves `crate::X::...` paths used throughout
 pub use parish_config as config;
 pub use parish_inference as inference;

--- a/crates/parish-server/src/session.rs
+++ b/crates/parish-server/src/session.rs
@@ -25,6 +25,10 @@ use crate::state::{AppState, UiConfigSnapshot, build_app_state};
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
+/// How often the server-side autosave task snapshots active sessions (seconds).
+/// Changing this risks silent data loss on crash — update tests accordingly.
+pub const AUTOSAVE_INTERVAL_SECS: u64 = 60;
+
 /// Google OAuth credentials (optional — feature disabled when absent).
 pub struct OAuthConfig {
     pub client_id: String,
@@ -863,7 +867,7 @@ fn spawn_session_ticks(state: Arc<AppState>) -> Vec<JoinHandle<()>> {
         }));
     }
 
-    // ── Autosave tick (60 s) ─────────────────────────────────────────────────
+    // ── Autosave tick ────────────────────────────────────────────────────────
     //
     // #230 — Fixes: previously a fresh `Database::open` (and therefore a full
     // `migrate()` round-trip) was executed on every tick.  Now we lazily open
@@ -879,7 +883,7 @@ fn spawn_session_ticks(state: Arc<AppState>) -> Vec<JoinHandle<()>> {
             // one user-visible warning per failure run, not one per tick.
             let mut last_autosave_failed = false;
             loop {
-                tokio::time::sleep(Duration::from_secs(60)).await;
+                tokio::time::sleep(Duration::from_secs(AUTOSAVE_INTERVAL_SECS)).await;
 
                 let save_path = s.save_path.lock().await.clone();
                 let branch_id = *s.current_branch_id.lock().await;
@@ -1011,6 +1015,16 @@ fn build_session_cloud_client(global: &GlobalState) -> Option<AnyClient> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn autosave_interval_is_60_seconds() {
+        // Regression sensor: if this changes, update comment in session.rs and
+        // verify players won't lose more than AUTOSAVE_INTERVAL_SECS of progress.
+        assert_eq!(
+            AUTOSAVE_INTERVAL_SECS, 60,
+            "autosave interval changed — verify data-loss risk is acceptable"
+        );
+    }
 
     /// Verifies that a fresh DB round-trips the Google OAuth link:
     /// after `link_oauth`, both `find_by_oauth` and

--- a/crates/parish-server/src/session.rs
+++ b/crates/parish-server/src/session.rs
@@ -25,9 +25,9 @@ use crate::state::{AppState, UiConfigSnapshot, build_app_state};
 
 // ── Public types ─────────────────────────────────────────────────────────────
 
-/// How often the server-side autosave task snapshots active sessions (seconds).
-/// Changing this risks silent data loss on crash — update tests accordingly.
-pub const AUTOSAVE_INTERVAL_SECS: u64 = 60;
+/// Re-export so the test in this module can reference the canonical constant
+/// without importing from parish_core directly.
+pub use parish_core::AUTOSAVE_INTERVAL_SECS;
 
 /// Google OAuth credentials (optional — feature disabled when absent).
 pub struct OAuthConfig {

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -7,10 +7,7 @@ pub mod commands;
 pub mod editor_commands;
 pub mod events;
 
-/// How often the Tauri autosave task snapshots the active session (seconds).
-/// Must match parish-server AUTOSAVE_INTERVAL_SECS — both represent the same
-/// player-visible save cadence.
-const AUTOSAVE_INTERVAL_SECS: u64 = 60;
+use parish_core::AUTOSAVE_INTERVAL_SECS;
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -7,6 +7,11 @@ pub mod commands;
 pub mod editor_commands;
 pub mod events;
 
+/// How often the Tauri autosave task snapshots the active session (seconds).
+/// Must match parish-server AUTOSAVE_INTERVAL_SECS — both represent the same
+/// player-visible save cadence.
+const AUTOSAVE_INTERVAL_SECS: u64 = 60;
+
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -1582,11 +1587,11 @@ pub fn run() {
                     }
                 });
 
-                // Autosave tick: save snapshot every 60 seconds (if a save file is active)
+                // Autosave tick: save snapshot every AUTOSAVE_INTERVAL_SECS (if a save file is active)
                 let state_autosave = Arc::clone(&state_setup);
                 tokio::spawn(async move {
                     loop {
-                        tokio::time::sleep(Duration::from_secs(60)).await;
+                        tokio::time::sleep(Duration::from_secs(AUTOSAVE_INTERVAL_SECS)).await;
 
                         // Only autosave if a save file and branch are active
                         let save_path = state_autosave.save_path.lock().await.clone();


### PR DESCRIPTION
Fixes #725.

The 60-second autosave loop in both `parish-server` and `parish-tauri` used a bare `60` literal with no test. A silent edit would go undetected until players reported session data loss.

**Changes:**
- Extract `AUTOSAVE_INTERVAL_SECS = 60` as a named `pub const` in `parish-server/session.rs` and a matching private const in `parish-tauri/lib.rs`
- Replace both `Duration::from_secs(60)` literals with the constant
- Add `autosave_interval_is_60_seconds` test in `session.rs` — asserts the constant equals 60, so any accidental change fails the test suite with an explicit message

**Commands run:** `just check`