### PR TITLE
feat: add `/techdebt` skill for iterative debt cleanup

### DIFF
--- a/.agents/skills/techdebt/SKILL.md
+++ b/.agents/skills/techdebt/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: techdebt
+description: Continuous technical-debt sweeper: consume TODO.md tasks (or discover debt when empty), dispatch focused fix agents, keep the list current, and repeat until no actionable debt remains.
+disable-model-invocation: false
+argument-hint: [path]
+---
+
+Use this skill to run a structured debt-reduction loop for a target file/folder. If no argument is provided, default to the current working directory.
+
+## Inputs
+
+- `$ARGUMENTS` (optional): file or directory path to scope work.
+  - If omitted, use `.`.
+  - If a file is provided, use its parent directory as debt-list home and keep analysis focused on that file.
+
+Set `TARGET` from the argument (or `.`), then resolve:
+
+- `SCOPE`: exact file/folder(s) agents should inspect/fix.
+- `ROOT`: directory where `TODO.md` is read/written.
+
+## Loop contract
+
+Run this cycle repeatedly until exit criteria are met.
+
+1. **Load or initialize debt list**
+   - Look for `TODO.md` under `ROOT`.
+   - If missing, create one with sections:
+     - `## Open`
+     - `## In Progress`
+     - `## Done`
+   - Keep entries concise and actionable, with stable IDs (`TD-001`, `TD-002`, ...), owner, and status.
+
+2. **Choose work source**
+   - If `## Open` has items, pick the highest-impact small batch (1–3 items).
+   - If no open items exist (or everything is done), spawn discovery agents to scan `SCOPE` for technical debt:
+     - dead/unreachable code
+     - duplication and abstraction opportunities
+     - weak or missing tests
+     - stale docs/comments/config
+     - high-complexity hotspots and brittle conditionals
+   - Add each validated finding to `## Open` before fixing.
+
+3. **Dispatch fix agents**
+   - Spawn parallel agents when tasks are independent; otherwise run serially.
+   - Give each agent exactly one debt item ID and acceptance criteria.
+   - Require each fix agent to:
+     - implement minimal, behavior-safe change
+     - add/update tests when behavior or guarantees change
+     - run relevant checks
+     - report file list + commands run + residual risks
+
+4. **Reconcile and update `TODO.md`**
+   - Move started items to `## In Progress`, then to `## Done` only after checks pass.
+   - For partially fixed work, keep item open with a narrowed remaining scope.
+   - Remove duplicates; merge equivalent debt items under the earliest ID.
+   - Append a short progress log entry (date + IDs completed).
+
+5. **Gate before next loop**
+   - Ensure repository is in a clean, buildable state for touched areas.
+   - If new debt was discovered during fixes, record it under `## Open`.
+   - Return to Step 2.
+
+## Exit criteria
+
+Stop only when all are true:
+
+- `## Open` is empty.
+- Discovery pass finds no credible new debt in `SCOPE`.
+- No `## In Progress` items remain.
+
+Then leave a final note in `TODO.md` summarizing what was checked and why the loop ended.
+
+## Operating rules
+
+- Keep tasks small and independently landable.
+- Prefer deleting dead code over refactoring it.
+- Do not invent speculative debt; every item needs concrete evidence (file/line/symptom).
+- Preserve AGENTS.md rules (tests, feature flags, mode parity, docs updates).
+- If uncertain whether something is debt vs intentional, record a question item instead of changing behavior.

--- a/docs/agent/skills.md
+++ b/docs/agent/skills.md
@@ -16,3 +16,4 @@ Custom slash commands defined in `.agents/skills/`, with `.claude/skills/` as a 
 | `/feature-scaffold <name>` | Depth-first decomposition: design note + failing fixture + plan, before any code |
 | `/triage-backlog` | Apply theme + priority labels to open issues lacking them. Vocabulary in [`triage-vocabulary.md`](triage-vocabulary.md). Paired with the `triage-audit` weekly workflow. |
 | `/crate-audit` | Audit workspace crate layout (naming, manifests, big-file splits, extraction candidates, README freshness). Produces a phased pure-relocation refactor PR. |
+| `/techdebt [path]` | Continuous debt loop: process `TODO.md`, dispatch fix agents, discover new debt when empty, and repeat until no actionable debt remains in scope. |


### PR DESCRIPTION
### Motivation

- Provide an automated, repeatable workflow for discovering and chipping away at repository technical debt in a scoped, evidence-first way.
- Make debt work tractable by codifying a small-task loop that reads/updates a `TODO.md` and spawns focused fix agents until no actionable items remain.
- Surface the new capability in the agent skills index so maintainers can call it with ` /techdebt [path]`.

### Description

- Added a new skill file `.agents/skills/techdebt/SKILL.md` that documents argument handling, scope/root resolution, a loop contract (load/initialize `TODO.md`, choose work, dispatch fix agents, reconcile, gate, repeat), exit criteria, and operating rules.
- The skill instructs agents to add validated findings (dead code, duplication, missing tests, stale docs, hotspots) to `## Open` and to move items through `## In Progress` → `## Done` with progress logs and stable IDs (`TD-001`, ...).
- Updated `docs/agent/skills.md` to include the `| /techdebt [path] | ... |` entry so the new skill appears in the public skills table.

### Testing

- Verified repository changes with `git status --short` and committed the new files using `git add` + `git commit`, both commands succeeded.
- Inspected the new and updated files with `sed`/`nl` to confirm the skill text and docs entry were written as intended, which succeeded.
- No automated build/test (`cargo test`/harness) was run as part of this change; follow-up runs of `just check`/`just verify` are recommended before landing operational fix agents.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f563ff3ec8832587d4a4de80376762)