### PR TITLE
test: tier4 and Samhain festival fixtures + rubrics

### DIFF
--- a/parish/crates/parish-cli/tests/eval_baselines.rs
+++ b/parish/crates/parish-cli/tests/eval_baselines.rs
@@ -22,7 +22,8 @@
 //!   `assert!` names the fixture, the step, the rule that fired, and the
 //!   canonical fix.
 
-use parish::testing::{ActionResult, ScriptResult, run_script_captured};
+use parish::testing::{ActionResult, GameTestHarness, ScriptResult, run_script_captured};
+use parish_types::events::GameEvent;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -204,4 +205,140 @@ fn rubric_look_descriptions_are_non_empty() {
             }
         }
     }
+}
+
+// ============================================================
+// Gameplay rubrics — Tier 4 CPU rules engine (#722)
+// ============================================================
+
+/// Asserts that at least one Tier 4 life event surfaces after advancing game
+/// time past the 90-day tick threshold onto a festival date.
+///
+/// Strategy:
+/// - Load the full Rundale world (real NPCs, real world graph).
+/// - Subscribe to the event bus *before* advancing time so no events are lost.
+/// - Advance exactly to Lughnasa (Aug 1, 1820): 134 days * 24 * 60 = 192 960
+///   minutes from start (1820-03-20).  134 days > the 90-day tier4 threshold,
+///   so the tick fires exactly once with `game_date = 1820-08-01`.
+///   `Festival::check(Aug 1)` returns `Some(Lughnasa)` unconditionally —
+///   no RNG involved — so at least one event is guaranteed.
+/// - Assert the tier4 tick was recorded, the debug log shows it, and the
+///   event bus received at least one GameEvent.
+///
+/// Fixture: `parish/testing/fixtures/test_tier4_far_npcs.txt`
+#[test]
+fn rubric_tier4_events_appear_in_journal() {
+    let mut h = GameTestHarness::new();
+
+    let tier4_count_before = h.app.npc_manager.tier4_npcs().len();
+
+    // Subscribe to the event bus BEFORE advancing time.
+    let mut rx = h.app.world.event_bus.subscribe();
+
+    // Advance exactly to Lughnasa (Aug 1): 134 days * 24 * 60 = 192 960 min.
+    // 134 days > 90-day tier4 threshold from a None baseline, so the tick
+    // fires with game_date = 1820-08-01 = Lughnasa.  Festival::check is pure
+    // date math — no RNG — guaranteeing at least one FestivalDetected event.
+    const MINUTES_TO_LUGHNASA: i64 = 134 * 24 * 60; // 192 960
+    h.advance_time(MINUTES_TO_LUGHNASA);
+
+    // Check 1: tier4 tick was recorded (last_tier4_game_time is Some).
+    assert!(
+        h.app.npc_manager.last_tier4_game_time().is_some(),
+        "test_tier4_far_npcs: tier4 tick should have fired after advancing \
+         {MINUTES_TO_LUGHNASA} game-minutes (~134 days to Lughnasa).\n\
+         FIX: check NpcManager::needs_tier4_tick and GameTestHarness::advance_time \
+         in parish/crates/parish-cli/src/testing.rs.\n\
+         Tier 4 NPC count at test start: {tier4_count_before}."
+    );
+
+    // Check 2: the debug log contains at least one `[tier4]` entry.
+    let tier4_log: Vec<&str> = h
+        .debug_log()
+        .into_iter()
+        .filter(|line| line.contains("[tier4]"))
+        .collect();
+    assert!(
+        !tier4_log.is_empty(),
+        "test_tier4_far_npcs: expected at least one '[tier4] N events' debug entry \
+         after the tick interval elapsed, but the debug log contained none.\n\
+         Full debug log: {:?}",
+        h.debug_log()
+    );
+
+    // Check 3: a FestivalStarted(Lughnasa) GameEvent was published on the bus.
+    // tick_tier4 calls Festival::check(1820-08-01) = Some(Lughnasa) and emits
+    // FestivalDetected; apply_tier4_events converts it to FestivalStarted.
+    let mut lughnasa_fired = false;
+    while let Ok(evt) = rx.try_recv() {
+        if let GameEvent::FestivalStarted { name, .. } = &evt
+            && name == "Lughnasa"
+        {
+            lughnasa_fired = true;
+        }
+    }
+    assert!(
+        lughnasa_fired,
+        "test_tier4_far_npcs: expected a FestivalStarted(\"Lughnasa\") GameEvent \
+         published on the tier4 tick with game_date = 1820-08-01, but it was absent.\n\
+         Debug log (tier4 entries): {tier4_log:?}\n\
+         FIX: verify tick_tier4 calls Festival::check(game_date) and \
+         apply_tier4_events emits GameEvent::FestivalStarted for FestivalDetected events."
+    );
+}
+
+// ============================================================
+// Gameplay rubrics — Festival fixture (#720)
+// ============================================================
+
+/// Asserts that a `FestivalStarted { name: "Samhain" }` `GameEvent` is
+/// published when the game clock is advanced to exactly November 1, 1820.
+///
+/// Strategy:
+/// - Load the full Rundale world.
+/// - Subscribe to the event bus *before* advancing time.
+/// - Advance exactly to Samhain (Nov 1, 1820): 226 days * 24 * 60 = 325 440
+///   minutes from start (1820-03-20).  226 days > 90-day tier4 threshold
+///   (last_tier4 = None), so the tick fires once with `game_date = 1820-11-01`.
+///   `Festival::check(Nov 1)` returns `Some(Samhain)` unconditionally.
+/// - Drain the event bus and assert that a `FestivalStarted { "Samhain" }`
+///   event was received.
+///
+/// Fixture: `parish/testing/fixtures/test_festival_samhain.txt`
+#[test]
+fn rubric_festival_event_published_on_festival_date() {
+    let mut h = GameTestHarness::new();
+
+    // Subscribe BEFORE advancing so no events are lost.
+    let mut rx = h.app.world.event_bus.subscribe();
+
+    // Advance exactly to Samhain (Nov 1): 226 days * 24 * 60 = 325 440 min.
+    // 226 days > 90-day tier4 threshold from a None baseline, so the tick
+    // fires with game_date = 1820-11-01 = Samhain.
+    const MINUTES_TO_SAMHAIN: i64 = 226 * 24 * 60; // 325 440
+    h.advance_time(MINUTES_TO_SAMHAIN);
+
+    // Drain the bus and collect FestivalStarted events.
+    let mut samhain_fired = false;
+    while let Ok(evt) = rx.try_recv() {
+        if let GameEvent::FestivalStarted { name, .. } = &evt
+            && name == "Samhain"
+        {
+            samhain_fired = true;
+        }
+    }
+
+    assert!(
+        samhain_fired,
+        "test_festival_samhain: expected a FestivalStarted(\"Samhain\") GameEvent \
+         after advancing {MINUTES_TO_SAMHAIN} game-minutes (226 days) to land on \
+         Samhain (Nov 1, 1820), but none was received.\n\
+         FIX: verify that tick_tier4 calls Festival::check(game_date) where \
+         game_date is the current clock date when the tier4 tick fires, that \
+         apply_tier4_events converts FestivalDetected → GameEvent::FestivalStarted, \
+         and that GameTestHarness::advance_time publishes tier4 events on \
+         world.event_bus.\n\
+         See: parish/crates/parish-npc/src/tier4.rs (tick_tier4) and \
+         parish/crates/parish-npc/src/manager.rs (apply_tier4_events)."
+    );
 }

--- a/parish/testing/fixtures/test_festival_samhain.txt
+++ b/parish/testing/fixtures/test_festival_samhain.txt
@@ -1,0 +1,25 @@
+# Advance the clock to exactly Samhain (Nov 1, 1820) and verify festival display.
+#
+# Start date: 1820-03-20 (spring equinox, 8:00 UTC).
+# Samhain (Nov 1) is 226 days later = 226 * 24 * 60 = 325 440 minutes.
+#
+# The Tier 4 tick fires when elapsed >= 90 days (last_tier4 = None at start).
+# Advancing exactly 325 440 min lands the tick on 1820-11-01 = Samhain.
+# Festival::check is pure date logic — no RNG — so FestivalDetected is
+# guaranteed and the FestivalStarted event is published unconditionally.
+#
+# /time shows "Festival: Samhain" because the clock's check_festival() method
+# reads the same date.
+#
+# Used by: rubric_festival_event_published_on_festival_date (eval_baselines.rs)
+
+/status
+/time
+
+# Jump exactly to Samhain: 226 days * 24 * 60 = 325 440 minutes.
+/wait 325440
+
+/status
+/time
+
+/quit

--- a/parish/testing/fixtures/test_tier4_far_npcs.txt
+++ b/parish/testing/fixtures/test_tier4_far_npcs.txt
@@ -1,0 +1,21 @@
+# Advance time to Lughnasa (Aug 1, 1820) so the Tier 4 CPU rules engine fires
+# on a festival date.  The default tick interval is 90 game-days (129 600 min).
+#
+# Start date: 1820-03-20 (spring equinox).
+# Aug 1 is 134 days later = 134 * 24 * 60 = 192 960 minutes.
+# 134 days > 90-day threshold, so the tier4 tick fires on the jump landing at
+# exactly 1820-08-01 = Lughnasa.  Festival::check is pure date logic — no RNG —
+# so at least one Tier 4 event (FestivalDetected) is guaranteed.
+#
+# Used by: rubric_tier4_events_appear_in_journal (eval_baselines.rs)
+
+/status
+/time
+
+# Jump exactly to Lughnasa: 134 days * 24 * 60 = 192 960 minutes.
+/wait 192960
+
+/status
+/time
+
+/quit


### PR DESCRIPTION
## Summary

- Add \`parish/testing/fixtures/test_tier4_far_npcs.txt\`: advances game clock to Lughnasa (Aug 1, 1820 — 134 days from start), landing the tier4 CPU tick exactly on a festival date with no RNG dependency.
- Add \`parish/testing/fixtures/test_festival_samhain.txt\`: advances clock to Samhain (Nov 1, 1820 — 226 days from start) so the tier4 tick fires with \`game_date = 1820-11-01\`.
- Add \`rubric_tier4_events_appear_in_journal\` in \`eval_baselines.rs\`: subscribes to the event bus before advancing, asserts tier4 tick was recorded, debug log has \`[tier4]\` entry, and a \`FestivalStarted("Lughnasa")\` GameEvent was received.
- Add \`rubric_festival_event_published_on_festival_date\` in \`eval_baselines.rs\`: asserts a \`FestivalStarted("Samhain")\` GameEvent is published when the clock lands on Nov 1.

Both rubrics are fully deterministic — \`Festival::check\` is pure date math (no RNG), and the event bus subscription is established before \`advance_time\` is called so no events are missed.

Fixes #722. Fixes #720.

## Design notes

**Why \`FestivalStarted\` rather than illness/death/birth/trade?**
\`GameTestHarness::advance_time\` uses unseeded \`rand::rng()\` internally, making all probabilistic \`Tier4Event\` paths (illness/death/birth/trade) non-deterministic without modifying production code. \`FestivalDetected\` is the only \`Tier4Event\` variant that fires unconditionally from pure date math (\`Festival::check(game_date)\`), so it's the correct anchor for a deterministic structural rubric. The per-NPC probabilistic paths are already covered by the unit tests in \`parish-npc/src/tier4.rs\`.

**Why direct \`GameTestHarness\` rather than \`run_script_captured\`?**
\`ActionResult\` has no tier4/festival variants — tier4 events surface on \`world.event_bus\` and in \`npc_manager.recent_tier4_events()\`, neither of which is captured in \`ScriptResult\`. The fixture \`.txt\` files remain useful for \`/play\` and manual \`parish script\` runs.

**Festival fixture uses \`/time\` not \`/status\`.**
The issue said "via \`/status\`" but \`Command::Status\` returns \`Location | TimeOfDay | Season\` with no festival field. Festival display lives in \`Command::Time\` (\`Festival: Samhain\` line). The fixture uses \`/time\` for correct behavior; the rubric asserts on the \`GameEvent\` directly.

## Test plan

- [x] \`cargo test --test eval_baselines rubric_\` — both new tests pass
- [x] \`just check\` — fmt, clippy, full test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)