### PR TITLE
security: tighten CSP connect-src and img-src (#751)

### DIFF
--- a/parish/Cargo.lock
+++ b/parish/Cargo.lock
@@ -3146,7 +3146,6 @@ dependencies = [
  "parish-types",
  "parish-world",
  "rand 0.9.2",
- "rand_chacha 0.3.1",
  "regex",
  "reqwest 0.12.28",
  "rusqlite",

--- a/parish/crates/parish-server/src/lib.rs
+++ b/parish/crates/parish-server/src/lib.rs
@@ -43,7 +43,42 @@ use parish_core::config::FeatureFlags;
 use session::{GlobalState, OAuthConfig, SessionRegistry};
 use state::{GameConfig, UiConfigSnapshot};
 
+/// Specific HTTPS origins the frontend genuinely connects to or loads images
+/// from.  These are the only external endpoints referenced in
+/// `apps/ui/src/` — everything else is same-origin (`'self'`).
+///
+/// - `https://tile.openstreetmap.org` — default OSM raster tile source
+///   (`parish-config` `default_tile_sources`).
+/// - `https://mapseries-tilesets.s3.amazonaws.com` — historic Ordnance Survey
+///   tiles (the "historic" tile source baked into `default_tile_sources`).
+/// - `https://demotiles.maplibre.org` — MapLibre glyph PBFs used by the
+///   map label layer (`style.ts` `GLYPHS_URL`).
+/// - `https://fonts.googleapis.com` — Google Fonts CSS `<link>` in `app.html`.
+/// - `https://fonts.gstatic.com` — Google Fonts glyph files (font-src).
+///
+/// Update this list whenever `apps/ui/src/` gains a new external dependency.
+/// Keeping it in a dedicated constant lets the security-headers test assert
+/// membership without repeating the origin strings.
+pub const ALLOWED_EXTERNAL_ORIGINS: &[&str] = &[
+    "https://tile.openstreetmap.org",
+    "https://mapseries-tilesets.s3.amazonaws.com",
+    "https://demotiles.maplibre.org",
+    "https://fonts.googleapis.com",
+    "https://fonts.gstatic.com",
+];
+
 /// Content-Security-Policy value shared between production and tests.
+///
+/// # connect-src and img-src
+///
+/// The bare `https:` wildcard has been replaced with only the specific HTTPS
+/// origins the frontend actually uses (see [`ALLOWED_EXTERNAL_ORIGINS`]).
+/// This addresses issue #751.
+///
+/// MapLibre fetches tiles via `fetch()` (CORS → connect-src) AND renders them
+/// as raster images (img-src), so the tile-server origins appear in both
+/// directives.  MapLibre also fetches glyph PBFs at runtime for the label
+/// layer, so `demotiles.maplibre.org` is in connect-src as well.
 ///
 /// # script-src 'unsafe-inline' (TODO: replace with hash)
 ///
@@ -55,18 +90,20 @@ use state::{GameConfig, UiConfigSnapshot};
 /// The proper fix is to compute the SHA-256 of that bootstrap block and add
 /// `'sha256-<base64>'` to `script-src`.  That hash is deterministic per build
 /// but must be regenerated whenever SvelteKit changes the bootstrap text.
-/// Until that build-time integration exists, `'unsafe-inline'` is restored here
+/// Until that build-time integration exists, `'unsafe-inline'` is retained here
 /// so the app keeps working.
 ///
 /// TODO: replace `'unsafe-inline'` with `'sha256-...'` computed from
-/// `apps/ui/dist/index.html` at build time.
+/// `apps/ui/dist/index.html` at build time.  SvelteKit exposes a `kit.csp`
+/// config option that emits hashes automatically — that is the recommended
+/// path forward.
 /// See: <https://github.com/dmooney/Rundale/issues/543>
 pub const CSP_POLICY: &str = "default-src 'self'; \
                               script-src 'self' 'unsafe-inline'; \
                               worker-src 'self' blob:; \
                               style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
-                              img-src 'self' data: blob: https:; \
-                              connect-src 'self' ws: wss: https:; \
+                              img-src 'self' data: blob: https://tile.openstreetmap.org https://mapseries-tilesets.s3.amazonaws.com; \
+                              connect-src 'self' ws: wss: https://tile.openstreetmap.org https://mapseries-tilesets.s3.amazonaws.com https://demotiles.maplibre.org https://fonts.googleapis.com; \
                               font-src 'self' https://fonts.gstatic.com; \
                               frame-ancestors 'none'; \
                               base-uri 'self'; \

--- a/parish/crates/parish-server/tests/security_headers.rs
+++ b/parish/crates/parish-server/tests/security_headers.rs
@@ -11,7 +11,7 @@ use axum::http::header::{
 };
 use axum::http::{HeaderValue, Request, StatusCode};
 use axum::routing::get;
-use parish_server::CSP_POLICY;
+use parish_server::{ALLOWED_EXTERNAL_ORIGINS, CSP_POLICY};
 use tower::ServiceExt;
 use tower_http::set_header::SetResponseHeaderLayer;
 
@@ -155,3 +155,146 @@ async fn response_has_permissions_policy() {
         .expect("Permissions-Policy header must be present");
     assert_eq!(pp, "camera=(), microphone=(), geolocation=()");
 }
+
+// ── CSP tightening assertions (issue #751) ────────────────────────────────────
+
+/// Parse a CSP header value into its directives, returning the tokens for the
+/// named directive (or an empty slice if the directive is absent).
+///
+/// Tokenisation: split on `;`, trim each part, find the one that starts with
+/// `directive_name`, then split the rest on whitespace to get the token list.
+fn csp_directive_tokens<'a>(csp: &'a str, directive: &str) -> Vec<&'a str> {
+    for part in csp.split(';') {
+        let part = part.trim();
+        if let Some(values) = part.strip_prefix(directive) {
+            // Skip the directive name itself and collect the value tokens.
+            return values.split_whitespace().collect();
+        }
+    }
+    vec![]
+}
+
+#[tokio::test]
+async fn csp_connect_src_no_bare_https_wildcard() {
+    // connect-src must NOT contain the bare `https:` scheme wildcard.
+    // The former policy had `https:` which allowed any HTTPS endpoint.
+    let tokens = csp_directive_tokens(CSP_POLICY, "connect-src");
+    assert!(
+        !tokens.is_empty(),
+        "CSP must contain a connect-src directive"
+    );
+    assert!(
+        !tokens.contains(&"https:"),
+        "connect-src must not contain bare `https:` wildcard; tokens: {tokens:?}"
+    );
+}
+
+#[tokio::test]
+async fn csp_connect_src_contains_required_ws_schemes() {
+    // WebSocket origins are still required for the game's live WS connection.
+    let tokens = csp_directive_tokens(CSP_POLICY, "connect-src");
+    assert!(
+        tokens.contains(&"'self'"),
+        "connect-src must contain 'self'; tokens: {tokens:?}"
+    );
+    assert!(
+        tokens.contains(&"ws:"),
+        "connect-src must contain ws: for WebSocket; tokens: {tokens:?}"
+    );
+    assert!(
+        tokens.contains(&"wss:"),
+        "connect-src must contain wss: for secure WebSocket; tokens: {tokens:?}"
+    );
+}
+
+#[tokio::test]
+async fn csp_connect_src_contains_allowed_external_origins() {
+    // Every origin in ALLOWED_EXTERNAL_ORIGINS that the frontend genuinely
+    // connects to must appear in connect-src.  The tile-server and glyph-server
+    // origins are fetched at runtime by MapLibre (tiles via fetch(), glyphs via
+    // XHR), so they must be explicitly listed.
+    //
+    // Exceptions: fonts.gstatic.com is only in font-src (file downloads), not
+    // connect-src, so we only check the subset that is actually fetched.
+    let connect_fetch_origins: &[&str] = &[
+        "https://tile.openstreetmap.org",
+        "https://mapseries-tilesets.s3.amazonaws.com",
+        "https://demotiles.maplibre.org",
+        "https://fonts.googleapis.com",
+    ];
+    let tokens = csp_directive_tokens(CSP_POLICY, "connect-src");
+    for origin in connect_fetch_origins {
+        assert!(
+            tokens.contains(origin),
+            "connect-src must contain {origin}; tokens: {tokens:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn csp_img_src_no_bare_https_wildcard() {
+    // img-src must NOT contain the bare `https:` scheme wildcard.
+    let tokens = csp_directive_tokens(CSP_POLICY, "img-src");
+    assert!(!tokens.is_empty(), "CSP must contain an img-src directive");
+    assert!(
+        !tokens.contains(&"https:"),
+        "img-src must not contain bare `https:` wildcard; tokens: {tokens:?}"
+    );
+}
+
+#[tokio::test]
+async fn csp_img_src_contains_tile_servers() {
+    // MapLibre renders tiles as raster images, so the tile-server origins must
+    // appear in img-src as well as connect-src.
+    let tile_origins: &[&str] = &[
+        "https://tile.openstreetmap.org",
+        "https://mapseries-tilesets.s3.amazonaws.com",
+    ];
+    let tokens = csp_directive_tokens(CSP_POLICY, "img-src");
+    for origin in tile_origins {
+        assert!(
+            tokens.contains(origin),
+            "img-src must contain {origin} for MapLibre raster tiles; tokens: {tokens:?}"
+        );
+    }
+    // data: and blob: must be retained for MapLibre canvas sprite sheets.
+    assert!(
+        tokens.contains(&"data:"),
+        "img-src must retain data: for canvas sprite data URIs; tokens: {tokens:?}"
+    );
+    assert!(
+        tokens.contains(&"blob:"),
+        "img-src must retain blob: for MapLibre blob URLs; tokens: {tokens:?}"
+    );
+}
+
+#[tokio::test]
+async fn csp_allowed_external_origins_list_exhaustive() {
+    // ALLOWED_EXTERNAL_ORIGINS lists all external HTTPS origins used by the
+    // frontend.  Assert that no origin in the list has been silently dropped
+    // from every directive that uses it.
+    //
+    // Each origin must appear in at least one of: connect-src, img-src, or
+    // font-src.  An origin in ALLOWED_EXTERNAL_ORIGINS that isn't in any of
+    // these directives indicates either a stale list or a CSP regression.
+    let connect_tokens = csp_directive_tokens(CSP_POLICY, "connect-src");
+    let img_tokens = csp_directive_tokens(CSP_POLICY, "img-src");
+    let font_tokens = csp_directive_tokens(CSP_POLICY, "font-src");
+
+    for origin in ALLOWED_EXTERNAL_ORIGINS {
+        let present = connect_tokens.contains(origin)
+            || img_tokens.contains(origin)
+            || font_tokens.contains(origin);
+        assert!(
+            present,
+            "ALLOWED_EXTERNAL_ORIGINS entry {origin} does not appear in any of \
+             connect-src, img-src, or font-src — either update the CSP or remove \
+             the stale entry from ALLOWED_EXTERNAL_ORIGINS"
+        );
+    }
+}
+
+// Note: 'unsafe-inline' in script-src is intentionally retained while the
+// SvelteKit hash-based replacement is pending (see TODO in lib.rs referencing
+// issues #543 and #751).  No assertion is made about its presence or absence
+// here to avoid the test becoming a no-op check once the TODO is resolved.


### PR DESCRIPTION
## Summary

- Replaces bare `https:` wildcard in `connect-src` and `img-src` with only the specific HTTPS origins the frontend genuinely uses.
- Introduces `ALLOWED_EXTERNAL_ORIGINS` constant (exported from `parish-server`) listing the five allowed external origins, so tests assert membership without duplicating strings.
- Adds six new CSP-specific assertions in `tests/security_headers.rs`.
- Defers `script-src 'unsafe-inline'` removal (option b) with expanded TODO comment pointing at SvelteKit's `kit.csp` config as the path forward.

## Before / After

**Before:**
```
connect-src 'self' ws: wss: https:
img-src     'self' data: blob: https:
```

**After:**
```
connect-src 'self' ws: wss:
            https://tile.openstreetmap.org
            https://mapseries-tilesets.s3.amazonaws.com
            https://demotiles.maplibre.org
            https://fonts.googleapis.com

img-src     'self' data: blob:
            https://tile.openstreetmap.org
            https://mapseries-tilesets.s3.amazonaws.com
```

## Origin rationale

| Origin | Directive | Why |
|---|---|---|
| `https://tile.openstreetmap.org` | connect-src + img-src | Default OSM raster tile source — MapLibre fetches via `fetch()` and renders as raster |
| `https://mapseries-tilesets.s3.amazonaws.com` | connect-src + img-src | Historic OS tile source (`default_tile_sources` in `parish-config`) |
| `https://demotiles.maplibre.org` | connect-src | MapLibre glyph PBFs for the location-label layer (`GLYPHS_URL` in `style.ts`) |
| `https://fonts.googleapis.com` | connect-src + style-src | Google Fonts CSS `<link>` in `app.html` |
| `https://fonts.gstatic.com` | font-src (already pinned) | Google Fonts glyph files |

`data:` and `blob:` are retained in `img-src` for MapLibre's canvas sprite data URIs (confirmed by `drawIconImage` usage in `controller.ts`).

## `script-src 'unsafe-inline'` (deferred)

SvelteKit's production build injects an inline bootstrap `<script>` in `dist/index.html`; removing `'unsafe-inline'` prevents page hydration (see #543). The proper fix requires the build pipeline to extract the SHA-256 of that inline block and inject it as `'sha256-...'` — SvelteKit exposes `kit.csp` config for exactly this, but wiring it into the Rust server's `CSP_POLICY` constant is non-trivial. Left as a TODO with expanded comment; the security_headers test includes a note explaining why no assertion is made about `'unsafe-inline'`.

## Tests

Six new tests in `tests/security_headers.rs`:
- `csp_connect_src_no_bare_https_wildcard` — connect-src must not contain `https:`
- `csp_connect_src_contains_required_ws_schemes` — ws: and wss: still present
- `csp_connect_src_contains_allowed_external_origins` — all fetch-time origins present
- `csp_img_src_no_bare_https_wildcard` — img-src must not contain `https:`
- `csp_img_src_contains_tile_servers` — tile origins and data:/blob: present
- `csp_allowed_external_origins_list_exhaustive` — every entry in `ALLOWED_EXTERNAL_ORIGINS` appears in at least one directive

## Verification

```
just check   PASS (fmt + clippy + 269 Rust tests)
just ui-test SKIP — node_modules absent in agent worktree (pre-existing environment gap, not caused by this change)
```

Smoke test (`just run-headless` + browser) was not runnable in this worktree environment. The CSP is validated entirely through the `security_headers` integration tests. A too-tight CSP would produce visible browser console errors (`Refused to load X because it violates CSP`) — reviewers can verify by running the web server locally with these headers and checking the map panel loads tiles and fonts correctly.

## Commands run

```sh
just check
cargo test -p parish-server --test security_headers
```

Fixes #751.