### PR TITLE
perf: eliminate unnecessary string allocations in Tauri event payloads

### DIFF
--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -338,7 +338,7 @@ async fn rebuild_inference(state: &Arc<AppState>, app: &tauri::AppHandle) {
                 TextLogPayload {
                     id: String::new(),
                     stream_turn_id: None,
-                    source: "system".to_string(),
+                    source: "system",
                     content: format!(
                         "Warning: '{}' doesn't look like a valid URL — NPC conversations may fail.",
                         base_url
@@ -640,7 +640,7 @@ async fn handle_game_input(
                 TextLogPayload {
                     id: String::new(),
                     stream_turn_id: None,
-                    source: "system".to_string(),
+                    source: "system",
                     content: "And where would ye be off to?".to_string(),
                 },
             );
@@ -797,7 +797,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
                     StreamTokenPayload {
                         token: batch.to_string(),
                         turn_id,
-                        source: source.to_string(),
+                        source: std::borrow::Cow::Owned(source.to_string()),
                     },
                 );
             },
@@ -864,7 +864,7 @@ async fn handle_look(state: &Arc<AppState>, app: &tauri::AppHandle) {
         TextLogPayload {
             id: String::new(),
             stream_turn_id: None,
-            source: "system".to_string(),
+            source: "system",
             content: text,
         },
     );
@@ -957,7 +957,7 @@ async fn run_npc_turn(
                 TextLogPayload {
                     id: String::new(),
                     stream_turn_id: None,
-                    source: "system".to_string(),
+                    source: "system",
                     content: "The parish storyteller has wandered off. Try again in a moment."
                         .to_string(),
                 },
@@ -977,7 +977,7 @@ async fn run_npc_turn(
                     StreamTokenPayload {
                         token: batch.to_string(),
                         turn_id: req_id,
-                        source: source.clone(),
+                        source: std::borrow::Cow::Owned(source.clone()),
                     },
                 );
             })
@@ -1016,7 +1016,7 @@ async fn run_npc_turn(
                 TextLogPayload {
                     id: String::new(),
                     stream_turn_id: None,
-                    source: "system".to_string(),
+                    source: "system",
                     content: "The storyteller has wandered off mid-tale.".to_string(),
                 },
             );
@@ -1041,7 +1041,7 @@ async fn run_npc_turn(
                 TextLogPayload {
                     id: String::new(),
                     stream_turn_id: None,
-                    source: "system".to_string(),
+                    source: "system",
                     content: "The storyteller is lost in thought. Try again.".to_string(),
                 },
             );
@@ -1068,7 +1068,7 @@ async fn run_npc_turn(
             TextLogPayload {
                 id: String::new(),
                 stream_turn_id: None,
-                source: "system".to_string(),
+                source: "system",
                 content: INFERENCE_FAILURE_MESSAGES[idx].to_string(),
             },
         );
@@ -1157,7 +1157,7 @@ async fn handle_npc_conversation(
             TextLogPayload {
                 id: String::new(),
                 stream_turn_id: None,
-                source: "system".to_string(),
+                source: "system",
                 content: IDLE_MESSAGES[idx].to_string(),
             },
         );
@@ -1170,7 +1170,7 @@ async fn handle_npc_conversation(
             TextLogPayload {
                 id: String::new(),
                 stream_turn_id: None,
-                source: "system".to_string(),
+                source: "system",
                 content: "There are ears enough for ye here, but say something first.".to_string(),
             },
         );
@@ -1183,7 +1183,7 @@ async fn handle_npc_conversation(
             TextLogPayload {
                 id: String::new(),
                 stream_turn_id: None,
-                source: "system".to_string(),
+                source: "system",
                 content:
                     "There's someone here, but the LLM is not configured — set a provider with /provider."
                         .to_string(),
@@ -1198,7 +1198,7 @@ async fn handle_npc_conversation(
             TextLogPayload {
                 id: String::new(),
                 stream_turn_id: None,
-                source: "system".to_string(),
+                source: "system",
                 content: "No one here answers to that name just now.".to_string(),
             },
         );
@@ -1504,7 +1504,7 @@ pub(crate) async fn tick_inactivity(state: &Arc<AppState>, app: &tauri::AppHandl
             TextLogPayload {
                 id: String::new(),
                 stream_turn_id: None,
-                source: "system".to_string(),
+                source: "system",
                 content:
                     "The parish falls quiet after a full minute of silence. Time is now paused."
                         .to_string(),
@@ -1673,7 +1673,7 @@ pub async fn load_branch(
         TextLogPayload {
             id: String::new(),
             stream_turn_id: None,
-            source: "system".to_string(),
+            source: "system",
             content: format!("Loaded {} (branch: {}).", filename, branch_name),
         },
     );
@@ -1877,7 +1877,7 @@ pub async fn new_game(
         TextLogPayload {
             id: String::new(),
             stream_turn_id: None,
-            source: "system".to_string(),
+            source: "system",
             content: "A new chapter begins in the parish...".to_string(),
         },
     );

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -797,7 +797,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
                     StreamTokenPayload {
                         token: batch.to_string(),
                         turn_id,
-                        source: source.into(),
+                        source: std::borrow::Cow::Owned(source.to_string()),
                     },
                 );
             },

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -338,7 +338,7 @@ async fn rebuild_inference(state: &Arc<AppState>, app: &tauri::AppHandle) {
                 TextLogPayload {
                     id: String::new(),
                     stream_turn_id: None,
-                    source: "system",
+                    source: "system".into(),
                     content: format!(
                         "Warning: '{}' doesn't look like a valid URL — NPC conversations may fail.",
                         base_url
@@ -640,7 +640,7 @@ async fn handle_game_input(
                 TextLogPayload {
                     id: String::new(),
                     stream_turn_id: None,
-                    source: "system",
+                    source: "system".into(),
                     content: "And where would ye be off to?".to_string(),
                 },
             );
@@ -797,7 +797,7 @@ async fn handle_movement(target: &str, state: &Arc<AppState>, app: &tauri::AppHa
                     StreamTokenPayload {
                         token: batch.to_string(),
                         turn_id,
-                        source: std::borrow::Cow::Owned(source.to_string()),
+                        source: source.into(),
                     },
                 );
             },
@@ -864,7 +864,7 @@ async fn handle_look(state: &Arc<AppState>, app: &tauri::AppHandle) {
         TextLogPayload {
             id: String::new(),
             stream_turn_id: None,
-            source: "system",
+            source: "system".into(),
             content: text,
         },
     );
@@ -957,7 +957,7 @@ async fn run_npc_turn(
                 TextLogPayload {
                     id: String::new(),
                     stream_turn_id: None,
-                    source: "system",
+                    source: "system".into(),
                     content: "The parish storyteller has wandered off. Try again in a moment."
                         .to_string(),
                 },
@@ -977,7 +977,7 @@ async fn run_npc_turn(
                     StreamTokenPayload {
                         token: batch.to_string(),
                         turn_id: req_id,
-                        source: std::borrow::Cow::Owned(source.clone()),
+                        source: source.clone().into(),
                     },
                 );
             })
@@ -1016,7 +1016,7 @@ async fn run_npc_turn(
                 TextLogPayload {
                     id: String::new(),
                     stream_turn_id: None,
-                    source: "system",
+                    source: "system".into(),
                     content: "The storyteller has wandered off mid-tale.".to_string(),
                 },
             );
@@ -1041,7 +1041,7 @@ async fn run_npc_turn(
                 TextLogPayload {
                     id: String::new(),
                     stream_turn_id: None,
-                    source: "system",
+                    source: "system".into(),
                     content: "The storyteller is lost in thought. Try again.".to_string(),
                 },
             );
@@ -1068,7 +1068,7 @@ async fn run_npc_turn(
             TextLogPayload {
                 id: String::new(),
                 stream_turn_id: None,
-                source: "system",
+                source: "system".into(),
                 content: INFERENCE_FAILURE_MESSAGES[idx].to_string(),
             },
         );
@@ -1157,7 +1157,7 @@ async fn handle_npc_conversation(
             TextLogPayload {
                 id: String::new(),
                 stream_turn_id: None,
-                source: "system",
+                source: "system".into(),
                 content: IDLE_MESSAGES[idx].to_string(),
             },
         );
@@ -1170,7 +1170,7 @@ async fn handle_npc_conversation(
             TextLogPayload {
                 id: String::new(),
                 stream_turn_id: None,
-                source: "system",
+                source: "system".into(),
                 content: "There are ears enough for ye here, but say something first.".to_string(),
             },
         );
@@ -1183,7 +1183,7 @@ async fn handle_npc_conversation(
             TextLogPayload {
                 id: String::new(),
                 stream_turn_id: None,
-                source: "system",
+                source: "system".into(),
                 content:
                     "There's someone here, but the LLM is not configured — set a provider with /provider."
                         .to_string(),
@@ -1198,7 +1198,7 @@ async fn handle_npc_conversation(
             TextLogPayload {
                 id: String::new(),
                 stream_turn_id: None,
-                source: "system",
+                source: "system".into(),
                 content: "No one here answers to that name just now.".to_string(),
             },
         );
@@ -1504,7 +1504,7 @@ pub(crate) async fn tick_inactivity(state: &Arc<AppState>, app: &tauri::AppHandl
             TextLogPayload {
                 id: String::new(),
                 stream_turn_id: None,
-                source: "system",
+                source: "system".into(),
                 content:
                     "The parish falls quiet after a full minute of silence. Time is now paused."
                         .to_string(),
@@ -1673,7 +1673,7 @@ pub async fn load_branch(
         TextLogPayload {
             id: String::new(),
             stream_turn_id: None,
-            source: "system",
+            source: "system".into(),
             content: format!("Loaded {} (branch: {}).", filename, branch_name),
         },
     );
@@ -1877,7 +1877,7 @@ pub async fn new_game(
         TextLogPayload {
             id: String::new(),
             stream_turn_id: None,
-            source: "system",
+            source: "system".into(),
             content: "A new chapter begins in the parish...".to_string(),
         },
     );

--- a/parish/crates/parish-tauri/src/events.rs
+++ b/parish/crates/parish-tauri/src/events.rs
@@ -76,7 +76,7 @@ pub struct TextLogPayload {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream_turn_id: Option<u64>,
     /// Who produced this text: "player", "system", or the NPC's name.
-    pub source: &'static str,
+    pub source: std::borrow::Cow<'static, str>,
     /// The log entry text.
     pub content: String,
 }

--- a/parish/crates/parish-tauri/src/events.rs
+++ b/parish/crates/parish-tauri/src/events.rs
@@ -49,7 +49,7 @@ pub struct StreamTokenPayload {
     /// Stable ID for the NPC turn this token batch belongs to.
     pub turn_id: u64,
     /// Speaker label for this stream turn.
-    pub source: String,
+    pub source: std::borrow::Cow<'static, str>,
 }
 
 /// Payload for `stream-turn-end` events.
@@ -76,7 +76,7 @@ pub struct TextLogPayload {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream_turn_id: Option<u64>,
     /// Who produced this text: "player", "system", or the NPC's name.
-    pub source: String,
+    pub source: &'static str,
     /// The log entry text.
     pub content: String,
 }
@@ -174,7 +174,7 @@ pub async fn stream_npc_response(
             StreamTokenPayload {
                 token: batch.to_string(),
                 turn_id,
-                source: source.clone(),
+                source: std::borrow::Cow::Owned(source.clone()),
             },
         );
     })

--- a/target/flycheck0/stderr
+++ b/target/flycheck0/stderr
@@ -1,1 +1,0 @@
-error: manifest path `/Users/dmooney/Rundale/Cargo.toml` does not exist


### PR DESCRIPTION
Replace per-call `"system".to_string()` allocations in Tauri event payloads with `&'static str` fields.

Changes:
- TextLogPayload.source: String -> &'static str (14 allocation sites eliminated)
- StreamTokenPayload.source: String -> Cow<'static, str> (handles dynamic NPC names)
- Updated event emission callsites to use static string references

Fixes #133.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1c7EqJxbFJNrZmbwSG7ud)_