### PR TITLE
chore: rename GitHub repository references from Parish to Rundale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Parish CI
+name: Rundale CI
 
 # Jobs run on GitHub-hosted `ubuntu-latest` runners.
 #

--- a/.github/workflows/railway-watchdog.yml
+++ b/.github/workflows/railway-watchdog.yml
@@ -1,6 +1,6 @@
 name: Railway deployment watchdog
 
-# Polls Railway every 10 minutes and opens a GitHub issue when the Parish
+# Polls Railway every 10 minutes and opens a GitHub issue when the Rundale
 # service has a FAILED/CRASHED deployment. See #562 for design notes and
 # roadmap toward Claude-driven auto-fix (v2).
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -260,7 +260,7 @@ Full text: `assets/fonts/NotoSansSymbols2-LICENSE.txt` and
   this file (`/THIRD_PARTY_NOTICES.md`) as public routes alongside the
   static bundle, so the licence travels with the deployed binary as
   GPL-3.0 requires. The corresponding source remains available at
-  <https://github.com/dmooney/Parish>.
+  <https://github.com/dmooney/Rundale>.
 - This file must be kept in sync with direct dependencies. Any PR that adds
   a new runtime dependency must update the relevant table above and/or
   regenerate the `.rust.md` / `.ui.md` companions.

--- a/docs/audits/regression-coverage-2026-04.md
+++ b/docs/audits/regression-coverage-2026-04.md
@@ -30,7 +30,7 @@ Per-area reports live under [`docs/audits/regression/`](regression/).
 
 > **Label note:** the user requested the `test-needed` label on each
 > issue. As of audit time this label does **not** exist on
-> `dmooney/parish`. Per the agreed policy, the issues below were filed
+> `dmooney/Rundale`. Per the agreed policy, the issues below were filed
 > with priority + theme labels only. Recommend creating
 > `test-needed` and back-applying it.
 
@@ -78,7 +78,7 @@ or worse).
 
 ## Prioritized backlog
 
-The 15 P0/P1 issues below are filed individually on `dmooney/parish`.
+The 15 P0/P1 issues below are filed individually on `dmooney/Rundale`.
 P2 gaps and any P0/P1 overflow are tracked in a single rolled-up
 issue. Each issue cites its area report.
 

--- a/docs/development/railway-watchdog.md
+++ b/docs/development/railway-watchdog.md
@@ -2,7 +2,7 @@
 
 The production Parish web service deploys to Railway via [`deploy/Dockerfile`](../../deploy/Dockerfile) (config in [`railway.toml`](../../railway.toml)). When a deployment fails, the service stays broken silently until someone notices. The **watchdog** is an automated check that turns a silent failure into a labeled GitHub issue.
 
-Scope is deliberately small. It **detects and notifies** today; it does not auto-fix. Auto-fix is the v2 goal tracked in [#562](https://github.com/dmooney/Parish/issues/562).
+Scope is deliberately small. It **detects and notifies** today; it does not auto-fix. Auto-fix is the v2 goal tracked in [#562](https://github.com/dmooney/Rundale/issues/562).
 
 ## How it works
 
@@ -48,7 +48,7 @@ Override the service or project by setting `RAILWAY_SERVICE`, `RAILWAY_ENVIRONME
 
 ## Roadmap — toward v2 (agent-driven auto-fix)
 
-The watchdog is step one of [#562](https://github.com/dmooney/Parish/issues/562). Once notification is reliable, the intended next moves:
+The watchdog is step one of [#562](https://github.com/dmooney/Rundale/issues/562). Once notification is reliable, the intended next moves:
 
 - **Diagnose:** extend the script to attach a short agent-authored summary of the log excerpt (not a fix — just a diagnosis).
 - **Fix draft:** on well-understood failure patterns (workspace-manifest errors, missing files referenced by `COPY`, lockfile/toolchain mismatches), spawn an agent to open a fix PR against `main`.

--- a/docs/plans/llm-quality-evals.md
+++ b/docs/plans/llm-quality-evals.md
@@ -6,7 +6,7 @@
 
 Continuous, **quantitative** quality regression sensors over Tier 1 / Tier 2 NPC output — independent of, and complementary to, the existing pentest plan. The pentest plan red-teams for security; this plan tracks output *quality* over model swaps, prompt edits, and gameplay changes.
 
-This is the deferred LLM-as-judge piece from Phase 3 of the harness-engineering plan ([PR #538](https://github.com/dmooney/Parish/pull/538)). When that PR lands, Phase 3 introduces capture-on-green snapshot baselines + structural rubrics in `crates/parish-cli/tests/eval_baselines.rs`; those are computational sensors. This plan adds the inferential sensors the article calls out as the hardest piece of the Behaviour harness.
+This is the deferred LLM-as-judge piece from Phase 3 of the harness-engineering plan ([PR #538](https://github.com/dmooney/Rundale/pull/538)). When that PR lands, Phase 3 introduces capture-on-green snapshot baselines + structural rubrics in `crates/parish-cli/tests/eval_baselines.rs`; those are computational sensors. This plan adds the inferential sensors the article calls out as the hardest piece of the Behaviour harness.
 
 ## Status
 
@@ -87,7 +87,7 @@ A small CLI (`scripts/eval-leaderboard.py` or extend `parish-cli`) that prints t
 - New: `testing/evals/quality/tier1.yaml`, `corpus/`, `leaderboard.json`
 - New: `.agents/skills/eval-quality/SKILL.md`
 - Edit: `justfile` (add `eval-quality` recipe)
-- Edit (after [PR #538](https://github.com/dmooney/Parish/pull/538) lands): `crates/parish-cli/tests/eval_baselines.rs` (cross-reference in module doc)
+- Edit (after [PR #538](https://github.com/dmooney/Rundale/pull/538) lands): `crates/parish-cli/tests/eval_baselines.rs` (cross-reference in module doc)
 - Reference: `mods/rundale/prompts/tier1_system.txt`, `tier1_context.txt`, `tier2_system.txt`
 
 ## Verification

--- a/parish/crates/parish-core/src/ipc/config.rs
+++ b/parish/crates/parish-core/src/ipc/config.rs
@@ -331,7 +331,7 @@ mod tests {
     fn resolve_category_client_anthropic_override_builds_native_client() {
         // Switching a single category to Anthropic should produce an
         // AnyClient::Anthropic variant, not a misrouted OpenAI-compat
-        // client. Regression guard for dmooney/parish#172.
+        // client. Regression guard for dmooney/Rundale#172.
         let mut cfg = GameConfig {
             provider_name: "ollama".to_string(),
             model_name: "base-model".to_string(),

--- a/parish/crates/parish-server/src/lib.rs
+++ b/parish/crates/parish-server/src/lib.rs
@@ -60,7 +60,7 @@ use state::{GameConfig, UiConfigSnapshot};
 ///
 /// TODO: replace `'unsafe-inline'` with `'sha256-...'` computed from
 /// `apps/ui/dist/index.html` at build time.
-/// See: <https://github.com/dmooney/Parish/issues/543>
+/// See: <https://github.com/dmooney/Rundale/issues/543>
 pub const CSP_POLICY: &str = "default-src 'self'; \
                               script-src 'self' 'unsafe-inline'; \
                               worker-src 'self' blob:; \


### PR DESCRIPTION
## Summary

- Updates all `dmooney/Parish` and `dmooney/parish` GitHub URL/shorthand references in docs, comments, and workflow files to `dmooney/Rundale`
- Renames the CI workflow from `Parish CI` → `Rundale CI` and updates the railway-watchdog workflow comment from "Parish service" → "Rundale service"
- Engine crate names (`parish-*`) are intentionally unchanged — **Parish** remains the engine name; **Rundale** is the game and the GitHub project name

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Workflow name: `Parish CI` → `Rundale CI` |
| `.github/workflows/railway-watchdog.yml` | Comment: "Parish service" → "Rundale service" |
| `THIRD_PARTY_NOTICES.md` | Source URL updated |
| `crates/parish-core/src/ipc/config.rs` | Regression guard comment updated |
| `crates/parish-server/src/lib.rs` | Issue link in doc comment updated |
| `docs/audits/regression-coverage-2026-04.md` | Repo shorthand updated (×2) |
| `docs/development/railway-watchdog.md` | Issue links updated (×2) |
| `docs/plans/llm-quality-evals.md` | PR links updated (×2) |

## ⚠️ Manual action required

The **GitHub repository itself** must be renamed separately — the GitHub API rename endpoint isn't available via the current MCP toolset. Go to **Settings → General → Repository name** on `dmooney/Parish` and rename it to `Rundale`. GitHub will set up redirects automatically.

## Test plan

- [x] `grep -r "dmooney/Parish" .` returns only local filesystem path references (not GitHub URLs) — confirmed clean
- [ ] `cargo test` passes (changed lines are comments/docs, not logic)
- [ ] After the repo is manually renamed on GitHub, confirm CI workflow shows as "Rundale CI" in the Actions tab

https://claude.ai/code/session_019PZPUnJddPSEyrQKPScuKv

---
_Generated by [Claude Code](https://claude.ai/code/session_019PZPUnJddPSEyrQKPScuKv)_