### PR TITLE
fix(test): use combobox role in InputField regression test

### DIFF
--- a/parish/apps/ui/src/components/InputField.test.ts
+++ b/parish/apps/ui/src/components/InputField.test.ts
@@ -612,7 +612,7 @@ describe('InputField', () => {
 
 		it('syncs editorText after npc chip click so send button is enabled (#684)', async () => {
 			const { container, getByRole } = render(InputField);
-			const editor = getByRole('textbox');
+			const editor = getByRole('combobox');
 			const sendBtn = getByRole('button', { name: 'Send' }) as HTMLButtonElement;
 			expect(sendBtn.disabled).toBe(true);
 


### PR DESCRIPTION
## Summary

- The a11y commit (#859) promoted the InputField editor from `role="textbox"` to `role="combobox"` and updated most test queries, but missed the regression test added by #857 (`syncs editorText after npc chip click so send button is enabled`)
- This caused the `ui-quality` CI job to fail on main with `Unable to find an accessible element with the role "textbox"`
- One-line fix: `getByRole('textbox')` → `getByRole('combobox')` at `InputField.test.ts:615`

## Test plan

- [x] `npx vitest run` from `parish/apps/ui` — 22 files, 292 tests, all pass

https://claude.ai/code/session_01AQpYmwJo9B7TBjtcKZf74T

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQpYmwJo9B7TBjtcKZf74T)_