### PR TITLE
bug: deduplicate reactions; fix drag mouseup scope

### DIFF
--- a/apps/ui/src/components/ChatPanel.svelte
+++ b/apps/ui/src/components/ChatPanel.svelte
@@ -8,6 +8,7 @@
 
 	let logEl: HTMLDivElement;
 	let hoveredMessageId: string | null = $state(null);
+	const pendingReactions = new Set<string>();
 
 	$effect(() => {
 		const _ = $textLog;
@@ -136,6 +137,9 @@
 
 	function handleReaction(entry: TextLogEntry, emoji: string) {
 		if (!entry.id) return;
+		const key = `${entry.id}:${emoji}`;
+		if (pendingReactions.has(key)) return;
+		pendingReactions.add(key);
 		// Optimistic UI update
 		addReaction(entry.id, emoji, 'player');
 		// Send to backend; roll back the optimistic reaction on failure
@@ -145,11 +149,15 @@
 		// reached a snapshot.
 		const messageId = entry.id;
 		const snippet = entry.content.slice(0, 80);
-		reactToMessage(entry.source, snippet, emoji).catch((err) => {
-			console.warn('reactToMessage failed:', err);
-			removeReaction(messageId, emoji, 'player');
-			pushErrorLog(`Could not record reaction ${emoji}: ${formatIpcError(err)}`);
-		});
+		reactToMessage(entry.source, snippet, emoji)
+			.catch((err) => {
+				console.warn('reactToMessage failed:', err);
+				removeReaction(messageId, emoji, 'player');
+				pushErrorLog(`Could not record reaction ${emoji}: ${formatIpcError(err)}`);
+			})
+			.finally(() => {
+				pendingReactions.delete(key);
+			});
 		// Close picker
 		hoveredMessageId = null;
 	}

--- a/apps/ui/src/components/editor/LocationDetail.svelte
+++ b/apps/ui/src/components/editor/LocationDetail.svelte
@@ -30,6 +30,7 @@
 	let componentDisposed = false;
 	let dragTargetId: number | null = null;
 	let dragMoved = false;
+	let dragMouseupHandler: (() => void) | null = null;
 
 	$: loc = $editorSelectedLocation;
 	$: locations = $editorLocations;
@@ -206,6 +207,10 @@
 
 	function destroyMap() {
 		mapLoaded = false;
+		if (dragMouseupHandler) {
+			window.removeEventListener('mouseup', dragMouseupHandler);
+			dragMouseupHandler = null;
+		}
 		map?.remove();
 		map = null;
 		// Reset animation memo so a later remount (deselect → reselect
@@ -326,11 +331,13 @@
 			dragMoved = true;
 			setMapData(locations, selectedId, { id: dragTargetId, lat: dragLat, lon: dragLon });
 		});
-		nextMap.on('mouseup', async () => {
+		// Listen on window so releasing outside the map canvas still ends the drag.
+		dragMouseupHandler = async () => {
+			if (!dragging) return;
 			// Capture dragTargetId before clearing it so the async update
 			// targets the correct location even if `loc` has since changed.
 			const targetId = dragTargetId;
-			if (dragging && dragMoved && targetId !== null) {
+			if (dragMoved && targetId !== null) {
 				await updateLocationById(targetId, (current) =>
 					applyDraggedCoordinates(current, locations, dragLat, dragLon)
 				);
@@ -339,7 +346,8 @@
 			dragTargetId = null;
 			dragMoved = false;
 			nextMap.dragPan.enable();
-		});
+		};
+		window.addEventListener('mouseup', dragMouseupHandler);
 		mapInitializing = false;
 	}
 

--- a/apps/ui/src/components/editor/LocationDetail.test.ts
+++ b/apps/ui/src/components/editor/LocationDetail.test.ts
@@ -292,7 +292,7 @@ describe('LocationDetail', () => {
 		);
 		// A move should not trigger any update because drag was never started
 		await map.trigger('mousemove', { lngLat: { lat: 53.52, lng: -8.12 } });
-		await map.trigger('mouseup', {});
+		window.dispatchEvent(new MouseEvent('mouseup'));
 
 		expect(mockState.editorUpdateLocationsMock).not.toHaveBeenCalled();
 	});
@@ -323,7 +323,7 @@ describe('LocationDetail', () => {
 		await waitFor(() => {}); // let Svelte flush reactivity
 
 		// Release mouse — should commit to location 1 (the dragged one), not location 2
-		await map.trigger('mouseup', {});
+		window.dispatchEvent(new MouseEvent('mouseup'));
 
 		await waitFor(() => {
 			expect(mockState.editorUpdateLocationsMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Fixes #693, fixes #694.

- **#693** ChatPanel: track in-flight reactions with a `pendingReactions` Set to block rapid double-click from sending the same reaction twice. Cleared in `.finally()` so re-clicking works after completion.
- **#694** LocationDetail: move drag-end mouseup from `map.on('mouseup')` → `window.addEventListener('mouseup')`. Releasing outside the map canvas no longer leaves the drag stuck.

Commands run: just ui-test (200 pass)