### PR TITLE
feat(ui): add nvidia-nim quick preset button to DebugPanel

### DIFF
--- a/apps/ui/src/components/DebugPanel.svelte
+++ b/apps/ui/src/components/DebugPanel.svelte
@@ -10,7 +10,7 @@
 	import { submitInput } from '$lib/ipc';
 
 	/** Providers exposed as one-click preset buttons in the Inference tab.
-	 * Other providers (xai, deepseek, together, nvidia-nim, vllm) remain
+	 * Other providers (xai, deepseek, together, vllm) remain
 	 * available via `/preset <name>` typed into the input field. */
 	const PRESET_PROVIDERS = [
 		'anthropic',
@@ -20,7 +20,8 @@
 		'groq',
 		'mistral',
 		'ollama',
-		'lmstudio'
+		'lmstudio',
+		'nvidia-nim'
 	] as const;
 
 	function applyPreset(provider: string) {


### PR DESCRIPTION
## Summary

- #806 added NVIDIA NIM as a provider with full backend support (`/preset nvidia-nim` works), but `PRESET_PROVIDERS` in `DebugPanel.svelte` was not updated.
- Adds `'nvidia-nim'` to the array so a one-click button appears in the Inference tab alongside the other eight providers.
- Updates the adjacent comment to remove `nvidia-nim` from the "available via typed command only" list.

## What changed

`apps/ui/src/components/DebugPanel.svelte` — one entry added to `PRESET_PROVIDERS`, comment updated.

## Test plan

- [x] `just check` passes (fmt + clippy + tests)
- [x] Dev server started; DebugPanel → Inference tab shows `nvidia-nim` button in the Quick Presets row
- [x] Per-role table confirms all four Nemotron models active after preset applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)