### PR TITLE
test: parish-tauri command-layer unit tests, partial (#706)

### DIFF
--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -241,12 +241,9 @@ pub async fn submit_input(
     state: tauri::State<'_, Arc<AppState>>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
-    let text = text.trim().to_string();
+    let text = validate_input_text(&text)?;
     if text.is_empty() {
         return Ok(());
-    }
-    if text.len() > 2000 {
-        return Err("Input too long (max 2000 characters).".to_string());
     }
     // #752 — cap addressed_to to prevent unbounded memory/allocation via the
     // NPC-addressing chip list.  Max 10 entries; each name ≤ 100 chars.
@@ -283,6 +280,20 @@ pub async fn submit_input(
 }
 
 // ── #752 — addressed_to validation ───────────────────────────────────────────
+
+/// Validates and trims player free-text input for `submit_input`.
+///
+/// - Trims leading/trailing whitespace.
+/// - Returns `Ok(String)` (the trimmed text) for empty input — callers should
+///   short-circuit before calling this if they want to silently drop empties.
+/// - Returns `Err` when the trimmed length exceeds 2000 characters.
+pub fn validate_input_text(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim().to_string();
+    if trimmed.len() > 2000 {
+        return Err("Input too long (max 2000 characters).".to_string());
+    }
+    Ok(trimmed)
+}
 
 /// Validates the `addressed_to` list from the `submit_input` command.
 ///
@@ -1912,6 +1923,15 @@ async fn do_branch_log_text(state: &Arc<AppState>) -> Result<String, String> {
 
 // ── Reaction commands ──────────────────────────────────────────────────────
 
+/// Returns `true` for characters that are banned from reaction message snippets
+/// to prevent NPC system-prompt injection (#687).
+///
+/// Banned: double-quote, backslash, Unicode line/paragraph separators, and
+/// all ASCII control characters (including newline, carriage return, tab).
+pub fn is_snippet_injection_char(c: char) -> bool {
+    c == '"' || c == '\\' || c == '\u{2028}' || c == '\u{2029}' || c.is_control()
+}
+
 /// Player reacts to an NPC message with an emoji.
 #[tauri::command]
 pub async fn react_to_message(
@@ -1920,10 +1940,6 @@ pub async fn react_to_message(
     emoji: String,
     state: tauri::State<'_, Arc<AppState>>,
 ) -> Result<(), String> {
-    fn is_snippet_injection_char(c: char) -> bool {
-        c == '"' || c == '\\' || c == '\u{2028}' || c == '\u{2029}' || c.is_control()
-    }
-
     // Validate emoji is in the palette
     if reactions::reaction_description(&emoji).is_none() {
         return Err("Unknown reaction emoji.".to_string());

--- a/parish/crates/parish-tauri/tests/command_logic.rs
+++ b/parish/crates/parish-tauri/tests/command_logic.rs
@@ -1,0 +1,158 @@
+//! Unit tests for pure-logic helpers extracted from Tauri command handlers.
+//!
+//! # Coverage scope — partial fix for #706
+//!
+//! These tests cover the command-layer validation functions that can be
+//! exercised without constructing `AppState` or booting the Tauri runtime.
+//! They complement the compile-time symbol checks in `command_registry.rs`
+//! and the addressed_to tests in `input_validation.rs`.
+//!
+//! ## Commands covered (3 of 28)
+//!
+//! | Command / helper           | Tests         | Reason                          |
+//! |----------------------------|---------------|---------------------------------|
+//! | `submit_input` (length)    | 4             | #752 — text length cap          |
+//! | `react_to_message` (emoji) | 3             | #687 — unknown emoji rejection  |
+//! | `react_to_message` (snip)  | 6             | #687 — injection char filter    |
+//!
+//! ## Commands deferred (25 of 28)
+//!
+//! All remaining commands bind `tauri::State<Arc<AppState>>` at their call
+//! boundary and require either the Tauri runtime or a non-trivial mock.
+//! Deferred until #706 provides a lightweight `AppState` test fixture:
+//!
+//! `get_world_snapshot`, `get_map`, `get_npcs_here`, `get_theme`,
+//! `get_debug_snapshot`, `get_ui_config`, `discover_save_files`,
+//! `save_game`, `load_branch`, `create_branch`, `new_save_file`,
+//! `new_game`, `get_save_state`, `react_to_message` (state side effects),
+//! all 12 `editor_*` commands (delegated to `parish_core::ipc::editor`
+//! which has its own test suite).
+
+use parish_tauri_lib::commands::{is_snippet_injection_char, validate_input_text};
+
+// ── submit_input — text length cap (#752) ────────────────────────────────────
+
+/// Empty string (after trimming) is returned as-is — callers short-circuit.
+#[test]
+fn validate_input_text_empty_string_is_ok() {
+    let result = validate_input_text("");
+    assert_eq!(result, Ok(String::new()));
+}
+
+/// Whitespace-only trims to empty and is OK.
+#[test]
+fn validate_input_text_whitespace_only_trims_to_empty() {
+    let result = validate_input_text("   \t\n   ");
+    assert_eq!(result, Ok(String::new()));
+}
+
+/// Text of exactly 2000 characters (after trim) is accepted.
+#[test]
+fn validate_input_text_exactly_2000_chars_is_ok() {
+    let text = "a".repeat(2000);
+    let result = validate_input_text(&text);
+    assert_eq!(result.map(|s| s.len()), Ok(2000));
+}
+
+/// Text of 2001 characters must be rejected.
+#[test]
+fn validate_input_text_2001_chars_is_rejected() {
+    let text = "a".repeat(2001);
+    let result = validate_input_text(&text);
+    assert!(result.is_err(), "2001-char input should be rejected");
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("2000"),
+        "error message should mention the limit: {err}"
+    );
+}
+
+// ── react_to_message — emoji validation (#687) ───────────────────────────────
+
+/// A valid palette emoji is recognised by the palette guard.
+///
+/// The Tauri command calls `reactions::reaction_description` directly;
+/// this test verifies the same function returns Some for a known emoji.
+#[test]
+fn valid_palette_emoji_is_recognised() {
+    use parish_core::npc::reactions::reaction_description;
+    assert!(
+        reaction_description("😊").is_some(),
+        "😊 should be a known palette emoji"
+    );
+}
+
+/// An arbitrary string that is not in the palette is rejected.
+#[test]
+fn unknown_emoji_string_is_not_in_palette() {
+    use parish_core::npc::reactions::reaction_description;
+    assert!(
+        reaction_description("NOTANEMOJI").is_none(),
+        "arbitrary string should not be in the palette"
+    );
+}
+
+/// Unicode thumbs-up (not in the 1820s parish palette) is rejected.
+#[test]
+fn thumbs_up_emoji_not_in_palette() {
+    use parish_core::npc::reactions::reaction_description;
+    // 👍 is a common emoji but not in the period-appropriate palette.
+    assert!(reaction_description("👍").is_none());
+}
+
+// ── react_to_message — snippet injection filter (#687) ───────────────────────
+
+/// Plain ASCII prose is allowed.
+#[test]
+fn plain_ascii_snippet_has_no_injection_chars() {
+    let snippet = "The weaver looked tired today.";
+    assert!(
+        !snippet.chars().any(is_snippet_injection_char),
+        "plain ASCII should contain no injection chars"
+    );
+}
+
+/// Double-quote is rejected (could break JSON / prompt string boundaries).
+#[test]
+fn double_quote_is_injection_char() {
+    assert!(
+        is_snippet_injection_char('"'),
+        "double-quote must be flagged as injection char"
+    );
+}
+
+/// Backslash is rejected (escape vector).
+#[test]
+fn backslash_is_injection_char() {
+    assert!(
+        is_snippet_injection_char('\\'),
+        "backslash must be flagged as injection char"
+    );
+}
+
+/// U+2028 LINE SEPARATOR is rejected (JSON/JS injection vector).
+#[test]
+fn unicode_line_separator_is_injection_char() {
+    assert!(
+        is_snippet_injection_char('\u{2028}'),
+        "U+2028 must be flagged as injection char"
+    );
+}
+
+/// U+2029 PARAGRAPH SEPARATOR is rejected.
+#[test]
+fn unicode_paragraph_separator_is_injection_char() {
+    assert!(
+        is_snippet_injection_char('\u{2029}'),
+        "U+2029 must be flagged as injection char"
+    );
+}
+
+/// Newline (control char) is rejected.
+#[test]
+fn newline_is_injection_char() {
+    assert!(
+        is_snippet_injection_char('\n'),
+        "newline (control char) must be flagged as injection char"
+    );
+}


### PR DESCRIPTION
## Summary

- Extracts two inline validation helpers in `commands.rs` to named `pub fn`s so they are independently testable without the Tauri runtime:
  - `validate_input_text` — trims and enforces the 2000-character cap in `submit_input` (#752)
  - `is_snippet_injection_char` — snippet injection filter in `react_to_message` (#687)
- Adds `tests/command_logic.rs` with 13 focused tests covering both helpers plus the emoji-palette guard that gates `react_to_message`.
- The `submit_input` implementation is updated to call `validate_input_text` rather than the previous inline check (no behaviour change).

**Partial — covers 3 of 28 commands; remaining 25 tracked in #706.**

The 25 deferred commands all bind `tauri::State<Arc<AppState>>` at their call boundary and require either the Tauri runtime or a lightweight `AppState` test fixture that does not yet exist. They are documented inline in the new test file.

## Commands covered

| Command / helper | Tests | Context |
|---|---|---|
| `submit_input` (length cap) | 4 | #752 |
| `react_to_message` (emoji validation) | 3 | #687 |
| `react_to_message` (snippet injection chars) | 6 | #687 |

## Commands deferred (25 of 28)

All persistence commands (`save_game`, `load_branch`, `create_branch`, `new_save_file`, `new_game`), all read commands (`get_world_snapshot`, `get_map`, etc.), and all 12 `editor_*` commands — see table in `tests/command_logic.rs`.

## Test plan

- [x] `cargo test -p parish-tauri` — 27 tests pass (0 failures)
- [x] New test file added to `parish/crates/parish-tauri/tests/command_logic.rs`
- [x] No behaviour change in production code — `submit_input` now calls `validate_input_text` instead of the identical inline check

Refs #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)