### PR TITLE
bug: explicit ipc.ts cast; cap GossipNetwork at 200 items

### DIFF
--- a/apps/ui/src/lib/ipc.ts
+++ b/apps/ui/src/lib/ipc.ts
@@ -46,9 +46,10 @@ export async function command<T>(name: string, args?: Record<string, unknown>): 
 	if (!resp.ok) {
 		throw new Error(`API error: ${resp.status} ${resp.statusText}`);
 	}
-	// submit_input returns 200 with no body
+	// submit_input returns 200 with no body; the two-step cast makes the
+	// unsoundness explicit and searchable rather than hiding it (#755).
 	const text = await resp.text();
-	if (!text) return undefined as T;
+	if (!text) return undefined as unknown as T;
 	return JSON.parse(text) as T;
 }
 

--- a/crates/parish-types/src/gossip.rs
+++ b/crates/parish-types/src/gossip.rs
@@ -12,6 +12,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::NpcId;
 
+/// Maximum gossip items retained by the network. Oldest items are evicted first
+/// when the cap is reached, matching the pattern used by ConversationLog and
+/// ShortTermMemory.
+const GOSSIP_CAPACITY: usize = 200;
+
 /// Probability that a gossip item is transmitted during an interaction.
 const TRANSMISSION_CHANCE: f64 = 0.60;
 
@@ -70,6 +75,12 @@ impl GossipNetwork {
             distortion_level: 0,
             timestamp,
         });
+
+        // Evict oldest items when over capacity.
+        if self.items.len() > GOSSIP_CAPACITY {
+            self.items.sort_unstable_by_key(|g| g.timestamp);
+            self.items.drain(..self.items.len() - GOSSIP_CAPACITY);
+        }
 
         id
     }


### PR DESCRIPTION
Fixes #755, fixes #744.

- **#755** `ipc.ts`: `undefined as T` → `undefined as unknown as T` — two-step cast is explicit and searchable, signals the intentional type-system lie for the submit_input no-body case.
- **#744** `GossipNetwork`: add GOSSIP_CAPACITY=200 with oldest-first eviction on overflow. Prevents unbounded save-file growth and O(n) scan degradation. Matches pattern of ConversationLog, ShortTermMemory, text_log.

Commands run: just check, just ui-test (200 pass)