### PR TITLE
refactor: replace if-else command dispatch chain with match statement

### DIFF
--- a/parish/crates/parish-input/src/lib.rs
+++ b/parish/crates/parish-input/src/lib.rs
@@ -64,6 +64,32 @@ mod tests {
         assert_eq!(parse_system_command("/help"), Some(Command::Help));
     }
 
+    /// Zero-argument commands must NOT match when trailing text is present.
+    /// Regression: the refactored match split on the first space, so
+    /// `/pause foo` would match when it should not.
+    #[test]
+    fn test_zero_arg_commands_reject_trailing_text() {
+        assert_eq!(parse_system_command("/pause foo"), None);
+        assert_eq!(parse_system_command("/resume now"), None);
+        assert_eq!(parse_system_command("/quit please"), None);
+        assert_eq!(parse_system_command("/save me"), None);
+        assert_eq!(parse_system_command("/branches list"), None);
+        assert_eq!(parse_system_command("/log all"), None);
+        assert_eq!(parse_system_command("/status detailed"), None);
+        assert_eq!(parse_system_command("/where am I"), None);
+        assert_eq!(parse_system_command("/help me"), None);
+        assert_eq!(parse_system_command("/irish on"), None);
+        assert_eq!(parse_system_command("/improv mode"), None);
+        assert_eq!(parse_system_command("/about us"), None);
+        assert_eq!(parse_system_command("/designer mode"), None);
+        assert_eq!(parse_system_command("/npcs here"), None);
+        assert_eq!(parse_system_command("/time now"), None);
+        assert_eq!(parse_system_command("/new game"), None);
+        assert_eq!(parse_system_command("/tick once"), None);
+        assert_eq!(parse_system_command("/flags all"), None);
+        assert_eq!(parse_system_command("/session start"), None);
+    }
+
     #[test]
     fn test_parse_unknown_command() {
         assert_eq!(parse_system_command("/unknown"), None);

--- a/parish/crates/parish-input/src/parser.rs
+++ b/parish/crates/parish-input/src/parser.rs
@@ -29,24 +29,26 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
     };
 
     match keyword {
-        "/pause" => Some(Command::Pause),
-        "/resume" => Some(Command::Resume),
-        "/quit" => Some(Command::Quit),
-        "/save" => Some(Command::Save),
-        "/branches" => Some(Command::Branches),
-        "/log" => Some(Command::Log),
-        "/status" | "/where" => Some(Command::Status),
-        "/help" => Some(Command::Help),
-        "/irish" => Some(Command::ToggleSidebar),
-        "/improv" => Some(Command::ToggleImprov),
-        "/about" => Some(Command::About),
-        "/designer" => Some(Command::Designer),
-        "/npcs" => Some(Command::NpcsHere),
-        "/time" => Some(Command::Time),
-        "/new" => Some(Command::NewGame),
-        "/tick" => Some(Command::Tick),
-        "/flags" => Some(Command::Flags),
-        "/session" | "/tune" | "/music" | "/fiddle" | "/seisiun" => Some(Command::Session),
+        "/pause" if rest_trimmed.is_empty() => Some(Command::Pause),
+        "/resume" if rest_trimmed.is_empty() => Some(Command::Resume),
+        "/quit" if rest_trimmed.is_empty() => Some(Command::Quit),
+        "/save" if rest_trimmed.is_empty() => Some(Command::Save),
+        "/branches" if rest_trimmed.is_empty() => Some(Command::Branches),
+        "/log" if rest_trimmed.is_empty() => Some(Command::Log),
+        "/status" | "/where" if rest_trimmed.is_empty() => Some(Command::Status),
+        "/help" if rest_trimmed.is_empty() => Some(Command::Help),
+        "/irish" if rest_trimmed.is_empty() => Some(Command::ToggleSidebar),
+        "/improv" if rest_trimmed.is_empty() => Some(Command::ToggleImprov),
+        "/about" if rest_trimmed.is_empty() => Some(Command::About),
+        "/designer" if rest_trimmed.is_empty() => Some(Command::Designer),
+        "/npcs" if rest_trimmed.is_empty() => Some(Command::NpcsHere),
+        "/time" if rest_trimmed.is_empty() => Some(Command::Time),
+        "/new" if rest_trimmed.is_empty() => Some(Command::NewGame),
+        "/tick" if rest_trimmed.is_empty() => Some(Command::Tick),
+        "/flags" if rest_trimmed.is_empty() => Some(Command::Flags),
+        "/session" | "/tune" | "/music" | "/fiddle" | "/seisiun" if rest_trimmed.is_empty() => {
+            Some(Command::Session)
+        }
 
         "/fork" => {
             if rest_trimmed.is_empty() {

--- a/parish/crates/parish-input/src/parser.rs
+++ b/parish/crates/parish-input/src/parser.rs
@@ -20,286 +20,256 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
     let trimmed = input.trim();
     let lower = trimmed.to_lowercase();
 
-    if lower == "/pause" {
-        Some(Command::Pause)
-    } else if lower == "/resume" {
-        Some(Command::Resume)
-    } else if lower == "/quit" {
-        Some(Command::Quit)
-    } else if lower == "/save" {
-        Some(Command::Save)
-    } else if lower == "/fork" || lower.starts_with("/fork ") {
-        let name = trimmed
-            .get("/fork".len()..)
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if name.is_empty() {
-            Some(Command::Help) // bare /fork → show help
-        } else {
-            match validate_branch_name(&name) {
-                Ok(valid) => Some(Command::Fork(valid)),
-                Err(msg) => Some(Command::InvalidBranchName(msg)),
+    // Split into the command keyword and the remainder argument string.
+    // e.g. "/map clonalis" → keyword="/map", rest="clonalis"
+    //      "/map"          → keyword="/map", rest=""
+    let (keyword, rest_trimmed) = match lower.find(' ') {
+        Some(pos) => (&lower[..pos], trimmed[pos..].trim()),
+        None => (lower.as_str(), ""),
+    };
+
+    match keyword {
+        "/pause" => Some(Command::Pause),
+        "/resume" => Some(Command::Resume),
+        "/quit" => Some(Command::Quit),
+        "/save" => Some(Command::Save),
+        "/branches" => Some(Command::Branches),
+        "/log" => Some(Command::Log),
+        "/status" | "/where" => Some(Command::Status),
+        "/help" => Some(Command::Help),
+        "/irish" => Some(Command::ToggleSidebar),
+        "/improv" => Some(Command::ToggleImprov),
+        "/about" => Some(Command::About),
+        "/designer" => Some(Command::Designer),
+        "/npcs" => Some(Command::NpcsHere),
+        "/time" => Some(Command::Time),
+        "/new" => Some(Command::NewGame),
+        "/tick" => Some(Command::Tick),
+        "/flags" => Some(Command::Flags),
+        "/session" | "/tune" | "/music" | "/fiddle" | "/seisiun" => Some(Command::Session),
+
+        "/fork" => {
+            if rest_trimmed.is_empty() {
+                Some(Command::Help) // bare /fork → show help
+            } else {
+                match validate_branch_name(rest_trimmed) {
+                    Ok(valid) => Some(Command::Fork(valid)),
+                    Err(msg) => Some(Command::InvalidBranchName(msg)),
+                }
             }
         }
-    } else if lower == "/load" || lower.starts_with("/load ") {
-        let name = trimmed
-            .get("/load".len()..)
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if name.is_empty() {
-            Some(Command::Load(String::new())) // empty string = show save picker
-        } else {
-            match validate_branch_name(&name) {
-                Ok(valid) => Some(Command::Load(valid)),
-                Err(msg) => Some(Command::InvalidBranchName(msg)),
+
+        "/load" => {
+            if rest_trimmed.is_empty() {
+                Some(Command::Load(String::new())) // empty string = show save picker
+            } else {
+                match validate_branch_name(rest_trimmed) {
+                    Ok(valid) => Some(Command::Load(valid)),
+                    Err(msg) => Some(Command::InvalidBranchName(msg)),
+                }
             }
         }
-    } else if lower == "/branches" {
-        Some(Command::Branches)
-    } else if lower == "/log" {
-        Some(Command::Log)
-    } else if lower == "/status" {
-        Some(Command::Status)
-    } else if lower == "/help" {
-        Some(Command::Help)
-    } else if lower == "/irish" {
-        Some(Command::ToggleSidebar)
-    } else if lower == "/improv" {
-        Some(Command::ToggleImprov)
-    } else if lower == "/about" {
-        Some(Command::About)
-    } else if lower == "/map" {
-        Some(Command::Map(None))
-    } else if lower.starts_with("/map ") {
-        let arg = trimmed
-            .get("/map ".len()..)
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if arg.is_empty() {
-            Some(Command::Map(None))
-        } else {
-            Some(Command::Map(Some(arg)))
+
+        "/map" => {
+            if rest_trimmed.is_empty() {
+                Some(Command::Map(None))
+            } else {
+                Some(Command::Map(Some(rest_trimmed.to_string())))
+            }
         }
-    } else if lower == "/designer" {
-        Some(Command::Designer)
-    } else if lower == "/npcs" {
-        Some(Command::NpcsHere)
-    } else if lower == "/time" {
-        Some(Command::Time)
-    } else if lower == "/where" {
-        Some(Command::Status)
-    } else if lower == "/wait" {
-        Some(Command::Wait(15))
-    } else if lower.starts_with("/wait ") {
-        let mins = trimmed[6..].trim().parse::<u32>().unwrap_or(15);
-        Some(Command::Wait(mins))
-    } else if lower == "/new" {
-        Some(Command::NewGame)
-    } else if lower == "/tick" {
-        Some(Command::Tick)
-    } else if lower == "/theme" {
-        Some(Command::Theme(None))
-    } else if lower.starts_with("/theme ") {
-        let arg = trimmed
-            .get("/theme ".len()..)
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if arg.is_empty() {
-            Some(Command::Theme(None))
-        } else {
-            Some(Command::Theme(Some(arg)))
+
+        "/wait" => {
+            let mins = rest_trimmed.parse::<u32>().unwrap_or(15);
+            Some(Command::Wait(mins))
         }
-    } else if lower == "/unexplored" {
-        Some(Command::Unexplored(None))
-    } else if lower.starts_with("/unexplored ") {
-        let arg = trimmed
-            .get("/unexplored ".len()..)
-            .unwrap_or("")
-            .trim()
-            .to_lowercase();
-        match arg.as_str() {
-            "reveal" | "show" | "on" => Some(Command::Unexplored(Some(true))),
-            "hide" | "off" => Some(Command::Unexplored(Some(false))),
-            _ => Some(Command::Unexplored(None)),
+
+        "/theme" => {
+            if rest_trimmed.is_empty() {
+                Some(Command::Theme(None))
+            } else {
+                Some(Command::Theme(Some(rest_trimmed.to_string())))
+            }
         }
-    } else if let Some(cmd) = parse_category_command(trimmed, &lower) {
-        Some(cmd)
-    } else if lower == "/preset" {
-        Some(Command::ShowPreset)
-    } else if lower.starts_with("/preset ") {
-        let name = trimmed
-            .get("/preset ".len()..)
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if name.is_empty() {
-            Some(Command::ShowPreset)
-        } else {
-            Some(Command::ApplyPreset(name))
+
+        "/unexplored" => {
+            let arg = rest_trimmed.to_lowercase();
+            match arg.as_str() {
+                "reveal" | "show" | "on" => Some(Command::Unexplored(Some(true))),
+                "hide" | "off" => Some(Command::Unexplored(Some(false))),
+                _ => Some(Command::Unexplored(None)),
+            }
         }
-    } else if lower == "/provider" {
-        Some(Command::ShowProvider)
-    } else if lower.starts_with("/provider ") {
-        let name = trimmed
-            .get("/provider ".len()..)
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if name.is_empty() {
-            Some(Command::ShowProvider)
-        } else {
-            Some(Command::SetProvider(name))
+
+        "/preset" => {
+            if rest_trimmed.is_empty() {
+                Some(Command::ShowPreset)
+            } else {
+                Some(Command::ApplyPreset(rest_trimmed.to_string()))
+            }
         }
-    } else if lower == "/model" {
-        Some(Command::ShowModel)
-    } else if lower.starts_with("/model ") {
-        let name = trimmed
-            .get("/model ".len()..)
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if name.is_empty() {
-            Some(Command::ShowModel)
-        } else {
-            Some(Command::SetModel(name))
+
+        "/provider" => {
+            if rest_trimmed.is_empty() {
+                Some(Command::ShowProvider)
+            } else {
+                Some(Command::SetProvider(rest_trimmed.to_string()))
+            }
         }
-    } else if lower == "/key" {
-        Some(Command::ShowKey)
-    } else if lower.starts_with("/key ") {
-        let value = trimmed
-            .get("/key ".len()..)
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if value.is_empty() {
-            Some(Command::ShowKey)
-        } else {
-            Some(Command::SetKey(value))
+
+        "/model" => {
+            if rest_trimmed.is_empty() {
+                Some(Command::ShowModel)
+            } else {
+                Some(Command::SetModel(rest_trimmed.to_string()))
+            }
         }
-    } else if lower == "/spinner" {
-        Some(Command::Spinner(SPINNER_DEFAULT_SECS))
-    } else if lower.starts_with("/spinner ") {
-        let secs = trimmed
-            .get("/spinner ".len()..)
-            .unwrap_or("")
-            .trim()
-            .parse::<u64>()
-            .unwrap_or(SPINNER_DEFAULT_SECS)
-            .min(SPINNER_MAX_SECS);
-        Some(Command::Spinner(secs))
-    } else if lower == "/debug" {
-        Some(Command::Debug(None))
-    } else if lower.starts_with("/debug ") {
-        let sub = trimmed
-            .get("/debug ".len()..)
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if sub.is_empty() {
-            Some(Command::Debug(None))
-        } else {
-            Some(Command::Debug(Some(sub)))
+
+        "/key" => {
+            if rest_trimmed.is_empty() {
+                Some(Command::ShowKey)
+            } else {
+                Some(Command::SetKey(rest_trimmed.to_string()))
+            }
         }
-    } else if lower == "/speed" {
-        Some(Command::ShowSpeed)
-    } else if lower.starts_with("/speed ") {
-        let arg = trimmed.get("/speed ".len()..).unwrap_or("").trim();
-        match GameSpeed::from_name(arg) {
-            Some(speed) => Some(Command::SetSpeed(speed)),
-            None if arg.is_empty() => Some(Command::ShowSpeed),
-            None => Some(Command::InvalidSpeed(arg.to_string())),
+
+        "/spinner" => {
+            let secs = rest_trimmed
+                .parse::<u64>()
+                .unwrap_or(SPINNER_DEFAULT_SECS)
+                .min(SPINNER_MAX_SECS);
+            Some(Command::Spinner(secs))
         }
-    } else if lower == "/cloud" {
-        Some(Command::ShowCloud)
-    } else if lower.starts_with("/cloud ") {
-        let rest = trimmed.get("/cloud ".len()..).unwrap_or("").trim();
-        let rest_lower = rest.to_lowercase();
-        if rest_lower.starts_with("provider ") {
-            let name = rest
-                .get("provider ".len()..)
-                .unwrap_or("")
-                .trim()
-                .to_string();
-            if name.is_empty() {
+
+        "/debug" => {
+            if rest_trimmed.is_empty() {
+                Some(Command::Debug(None))
+            } else {
+                Some(Command::Debug(Some(rest_trimmed.to_string())))
+            }
+        }
+
+        "/speed" => {
+            if rest_trimmed.is_empty() {
+                Some(Command::ShowSpeed)
+            } else {
+                match GameSpeed::from_name(rest_trimmed) {
+                    Some(speed) => Some(Command::SetSpeed(speed)),
+                    None => Some(Command::InvalidSpeed(rest_trimmed.to_string())),
+                }
+            }
+        }
+
+        "/cloud" => {
+            if rest_trimmed.is_empty() {
                 Some(Command::ShowCloud)
             } else {
-                Some(Command::SetCloudProvider(name))
+                parse_cloud_subcommand(rest_trimmed)
             }
-        } else if rest_lower == "provider" {
-            Some(Command::ShowCloud)
-        } else if rest_lower.starts_with("model ") {
-            let name = rest.get("model ".len()..).unwrap_or("").trim().to_string();
-            if name.is_empty() {
+        }
+
+        "/weather" => {
+            if rest_trimmed.is_empty() {
+                Some(Command::Weather(None))
+            } else {
+                Some(Command::Weather(Some(rest_trimmed.to_string())))
+            }
+        }
+
+        "/flag" => {
+            if rest_trimmed.is_empty() || rest_trimmed.to_lowercase() == "list" {
+                Some(Command::Flag(FlagSubcommand::List))
+            } else {
+                parse_flag_subcommand(rest_trimmed)
+            }
+        }
+
+        // Dot-notation per-category commands: /model.<cat>, /provider.<cat>, /key.<cat>
+        kw if kw.starts_with("/model.")
+            || kw.starts_with("/provider.")
+            || kw.starts_with("/key.") =>
+        {
+            // Re-assemble the full trimmed string for parse_category_command since it
+            // expects the original (potentially mixed-case) trimmed input alongside the
+            // lowercase version for prefix-stripping.
+            parse_category_command(trimmed, &lower)
+        }
+
+        _ => None,
+    }
+}
+
+/// Parses `/cloud <subcommand>` arguments.
+fn parse_cloud_subcommand(rest: &str) -> Option<Command> {
+    let rest_lower = rest.to_lowercase();
+
+    // Split subcommand keyword from its argument.
+    let (sub_kw, sub_arg) = match rest_lower.find(' ') {
+        Some(pos) => (&rest_lower[..pos], rest[pos..].trim()),
+        None => (rest_lower.as_str(), ""),
+    };
+
+    match sub_kw {
+        "provider" => {
+            if sub_arg.is_empty() {
+                Some(Command::ShowCloud)
+            } else {
+                Some(Command::SetCloudProvider(sub_arg.to_string()))
+            }
+        }
+        "model" => {
+            if sub_arg.is_empty() {
                 Some(Command::ShowCloudModel)
             } else {
-                Some(Command::SetCloudModel(name))
+                Some(Command::SetCloudModel(sub_arg.to_string()))
             }
-        } else if rest_lower == "model" {
-            Some(Command::ShowCloudModel)
-        } else if rest_lower.starts_with("key ") {
-            let value = rest.get("key ".len()..).unwrap_or("").trim().to_string();
-            if value.is_empty() {
+        }
+        "key" => {
+            if sub_arg.is_empty() {
                 Some(Command::ShowCloudKey)
             } else {
-                Some(Command::SetCloudKey(value))
+                Some(Command::SetCloudKey(sub_arg.to_string()))
             }
-        } else if rest_lower == "key" {
-            Some(Command::ShowCloudKey)
-        } else {
-            Some(Command::ShowCloud)
         }
-    } else if lower == "/flags" {
-        Some(Command::Flags)
-    } else if lower == "/weather" {
-        Some(Command::Weather(None))
-    } else if lower.starts_with("/weather ") {
-        let arg = trimmed
-            .get("/weather ".len()..)
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        if arg.is_empty() {
-            Some(Command::Weather(None))
-        } else {
-            Some(Command::Weather(Some(arg)))
-        }
-    } else if matches!(
-        lower.as_str(),
-        "/session" | "/tune" | "/music" | "/fiddle" | "/seisiun"
-    ) {
-        Some(Command::Session)
-    } else if lower == "/flag" || lower == "/flag list" {
-        Some(Command::Flag(FlagSubcommand::List))
-    } else if lower.starts_with("/flag ") {
-        let rest = trimmed.get("/flag ".len()..).unwrap_or("").trim();
-        let rest_lower = rest.to_lowercase();
-        if rest_lower.starts_with("enable ") {
-            let name = rest.get("enable ".len()..).unwrap_or("").trim();
-            match validate_flag_name(name) {
-                Ok(valid) => Some(Command::Flag(FlagSubcommand::Enable(valid))),
-                Err(msg) => Some(Command::InvalidFlagName(msg)),
+        _ => Some(Command::ShowCloud),
+    }
+}
+
+/// Parses `/flag <subcommand>` arguments (enable/disable/list).
+fn parse_flag_subcommand(rest: &str) -> Option<Command> {
+    let rest_lower = rest.to_lowercase();
+
+    let (sub_kw, sub_arg) = match rest_lower.find(' ') {
+        Some(pos) => (&rest_lower[..pos], rest[pos..].trim()),
+        None => (rest_lower.as_str(), ""),
+    };
+
+    match sub_kw {
+        "enable" => {
+            if sub_arg.is_empty() {
+                // `/flag enable` with no name → show list
+                Some(Command::Flag(FlagSubcommand::List))
+            } else {
+                match validate_flag_name(sub_arg) {
+                    Ok(valid) => Some(Command::Flag(FlagSubcommand::Enable(valid))),
+                    Err(msg) => Some(Command::InvalidFlagName(msg)),
+                }
             }
-        } else if rest_lower.starts_with("disable ") {
-            let name = rest.get("disable ".len()..).unwrap_or("").trim();
-            match validate_flag_name(name) {
-                Ok(valid) => Some(Command::Flag(FlagSubcommand::Disable(valid))),
-                Err(msg) => Some(Command::InvalidFlagName(msg)),
-            }
-        } else if rest_lower == "enable" || rest_lower == "disable" || rest_lower == "list" {
-            Some(Command::Flag(FlagSubcommand::List))
-        } else {
-            // `/flag <name>` without enable/disable — treat as usage error
-            Some(Command::InvalidFlagName(format!(
-                "Unknown flag sub-command '{}'. Use: /flag enable <name>, /flag disable <name>, /flag list",
-                rest
-            )))
         }
-    } else {
-        None
+        "disable" => {
+            if sub_arg.is_empty() {
+                Some(Command::Flag(FlagSubcommand::List))
+            } else {
+                match validate_flag_name(sub_arg) {
+                    Ok(valid) => Some(Command::Flag(FlagSubcommand::Disable(valid))),
+                    Err(msg) => Some(Command::InvalidFlagName(msg)),
+                }
+            }
+        }
+        "list" => Some(Command::Flag(FlagSubcommand::List)),
+        _ => Some(Command::InvalidFlagName(format!(
+            "Unknown flag sub-command '{}'. Use: /flag enable <name>, /flag disable <name>, /flag list",
+            rest
+        ))),
     }
 }
 

--- a/parish/crates/parish-input/src/parser.rs
+++ b/parish/crates/parish-input/src/parser.rs
@@ -28,73 +28,55 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
         None => (lower.as_str(), ""),
     };
 
-    match keyword {
-        "/pause" if rest_trimmed.is_empty() => Some(Command::Pause),
-        "/resume" if rest_trimmed.is_empty() => Some(Command::Resume),
-        "/quit" if rest_trimmed.is_empty() => Some(Command::Quit),
-        "/save" if rest_trimmed.is_empty() => Some(Command::Save),
-        "/branches" if rest_trimmed.is_empty() => Some(Command::Branches),
-        "/log" if rest_trimmed.is_empty() => Some(Command::Log),
-        "/status" | "/where" if rest_trimmed.is_empty() => Some(Command::Status),
-        "/help" if rest_trimmed.is_empty() => Some(Command::Help),
-        "/irish" if rest_trimmed.is_empty() => Some(Command::ToggleSidebar),
-        "/improv" if rest_trimmed.is_empty() => Some(Command::ToggleImprov),
-        "/about" if rest_trimmed.is_empty() => Some(Command::About),
-        "/designer" if rest_trimmed.is_empty() => Some(Command::Designer),
-        "/npcs" if rest_trimmed.is_empty() => Some(Command::NpcsHere),
-        "/time" if rest_trimmed.is_empty() => Some(Command::Time),
-        "/new" if rest_trimmed.is_empty() => Some(Command::NewGame),
-        "/tick" if rest_trimmed.is_empty() => Some(Command::Tick),
-        "/flags" if rest_trimmed.is_empty() => Some(Command::Flags),
-        "/session" | "/tune" | "/music" | "/fiddle" | "/seisiun" if rest_trimmed.is_empty() => {
+    match (keyword, rest_trimmed) {
+        // Zero-argument commands
+        ("/pause", "") => Some(Command::Pause),
+        ("/resume", "") => Some(Command::Resume),
+        ("/quit", "") => Some(Command::Quit),
+        ("/save", "") => Some(Command::Save),
+        ("/branches", "") => Some(Command::Branches),
+        ("/log", "") => Some(Command::Log),
+        ("/status", "") | ("/where", "") => Some(Command::Status),
+        ("/help", "") => Some(Command::Help),
+        ("/irish", "") => Some(Command::ToggleSidebar),
+        ("/improv", "") => Some(Command::ToggleImprov),
+        ("/about", "") => Some(Command::About),
+        ("/designer", "") => Some(Command::Designer),
+        ("/npcs", "") => Some(Command::NpcsHere),
+        ("/time", "") => Some(Command::Time),
+        ("/new", "") => Some(Command::NewGame),
+        ("/tick", "") => Some(Command::Tick),
+        ("/flags", "") => Some(Command::Flags),
+        ("/session", "") | ("/tune", "") | ("/music", "") | ("/fiddle", "") | ("/seisiun", "") => {
             Some(Command::Session)
         }
 
-        "/fork" => {
-            if rest_trimmed.is_empty() {
-                Some(Command::Help) // bare /fork → show help
-            } else {
-                match validate_branch_name(rest_trimmed) {
-                    Ok(valid) => Some(Command::Fork(valid)),
-                    Err(msg) => Some(Command::InvalidBranchName(msg)),
-                }
-            }
-        }
+        // Commands with arguments
+        ("/fork", "") => Some(Command::Help), // bare /fork → show help
+        ("/fork", rest) => match validate_branch_name(rest) {
+            Ok(valid) => Some(Command::Fork(valid)),
+            Err(msg) => Some(Command::InvalidBranchName(msg)),
+        },
 
-        "/load" => {
-            if rest_trimmed.is_empty() {
-                Some(Command::Load(String::new())) // empty string = show save picker
-            } else {
-                match validate_branch_name(rest_trimmed) {
-                    Ok(valid) => Some(Command::Load(valid)),
-                    Err(msg) => Some(Command::InvalidBranchName(msg)),
-                }
-            }
-        }
+        ("/load", "") => Some(Command::Load(String::new())), // empty string = show save picker
+        ("/load", rest) => match validate_branch_name(rest) {
+            Ok(valid) => Some(Command::Load(valid)),
+            Err(msg) => Some(Command::InvalidBranchName(msg)),
+        },
 
-        "/map" => {
-            if rest_trimmed.is_empty() {
-                Some(Command::Map(None))
-            } else {
-                Some(Command::Map(Some(rest_trimmed.to_string())))
-            }
-        }
+        ("/map", "") => Some(Command::Map(None)),
+        ("/map", rest) => Some(Command::Map(Some(rest.to_string()))),
 
-        "/wait" => {
-            let mins = rest_trimmed.parse::<u32>().unwrap_or(15);
+        ("/wait", rest) => {
+            let mins = rest.parse::<u32>().unwrap_or(15);
             Some(Command::Wait(mins))
         }
 
-        "/theme" => {
-            if rest_trimmed.is_empty() {
-                Some(Command::Theme(None))
-            } else {
-                Some(Command::Theme(Some(rest_trimmed.to_string())))
-            }
-        }
+        ("/theme", "") => Some(Command::Theme(None)),
+        ("/theme", rest) => Some(Command::Theme(Some(rest.to_string()))),
 
-        "/unexplored" => {
-            let arg = rest_trimmed.to_lowercase();
+        ("/unexplored", rest) => {
+            let arg = rest.to_lowercase();
             match arg.as_str() {
                 "reveal" | "show" | "on" => Some(Command::Unexplored(Some(true))),
                 "hide" | "off" => Some(Command::Unexplored(Some(false))),
@@ -102,93 +84,52 @@ pub fn parse_system_command(input: &str) -> Option<Command> {
             }
         }
 
-        "/preset" => {
-            if rest_trimmed.is_empty() {
-                Some(Command::ShowPreset)
-            } else {
-                Some(Command::ApplyPreset(rest_trimmed.to_string()))
-            }
-        }
+        ("/preset", "") => Some(Command::ShowPreset),
+        ("/preset", rest) => Some(Command::ApplyPreset(rest.to_string())),
 
-        "/provider" => {
-            if rest_trimmed.is_empty() {
-                Some(Command::ShowProvider)
-            } else {
-                Some(Command::SetProvider(rest_trimmed.to_string()))
-            }
-        }
+        ("/provider", "") => Some(Command::ShowProvider),
+        ("/provider", rest) => Some(Command::SetProvider(rest.to_string())),
 
-        "/model" => {
-            if rest_trimmed.is_empty() {
-                Some(Command::ShowModel)
-            } else {
-                Some(Command::SetModel(rest_trimmed.to_string()))
-            }
-        }
+        ("/model", "") => Some(Command::ShowModel),
+        ("/model", rest) => Some(Command::SetModel(rest.to_string())),
 
-        "/key" => {
-            if rest_trimmed.is_empty() {
-                Some(Command::ShowKey)
-            } else {
-                Some(Command::SetKey(rest_trimmed.to_string()))
-            }
-        }
+        ("/key", "") => Some(Command::ShowKey),
+        ("/key", rest) => Some(Command::SetKey(rest.to_string())),
 
-        "/spinner" => {
-            let secs = rest_trimmed
+        ("/spinner", rest) => {
+            let secs = rest
                 .parse::<u64>()
                 .unwrap_or(SPINNER_DEFAULT_SECS)
                 .min(SPINNER_MAX_SECS);
             Some(Command::Spinner(secs))
         }
 
-        "/debug" => {
-            if rest_trimmed.is_empty() {
-                Some(Command::Debug(None))
-            } else {
-                Some(Command::Debug(Some(rest_trimmed.to_string())))
-            }
-        }
+        ("/debug", "") => Some(Command::Debug(None)),
+        ("/debug", rest) => Some(Command::Debug(Some(rest.to_string()))),
 
-        "/speed" => {
-            if rest_trimmed.is_empty() {
-                Some(Command::ShowSpeed)
-            } else {
-                match GameSpeed::from_name(rest_trimmed) {
-                    Some(speed) => Some(Command::SetSpeed(speed)),
-                    None => Some(Command::InvalidSpeed(rest_trimmed.to_string())),
-                }
-            }
-        }
+        ("/speed", "") => Some(Command::ShowSpeed),
+        ("/speed", rest) => match GameSpeed::from_name(rest) {
+            Some(speed) => Some(Command::SetSpeed(speed)),
+            None => Some(Command::InvalidSpeed(rest.to_string())),
+        },
 
-        "/cloud" => {
-            if rest_trimmed.is_empty() {
-                Some(Command::ShowCloud)
-            } else {
-                parse_cloud_subcommand(rest_trimmed)
-            }
-        }
+        ("/cloud", "") => Some(Command::ShowCloud),
+        ("/cloud", rest) => parse_cloud_subcommand(rest),
 
-        "/weather" => {
-            if rest_trimmed.is_empty() {
-                Some(Command::Weather(None))
-            } else {
-                Some(Command::Weather(Some(rest_trimmed.to_string())))
-            }
-        }
+        ("/weather", "") => Some(Command::Weather(None)),
+        ("/weather", rest) => Some(Command::Weather(Some(rest.to_string()))),
 
-        "/flag" => {
-            if rest_trimmed.is_empty() || rest_trimmed.to_lowercase() == "list" {
-                Some(Command::Flag(FlagSubcommand::List))
-            } else {
-                parse_flag_subcommand(rest_trimmed)
-            }
+        ("/flag", "") => Some(Command::Flag(FlagSubcommand::List)),
+        ("/flag", rest) if rest.to_lowercase() == "list" => {
+            Some(Command::Flag(FlagSubcommand::List))
         }
+        ("/flag", rest) => parse_flag_subcommand(rest),
 
         // Dot-notation per-category commands: /model.<cat>, /provider.<cat>, /key.<cat>
-        kw if kw.starts_with("/model.")
-            || kw.starts_with("/provider.")
-            || kw.starts_with("/key.") =>
+        (kw, _)
+            if kw.starts_with("/model.")
+                || kw.starts_with("/provider.")
+                || kw.starts_with("/key.") =>
         {
             // Re-assemble the full trimmed string for parse_category_command since it
             // expects the original (potentially mixed-case) trimmed input alongside the


### PR DESCRIPTION
Refactors the 100+ line if-else command parsing chain to a `match` statement for maintainability.

## What changed

- `parse_system_command` in `parish/crates/parish-input/src/parser.rs` now splits the input into a command keyword and trailing arguments, then uses a single `match` on the keyword.
- Two new private helpers extracted: `parse_cloud_subcommand` and `parse_flag_subcommand`, keeping the main function readable.
- `parse_category_command` (dot-notation `/model.<cat>` etc.) is unchanged — it is delegated via a match guard arm.
- Pure refactor: no behaviour changes. All 114 unit tests + 6 integration tests pass.

## Commands run

```
cargo check -p parish-input
cargo test -p parish-input
cargo fmt -- --check
cargo clippy -p parish-input
```

Fixes #112.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1c7EqJxbFJNrZmbwSG7ud)_