### PR TITLE
feat: move inference bootstrap progress to GUI setup overlay

### DIFF
--- a/parish/apps/ui/src/components/InputField.test.ts
+++ b/parish/apps/ui/src/components/InputField.test.ts
@@ -612,7 +612,7 @@ describe('InputField', () => {
 
 		it('syncs editorText after npc chip click so send button is enabled (#684)', async () => {
 			const { container, getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 			const sendBtn = getByRole('button', { name: 'Send' }) as HTMLButtonElement;
 			expect(sendBtn.disabled).toBe(true);
 

--- a/parish/apps/ui/src/components/SetupOverlay.svelte
+++ b/parish/apps/ui/src/components/SetupOverlay.svelte
@@ -20,7 +20,7 @@
 	let downloadTotal = $state(0);
 	let hasError = $state(false);
 	let errorMsg = $state('');
-	let messagesEl: HTMLDivElement | null = $state(null);
+	let messagesEl: HTMLDivElement;
 
 	let downloadPct = $derived(
 		downloadTotal > 0 ? Math.min(100, (downloadCompleted / downloadTotal) * 100) : null

--- a/parish/apps/ui/src/components/SetupOverlay.svelte
+++ b/parish/apps/ui/src/components/SetupOverlay.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+	import { onMount, onDestroy, tick } from 'svelte';
+	import {
+		isTauri,
+		onSetupStatus,
+		onSetupProgress,
+		onSetupDone,
+		type SetupStatusPayload,
+		type SetupProgressPayload,
+		type SetupDonePayload
+	} from '$lib/ipc';
+
+	const tauri = isTauri();
+
+	let visible = $state(tauri);
+	let fading = $state(false);
+	let messages: string[] = $state([]);
+	let currentPhrase = $state('');
+	let downloadCompleted = $state(0);
+	let downloadTotal = $state(0);
+	let hasError = $state(false);
+	let errorMsg = $state('');
+	let messagesEl: HTMLDivElement | null = $state(null);
+
+	let downloadPct = $derived(
+		downloadTotal > 0 ? Math.min(100, (downloadCompleted / downloadTotal) * 100) : null
+	);
+
+	let cleanupFns: Array<() => void> = [];
+
+	onMount(async () => {
+		if (!tauri) return;
+
+		cleanupFns.push(
+			await onSetupStatus((p: SetupStatusPayload) => {
+				currentPhrase = p.message;
+				messages = [...messages.slice(-49), p.message];
+				tick().then(() => {
+					if (messagesEl) messagesEl.scrollTop = messagesEl.scrollHeight;
+				});
+			})
+		);
+
+		cleanupFns.push(
+			await onSetupProgress((p: SetupProgressPayload) => {
+				downloadCompleted = p.completed;
+				downloadTotal = p.total;
+			})
+		);
+
+		cleanupFns.push(
+			await onSetupDone((p: SetupDonePayload) => {
+				if (p.success) {
+					fading = true;
+					setTimeout(() => {
+						visible = false;
+					}, 650);
+				} else {
+					hasError = true;
+					errorMsg = p.error;
+				}
+			})
+		);
+	});
+
+	onDestroy(() => {
+		cleanupFns.forEach((fn) => fn());
+	});
+</script>
+
+{#if visible}
+	<div class="setup-overlay" class:fading>
+		<div class="setup-box">
+			<svg
+				class="triquetra-spinner"
+				viewBox="0 0 100 100"
+				xmlns="http://www.w3.org/2000/svg"
+				aria-hidden="true"
+			>
+				<circle
+					class="knot-circle"
+					pathLength="120"
+					cx="50"
+					cy="50"
+					r="16"
+					fill="none"
+					stroke="var(--color-accent)"
+					stroke-width="3"
+					stroke-linecap="round"
+				/>
+				<path
+					class="triquetra-path"
+					pathLength="120"
+					d="M 50 22
+					   A 28 28 0 0 0 74.25 64
+					   A 28 28 0 0 0 25.75 64
+					   A 28 28 0 0 0 50 22 Z"
+					fill="none"
+					stroke="var(--color-accent)"
+					stroke-width="3"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
+			</svg>
+
+			{#if currentPhrase && !hasError}
+				<p class="current-phrase">{currentPhrase}</p>
+			{/if}
+
+			{#if downloadPct !== null}
+				<div class="progress-track" role="progressbar" aria-valuenow={downloadPct} aria-valuemin={0} aria-valuemax={100}>
+					<div class="progress-fill" style="width: {downloadPct}%"></div>
+				</div>
+				<p class="progress-label">{downloadPct.toFixed(1)}%</p>
+			{/if}
+
+			{#if messages.length > 0}
+				<div class="messages" bind:this={messagesEl}>
+					{#each messages as msg}
+						<p class="msg">{msg}</p>
+					{/each}
+				</div>
+			{/if}
+
+			{#if hasError}
+				<div class="error-box">
+					<p class="error-title">Something went wrong.</p>
+					<p class="error-msg">{errorMsg}</p>
+					<p class="error-hint">Close the app and check the terminal for details.</p>
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}
+
+<style>
+	.setup-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 200;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: var(--color-bg);
+		opacity: 1;
+		transition: opacity 0.6s ease;
+	}
+
+	.setup-overlay.fading {
+		opacity: 0;
+		pointer-events: none;
+	}
+
+	.setup-box {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1.25rem;
+		max-width: 26rem;
+		width: 90%;
+		text-align: center;
+	}
+
+	.triquetra-spinner {
+		width: 6rem;
+		height: 6rem;
+		animation: triquetra-rotate 6s linear infinite;
+	}
+
+	.triquetra-path {
+		stroke-dasharray: 80 40;
+		stroke-dashoffset: 0;
+		animation: triquetra-draw 2.4s linear infinite;
+	}
+
+	.knot-circle {
+		stroke-dasharray: 0 120;
+		stroke-dashoffset: 0;
+		animation: circle-draw 3s ease-in-out infinite;
+		animation-delay: 0.4s;
+	}
+
+	@keyframes triquetra-draw {
+		to {
+			stroke-dashoffset: -120;
+		}
+	}
+
+	@keyframes circle-draw {
+		0%   { stroke-dasharray: 0 120;   stroke-dashoffset: 0; }
+		30%  { stroke-dasharray: 120 120; stroke-dashoffset: 0; }
+		70%  { stroke-dasharray: 120 120; stroke-dashoffset: 0; }
+		100% { stroke-dasharray: 0 120;   stroke-dashoffset: -120; }
+	}
+
+	@keyframes triquetra-rotate {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.current-phrase {
+		color: var(--color-accent);
+		font-size: 0.95rem;
+		font-style: italic;
+		margin: 0;
+		min-height: 1.4em;
+	}
+
+	.progress-track {
+		width: 100%;
+		height: 4px;
+		background: var(--color-border, rgba(255, 255, 255, 0.1));
+		border-radius: 2px;
+		overflow: hidden;
+	}
+
+	.progress-fill {
+		height: 100%;
+		background: var(--color-accent);
+		border-radius: 2px;
+		transition: width 0.3s ease;
+	}
+
+	.progress-label {
+		font-size: 0.8rem;
+		color: var(--color-muted);
+		margin: -0.75rem 0 0;
+	}
+
+	.messages {
+		width: 100%;
+		max-height: 8rem;
+		overflow-y: auto;
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		border-top: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
+		padding-top: 0.75rem;
+	}
+
+	.msg {
+		font-size: 0.8rem;
+		color: var(--color-muted);
+		margin: 0;
+		text-align: left;
+	}
+
+	.error-box {
+		width: 100%;
+		border-left: 3px solid #c0554a;
+		padding: 0.75rem;
+		text-align: left;
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.error-title {
+		color: #c0554a;
+		font-size: 0.95rem;
+		font-weight: 600;
+		margin: 0;
+	}
+
+	.error-msg {
+		color: var(--color-muted);
+		font-size: 0.85rem;
+		font-family: monospace;
+		margin: 0;
+		word-break: break-word;
+	}
+
+	.error-hint {
+		color: var(--color-muted);
+		font-size: 0.8rem;
+		font-style: italic;
+		margin: 0;
+	}
+</style>

--- a/parish/apps/ui/src/components/SetupOverlay.svelte
+++ b/parish/apps/ui/src/components/SetupOverlay.svelte
@@ -50,11 +50,13 @@
 			})
 		);
 
+		let fadeTimer: ReturnType<typeof setTimeout> | undefined;
+		cleanupFns.push(() => clearTimeout(fadeTimer));
 		cleanupFns.push(
 			await onSetupDone((p: SetupDonePayload) => {
 				if (p.success) {
 					fading = true;
-					setTimeout(() => {
+					fadeTimer = setTimeout(() => {
 						visible = false;
 					}, 650);
 				} else {

--- a/parish/apps/ui/src/components/SetupOverlay.svelte
+++ b/parish/apps/ui/src/components/SetupOverlay.svelte
@@ -20,7 +20,7 @@
 	let downloadTotal = $state(0);
 	let hasError = $state(false);
 	let errorMsg = $state('');
-	let messagesEl: HTMLDivElement;
+	let messagesEl = $state<HTMLDivElement | undefined>(undefined);
 
 	let downloadPct = $derived(
 		downloadTotal > 0 ? Math.min(100, (downloadCompleted / downloadTotal) * 100) : null
@@ -36,7 +36,9 @@
 				currentPhrase = p.message;
 				messages = [...messages.slice(-49), p.message];
 				tick().then(() => {
-					if (messagesEl) messagesEl.scrollTop = messagesEl.scrollHeight;
+					if (messagesEl) {
+						messagesEl.scrollTop = messagesEl.scrollHeight;
+					}
 				});
 			})
 		);

--- a/parish/apps/ui/src/lib/ipc.ts
+++ b/parish/apps/ui/src/lib/ipc.ts
@@ -297,3 +297,30 @@ export const onNpcReaction = (cb: (payload: NpcReactionPayload) => void) =>
 
 export const onTravelStart = (cb: (payload: TravelStartPayload) => void) =>
 	onEvent<TravelStartPayload>('travel-start', cb);
+
+// ── Setup overlay events ────────────────────────────────────────────────────
+
+export function isTauri(): boolean {
+	return IS_TAURI;
+}
+
+export interface SetupStatusPayload {
+	message: string;
+}
+export interface SetupProgressPayload {
+	completed: number;
+	total: number;
+}
+export interface SetupDonePayload {
+	success: boolean;
+	error: string;
+}
+
+export const onSetupStatus = (cb: (payload: SetupStatusPayload) => void) =>
+	onEvent<SetupStatusPayload>('setup-status', cb);
+
+export const onSetupProgress = (cb: (payload: SetupProgressPayload) => void) =>
+	onEvent<SetupProgressPayload>('setup-progress', cb);
+
+export const onSetupDone = (cb: (payload: SetupDonePayload) => void) =>
+	onEvent<SetupDonePayload>('setup-done', cb);

--- a/parish/apps/ui/src/routes/+page.svelte
+++ b/parish/apps/ui/src/routes/+page.svelte
@@ -10,6 +10,7 @@
 	import InputField from '../components/InputField.svelte';
 	import DebugPanel from '../components/DebugPanel.svelte';
 	import SavePicker from '../components/SavePicker.svelte';
+	import SetupOverlay from '../components/SetupOverlay.svelte';
 
 	import { worldState, mapData, npcsHere, textLog, streamingActive, loadingSpinner, loadingPhrase, loadingColor, languageHints, nameHints, uiConfig, fullMapOpen, focailOpen, addReaction, trimTextLog, messageHints, pushErrorLog, formatIpcError } from '../stores/game';
 
@@ -661,6 +662,7 @@
 
 <DebugPanel />
 <SavePicker />
+<SetupOverlay />
 
 <style>
 	.app-shell {

--- a/parish/crates/parish-inference/src/setup.rs
+++ b/parish/crates/parish-inference/src/setup.rs
@@ -103,7 +103,7 @@ pub struct OllamaSetup {
 ///
 /// Implemented differently by headless and other modes to show
 /// installation, detection, and download progress appropriately.
-pub trait SetupProgress {
+pub trait SetupProgress: Send + Sync {
     /// Reports a status message during setup.
     fn on_status(&self, msg: &str);
     /// Reports model pull progress (bytes downloaded vs total).
@@ -1326,34 +1326,38 @@ mod tests {
 
     /// Tracks status messages for testing.
     struct TestProgress {
-        messages: std::cell::RefCell<Vec<String>>,
+        messages: std::sync::Mutex<Vec<String>>,
     }
 
     impl TestProgress {
         fn new() -> Self {
             Self {
-                messages: std::cell::RefCell::new(Vec::new()),
+                messages: std::sync::Mutex::new(Vec::new()),
             }
         }
 
         fn messages(&self) -> Vec<String> {
-            self.messages.borrow().clone()
+            self.messages.lock().unwrap().clone()
         }
     }
 
     impl SetupProgress for TestProgress {
         fn on_status(&self, msg: &str) {
-            self.messages.borrow_mut().push(msg.to_string());
+            self.messages.lock().unwrap().push(msg.to_string());
         }
 
         fn on_pull_progress(&self, completed: u64, total: u64) {
             self.messages
-                .borrow_mut()
+                .lock()
+                .unwrap()
                 .push(format!("progress: {}/{}", completed, total));
         }
 
         fn on_error(&self, msg: &str) {
-            self.messages.borrow_mut().push(format!("ERROR: {}", msg));
+            self.messages
+                .lock()
+                .unwrap()
+                .push(format!("ERROR: {}", msg));
         }
     }
 

--- a/parish/crates/parish-tauri/src/events.rs
+++ b/parish/crates/parish-tauri/src/events.rs
@@ -35,6 +35,12 @@ pub const EVENT_TRAVEL_START: &str = "travel-start";
 pub const EVENT_THEME_SWITCH: &str = "theme-switch";
 /// Event emitted when a `/map` command selects a new map tile source.
 pub const EVENT_TILES_SWITCH: &str = "tiles-switch";
+/// Event emitted during inference provider bootstrap with a status message.
+pub const EVENT_SETUP_STATUS: &str = "setup-status";
+/// Event emitted during model download with byte-level progress.
+pub const EVENT_SETUP_PROGRESS: &str = "setup-progress";
+/// Event emitted when bootstrap finishes (success or failure).
+pub const EVENT_SETUP_DONE: &str = "setup-done";
 
 /// How many milliseconds to batch streaming tokens before emitting.
 pub const BATCH_MS: u64 = 16;
@@ -79,6 +85,31 @@ pub struct TextLogPayload {
     pub source: String,
     /// The log entry text.
     pub content: String,
+}
+
+/// Payload for `setup-status` and `setup-progress` / `setup-done` events.
+#[derive(serde::Serialize, Clone)]
+pub struct SetupStatusPayload {
+    /// Human-readable status message.
+    pub message: String,
+}
+
+/// Payload for `setup-progress` events (model download progress).
+#[derive(serde::Serialize, Clone)]
+pub struct SetupProgressPayload {
+    /// Bytes downloaded so far.
+    pub completed: u64,
+    /// Total bytes expected (0 if unknown).
+    pub total: u64,
+}
+
+/// Payload for `setup-done` events.
+#[derive(serde::Serialize, Clone)]
+pub struct SetupDonePayload {
+    /// True if bootstrap succeeded.
+    pub success: bool,
+    /// Error message if `success` is false; empty string otherwise.
+    pub error: String,
 }
 
 /// Payload for `npc-reaction` events.

--- a/parish/crates/parish-tauri/src/lib.rs
+++ b/parish/crates/parish-tauri/src/lib.rs
@@ -428,6 +428,39 @@ async fn dispatch_screenshot(_path: std::path::PathBuf) -> anyhow::Result<()> {
     anyhow::bail!("screenshot capture is only implemented on Linux")
 }
 
+// ── Setup progress reporter (GUI mode) ───────────────────────────────────────
+
+/// Forwards inference bootstrap progress to the frontend via Tauri events.
+/// Used inside the async `.setup()` spawn so the window exists before we call it.
+struct TauriProgress {
+    app: tauri::AppHandle,
+}
+
+impl parish_core::inference::setup::SetupProgress for TauriProgress {
+    fn on_status(&self, msg: &str) {
+        tracing::info!("{}", msg);
+        let _ = self.app.emit(
+            events::EVENT_SETUP_STATUS,
+            events::SetupStatusPayload { message: msg.to_string() },
+        );
+    }
+
+    fn on_pull_progress(&self, completed: u64, total: u64) {
+        let _ = self.app.emit(
+            events::EVENT_SETUP_PROGRESS,
+            events::SetupProgressPayload { completed, total },
+        );
+    }
+
+    fn on_error(&self, msg: &str) {
+        tracing::error!("{}", msg);
+        let _ = self.app.emit(
+            events::EVENT_SETUP_STATUS,
+            events::SetupStatusPayload { message: format!("Error: {}", msg) },
+        );
+    }
+}
+
 // ── Tauri entry point ─────────────────────────────────────────────────────────
 
 /// Called from `main.rs`. Initialises game state and launches the Tauri app.
@@ -535,24 +568,14 @@ pub fn run() {
     let engine_config = parish_core::config::load_engine_config(None);
 
     // Read provider config from env vars (optional).
-    // On Ollama this runs the full install / auto-start / GPU-detect / pull
-    // / warmup sequence — so the desktop app matches the CLI on first launch.
     let (provider_config, provider_name, base_url, api_key) = provider_config_from_env();
-    let setup_runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("failed to build tokio runtime for provider bootstrap");
-    let (client, model_name, ollama_process) = setup_runtime
-        .block_on(bootstrap_provider(
-            &provider_config,
-            &engine_config.inference,
-        ))
-        .unwrap_or_else(|e| {
-            tracing::error!("Failed to initialise inference provider: {}", e);
-            eprintln!("[Parish] Failed to initialise inference provider: {}", e);
-            std::process::exit(1);
-        });
     let cloud_env = build_cloud_client_from_env(&engine_config.inference);
+
+    // Clone configs so they can be moved into the async setup spawn.
+    // Bootstrap itself is deferred until after the Tauri window opens so it
+    // can emit progress events to the frontend setup overlay.
+    let provider_config_for_spawn = provider_config.clone();
+    let inference_config_for_spawn = engine_config.inference.clone();
 
     // Build splash text from mod title + build info
     let game_title = game_mod
@@ -623,7 +646,7 @@ pub fn run() {
         provider_name,
         base_url,
         api_key,
-        model_name,
+        model_name: String::new(), // filled in after async bootstrap
         cloud_provider_name: cloud_env.provider_name,
         cloud_model_name: cloud_env.model_name,
         cloud_api_key: cloud_env.api_key,
@@ -655,7 +678,7 @@ pub fn run() {
         world: Mutex::new(world),
         npc_manager: Mutex::new(npc_manager),
         inference_queue: Mutex::new(None),
-        client: Mutex::new(client.clone()),
+        client: Mutex::new(None), // populated after async bootstrap completes
         cloud_client: Mutex::new(cloud_env.client),
         conversation: Mutex::new(ConversationRuntimeState::new()),
         debug_events: Mutex::new(std::collections::VecDeque::with_capacity(
@@ -678,7 +701,7 @@ pub fn run() {
         worker_handle: Mutex::new(None),
         editor: std::sync::Mutex::new(parish_core::ipc::editor::EditorSession::default()),
         save_lock: Mutex::new(None),
-        ollama_process: Mutex::new(ollama_process),
+        ollama_process: Mutex::new(parish_core::inference::client::OllamaProcess::none()),
         inference_config: engine_config.inference, // (#417) store TOML-configured timeouts
         config: Mutex::new(game_config),
     });
@@ -778,7 +801,53 @@ pub fn run() {
             // so tokio::spawn cannot be called directly here — we must go through
             // tauri::async_runtime::spawn, which uses the Tauri-managed tokio handle.
             let state_setup = Arc::clone(&state);
+            let handle_setup = handle.clone();
             tauri::async_runtime::spawn(async move {
+                // ── Bootstrap inference provider ─────────────────────────────
+                // Runs here (inside the async spawn) rather than synchronously in
+                // run() so the Tauri window is open and can receive setup-status /
+                // setup-progress events while Ollama is being installed/started.
+                {
+                    let progress = TauriProgress { app: handle_setup.clone() };
+                    match bootstrap_provider(
+                        &provider_config_for_spawn,
+                        &inference_config_for_spawn,
+                        &progress,
+                    )
+                    .await
+                    {
+                        Ok((client, model_name, ollama_process)) => {
+                            *state_setup.client.lock().await = client;
+                            *state_setup.ollama_process.lock().await = ollama_process;
+                            {
+                                let mut config = state_setup.config.lock().await;
+                                config.model_name = model_name;
+                                config.fill_missing_models_from_presets();
+                            }
+                            let _ = handle_setup.emit(
+                                events::EVENT_SETUP_DONE,
+                                events::SetupDonePayload {
+                                    success: true,
+                                    error: String::new(),
+                                },
+                            );
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to initialise inference provider: {}", e);
+                            let _ = handle_setup.emit(
+                                events::EVENT_SETUP_DONE,
+                                events::SetupDonePayload {
+                                    success: false,
+                                    error: e.to_string(),
+                                },
+                            );
+                            // Do not call process::exit — leave the window open so
+                            // the user can read the error in the setup overlay.
+                            return;
+                        }
+                    }
+                }
+
                 // Initialise inference queue now that the tokio runtime is running
                 {
                     let provider_name = {
@@ -1682,6 +1751,7 @@ fn provider_config_from_env() -> (ProviderConfig, String, String, Option<String>
 async fn bootstrap_provider(
     config: &ProviderConfig,
     inference_config: &parish_core::config::InferenceConfig,
+    progress: &dyn parish_core::inference::setup::SetupProgress,
 ) -> anyhow::Result<(
     Option<AnyClient>,
     String,
@@ -1697,11 +1767,10 @@ async fn bootstrap_provider(
         ));
     }
 
-    let progress = parish_core::inference::setup::StdoutProgress;
     let (client, model, process) = parish_core::inference::setup::setup_provider_client(
         config,
         inference_config, // (#417) use TOML-configured timeouts
-        &progress,
+        progress,
     )
     .await?;
     Ok((Some(client), model, process))

--- a/parish/crates/parish-tauri/src/lib.rs
+++ b/parish/crates/parish-tauri/src/lib.rs
@@ -441,7 +441,9 @@ impl parish_core::inference::setup::SetupProgress for TauriProgress {
         tracing::info!("{}", msg);
         let _ = self.app.emit(
             events::EVENT_SETUP_STATUS,
-            events::SetupStatusPayload { message: msg.to_string() },
+            events::SetupStatusPayload {
+                message: msg.to_string(),
+            },
         );
     }
 
@@ -456,7 +458,9 @@ impl parish_core::inference::setup::SetupProgress for TauriProgress {
         tracing::error!("{}", msg);
         let _ = self.app.emit(
             events::EVENT_SETUP_STATUS,
-            events::SetupStatusPayload { message: format!("Error: {}", msg) },
+            events::SetupStatusPayload {
+                message: format!("Error: {}", msg),
+            },
         );
     }
 }
@@ -571,10 +575,9 @@ pub fn run() {
     let (provider_config, provider_name, base_url, api_key) = provider_config_from_env();
     let cloud_env = build_cloud_client_from_env(&engine_config.inference);
 
-    // Clone configs so they can be moved into the async setup spawn.
-    // Bootstrap itself is deferred until after the Tauri window opens so it
-    // can emit progress events to the frontend setup overlay.
-    let provider_config_for_spawn = provider_config.clone();
+    // Clone inference config before it is moved into AppState so the async
+    // setup spawn can still reference it during bootstrap. provider_config
+    // itself is not stored in AppState and will be moved directly into the spawn.
     let inference_config_for_spawn = engine_config.inference.clone();
 
     // Build splash text from mod title + build info
@@ -801,16 +804,15 @@ pub fn run() {
             // so tokio::spawn cannot be called directly here — we must go through
             // tauri::async_runtime::spawn, which uses the Tauri-managed tokio handle.
             let state_setup = Arc::clone(&state);
-            let handle_setup = handle.clone();
             tauri::async_runtime::spawn(async move {
                 // ── Bootstrap inference provider ─────────────────────────────
                 // Runs here (inside the async spawn) rather than synchronously in
                 // run() so the Tauri window is open and can receive setup-status /
                 // setup-progress events while Ollama is being installed/started.
                 {
-                    let progress = TauriProgress { app: handle_setup.clone() };
+                    let progress = TauriProgress { app: handle.clone() };
                     match bootstrap_provider(
-                        &provider_config_for_spawn,
+                        &provider_config,
                         &inference_config_for_spawn,
                         &progress,
                     )
@@ -824,7 +826,7 @@ pub fn run() {
                                 config.model_name = model_name;
                                 config.fill_missing_models_from_presets();
                             }
-                            let _ = handle_setup.emit(
+                            let _ = handle.emit(
                                 events::EVENT_SETUP_DONE,
                                 events::SetupDonePayload {
                                     success: true,
@@ -834,7 +836,7 @@ pub fn run() {
                         }
                         Err(e) => {
                             tracing::error!("Failed to initialise inference provider: {}", e);
-                            let _ = handle_setup.emit(
+                            let _ = handle.emit(
                                 events::EVENT_SETUP_DONE,
                                 events::SetupDonePayload {
                                     success: false,


### PR DESCRIPTION
## Summary

- Moves the Ollama/inference setup messages from stdout/stderr to a full-screen GUI overlay in the Tauri desktop app
- The overlay appears immediately when the window opens, streams progress messages in real-time, then fades out when setup completes (or shows an error if it fails)
- Web and headless modes are unaffected — the overlay is a no-op outside of Tauri

## Changes

**Rust (`parish-tauri`)**
- `bootstrap_provider()` now accepts `&dyn SetupProgress` instead of hard-coding `StdoutProgress`, so the caller controls the reporter
- New `TauriProgress` struct emits `setup-status`, `setup-progress`, and `setup-done` Tauri events instead of writing to stdout
- Bootstrap is deferred from the synchronous `run()` into the async `.setup()` spawn so the Tauri `AppHandle` exists before progress events fire; on failure the window stays open showing the error rather than calling `process::exit`
- Three new event constants + payload types in `events.rs`

**Frontend (`parish/apps/ui`)**
- `SetupOverlay.svelte` — full-screen overlay using the existing triquetra knot spinner (scaled up to 6 rem), current status message as an animated phrase below it, a download progress bar for model pulls, a scrollable log of past messages, and an error state with instructions; fades out on success
- `ipc.ts` — exports `isTauri()` and three new typed event listeners (`onSetupStatus`, `onSetupProgress`, `onSetupDone`)
- `+page.svelte` — mounts `<SetupOverlay />`; fully self-contained, no props needed

## Test plan

- [ ] `cargo check -p parish-inference -p parish-config` passes (non-GTK crates verified clean)
- [ ] `just run` — Tauri desktop: setup overlay appears immediately on first open, progress messages stream in as Ollama is checked/started and the model pulled, overlay fades out, game becomes interactive
- [ ] Simulate bootstrap failure: overlay shows error message, window stays open
- [ ] `just run-headless` — CLI unchanged, still uses `StdoutProgress`
- [ ] Web mode — no setup overlay renders

https://claude.ai/code/session_01U47m1Rapqiy83QonUf438e

---
_Generated by [Claude Code](https://claude.ai/code/session_01U47m1Rapqiy83QonUf438e)_