### PR TITLE
test: remove silent-pass guards in harness and async LLM tests

### DIFF
--- a/parish/crates/parish-cli/tests/game_harness_integration.rs
+++ b/parish/crates/parish-cli/tests/game_harness_integration.rs
@@ -436,17 +436,20 @@ fn test_multiple_looks_same_location() {
 fn test_long_journey_fairy_fort() {
     let mut h = GameTestHarness::new();
 
-    // Navigate to the Fairy Fort (multiple hops from Kilteevan)
+    // Navigate to the Fairy Fort (multiple hops from Kilteevan).
+    // world.json confirms The Fairy Fort (id=11) is connected via The Bog Road
+    // (id=12), which is reachable from Kilteevan Village. NotFound is a bug.
     let r = h.execute("go to fairy fort");
     match r {
         ActionResult::Moved { to, minutes, .. } => {
             assert_eq!(to, "The Fairy Fort");
             assert!(minutes > 0);
         }
-        ActionResult::NotFound { .. } => {
-            // If graph doesn't have fairy fort connected, that's also valid
-        }
-        other => panic!("Unexpected result: {:?}", other),
+        other => panic!(
+            "Expected Moved to 'The Fairy Fort' but got: {other:?}\n\
+             The Fairy Fort exists in world.json (id=11) and is reachable \
+             from Kilteevan Village via The Bog Road — NotFound is a bug."
+        ),
     }
 }
 

--- a/parish/crates/parish-core/tests/async_llm_integration.rs
+++ b/parish/crates/parish-core/tests/async_llm_integration.rs
@@ -111,15 +111,13 @@ async fn stream_reaction_texts_streams_llm_response_on_success() {
 
     assert_eq!(log_names.lock().unwrap().len(), 1);
     let streamed = tokens.lock().unwrap().join("");
-    // Depending on scheduler timing, the background streaming task may
-    // complete after this helper returns, yielding an empty capture.
-    // If we *did* capture text, it must contain the mocked payload.
-    if !streamed.is_empty() {
-        assert!(
-            streamed.contains("Well, good day to ye"),
-            "LLM success path streamed unexpected content: got '{streamed}'"
-        );
-    }
+    // stream_reaction_texts awaits stream_npc_tokens, which drains the
+    // receiver channel before returning. All tokens are captured by the
+    // time the .await above completes — no scheduler-timing ambiguity.
+    assert!(
+        streamed.contains("Well, good day to ye"),
+        "LLM success path streamed unexpected content: got '{streamed}'"
+    );
 }
 
 #[tokio::test]
@@ -152,10 +150,15 @@ async fn stream_reaction_texts_falls_back_to_canned_on_http_error() {
     )
     .await;
 
-    // In the streaming design, HTTP errors cause the spawned task to drop
-    // the channel, so stream_npc_tokens finishes with an empty stream.
-    // The key invariant is: no panic, no hang, function completes.
-    let _ = tokens.lock().unwrap().join("");
+    // When the upstream HTTP call returns a 500, the spawned task's
+    // generate_stream call fails and drops tx, closing the channel.
+    // stream_npc_tokens drains an empty channel and returns "".
+    // The key invariants: no panic, no hang, and no tokens emitted.
+    let streamed = tokens.lock().unwrap().join("");
+    assert!(
+        streamed.is_empty(),
+        "HTTP error path must emit no tokens (got '{streamed}')"
+    );
 }
 
 #[tokio::test]
@@ -194,10 +197,15 @@ async fn stream_reaction_texts_falls_back_to_canned_on_timeout() {
     )
     .await;
 
-    // On timeout, the channel is closed immediately, and stream_npc_tokens
-    // finishes with whatever was received (likely empty). This is still a
-    // non-panic outcome.
-    let _ = tokens.lock().unwrap().join("");
+    // The mock delays 6 s; the timeout fires after 5 s (ReactionConfig default).
+    // tokio::time::timeout drops tx, closing the channel before any data
+    // arrives. stream_npc_tokens drains an empty channel and returns "".
+    // Invariants: no panic, no hang, and no tokens emitted.
+    let streamed = tokens.lock().unwrap().join("");
+    assert!(
+        streamed.is_empty(),
+        "Timeout path must emit no tokens (got '{streamed}')"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes two test-rigor issues where tests could pass while asserting nothing meaningful.

**#761 — `test_long_journey_fairy_fort`:** The test accepted `ActionResult::NotFound` as a valid outcome with a comment "if graph doesn't have fairy fort connected, that's also valid." Checked `mods/rundale/world.json`: The Fairy Fort (id=11) connects to The Bog Road (id=12), which is reachable from Kilteevan Village. BFS confirms id=11 is in the reachable set. Removed the `NotFound` acceptance branch; the test now panics on any non-`Moved` result with a diagnostic explaining why `NotFound` is a bug.

**#760 — `async_llm_integration.rs`:** Three tests had silent-pass defects:

1. `stream_reaction_texts_streams_llm_response_on_success` guarded `assert!(streamed.contains(...))` behind `if !streamed.is_empty()`. The comment claimed background task timing could yield an empty capture. This is wrong: `stream_reaction_texts` awaits `stream_npc_tokens`, which drains the mpsc receiver before returning — all tokens are captured before the `.await` completes. Removed the guard; assertion is unconditional.

2. `stream_reaction_texts_falls_back_to_canned_on_http_error` and `…_on_timeout` both assigned `let _ = tokens.lock().unwrap().join("")` — discarding the result without asserting anything. In both paths, the spawned task fails/times out and drops `tx`, so `stream_npc_tokens` drains an empty channel. Added `assert!(streamed.is_empty(), ...)` to pin the expected behavior.

## Test plan

- [x] `just check` — all tests pass (148 parish-cli integration tests, 28 world-graph tests, 6 async_llm_integration tests)
- [x] `cargo test -p parish-core --test async_llm_integration` — 6 passed in ~5s (timeout test exercises the 5s ReactionConfig timeout path)
- [x] `test_long_journey_fairy_fort` — ok (Fairy Fort is reachable; the new stricter match passes)

Fixes #761. Fixes #760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)