### PR TITLE
fix(a11y): InputField chips/dropdown + MapPanel keyboard nav (#683, #111)

### DIFF
--- a/parish/apps/ui/src/components/InputField.svelte
+++ b/parish/apps/ui/src/components/InputField.svelte
@@ -37,6 +37,17 @@
 
 	const filteredModels = $derived(filterModels(modelQuery));
 
+	/** Computes the id of the currently-highlighted dropdown option for
+	 *  `aria-activedescendant`. Returns undefined when no dropdown is open. */
+	const activeDescendantId = $derived(
+		dropdownMode !== null ? `${dropdownMode}-option-${selectedIndex}` : undefined
+	);
+
+	/** The id of the currently-open listbox, for `aria-controls`. */
+	const dropdownListboxId = $derived(
+		dropdownMode !== null ? `${dropdownMode}-listbox` : undefined
+	);
+
 	// ── Input history ───────────────────────────────────────────────────────
 	const HISTORY_KEY = 'parish-input-history';
 	const HISTORY_MAX = 50;
@@ -407,6 +418,8 @@
 			chip.contentEditable = 'false';
 			chip.dataset.npc = npcName;
 			chip.textContent = `@${npcName}`;
+			chip.setAttribute('role', 'img');
+			chip.setAttribute('aria-label', `Mention: ${npcName}`);
 			editorEl.textContent = '';
 			editorEl.appendChild(chip);
 			const trailing = document.createTextNode('\u00A0');
@@ -437,6 +450,8 @@
 		chip.contentEditable = 'false';
 		chip.dataset.npc = npcName;
 		chip.textContent = `@${npcName}`;
+		chip.setAttribute('role', 'img');
+		chip.setAttribute('aria-label', `Mention: ${npcName}`);
 
 		const parent = textNode.parentNode!;
 		if (before) {
@@ -552,6 +567,8 @@
 		chip.contentEditable = 'false';
 		chip.dataset.npc = npcName;
 		chip.textContent = `@${npcName}`;
+		chip.setAttribute('role', 'img');
+		chip.setAttribute('aria-label', `Mention: ${npcName}`);
 
 		const trailing = document.createTextNode('\u00A0');
 		const sel = window.getSelection();
@@ -888,9 +905,10 @@
 
 <div class="input-wrapper">
 	{#if dropdownMode === 'mention' && filteredNpcs.length > 0}
-		<ul class="mention-dropdown" role="listbox" aria-label="Mention NPC">
+		<ul id="mention-listbox" class="mention-dropdown" role="listbox" aria-label="Mention NPC">
 			{#each filteredNpcs as npc, i}
 				<li
+					id="mention-option-{i}"
 					role="option"
 					aria-selected={i === selectedIndex}
 					class="mention-item"
@@ -907,9 +925,10 @@
 		</ul>
 	{/if}
 	{#if dropdownMode === 'slash' && filteredCommands.length > 0}
-		<ul class="mention-dropdown" role="listbox" aria-label="Slash commands">
+		<ul id="slash-listbox" class="mention-dropdown" role="listbox" aria-label="Slash commands">
 			{#each filteredCommands as cmd, i}
 				<li
+					id="slash-option-{i}"
 					role="option"
 					aria-selected={i === selectedIndex}
 					class="mention-item"
@@ -924,9 +943,10 @@
 		</ul>
 	{/if}
 	{#if dropdownMode === 'model' && filteredModels.length > 0}
-		<ul class="mention-dropdown" role="listbox" aria-label="Model suggestions">
+		<ul id="model-listbox" class="mention-dropdown" role="listbox" aria-label="Model suggestions">
 			{#each filteredModels as model, i}
 				<li
+					id="model-option-{i}"
 					role="option"
 					aria-selected={i === selectedIndex}
 					class="mention-item"
@@ -993,10 +1013,14 @@
 				class="input-field"
 				class:disabled={$streamingActive}
 				contenteditable={!$streamingActive}
-				role="textbox"
+				role="combobox"
 				tabindex="0"
 				aria-label="Player input"
 				aria-disabled={$streamingActive}
+				aria-haspopup="listbox"
+				aria-expanded={dropdownMode !== null}
+				aria-controls={dropdownListboxId}
+				aria-activedescendant={activeDescendantId}
 				data-testid="input-field"
 				onkeydown={handleKeydown}
 				oninput={handleInput}

--- a/parish/apps/ui/src/components/InputField.test.ts
+++ b/parish/apps/ui/src/components/InputField.test.ts
@@ -57,27 +57,27 @@ describe('InputField', () => {
 
 	it('renders an editable input area', () => {
 		const { getByRole } = render(InputField);
-		const editor = getByRole('textbox');
+		const editor = getByRole('combobox');
 		expect(editor).toBeTruthy();
 		expect(editor.getAttribute('contenteditable')).toBe('true');
 	});
 
 	it('shows placeholder when empty', () => {
 		const { getByRole } = render(InputField);
-		const editor = getByRole('textbox');
+		const editor = getByRole('combobox');
 		expect(editor.dataset.placeholder).toBe('What do you do? (@ to mention NPC)');
 	});
 
 	it('is not editable when streaming', () => {
 		streamingActive.set(true);
 		const { getByRole } = render(InputField);
-		const editor = getByRole('textbox');
+		const editor = getByRole('combobox');
 		expect(editor.getAttribute('contenteditable')).toBe('false');
 	});
 
 	it('clears editor after submit', async () => {
 		const { getByRole } = render(InputField);
-		const editor = getByRole('textbox');
+		const editor = getByRole('combobox');
 		editor.textContent = 'hello';
 		await fireEvent.input(editor);
 		await fireEvent.keyDown(editor, { key: 'Enter' });
@@ -86,7 +86,7 @@ describe('InputField', () => {
 
 	it('enables send button when editor has text', async () => {
 		const { getByRole } = render(InputField);
-		const editor = getByRole('textbox');
+		const editor = getByRole('combobox');
 		const sendBtn = getByRole('button', { name: 'Send' }) as HTMLButtonElement;
 		expect(sendBtn.disabled).toBe(true);
 
@@ -124,7 +124,7 @@ describe('InputField', () => {
 
 		it('shows mention dropdown when @ is typed with a letter', async () => {
 			const { getByRole, queryByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			expect(queryByRole('listbox')).toBeNull();
 
@@ -135,7 +135,7 @@ describe('InputField', () => {
 
 		it('filters NPCs by typed text', async () => {
 			const { getByRole, queryAllByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '@P');
 			await fireEvent.input(editor);
@@ -146,7 +146,7 @@ describe('InputField', () => {
 
 		it('shows matching NPCs for @S', async () => {
 			const { getByRole, queryAllByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '@S');
 			await fireEvent.input(editor);
@@ -158,7 +158,7 @@ describe('InputField', () => {
 		it('does not show dropdown when no NPCs present', async () => {
 			npcsHere.set([]);
 			const { getByRole, queryByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '@P');
 			await fireEvent.input(editor);
@@ -167,7 +167,7 @@ describe('InputField', () => {
 
 		it('dismisses dropdown on Escape', async () => {
 			const { getByRole, queryByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '@P');
 			await fireEvent.input(editor);
@@ -179,7 +179,7 @@ describe('InputField', () => {
 
 		it('shows occupation for introduced NPCs', async () => {
 			const { getByRole, queryAllByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '@P');
 			await fireEvent.input(editor);
@@ -189,7 +189,7 @@ describe('InputField', () => {
 
 		it('inserts a mention chip with full name on selection', async () => {
 			const { getByRole, queryAllByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '@P');
 			await fireEvent.input(editor);
@@ -224,7 +224,7 @@ describe('InputField', () => {
 
 		it('shows slash dropdown when / is typed', async () => {
 			const { getByRole, queryByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/');
 			await fireEvent.input(editor);
@@ -235,7 +235,7 @@ describe('InputField', () => {
 
 		it('filters commands by typed text', async () => {
 			const { getByRole, queryAllByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/pa');
 			await fireEvent.input(editor);
@@ -246,7 +246,7 @@ describe('InputField', () => {
 
 		it('navigates dropdown with ArrowDown/ArrowUp', async () => {
 			const { getByRole, queryAllByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/he');
 			await fireEvent.input(editor);
@@ -257,7 +257,7 @@ describe('InputField', () => {
 
 		it('dismisses slash dropdown on Escape', async () => {
 			const { getByRole, queryByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/');
 			await fireEvent.input(editor);
@@ -269,7 +269,7 @@ describe('InputField', () => {
 
 		it('selects no-arg command via Enter and submits', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/pa');
 			await fireEvent.input(editor);
@@ -280,7 +280,7 @@ describe('InputField', () => {
 
 		it('selects arg command via Tab and inserts with trailing space', async () => {
 			const { getByRole, queryByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/fo');
 			await fireEvent.input(editor);
@@ -293,7 +293,7 @@ describe('InputField', () => {
 
 		it('does not show slash dropdown when / is mid-text', async () => {
 			const { getByRole, queryByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, 'go to a/b');
 			await fireEvent.input(editor);
@@ -320,7 +320,7 @@ describe('InputField', () => {
 
 		it('shows model dropdown after `/model ` is typed', async () => {
 			const { getByRole, queryByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/model ');
 			await fireEvent.input(editor);
@@ -331,7 +331,7 @@ describe('InputField', () => {
 
 		it('filters models by typed substring', async () => {
 			const { getByRole, queryAllByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/model claude');
 			await fireEvent.input(editor);
@@ -346,7 +346,7 @@ describe('InputField', () => {
 			// must submit exactly what was typed so a partial / custom ID is never
 			// silently swapped for a catalog match.
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/model my-custom-fork');
 			await fireEvent.input(editor);
@@ -360,7 +360,7 @@ describe('InputField', () => {
 			// Without this, an empty `/model ` + Enter would pick the first
 			// catalog suggestion and silently change the active model.
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/model ');
 			await fireEvent.input(editor);
@@ -372,7 +372,7 @@ describe('InputField', () => {
 
 		it('Tab picks the highlighted suggestion and submits it', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/model claude');
 			await fireEvent.input(editor);
@@ -386,7 +386,7 @@ describe('InputField', () => {
 
 		it('Tab preserves the per-category prefix when picking a suggestion', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/model.dialogue claude');
 			await fireEvent.input(editor);
@@ -398,7 +398,7 @@ describe('InputField', () => {
 
 		it('clears the editor after picking a model with Tab', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/model claude');
 			await fireEvent.input(editor);
@@ -409,7 +409,7 @@ describe('InputField', () => {
 
 		it('Escape dismisses the model dropdown', async () => {
 			const { getByRole, queryByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/model ');
 			await fireEvent.input(editor);
@@ -421,7 +421,7 @@ describe('InputField', () => {
 
 		it('does not show model dropdown for `/model` without a trailing space', async () => {
 			const { getByRole, queryByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/model');
 			await fireEvent.input(editor);
@@ -433,7 +433,7 @@ describe('InputField', () => {
 
 		it('does not show model dropdown for unrelated commands', async () => {
 			const { getByRole, queryByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '/provider llama3');
 			await fireEvent.input(editor);
@@ -461,14 +461,14 @@ describe('InputField', () => {
 
 		it('ArrowUp on empty editor with no history does nothing', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 			await fireEvent.keyDown(editor, { key: 'ArrowUp' });
 			expect(editor.textContent).toBe('');
 		});
 
 		it('recalls previous input with ArrowUp after submit', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, 'hello');
 			await fireEvent.input(editor);
@@ -489,7 +489,7 @@ describe('InputField', () => {
 
 		it('ArrowDown restores draft after navigating history', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, 'first');
 			await fireEvent.input(editor);
@@ -508,7 +508,7 @@ describe('InputField', () => {
 
 		it('persists history to sessionStorage', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, 'persist me');
 			await fireEvent.input(editor);
@@ -520,7 +520,7 @@ describe('InputField', () => {
 
 		it('does not store consecutive duplicate inputs', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, 'same');
 			await fireEvent.input(editor);
@@ -540,7 +540,7 @@ describe('InputField', () => {
 	describe('multi-line input', () => {
 		it('Shift+Enter does not submit', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			editor.textContent = 'line one';
 			await fireEvent.input(editor);
@@ -553,7 +553,7 @@ describe('InputField', () => {
 
 		it('Enter without Shift submits', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			editor.textContent = 'submit me';
 			await fireEvent.input(editor);
@@ -600,7 +600,7 @@ describe('InputField', () => {
 
 		it('clicking an npc chip inserts an @name mention chip into the editor', async () => {
 			const { container, getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 			const chip = container.querySelector('.npc-chip') as HTMLButtonElement;
 			await fireEvent.click(chip);
 
@@ -702,7 +702,7 @@ describe('InputField', () => {
 
 		it('inserts pasted plain text into an empty editor', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox') as HTMLElement;
+			const editor = getByRole('combobox') as HTMLElement;
 			editor.focus();
 			placeCursorAtEnd(editor);
 
@@ -715,7 +715,7 @@ describe('InputField', () => {
 
 		it('inserts pasted text at the cursor and keeps editorText state in sync (send enabled)', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox') as HTMLElement;
+			const editor = getByRole('combobox') as HTMLElement;
 			const sendBtn = getByRole('button', { name: 'Send' }) as HTMLButtonElement;
 			expect(sendBtn.disabled).toBe(true);
 
@@ -731,7 +731,7 @@ describe('InputField', () => {
 
 		it('pasting submits via Enter with the pasted content', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox') as HTMLElement;
+			const editor = getByRole('combobox') as HTMLElement;
 			editor.focus();
 			placeCursorAtEnd(editor);
 
@@ -846,7 +846,7 @@ describe('InputField', () => {
 
 		it('Tab completes a matching prefix', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, 'go to pub');
 			await fireEvent.input(editor);
@@ -857,7 +857,7 @@ describe('InputField', () => {
 
 		it('Tab does nothing when no matches', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, 'go to xyz');
 			await fireEvent.input(editor);
@@ -868,7 +868,7 @@ describe('InputField', () => {
 
 		it('Tab cycles through all visited locations on empty input', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			await fireEvent.keyDown(editor, { key: 'Tab' });
 			const first = editor.textContent ?? '';
@@ -881,7 +881,7 @@ describe('InputField', () => {
 
 		it('Tab completes unvisited (frontier) locations with lower priority', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, 'mill');
 			await fireEvent.input(editor);
@@ -893,7 +893,7 @@ describe('InputField', () => {
 
 		it('Tab cycles through multiple matches', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			// "the" matches "The Crossroads" and "The Church"
 			typeIntoEditor(editor, 'the');
@@ -911,7 +911,7 @@ describe('InputField', () => {
 
 		it('typing resets completion state', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, 'pub');
 			await fireEvent.input(editor);
@@ -940,7 +940,7 @@ describe('InputField', () => {
 				}
 			]);
 			const { getByRole, queryByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			typeIntoEditor(editor, '@P');
 			await fireEvent.input(editor);
@@ -961,7 +961,7 @@ describe('InputField', () => {
 				throw new Error('network down');
 			});
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			editor.textContent = 'hello there';
 			await fireEvent.input(editor);
@@ -1024,7 +1024,7 @@ describe('InputField', () => {
 
 		it('does not resume game just by typing non-slash command while paused', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			editor.textContent = 'h';
 			await fireEvent.input(editor);
@@ -1034,7 +1034,7 @@ describe('InputField', () => {
 
 		it('resumes game when sending non-slash command while paused', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			editor.textContent = 'hello';
 			await fireEvent.input(editor);
@@ -1046,7 +1046,7 @@ describe('InputField', () => {
 
 		it('does not resume game when sending a slash command while paused', async () => {
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			editor.textContent = '/help';
 			await fireEvent.input(editor);
@@ -1059,7 +1059,7 @@ describe('InputField', () => {
 		it('does not resume game if not paused', async () => {
 			worldState.set({ paused: false } as any);
 			const { getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 
 			editor.textContent = 'hello';
 			await fireEvent.input(editor);
@@ -1067,6 +1067,66 @@ describe('InputField', () => {
 
 			expect(mockSubmitInput).not.toHaveBeenCalledWith('/resume');
 			expect(mockSubmitInput).toHaveBeenCalledWith('hello', []);
+		});
+	});
+
+	// ── ARIA: combobox + listbox attributes (#683) ──────────────────────────
+	describe('ARIA combobox attributes (#683)', () => {
+		const testNpcs = [
+			{ name: 'Padraig Darcy', real_name: 'Padraig Darcy', occupation: 'Publican', mood: 'content', introduced: true, mood_emoji: '😌' }
+		];
+
+		function typeIntoEditor(editor: HTMLElement, text: string) {
+			editor.textContent = text;
+			const range = document.createRange();
+			const sel = window.getSelection();
+			if (editor.firstChild) {
+				range.setStart(editor.firstChild, text.length);
+			} else {
+				range.setStart(editor, 0);
+			}
+			range.collapse(true);
+			sel?.removeAllRanges();
+			sel?.addRange(range);
+		}
+
+		it('editor has aria-haspopup="listbox" and aria-expanded=false when closed', () => {
+			const { getByRole } = render(InputField);
+			const editor = getByRole('combobox');
+			expect(editor.getAttribute('aria-haspopup')).toBe('listbox');
+			expect(editor.getAttribute('aria-expanded')).toBe('false');
+		});
+
+		it('aria-expanded becomes true when mention dropdown opens', async () => {
+			npcsHere.set(testNpcs);
+			const { getByRole } = render(InputField);
+			const editor = getByRole('combobox');
+			typeIntoEditor(editor, '@P');
+			await fireEvent.input(editor);
+			expect(editor.getAttribute('aria-expanded')).toBe('true');
+		});
+
+		it('mention chip inserted via selectNpc has role="img" and aria-label', async () => {
+			npcsHere.set(testNpcs);
+			const { getByRole } = render(InputField);
+			const editor = getByRole('combobox');
+			typeIntoEditor(editor, '@P');
+			await fireEvent.input(editor);
+			await fireEvent.keyDown(editor, { key: 'Enter' });
+			const chip = editor.querySelector('.mention-chip') as HTMLElement;
+			expect(chip.getAttribute('role')).toBe('img');
+			expect(chip.getAttribute('aria-label')).toBe('Mention: Padraig Darcy');
+		});
+
+		it('mention chip inserted via npc-chip button has role="img" and aria-label', async () => {
+			npcsHere.set(testNpcs);
+			const { container, getByRole } = render(InputField);
+			const editor = getByRole('combobox');
+			const npcBtn = container.querySelector('.npc-chip') as HTMLButtonElement;
+			await fireEvent.click(npcBtn);
+			const chip = editor.querySelector('.mention-chip') as HTMLElement;
+			expect(chip.getAttribute('role')).toBe('img');
+			expect(chip.getAttribute('aria-label')).toBe('Mention: Padraig Darcy');
 		});
 	});
 });

--- a/parish/apps/ui/src/components/MapPanel.svelte
+++ b/parish/apps/ui/src/components/MapPanel.svelte
@@ -268,6 +268,39 @@
 			</svg>
 		</button>
 	</div>
+	<!-- Accessible location list — visually hidden, keyboard-navigable.
+	     The canvas map has no HTML nodes per location, so this list gives
+	     screen readers and keyboard users access to nearby locations. -->
+	{#if $mapData}
+		<nav aria-label="Nearby locations">
+			<ul class="sr-only-list" role="list">
+				{#each $mapData.locations.filter(l => l.id !== $mapData?.player_location) as loc}
+					<li>
+						<button
+							tabindex="0"
+							aria-label="{loc.name}{loc.adjacent ? '' : ' (not adjacent)'}"
+							aria-disabled={!loc.adjacent}
+							class="sr-only-loc-btn"
+							onclick={() => {
+								if (!loc.adjacent) return;
+								submitInput(`go to ${loc.name}`).catch((err) => {
+									pushErrorLog(`Could not travel to ${loc.name}: ${formatIpcError(err)}`);
+								});
+							}}
+							onkeydown={(e) => {
+								if ((e.key === 'Enter' || e.key === ' ') && loc.adjacent) {
+									e.preventDefault();
+									submitInput(`go to ${loc.name}`).catch((err) => {
+										pushErrorLog(`Could not travel to ${loc.name}: ${formatIpcError(err)}`);
+									});
+								}
+							}}
+						>{loc.name}</button>
+					</li>
+				{/each}
+			</ul>
+		</nav>
+	{/if}
 	<!-- map-wrap is always in the DOM so onMount can bind the container
 	     before mapData arrives. MapLibre needs a stable element to attach to. -->
 	<div class="map-wrap">
@@ -442,5 +475,24 @@
 		font-style: italic;
 		font-size: 0.85rem;
 		pointer-events: none;
+	}
+
+	/* Screen-reader-only location list: visually hidden but fully keyboard/AT
+	   accessible. Provides a text alternative for the canvas-based map nodes. */
+	.sr-only-list {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
+		list-style: none;
+	}
+
+	.sr-only-loc-btn {
+		all: unset;
 	}
 </style>

--- a/parish/apps/ui/src/components/MapPanel.test.ts
+++ b/parish/apps/ui/src/components/MapPanel.test.ts
@@ -106,4 +106,38 @@ describe('MapPanel', () => {
 		const { container } = render(MapPanel);
 		expect(container.querySelector('[data-testid="map-panel"]')).toBeTruthy();
 	});
+
+	// ── Accessible location list (#111) ────────────────────────────────
+	describe('accessible location list (#111)', () => {
+		it('renders a navigation landmark with nearby locations when map data present', () => {
+			mapData.set(testMap);
+			const { getByRole } = render(MapPanel);
+			expect(getByRole('navigation', { name: 'Nearby locations' })).toBeTruthy();
+		});
+
+		it('adjacent location button has aria-disabled="false", non-adjacent has aria-disabled="true"', () => {
+			const mapWithBoth = {
+				...testMap,
+				locations: [
+					...testMap.locations,
+					{ id: 'loc3', name: 'Dalkey', lat: 53.27, lon: -6.1, adjacent: false, hops: 2 }
+				]
+			};
+			mapData.set(mapWithBoth);
+			const { getAllByRole } = render(MapPanel);
+			const locBtns = getAllByRole('button').filter(
+				(b) => b.classList.contains('sr-only-loc-btn')
+			);
+			const howth = locBtns.find((b) => b.textContent === 'Howth') as HTMLButtonElement;
+			const dalkey = locBtns.find((b) => b.textContent === 'Dalkey') as HTMLButtonElement;
+			expect(howth.getAttribute('aria-disabled')).toBe('false');
+			expect(dalkey.getAttribute('aria-disabled')).toBe('true');
+		});
+
+		it('does not render navigation landmark when no map data', () => {
+			mapData.set(null);
+			const { queryByRole } = render(MapPanel);
+			expect(queryByRole('navigation', { name: 'Nearby locations' })).toBeNull();
+		});
+	});
 });


### PR DESCRIPTION
Fixes #683. Fixes #111.

## Changes

**InputField.svelte (#683)**
- All three chip-creation call sites (`selectNpc` no-text-node path, `selectNpc` text-node path, `insertNpcMention`) now set `role="img"` and `aria-label="Mention: {name}"` on each chip element
- Dropdown `<ul>` elements gain `id` attributes (`mention-listbox`, `slash-listbox`, `model-listbox`) for `aria-controls`
- Dropdown `<li>` items gain `id="<mode>-option-{i}"` for `aria-activedescendant`
- Editor `<div>` promoted from `role="textbox"` to `role="combobox"` with `aria-haspopup="listbox"`, `aria-expanded`, `aria-controls`, and `aria-activedescendant` wired to reactive derived state
- Added `activeDescendantId` and `dropdownListboxId` derived values

**MapPanel.svelte (#111)**
- Added visually-hidden `<nav aria-label="Nearby locations">` containing one `<button>` per non-player location
- Buttons carry `tabindex="0"`, implicit `role="button"`, `aria-disabled` (`false` for adjacent, `true` for non-adjacent), and `aria-label` that appends " (not adjacent)" for unreachable locations
- Enter/Space `onkeydown` handler triggers travel for adjacent locations
- SR-only CSS (`.sr-only-list` / `.sr-only-loc-btn`) clips list off-screen while keeping it keyboard and AT accessible
- No `svelte-ignore` comments were present in MapPanel (confirmed by grep); the task description for those lines referenced phantom markup — the canvas-based map has no static clickable elements to annotate

**Tests**
- `InputField.test.ts`: updated all `getByRole('textbox')` → `getByRole('combobox')` (role change); added 4 ARIA assertions (aria-haspopup/expanded, aria-expanded on dropdown open, chip role/label via selectNpc, chip role/label via npc-chip button)
- `MapPanel.test.ts`: added 3 ARIA assertions (nav landmark present, aria-disabled values, landmark absent without map data)

**Note on branch name**: This uses `a11y/683-111-input-field-and-map-panel-v2` because a prior stalled agent left the canonical branch name locked in worktree `agent-a803426a456d7d498` with uncommitted changes that were never pushed. Git refuses to force-move a branch held by an active worktree, and no permitted command could release the lock.

## Commands run

```
just ui-test  # PASS (290) FAIL (0)
```