### PR TITLE
fix: replace silent .ok()? chains with logged error branches

### DIFF
--- a/parish/crates/parish-config/src/flags.rs
+++ b/parish/crates/parish-config/src/flags.rs
@@ -68,12 +68,24 @@ impl FeatureFlags {
     ///
     /// Returns `Default::default()` if the file does not exist or cannot be
     /// parsed — this is not an error, since a missing file simply means no
-    /// flags have been persisted yet.
+    /// flags have been persisted yet. A parse failure (corrupt/stale JSON)
+    /// is unexpected, so it is logged as a warning.
     pub fn load_from_file(path: &Path) -> Self {
-        std::fs::read_to_string(path)
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default()
+        let content = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Self::default(),
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "could not read feature-flags file");
+                return Self::default();
+            }
+        };
+        match serde_json::from_str(&content) {
+            Ok(flags) => flags,
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "feature-flags file contains invalid JSON; using defaults");
+                Self::default()
+            }
+        }
     }
 
     /// Saves the current flag state to a JSON file, creating parent
@@ -180,6 +192,29 @@ mod tests {
         let flags = FeatureFlags::default();
         flags.save_to_file(&path).unwrap();
         assert!(path.exists());
+    }
+
+    #[test]
+    fn test_load_corrupt_json_returns_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("parish-flags.json");
+        std::fs::write(&path, b"not valid json {{{{").unwrap();
+        // Should not panic; should return a default (empty) FeatureFlags.
+        let flags = FeatureFlags::load_from_file(&path);
+        assert!(flags.is_empty(), "corrupt JSON must yield default flags");
+    }
+
+    #[test]
+    fn test_load_wrong_schema_returns_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("parish-flags.json");
+        // Valid JSON but wrong shape (array instead of object).
+        std::fs::write(&path, b"[1, 2, 3]").unwrap();
+        let flags = FeatureFlags::load_from_file(&path);
+        assert!(
+            flags.is_empty(),
+            "wrong-schema JSON must yield default flags"
+        );
     }
 
     #[test]

--- a/parish/crates/parish-npc/src/reactions.rs
+++ b/parish/crates/parish-npc/src/reactions.rs
@@ -329,7 +329,20 @@ pub async fn infer_player_message_reaction(
     let call =
         client.generate_json::<LlmReactionDecision>(model, &prompt, Some(&system), Some(40), None);
 
-    let response = tokio::time::timeout(timeout, call).await.ok()?.ok()?;
+    let response = match tokio::time::timeout(timeout, call).await {
+        Ok(Ok(r)) => r,
+        Ok(Err(e)) => {
+            tracing::error!(error = ?e, "inference call failed in infer_player_message_reaction");
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!(
+                "inference call timed out after {:?} in infer_player_message_reaction",
+                timeout
+            );
+            return None;
+        }
+    };
     let emoji = response.emoji?;
     reaction_description(&emoji)?;
     if rand::random::<f64>() >= 0.6 {
@@ -1822,6 +1835,30 @@ mod tests {
             );
         }
         // None is also valid (probabilistic gate or null from model).
+    }
+
+    /// Timeout path: a zero-duration timeout always fires, so the function
+    /// must return `None` (not panic).
+    #[tokio::test]
+    async fn infer_player_message_reaction_timeout_returns_none() {
+        use parish_inference::AnyClient;
+
+        let client = AnyClient::simulator();
+        let npc = test_npc(99, "Timeout Npc", "Farmer", None);
+
+        let result = infer_player_message_reaction(
+            &client,
+            "any-model",
+            &npc,
+            "Will this time out?",
+            std::time::Duration::ZERO,
+        )
+        .await;
+
+        assert!(
+            result.is_none(),
+            "zero-timeout must return None, got: {result:?}"
+        );
     }
 
     /// Fallback: generate_rule_reaction still fires for keyword inputs when


### PR DESCRIPTION
Fixes #704.

## What changed

### Site 1 — `parish/crates/parish-npc/src/reactions.rs:332`

**Before:**
\`\`\`rust
let response = tokio::time::timeout(timeout, call).await.ok()?.ok()?;
\`\`\`

**After:** explicit `match` with `tracing::error!` on inference failure and `tracing::warn!` on timeout. Behavior is identical (`None` in both cases) but failures are now visible in logs.

**Test added:** `infer_player_message_reaction_timeout_returns_none` — uses `AnyClient::simulator()` with `Duration::ZERO` to exercise the timeout arm.

### Site 2 — `parish/crates/parish-config/src/flags.rs:73-75`

**Before:**
\`\`\`rust
std::fs::read_to_string(path)
    .ok()
    .and_then(|s| serde_json::from_str(&s).ok())
    .unwrap_or_default()
\`\`\`

**After:** explicit match; missing file (`NotFound`) → silent default (preserves existing contract); other read errors → `tracing::warn!`; parse errors → `tracing::warn!` with path + error detail.

**Tests added:** `test_load_corrupt_json_returns_default`, `test_load_wrong_schema_returns_default`.

## Deferred (audit results)

| Location | Pattern | Rationale for deferral |
|---|---|---|
| `parish-inference/src/setup.rs:234,235,269,270,322,323,437,438,467,468` | `spawn_blocking().await.ok()?.ok()?` in `detect_apple_silicon`, `detect_nvidia`, `detect_windows_gpu`, `detect_windows_vram_from_registry` | GPU-detection path — `None` silently falls through to CPU fallback, which is intentional. Adding warn! logs here is worthwhile but low-urgency; the callers already handle `None` gracefully. |
| `parish-inference/src/setup.rs:242,293,294` | `parse().ok()?` on sysctl/nvidia-smi numeric output | Trivial parse of a single integer; `None` means "couldn't detect VRAM, skip tier". Low-value to log. |
| `parish-core/src/game_session.rs:538-540` | `GameMod::load().ok()?.ok()?` in test `setup()` helper | Test-only function; `None` skips the test. Correct behavior. |
| `parish-core/src/game_mod.rs:780` | `current_dir().ok()?` | Infallible in practice; `None` just skips mod discovery. |
| `parish-inference/src/anthropic_client.rs:1397` | `from_str(body).ok()?` in `extract_api_error_message` | Error-message extraction helper — failure to parse the error body means we fall back to the raw body string. Silent is correct. |
| `parish-server/src/cf_auth.rs:156-157` | `env::var().ok()?` | Missing env var → CF auth disabled. Intentional silent skip. |
| `parish-tauri/src/lib.rs:847` | `list_branches().ok().and_then(...)` | Tauri IPC convenience accessor; `None` → UI shows no branch. Low-urgency. |

## Commands run

\`\`\`
just check           # fmt + clippy + all tests — green
cargo test -p parish-config   # 80 passed
cargo test -p parish-npc      # 390 passed
\`\`\`