### PR TITLE
security: Secure cookie flag + guard zero speed + cap spinner

### DIFF
--- a/crates/parish-input/src/parser.rs
+++ b/crates/parish-input/src/parser.rs
@@ -9,6 +9,9 @@ use parish_types::GameSpeed;
 use crate::commands::{Command, FlagSubcommand, validate_branch_name, validate_flag_name};
 use crate::intent_types::InputResult;
 
+const SPINNER_DEFAULT_SECS: u64 = 30;
+const SPINNER_MAX_SECS: u64 = 300;
+
 /// Attempts to parse a system command from raw input.
 ///
 /// Returns `Some(Command)` if the input matches a known `/` command,
@@ -165,15 +168,15 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
             Some(Command::SetKey(value))
         }
     } else if lower == "/spinner" {
-        Some(Command::Spinner(30))
+        Some(Command::Spinner(SPINNER_DEFAULT_SECS))
     } else if lower.starts_with("/spinner ") {
         let secs = trimmed
             .get("/spinner ".len()..)
             .unwrap_or("")
             .trim()
             .parse::<u64>()
-            .unwrap_or(30)
-            .min(300);
+            .unwrap_or(SPINNER_DEFAULT_SECS)
+            .min(SPINNER_MAX_SECS);
         Some(Command::Spinner(secs))
     } else if lower == "/debug" {
         Some(Command::Debug(None))

--- a/crates/parish-input/src/parser.rs
+++ b/crates/parish-input/src/parser.rs
@@ -172,7 +172,8 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
             .unwrap_or("")
             .trim()
             .parse::<u64>()
-            .unwrap_or(30);
+            .unwrap_or(30)
+            .min(300);
         Some(Command::Spinner(secs))
     } else if lower == "/debug" {
         Some(Command::Debug(None))

--- a/crates/parish-server/src/auth.rs
+++ b/crates/parish-server/src/auth.rs
@@ -74,7 +74,7 @@ pub async fn login_google(State(global): State<Arc<GlobalState>>) -> Response {
     );
 
     let state_cookie = format!(
-        "{}={}; HttpOnly; SameSite=Lax; Max-Age=600; Path=/",
+        "{}={}; HttpOnly; Secure; SameSite=Lax; Max-Age=600; Path=/",
         OAUTH_STATE_COOKIE, csrf_state
     );
 
@@ -197,11 +197,11 @@ pub async fn callback_google(
     // Build the response: set the parish_sid cookie to the target session,
     // clear the CSRF state cookie, and redirect to the game.
     let session_cookie = format!(
-        "{}={}; HttpOnly; SameSite=Lax; Max-Age=31536000; Path=/",
+        "{}={}; HttpOnly; Secure; SameSite=Lax; Max-Age=31536000; Path=/",
         SESSION_COOKIE, target_session_id
     );
     let clear_state_cookie = format!(
-        "{}=; HttpOnly; SameSite=Lax; Max-Age=0; Path=/",
+        "{}=; HttpOnly; Secure; SameSite=Lax; Max-Age=0; Path=/",
         OAUTH_STATE_COOKIE
     );
 
@@ -225,7 +225,7 @@ pub async fn logout(State(global): State<Arc<GlobalState>>) -> Response {
     global.sessions.persist_new(&new_session_id);
 
     let cookie = format!(
-        "{}={}; HttpOnly; SameSite=Lax; Max-Age=31536000; Path=/",
+        "{}={}; HttpOnly; Secure; SameSite=Lax; Max-Age=31536000; Path=/",
         SESSION_COOKIE, new_session_id
     );
     let mut response = Redirect::to("/").into_response();

--- a/crates/parish-server/src/middleware.rs
+++ b/crates/parish-server/src/middleware.rs
@@ -59,7 +59,7 @@ pub async fn session_middleware(
     // Set the cookie when a new session was created.
     if is_new
         && let Ok(value) = HeaderValue::from_str(&format!(
-            "{}={}; HttpOnly; SameSite=Lax; Max-Age=31536000; Path=/",
+            "{}={}; HttpOnly; Secure; SameSite=Lax; Max-Age=31536000; Path=/",
             SESSION_COOKIE, session_id
         ))
     {

--- a/crates/parish-world/src/geo.rs
+++ b/crates/parish-world/src/geo.rs
@@ -6,6 +6,11 @@
 /// Earth's mean radius in meters (WGS-84 approximation).
 const EARTH_RADIUS_M: f64 = 6_371_000.0;
 
+/// Minimum traversal time in game-minutes (never show 0 for any non-zero distance).
+const TRAVEL_MIN_MINUTES: f64 = 1.0;
+/// Maximum traversal time in game-minutes (2-hour cap to keep travel feel grounded).
+const TRAVEL_MAX_MINUTES: f64 = 120.0;
+
 /// Calculates the Haversine distance in meters between two WGS-84 coordinate pairs.
 pub fn haversine_distance(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
     let dlat = (lat2 - lat1).to_radians();
@@ -29,10 +34,12 @@ pub fn haversine_distance(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
 pub fn meters_to_minutes(meters: f64, speed_m_per_s: f64) -> u16 {
     debug_assert!(speed_m_per_s > 0.0, "speed_m_per_s must be positive");
     if speed_m_per_s <= 0.0 {
-        return 120;
+        return TRAVEL_MAX_MINUTES as u16;
     }
     let speed_m_per_min = speed_m_per_s * 60.0;
-    (meters / speed_m_per_min).ceil().clamp(1.0, 120.0) as u16
+    (meters / speed_m_per_min)
+        .ceil()
+        .clamp(TRAVEL_MIN_MINUTES, TRAVEL_MAX_MINUTES) as u16
 }
 
 #[cfg(test)]

--- a/crates/parish-world/src/geo.rs
+++ b/crates/parish-world/src/geo.rs
@@ -23,7 +23,14 @@ pub fn haversine_distance(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
 /// Converts a real-world distance in meters to game traversal minutes at a given speed.
 ///
 /// Returns at least 1 minute and at most 120 minutes (2-hour cap).
+///
+/// Panics in debug builds if `speed_m_per_s` is not positive; returns the
+/// cap (120 min) in release builds so callers always get a valid travel time.
 pub fn meters_to_minutes(meters: f64, speed_m_per_s: f64) -> u16 {
+    debug_assert!(speed_m_per_s > 0.0, "speed_m_per_s must be positive");
+    if speed_m_per_s <= 0.0 {
+        return 120;
+    }
     let speed_m_per_min = speed_m_per_s * 60.0;
     (meters / speed_m_per_min).ceil().clamp(1.0, 120.0) as u16
 }


### PR DESCRIPTION
Fixes #743, fixes #770, fixes #788.

- **#743** Add `Secure` attribute to all Set-Cookie headers (middleware + auth). Browsers now refuse to send cookies over HTTP. localhost is exempt so local dev is unaffected.
- **#770** `meters_to_minutes`: guard zero/negative speed — division by zero produced +inf/NaN → 0 travel time. Debug panic, release returns 120 min cap.
- **#788** `/spinner` duration capped at 300 s (5 min) — previously unbounded user input could lock the UI spinner indefinitely.

Commands run: just check