### PR TITLE
fix: use just commands in check/verify skills

### DIFF
--- a/.agents/skills/check/SKILL.md
+++ b/.agents/skills/check/SKILL.md
@@ -6,9 +6,14 @@ disable-model-invocation: true
 
 Run the full Rundale quality gate. All three must pass before any commit.
 
-1. **Format check**: Run `cargo fmt --check`. If it fails, run `cargo fmt` to fix, then re-check.
-2. **Lint**: Run `cargo clippy -- -D warnings`. Fix any warnings before proceeding.
-3. **Tests**: Run `cargo test`. All tests must pass.
+**Important:** The Cargo workspace lives in `parish/`. There is no `Cargo.toml` at the repo root. All cargo commands must run from inside `parish/`. Use the top-level `just` commands which handle the `cd` automatically, OR prefix cargo commands with `cd parish &&`.
+
+Run `just check` from the repo root. This runs: `fmt-check`, `clippy`, `test`, `witness-scan`, and `check-doc-paths`.
+
+If `just check` fails, diagnose by running the steps individually:
+1. **Format**: `cd parish && cargo fmt --check`. Fix with `cd parish && cargo fmt`, then re-check.
+2. **Lint**: `cd parish && cargo clippy -- -D warnings`. Fix warnings before proceeding.
+3. **Tests**: `cd parish && cargo test`. All tests must pass.
 
 Report a summary at the end:
 - Which steps passed/failed

--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -6,12 +6,18 @@ disable-model-invocation: true
 
 Run the complete Rundale pre-push verification checklist.
 
+**Important:** The Cargo workspace lives in `parish/`. There is no `Cargo.toml` at the repo root. Use `just` commands from the repo root, which handle `cd parish &&` internally.
+
 ## Steps
 
-1. **Format check**: Run `cargo fmt --check`. If it fails, run `cargo fmt` to fix, then report what changed.
-2. **Lint**: Run `cargo clippy -- -D warnings`. Fix any warnings before proceeding.
-3. **Tests**: Run `cargo test`. All tests must pass.
-4. **Game harness**: Run `cargo run -- --script testing/fixtures/test_walkthrough.txt` and inspect the JSON output for correctness.
+Run `just verify` from the repo root. This runs: fmt-check, clippy, tests, witness-scan, doc-paths, and the game harness walkthrough script.
+
+If `just verify` fails, diagnose by running steps individually:
+1. **Format check**: `cd parish && cargo fmt --check`. Fix with `cd parish && cargo fmt`, then report what changed.
+2. **Lint**: `cd parish && cargo clippy -- -D warnings`. Fix any warnings before proceeding.
+3. **Tests**: `cd parish && cargo test`. All tests must pass.
+4. **Game harness**: `cd parish && cargo run -p parish -- --script testing/fixtures/test_walkthrough.txt` and inspect JSON output for correctness.
+
 5. **Summary**: Report pass/fail for each step. Only if ALL steps pass, confirm it is safe to push.
 
 If any step fails, stop and report the failure. Do NOT push. Fix the issue first.


### PR DESCRIPTION
## Summary

- `/check` and `/verify` skills ran bare `cargo` commands from repo root, which has no `Cargo.toml`
- Fixed both skills to use `just check` / `just verify` from repo root, which proxy into `parish/` internally
- Added fallback instructions for per-step diagnosis using `cd parish && cargo ...`

## Test plan

- [ ] Run `/check` — should execute `just check` without "no Cargo.toml" error
- [ ] Run `/verify` — should execute `just verify` end-to-end

🤖 Generated with [Claude Code](https://claude.ai/claude-code)