### PR TITLE
perf: stop rAF loop when frozen; cache eval fixture runs (#757, #782)

### DIFF
--- a/parish/apps/ui/src/components/StatusBar.svelte
+++ b/parish/apps/ui/src/components/StatusBar.svelte
@@ -2,7 +2,7 @@
 	import { worldState } from '../stores/game';
 	import { debugVisible } from '../stores/debug';
 	import { savePickerVisible } from '../stores/save';
-	import { onMount, onDestroy } from 'svelte';
+	import { onDestroy } from 'svelte';
 	import AuthStatus from './AuthStatus.svelte';
 
 	let displayHour = $state(0);
@@ -13,7 +13,7 @@
 	let anchorRealMs = 0;
 	let anchorGameMs = 0;
 	let speedFactor = 36.0;
-	let clockFrozen = false;
+	let clockFrozen = $state(false);
 
 	let rafId: number;
 
@@ -28,35 +28,50 @@
 	}
 
 	function tick() {
-		if (clockFrozen) {
-			// Use the anchored game time directly
-			const d = new Date(anchorGameMs);
-			displayHour = d.getUTCHours();
-			displayMinute = d.getUTCMinutes();
-		} else {
-			const elapsedRealMs = Date.now() - anchorRealMs;
-			const currentGameMs = anchorGameMs + elapsedRealMs * speedFactor;
-			const d = new Date(currentGameMs);
-			displayHour = d.getUTCHours();
-			displayMinute = d.getUTCMinutes();
-		}
+		// When frozen, don't schedule another frame — the display is already
+		// set to anchorGameMs by the snapshot $effect below.
+		if (clockFrozen) return;
+		const elapsedRealMs = Date.now() - anchorRealMs;
+		const currentGameMs = anchorGameMs + elapsedRealMs * speedFactor;
+		const d = new Date(currentGameMs);
+		displayHour = d.getUTCHours();
+		displayMinute = d.getUTCMinutes();
 		displayTimeLabel = timeOfDayLabel(displayHour);
 		rafId = requestAnimationFrame(tick);
 	}
 
-	// Re-anchor whenever we get a new world snapshot from the backend
+	// Re-anchor whenever we get a new world snapshot from the backend.
+	// When the clock freezes, update the display once and let the rAF loop
+	// stop naturally (tick() bails on the next frame). When it unfreezes,
+	// restart the loop.
 	$effect(() => {
 		const snap = $worldState;
 		if (snap) {
 			anchorRealMs = Date.now();
 			anchorGameMs = snap.game_epoch_ms;
 			speedFactor = snap.speed_factor;
+			const wasFrozen = clockFrozen;
 			clockFrozen = snap.paused || snap.inference_paused;
+
+			if (clockFrozen) {
+				// Snap display to anchored game time immediately.
+				const d = new Date(anchorGameMs);
+				displayHour = d.getUTCHours();
+				displayMinute = d.getUTCMinutes();
+				displayTimeLabel = timeOfDayLabel(displayHour);
+			}
 		}
 	});
 
-	onMount(() => {
-		rafId = requestAnimationFrame(tick);
+	// React to clockFrozen transitions: cancel the loop when frozen,
+	// restart it when unfrozen.
+	$effect(() => {
+		if (clockFrozen) {
+			cancelAnimationFrame(rafId);
+		} else {
+			// Start (or restart) the rAF loop.
+			rafId = requestAnimationFrame(tick);
+		}
 	});
 
 	onDestroy(() => {

--- a/parish/apps/ui/src/components/StatusBar.test.ts
+++ b/parish/apps/ui/src/components/StatusBar.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { render } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { worldState } from '../stores/game';
 import StatusBar from './StatusBar.svelte';
 import type { WorldSnapshot } from '$lib/types';
@@ -34,6 +35,10 @@ const snapshot: WorldSnapshot = {
 describe('StatusBar', () => {
 	beforeEach(() => {
 		worldState.set(null);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
 	});
 
 	it('shows loading when no world state', () => {
@@ -77,5 +82,33 @@ describe('StatusBar', () => {
 		const { container } = render(StatusBar);
 		const clock = container.querySelector('.clock');
 		expect(clock).toBeTruthy();
+	});
+
+	it('does not schedule another rAF frame after clockFrozen becomes true', async () => {
+		// Capture the rAF callback so we can invoke it manually.
+		let capturedCb: FrameRequestCallback | null = null;
+		const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+			capturedCb = cb;
+			return 1;
+		});
+
+		// Start with an unfrozen clock so the rAF loop is running.
+		worldState.set(snapshot); // paused: false
+		render(StatusBar);
+		await tick();
+
+		// Freeze the clock.
+		worldState.set({ ...snapshot, paused: true });
+		await tick();
+
+		// Clear any rAF calls made while transitioning to frozen.
+		rafSpy.mockClear();
+
+		// Simulate the next animation frame firing while the clock is frozen.
+		// tick() should bail immediately without scheduling another frame.
+		expect(capturedCb).not.toBeNull();
+		capturedCb!(performance.now());
+
+		expect(rafSpy).not.toHaveBeenCalled();
 	});
 });

--- a/parish/crates/parish-cli/tests/eval_baselines.rs
+++ b/parish/crates/parish-cli/tests/eval_baselines.rs
@@ -23,8 +23,10 @@
 //!   canonical fix.
 
 use parish::testing::{ActionResult, ScriptResult, run_script_captured};
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 /// Fixtures whose structured output is deterministic enough to baseline.
 /// Add new entries cautiously — non-deterministic NPC dialogue, weather
@@ -38,6 +40,25 @@ const BASELINED_FIXTURES: &[&str] = &[
     "test_all_locations",
 ];
 
+/// Cache of fixture results, populated once on first access.
+/// Each fixture runs exactly once regardless of how many tests reference it.
+static FIXTURE_CACHE: LazyLock<HashMap<&'static str, Vec<ScriptResult>>> = LazyLock::new(|| {
+    BASELINED_FIXTURES
+        .iter()
+        .map(|&name| {
+            let path = fixture_path(name);
+            assert!(
+                path.exists(),
+                "fixture {} not found at {}",
+                name,
+                path.display()
+            );
+            let results = run_script_captured(&path).expect("script execution");
+            (name, results)
+        })
+        .collect()
+});
+
 fn fixture_path(name: &str) -> PathBuf {
     Path::new("../../testing/fixtures").join(format!("{name}.txt"))
 }
@@ -46,15 +67,11 @@ fn baseline_path(name: &str) -> PathBuf {
     Path::new("../../testing/evals/baselines").join(format!("{name}.json"))
 }
 
-fn capture(name: &str) -> Vec<ScriptResult> {
-    let path = fixture_path(name);
-    assert!(
-        path.exists(),
-        "fixture {} not found at {}",
-        name,
-        path.display()
-    );
-    run_script_captured(&path).expect("script execution")
+fn capture(name: &str) -> &'static [ScriptResult] {
+    FIXTURE_CACHE
+        .get(name)
+        .unwrap_or_else(|| panic!("fixture {name} not in FIXTURE_CACHE"))
+        .as_slice()
 }
 
 fn updating_baselines() -> bool {


### PR DESCRIPTION
## Summary

- **#757 StatusBar rAF bail-early:** `tick()` now returns immediately when `clockFrozen` is true, so no new `requestAnimationFrame` is scheduled. A dedicated `$effect` reacts to `clockFrozen` transitions — `cancelAnimationFrame` when frozen, `requestAnimationFrame(tick)` when unfrozen. The snapshot `$effect` snaps `displayHour/Minute/Label` to `anchorGameMs` inline when freezing, so the displayed time is always correct even without the loop. `onMount` is removed; the rAF `$effect` owns loop startup.
- **#782 eval fixture caching:** A `LazyLock<HashMap<&'static str, Vec<ScriptResult>>>` (`FIXTURE_CACHE`) populates all three fixtures once on first access. `capture(name)` is now a cheap map lookup returning `&'static [ScriptResult]`. Previously 6 tests triggered 12 fixture executions (3 snapshot + 3×3 rubric); now there are 3.

## Tests

- New `StatusBar.test.ts` case: spies on `window.requestAnimationFrame` with `vi.spyOn`, sets `paused: true`, clears the spy, invokes the captured rAF callback manually, and asserts `requestAnimationFrame` was NOT called again.
- All 284 frontend tests pass (`just ui-test`).
- All Rust tests pass (`just check`).

## Before/After eval timing

`cargo test -p parish --test eval_baselines -- --nocapture`

| | fixture executions | test time |
|---|---|---|
| before | 12 (3 snapshot + 9 rubric) | 0.05s |
| after | 3 (cache populated once) | 0.04s |

The fixture scripts themselves are fast; the real improvement is eliminating 9 redundant script runs that would compound as more fixtures or rubrics are added.

Fixes #757. Fixes #782.