### PR TITLE
fix(ui): sync editorText to DOM after imperative chip mutation (#684)

### DIFF
--- a/parish/apps/ui/src/components/InputField.svelte
+++ b/parish/apps/ui/src/components/InputField.svelte
@@ -512,10 +512,7 @@
 		// send or clear their draft first. Surface a clear reminder and
 		// bail out.
 		//
-		// codex P2 on #573: isEditorEmpty() reads the cached editorText,
-		// which can be stale when the DOM was modified programmatically
-		// (e.g. insertNpcMention drops in chips without firing input
-		// events that re-sync). Pull a fresh plain-text view first so a
+		// #684: pull a fresh plain-text view before the empty check so a
 		// non-empty draft can't sneak past this guard.
 		syncEditorText();
 		if (!isEditorEmpty()) {
@@ -572,6 +569,7 @@
 		sel?.removeAllRanges();
 		sel?.addRange(range);
 		editorEl.focus();
+		syncEditorText();
 	}
 
 	// ── Submit ──────────────────────────────────────────────────────────────

--- a/parish/apps/ui/src/components/InputField.test.ts
+++ b/parish/apps/ui/src/components/InputField.test.ts
@@ -610,6 +610,21 @@ describe('InputField', () => {
 			expect((mention as HTMLElement)?.dataset.npc).toBe('Padraig Darcy');
 		});
 
+		it('syncs editorText after npc chip click so send button is enabled (#684)', async () => {
+			const { container, getByRole } = render(InputField);
+			const editor = getByRole('textbox');
+			const sendBtn = getByRole('button', { name: 'Send' }) as HTMLButtonElement;
+			expect(sendBtn.disabled).toBe(true);
+
+			const chip = container.querySelector('.npc-chip') as HTMLButtonElement;
+			await fireEvent.click(chip);
+
+			// editorText must be synced synchronously — send button must be enabled.
+			expect(sendBtn.disabled).toBe(false);
+			// The DOM text representation must contain the NPC name.
+			expect(editor.textContent).toContain('Padraig Darcy');
+		});
+
 		it('disables npc buttons during streaming but keeps them visible', () => {
 			streamingActive.set(true);
 			const { container } = render(InputField);


### PR DESCRIPTION
Fixes #684.

## What

`insertNpcMention` mutated the DOM directly (inserting a `.mention-chip` span) without calling `syncEditorText()`, leaving the `editorText` reactive state stale. This had two observable effects:

- The send button stayed disabled after clicking an NPC chip button, even though the editor visually contained text.
- The `quickTravel` empty-draft guard could be bypassed — a draft containing only a chip would appear empty to the guard, potentially clobbering it silently.

`selectNpc`, `dissolveChip`, and `quickTravel` already called `syncEditorText()` after DOM mutations; `insertNpcMention` was the missing case.

## Fix

- Add `syncEditorText()` at the end of `insertNpcMention` (one line, matching the pattern used everywhere else).
- Update the stale comment in `quickTravel` that described `insertNpcMention` as a known non-syncing path.
- Add regression test: clicking an NPC chip enables the send button synchronously (previously it would stay disabled).

## Commands run

```
just ui-test  # 284 passed (284)
```