### PR TITLE
chore(claude): make vite-dev launch entry portable

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,9 +3,11 @@
   "configurations": [
     {
       "name": "vite-dev",
-      "runtimeExecutable": "/bin/sh",
-      "runtimeArgs": ["-c", "cd apps/ui && PATH=/usr/local/Cellar/node/25.8.1_1/bin:$PATH npx vite dev"],
-      "port": 5173
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "cwd": "apps/ui",
+      "port": 5173,
+      "autoPort": true
     },
     {
       "name": "parish-web",

--- a/parish/apps/ui/vite.config.ts
+++ b/parish/apps/ui/vite.config.ts
@@ -10,7 +10,12 @@ export default defineConfig({
 	plugins: [sveltekit(), svelteTesting()],
 	clearScreen: false,
 	server: {
-		port: parseInt(process.env.PARISH_DEV_PORT || '5173', 10) || 5173,
+		// Port priority: PARISH_DEV_PORT (project-specific override) > PORT
+		// (set by harnesses such as Claude Code Desktop's `autoPort` and other
+		// PaaS-style runners) > the conventional Vite default 5173.
+		port:
+			parseInt(process.env.PARISH_DEV_PORT || process.env.PORT || '5173', 10) ||
+			5173,
 		strictPort: true,
 		fs: {
 			allow: ['.']


### PR DESCRIPTION
## Summary

The previous `.claude/launch.json` hard-coded `/usr/local/Cellar/node/25.8.1_1/bin` for the `vite-dev` configuration. On any machine where Node lives elsewhere — Linux sandboxes, macOS users on a different Node version, anyone using fnm/nvm — that PATH points at nothing, `npx` resolves via the surrounding `$PATH` (or fails outright), and Claude Code Desktop silently treats the configuration as unrunnable. The Preview tab never appears.

This switches the entry to the portable form recommended by the [Claude Code Desktop docs](https://code.claude.com/docs/en/desktop):

```json
{
  "name": "vite-dev",
  "runtimeExecutable": "npm",
  "runtimeArgs": ["run", "dev"],
  "cwd": "apps/ui",
  "port": 5173,
  "autoPort": true
}
```

`autoPort: true` lets the desktop app reroute via the `PORT` env var if 5173 is already in use.

The `parish-web` and `parish-e2e` entries are unchanged — they only depend on `$HOME/.cargo/env` which is already portable.

## Test plan

- [x] `cat .claude/launch.json` — parses as valid JSON, three configurations present.
- [ ] Quit and reopen Claude Code Desktop on this folder; verify the Preview tab is now in the menu and `vite-dev` is selectable.
- [ ] Click "Start dev server" → preview pane attaches to `http://localhost:5173/` and the Parish UI loads.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NtbapX3r54kZTU8cBX7jMh)_