### PR TITLE
security: gate /api/debug-snapshot behind PARISH_ADMIN_EMAILS

### DIFF
--- a/parish/crates/parish-server/src/routes.rs
+++ b/parish/crates/parish-server/src/routes.rs
@@ -98,14 +98,26 @@ pub async fn get_ui_config(
 
 /// `GET /api/debug-snapshot` — returns debug state for the debug panel.
 ///
+/// **Admin-only** (#753): gated by `PARISH_ADMIN_EMAILS` via the same
+/// [`check_admin`] guard used for provider/key commands.  Non-admin
+/// authenticated users receive 403; unauthenticated callers are rejected
+/// upstream by `cf_access_guard` with 401.
+///
+/// The DebugPanel in the UI is an admin-only feature accessed via F12 dev
+/// tooling; the endpoint gate makes that intent explicit and enforced.
+///
 /// The inference call log is **redacted** for web clients (#333): `prompt_text`,
 /// `response_text`, `system_prompt`, and `base_url` are stripped so that one
 /// user's LLM prompts are never exposed to other authenticated visitors.
 pub async fn get_debug_snapshot(
     Extension(state): Extension<Arc<AppState>>,
     Extension(session_id): Extension<SessionId>,
+    Extension(cf_auth): Extension<crate::cf_auth::AuthContext>,
     State(global): State<Arc<GlobalState>>,
-) -> impl IntoResponse {
+) -> Result<Json<debug_snapshot::DebugSnapshot>, StatusCode> {
+    // #753 — admin gate: only PARISH_ADMIN_EMAILS members may read the snapshot.
+    check_admin(&cf_auth.email, "debug-snapshot", admin_emails())?;
+
     // Snapshot each piece of state with a brief, non-overlapping lock window.
     // This avoids holding all 5+ locks simultaneously (#105, #282), which
     // caused latency spikes on all concurrent game operations and created
@@ -214,7 +226,7 @@ pub async fn get_debug_snapshot(
     // Also redact base_url from the inference config block.
     snapshot.inference.base_url = String::new();
 
-    Json(snapshot)
+    Ok(Json(snapshot))
 }
 
 // ── Input endpoint ──────────────────────────────────────────────────────────

--- a/parish/crates/parish-server/tests/isolation.rs
+++ b/parish/crates/parish-server/tests/isolation.rs
@@ -459,3 +459,58 @@ fn create_branch_65_char_name_is_400() {
 fn create_branch_valid_name_passes_validation() {
     assert_eq!(validate_branch_name("valid name"), Ok(()));
 }
+
+// ── #753 — /api/debug-snapshot admin gate ────────────────────────────────────
+//
+// `check_admin_against` is the testable variant of the production `check_admin`
+// call that now guards `get_debug_snapshot`.  These tests mirror the isolation
+// tests for admin commands (#332, #605) above: they supply an explicit admin
+// email rather than touching the `PARISH_ADMIN_EMAILS` OnceCell cache, so
+// they remain fully self-contained and order-independent regardless of how
+// other tests set the env var.
+
+/// Non-admin authenticated user must be rejected (403) from `/api/debug-snapshot`.
+#[test]
+fn debug_snapshot_non_admin_is_403() {
+    assert_eq!(
+        check_admin_against(
+            "attacker@example.com",
+            "debug-snapshot",
+            Some("operator@example.com"),
+        ),
+        Err(StatusCode::FORBIDDEN),
+        "non-admin user must receive 403 from debug-snapshot gate"
+    );
+}
+
+/// Admin user must be allowed through the gate (Ok(())).
+#[test]
+fn debug_snapshot_admin_is_ok() {
+    assert_eq!(
+        check_admin_against(
+            "operator@example.com",
+            "debug-snapshot",
+            Some("operator@example.com"),
+        ),
+        Ok(()),
+        "admin user must be allowed through the debug-snapshot gate"
+    );
+}
+
+/// Unauthenticated requests (no CF JWT) are rejected upstream by
+/// `cf_access_guard` with 401 before the handler is even reached.
+///
+/// That path is covered by `tests/auth_guard.rs`; this test confirms
+/// that the admin gate is independent from the auth gate: a completely
+/// un-configured admin list (`None`) behaves consistently with the
+/// rest of the admin-gate tests (fail-open in debug, fail-closed in release).
+#[test]
+fn debug_snapshot_no_admin_config_is_deterministic() {
+    let result = check_admin_against("any@example.com", "debug-snapshot", None);
+    // Debug builds (tests) are fail-open for local dev.
+    assert_eq!(
+        result,
+        Ok(()),
+        "debug build with no admin config must allow (fail-open for local dev)"
+    );
+}


### PR DESCRIPTION
## Summary

- `/api/debug-snapshot` was accessible to all authenticated users, exposing full game state including NPC manager data, debug events, and session info (issue #753).
- Added the same `check_admin` guard used by provider/key/model commands before the snapshot is built or returned.
- Non-admin authenticated users now receive **403 Forbidden**; unauthenticated callers continue to receive **401** from `cf_access_guard` upstream (unchanged behavior).
- The DebugPanel in the UI is an admin-only feature accessed via F12 dev tooling; this endpoint gate makes that intent explicit and mechanically enforced.

## Files changed

- `parish/crates/parish-server/src/routes.rs` — added `Extension(cf_auth): Extension<crate::cf_auth::AuthContext>` parameter and `check_admin(...)` call; return type narrowed to `Result<Json<DebugSnapshot>, StatusCode>`.
- `parish/crates/parish-server/tests/isolation.rs` — three new tests: `debug_snapshot_non_admin_is_403`, `debug_snapshot_admin_is_ok`, `debug_snapshot_no_admin_config_is_deterministic`.

## Test plan

- [x] `cargo test -p parish-server` — 162 tests pass (3 new)
- [x] `just check` — fmt + clippy + all tests clean, no warnings

Fixes #753.