### PR TITLE
chore(deps): bump parish-server governor 0.6 → 0.10

### DIFF
--- a/parish/Cargo.lock
+++ b/parish/Cargo.lock
@@ -771,19 +771,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -1703,32 +1690,12 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
-dependencies = [
- "cfg-if",
- "dashmap 5.5.3",
- "futures",
- "futures-timer",
- "no-std-compat",
- "nonzero_ext",
- "parking_lot",
- "portable-atomic",
- "quanta",
- "rand 0.8.5",
- "smallvec",
- "spinning_top",
-]
-
-[[package]]
-name = "governor"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
 dependencies = [
  "cfg-if",
- "dashmap 6.1.0",
+ "dashmap",
  "futures-sink",
  "futures-timer",
  "futures-util",
@@ -2733,12 +2700,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,7 +3107,6 @@ dependencies = [
  "parish-types",
  "parish-world",
  "rand 0.9.2",
- "rand_chacha 0.3.1",
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
@@ -3186,7 +3146,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "governor 0.10.4",
+ "governor",
  "parish-config",
  "parish-types",
  "reqwest 0.12.28",
@@ -3279,9 +3239,9 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
- "dashmap 6.1.0",
+ "dashmap",
  "dotenvy",
- "governor 0.6.3",
+ "governor",
  "hex",
  "hmac",
  "jsonwebtoken",

--- a/parish/crates/parish-server/Cargo.toml
+++ b/parish/crates/parish-server/Cargo.toml
@@ -31,7 +31,7 @@ hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
 base64 = "0.22"
-governor = "0.6"
+governor = "0.10"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary

- Bumps `governor` in `parish/crates/parish-server/Cargo.toml` from `0.6` to `0.10` to match `parish-inference`, which already used `0.10`
- No source code changes were required — `RateLimiter::keyed()`, `Quota::per_minute()`, `DefaultKeyedStateStore<K>`, `DefaultClock`, and `check_key()` all have identical signatures in 0.10
- Lockfile now contains a single `governor` entry (0.10.4); the `dashmap 5.5.3` transitive dep pulled in by `governor 0.6` is also removed

Fixes #764.

## API migration notes

No breaking changes encountered. The 0.6 → 0.10 delta for the API surface used in `parish-server`:

| Symbol | 0.6 | 0.10 | Change |
|--------|-----|------|--------|
| `RateLimiter::keyed(quota)` | present | present | none |
| `Quota::per_minute(n)` | present | present | none |
| `DefaultKeyedStateStore<K>` | `= DashMapStateStore<K>` | `= DashMapStateStore<K, DefaultHasher>` (added defaulted hasher param) | backward-compatible |
| `DefaultClock` | present | present | none |
| `check_key(&K)` | present | present | none |

## Verification

```
cargo tree -p parish-server -i governor
governor v0.10.4
├── parish-inference v0.1.0
│   ├── parish-core v0.1.0
│   │   └── parish-server v0.1.0
│   ...
└── parish-server v0.1.0

grep -c '^name = "governor"' parish/Cargo.lock
1
```

## Test plan

- [x] `cargo build -p parish-server` — clean build, no errors
- [x] `just check` — fmt + clippy + all tests pass (148 + 74 + 29 + ... tests, 0 failures)
- [x] Single `governor` entry in lockfile confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)