### PR TITLE
bug: replace silent panics and swallowed filesystem errors

### DIFF
--- a/crates/parish-npc/src/manager.rs
+++ b/crates/parish-npc/src/manager.rs
@@ -681,7 +681,9 @@ impl NpcManager {
                                 minutes = travel_minutes,
                                 "NPC starting transit"
                             );
-                            let npc = self.npcs.get_mut(&id).unwrap();
+                            let Some(npc) = self.npcs.get_mut(&id) else {
+                                continue;
+                            };
                             npc.state = NpcState::InTransit {
                                 from,
                                 to: desired,
@@ -1120,12 +1122,11 @@ impl NpcManager {
                 let Some(npc) = self.npcs.get(&id) else {
                     continue;
                 };
-                (
-                    npc.doom.expect("doom was Some when collected"),
-                    npc.banshee_heralded,
-                    npc.name.clone(),
-                    npc.home,
-                )
+                let Some(d) = npc.doom else {
+                    // Doom was cleared between collection and processing — skip.
+                    continue;
+                };
+                (d, npc.banshee_heralded, npc.name.clone(), npc.home)
             };
 
             if now >= doom {

--- a/crates/parish-persistence/src/picker.rs
+++ b/crates/parish-persistence/src/picker.rs
@@ -80,7 +80,9 @@ pub struct SaveFileInfo {
 /// migration of the legacy `parish_saves.db` file from the project root.
 pub fn ensure_saves_dir() -> PathBuf {
     let saves_dir = PathBuf::from(SAVES_DIR);
-    std::fs::create_dir_all(&saves_dir).ok();
+    if let Err(e) = std::fs::create_dir_all(&saves_dir) {
+        tracing::warn!(path = %saves_dir.display(), error = %e, "failed to create saves directory");
+    }
 
     // One-time migration from legacy location
     let legacy = Path::new("parish_saves.db");

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -1484,7 +1484,9 @@ fn saves_dir() -> std::path::PathBuf {
     for _ in 0..4 {
         if p.join("mods/rundale/world.json").exists() {
             let sd = p.join("saves");
-            std::fs::create_dir_all(&sd).ok();
+            if let Err(e) = std::fs::create_dir_all(&sd) {
+                tracing::warn!(path = %sd.display(), error = %e, "failed to create saves dir");
+            }
             return sd;
         }
         match p.parent() {

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -442,7 +442,9 @@ pub fn run() {
                     workspace_root.join(p)
                 };
                 // Create the directory so canonicalize can resolve it
-                std::fs::create_dir_all(&resolved).ok();
+                if let Err(e) = std::fs::create_dir_all(&resolved) {
+                    tracing::warn!(path = %resolved.display(), error = %e, "failed to create mod dir");
+                }
                 let canonical = match resolved.canonicalize() {
                     Ok(c) => c,
                     Err(_) => {
@@ -712,7 +714,9 @@ pub fn run() {
                     let times: &[(&str, u32)] =
                         &[("morning", 7), ("midday", 12), ("dusk", 18), ("night", 22)];
 
-                    std::fs::create_dir_all(&dir).ok();
+                    if let Err(e) = std::fs::create_dir_all(&dir) {
+                        tracing::warn!(path = %dir.display(), error = %e, "failed to create screenshot dir");
+                    }
 
                     for (name, target_hour) in times {
                         // Advance clock to target hour
@@ -800,7 +804,9 @@ pub fn run() {
                         for _ in 0..4 {
                             if p.join("mods/rundale/world.json").exists() {
                                 let sd = p.join("saves");
-                                std::fs::create_dir_all(&sd).ok();
+                                if let Err(e) = std::fs::create_dir_all(&sd) {
+                                    tracing::warn!(path = %sd.display(), error = %e, "failed to create saves dir");
+                                }
                                 found = Some(sd);
                                 break;
                             }


### PR DESCRIPTION
Fixes #681, fixes #690, fixes #691.

- **#681** tick_schedules NPC lookup: `.unwrap()` → `let Some(npc) else { continue; }`
- **#690** doom processing: `.expect("doom was Some")` → `let Some(d) else { continue; }`
- **#691** 5x `create_dir_all().ok()` → `if let Err(e) { tracing::warn!(...) }` so filesystem failures appear in logs

Commands run: just check