### PR TITLE
refactor: migrate 9 components from Svelte 4 syntax to Svelte 5 runes

### DIFF
--- a/parish/apps/ui/src/components/DebugPanel.svelte
+++ b/parish/apps/ui/src/components/DebugPanel.svelte
@@ -42,7 +42,7 @@
 		'Inference'
 	];
 
-	let selectedLogId: number | null = null;
+	let selectedLogId: number | null = $state(null);
 
 	function selectTab(index: number) {
 		debugTab.set(index);
@@ -86,10 +86,10 @@
 		return m ? m[1].trim() : null;
 	}
 
-	$: snap = $debugSnapshot;
-	$: tab = $debugTab;
-	$: npcId = $selectedNpcId;
-	$: selectedNpc = snap?.npcs.find((n: NpcDebug) => n.id === npcId) ?? null;
+	const snap = $derived($debugSnapshot);
+	const tab = $derived($debugTab);
+	const npcId = $derived($selectedNpcId);
+	const selectedNpc = $derived(snap?.npcs.find((n: NpcDebug) => n.id === npcId) ?? null);
 </script>
 
 {#if $debugVisible && snap}

--- a/parish/apps/ui/src/components/SavePicker.svelte
+++ b/parish/apps/ui/src/components/SavePicker.svelte
@@ -229,7 +229,7 @@
 	// Phantom branch ID used to identify the new-branch node in the layout
 	const PHANTOM_ID = -999;
 
-	const layoutBranches = $derived((() => {
+	const layoutBranches = $derived.by(() => {
 		if (!activeFile) return [];
 		const branches = [...activeFile.branches];
 		if (forkingBranchId !== null) {
@@ -247,7 +247,7 @@
 			}
 		}
 		return branches;
-	})());
+	});
 	const layout = $derived(layoutBranches.length > 0 ? layoutTree(layoutBranches) : null);
 </script>
 

--- a/parish/apps/ui/src/components/SavePicker.svelte
+++ b/parish/apps/ui/src/components/SavePicker.svelte
@@ -6,14 +6,14 @@
 	import type { SaveFileInfo, SaveBranchDisplay } from '$lib/types';
 	import { layoutTree, NODE_W, NODE_H, GAP_Y } from '$lib/save-picker/dag';
 
-	let loadingCount = 0;
-	$: loading = loadingCount > 0;
-	let forkingBranchId: number | null = null;
-	let forkName = '';
-	let forkError = '';
-	let showLedgers = false;
+	let loadingCount = $state(0);
+	const loading = $derived(loadingCount > 0);
+	let forkingBranchId: number | null = $state(null);
+	let forkName = $state('');
+	let forkError = $state('');
+	let showLedgers = $state(false);
 
-	$: activeFile = files.find(f => f.filename === saveState?.filename) ?? files[0] ?? null;
+	const activeFile = $derived(files.find(f => f.filename === saveState?.filename) ?? files[0] ?? null);
 
 	// ── Handlers ────────────────────────────────────────────────────
 
@@ -215,22 +215,22 @@
 		}
 	}
 
-	let prevVisible = false;
-	$: {
+	let prevVisible = $state(false);
+	$effect(() => {
 		const visible = $savePickerVisible;
 		if (visible && !prevVisible) {
 			refreshSaves().then(scrollToCurrentNode);
 		}
 		prevVisible = visible;
-	}
+	});
 
-	$: files = $saveFiles;
-	$: saveState = $currentSaveState;
+	const files = $derived($saveFiles);
+	const saveState = $derived($currentSaveState);
 
 	// Phantom branch ID used to identify the new-branch node in the layout
 	const PHANTOM_ID = -999;
 
-	$: layoutBranches = (() => {
+	const layoutBranches = $derived((() => {
 		if (!activeFile) return [];
 		const branches = [...activeFile.branches];
 		if (forkingBranchId !== null) {
@@ -248,11 +248,11 @@
 			}
 		}
 		return branches;
-	})();
-	$: layout = layoutBranches.length > 0 ? layoutTree(layoutBranches) : null;
+	})());
+	const layout = $derived(layoutBranches.length > 0 ? layoutTree(layoutBranches) : null);
 </script>
 
-<svelte:window on:keydown={handleKeydown} />
+<svelte:window onkeydown={handleKeydown} />
 
 {#if $savePickerVisible}
 	<div class="overlay" role="dialog" aria-modal="true" aria-label="The Parish Ledger">
@@ -289,17 +289,17 @@
 							{:else if file.locked}
 								<span class="ledger-locked">In Use</span>
 							{:else}
-								<button class="action-btn" on:click={() => handleSwitchLedger(file)} disabled={loading}>Open</button>
+								<button class="action-btn" onclick={() => handleSwitchLedger(file)} disabled={loading}>Open</button>
 							{/if}
 						</div>
 					{/each}
 
-					<div class="ledger-row new-ledger" on:click={() => { if (!loading) handleForkLedger(); }} role="button" tabindex="0" aria-disabled={loading} on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); if (!loading && !e.repeat) handleForkLedger(); } }}>
+					<div class="ledger-row new-ledger" onclick={() => { if (!loading) handleForkLedger(); }} role="button" tabindex="0" aria-disabled={loading} onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); if (!loading && !e.repeat) handleForkLedger(); } }}>
 						<span class="file-number">+</span>
 						<span class="file-name">Fork New Ledger</span>
 					</div>
 
-					<div class="ledger-row new-ledger" on:click={() => { if (!loading) handleNewGame(); }} role="button" tabindex="0" aria-disabled={loading} on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); if (!loading && !e.repeat) handleNewGame(); } }}>
+					<div class="ledger-row new-ledger" onclick={() => { if (!loading) handleNewGame(); }} role="button" tabindex="0" aria-disabled={loading} onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); if (!loading && !e.repeat) handleNewGame(); } }}>
 						<span class="file-number">+</span>
 						<span class="file-name">New Game</span>
 					</div>
@@ -334,8 +334,8 @@
 												type="text"
 												bind:value={forkName}
 												use:autofocus
-												on:keydown|stopPropagation={(e) => { if (e.key === 'Enter' && parent) { e.preventDefault(); handleFork(parent); } if (e.key === 'Escape') cancelFork(); }}
-												on:input={() => { forkError = ''; }}
+												onkeydown={(e) => { e.stopPropagation(); if (e.key === 'Enter' && parent) { e.preventDefault(); handleFork(parent); } if (e.key === 'Escape') cancelFork(); }}
+												oninput={() => { forkError = ''; }}
 											/>
 											{#if forkError}
 												<span class="fork-error">{forkError}</span>
@@ -343,8 +343,8 @@
 												<span class="node-location">{node.branch.latest_location ?? 'New'}</span>
 											{/if}
 											<div class="phantom-actions">
-												<button class="phantom-btn" on:click|stopPropagation={() => { if (parent) handleFork(parent); }} disabled={loading || !forkName.trim()}>Create</button>
-												<button class="phantom-btn" on:click|stopPropagation={cancelFork}>Cancel</button>
+												<button class="phantom-btn" onclick={(e) => { e.stopPropagation(); if (parent) handleFork(parent); }} disabled={loading || !forkName.trim()}>Create</button>
+												<button class="phantom-btn" onclick={(e) => { e.stopPropagation(); cancelFork(); }}>Cancel</button>
 											</div>
 										</div>
 									</div>
@@ -358,7 +358,7 @@
 										<button
 											class="node-body"
 											disabled={loading}
-											on:click={() => handleLoadBranch(activeFile, node.branch)}
+											onclick={() => handleLoadBranch(activeFile, node.branch)}
 										>
 											<span class="node-name">{node.branch.name}</span>
 											<span class="node-location">{node.branch.latest_location ?? 'New'}</span>
@@ -370,7 +370,7 @@
 										<button
 											class="node-branch-btn"
 											disabled={loading}
-											on:click|stopPropagation={() => startFork(node.branch.id)}
+											onclick={(e) => { e.stopPropagation(); startFork(node.branch.id); }}
 										>Branch From Here</button>
 									</div>
 								{/if}
@@ -384,16 +384,16 @@
 
 			<div class="modal-footer">
 				{#if showLedgers}
-					<button class="footer-btn" on:click={() => { showLedgers = false; }}>
+					<button class="footer-btn" onclick={() => { showLedgers = false; }}>
 						← Back
 					</button>
 				{:else}
-					<button class="footer-btn" on:click={() => { showLedgers = true; }}>
+					<button class="footer-btn" onclick={() => { showLedgers = true; }}>
 						Ledgers
 					</button>
 				{/if}
 				<span class="footer-spacer"></span>
-				<button class="footer-btn" on:click={close}>Close</button>
+				<button class="footer-btn" onclick={close}>Close</button>
 			</div>
 		</div>
 	</div>

--- a/parish/apps/ui/src/components/SavePicker.svelte
+++ b/parish/apps/ui/src/components/SavePicker.svelte
@@ -13,8 +13,6 @@
 	let forkError = $state('');
 	let showLedgers = $state(false);
 
-	const activeFile = $derived(files.find(f => f.filename === saveState?.filename) ?? files[0] ?? null);
-
 	// ── Handlers ────────────────────────────────────────────────────
 
 	async function refreshSaves() {
@@ -215,6 +213,10 @@
 		}
 	}
 
+	const files = $derived($saveFiles);
+	const saveState = $derived($currentSaveState);
+	const activeFile = $derived(files.find(f => f.filename === saveState?.filename) ?? files[0] ?? null);
+
 	let prevVisible = $state(false);
 	$effect(() => {
 		const visible = $savePickerVisible;
@@ -223,9 +225,6 @@
 		}
 		prevVisible = visible;
 	});
-
-	const files = $derived($saveFiles);
-	const saveState = $derived($currentSaveState);
 
 	// Phantom branch ID used to identify the new-branch node in the layout
 	const PHANTOM_ID = -999;

--- a/parish/apps/ui/src/components/editor/LocationDetail.svelte
+++ b/parish/apps/ui/src/components/editor/LocationDetail.svelte
@@ -358,22 +358,23 @@
 		};
 	});
 
-	// Manage the MapLibre instance lifecycle in a single effect so that
-	// create/destroy logic is centralised and ordering is unambiguous.
+	// Lifecycle management: ensure map exists when loc is selected,
+	// and destroy it when deselected or the container is unmounted.
 	// Background: the `{#if loc}` wrapper unmounts the map-frame div, but
 	// Svelte's `bind:this` does not always reset `mapContainer` to
 	// `undefined` in time — so we couple cleanup to `loc` directly (#409).
 	// Without explicit teardown each deselect leaks a WebGL context
 	// (MapLibre allocates one per Map instance) and after a few navigations
 	// the browser aborts further WebGL contexts.
+	// Also update map data when locations or selection changes.
 	$effect(() => {
 		if (loc && mapContainer) {
 			if (!map) void ensureMap();
 		} else if (map) {
 			destroyMap();
 		}
+		setMapData(locations, selectedId);
 	});
-	$effect(() => { setMapData(locations, selectedId); });
 </script>
 
 <div class="loc-detail">

--- a/parish/apps/ui/src/components/editor/LocationDetail.svelte
+++ b/parish/apps/ui/src/components/editor/LocationDetail.svelte
@@ -23,7 +23,7 @@
 	import { buildStyle, readThemeColors } from '$lib/map/style';
 	import type { TileSource } from '$lib/types';
 
-	let mapContainer: HTMLDivElement | undefined;
+	let mapContainer: HTMLDivElement | undefined = $state(undefined);
 	let map: maplibregl.Map | null = null;
 	let mapLoaded = false;
 	let mapInitializing = false;
@@ -32,10 +32,10 @@
 	let dragMoved = false;
 	let dragMouseupHandler: (() => void) | null = null;
 
-	$: loc = $editorSelectedLocation;
-	$: locations = $editorLocations;
-	$: npcs = $editorNpcs;
-	$: selectedId = $editorSelectedLocationId;
+	const loc = $derived($editorSelectedLocation);
+	const locations = $derived($editorLocations);
+	const npcs = $derived($editorNpcs);
+	const selectedId = $derived($editorSelectedLocationId);
 
 	function locationName(id: number): string {
 		return locations.find((l) => l.id === id)?.name ?? `#${id}`;
@@ -366,25 +366,31 @@
 	// each deselect leaks a WebGL context (MapLibre allocates one per
 	// Map instance) and after a few navigations the browser aborts
 	// further WebGL contexts.
-	$: if (!loc && map) {
-		destroyMap();
-	}
-	$: if (loc && mapContainer && !map) {
-		void ensureMap();
-	}
+	$effect(() => {
+		if (!loc && map) {
+			destroyMap();
+		}
+	});
+	$effect(() => {
+		if (loc && mapContainer && !map) {
+			void ensureMap();
+		}
+	});
 	// Defensive secondary cleanup for any case where the div is
 	// unmounted without `loc` flipping (e.g. future refactors).
-	$: if (!mapContainer && map) {
-		destroyMap();
-	}
-	$: setMapData(locations, selectedId);
+	$effect(() => {
+		if (!mapContainer && map) {
+			destroyMap();
+		}
+	});
+	$effect(() => { setMapData(locations, selectedId); });
 </script>
 
 <div class="loc-detail">
 	{#if loc}
 		<div class="detail-header">
 			<h3 class="detail-title">{loc.name}</h3>
-			<button class="save-btn" on:click={handleSave} disabled={!$editorDirty}>Save World</button>
+			<button class="save-btn" onclick={handleSave} disabled={!$editorDirty}>Save World</button>
 		</div>
 
 		<div class="detail-scroll">
@@ -403,7 +409,7 @@
 						class="field-input"
 						type="text"
 						value={loc.name}
-						on:change={(e) => handleFieldChange('name', e.currentTarget.value)}
+						onchange={(e) => handleFieldChange('name', e.currentTarget.value)}
 					/>
 				</div>
 				<div class="field-row">
@@ -412,7 +418,7 @@
 						id="loc-indoor"
 						type="checkbox"
 						checked={loc.indoor}
-						on:change={(e) => handleFieldChange('indoor', e.currentTarget.checked)}
+						onchange={(e) => handleFieldChange('indoor', e.currentTarget.checked)}
 					/>
 				</div>
 				<div class="field-row">
@@ -421,7 +427,7 @@
 						id="loc-public"
 						type="checkbox"
 						checked={loc.public}
-						on:change={(e) => handleFieldChange('public', e.currentTarget.checked)}
+						onchange={(e) => handleFieldChange('public', e.currentTarget.checked)}
 					/>
 				</div>
 			</section>
@@ -434,7 +440,7 @@
 						id="loc-geo-kind"
 						class="field-input"
 						value={loc.geo_kind ?? 'fictional'}
-						on:change={(e) => handleFieldChange('geo_kind', e.currentTarget.value as GeoKind)}
+						onchange={(e) => handleFieldChange('geo_kind', e.currentTarget.value as GeoKind)}
 					>
 						<option value="real">Real</option>
 						<option value="manual">Manual</option>
@@ -447,7 +453,7 @@
 						id="loc-coord-mode"
 						class="field-input"
 						value={loc.relative_to ? 'relative' : 'absolute'}
-						on:change={(e) => setCoordinateMode(e.currentTarget.value as 'absolute' | 'relative')}
+						onchange={(e) => setCoordinateMode(e.currentTarget.value as 'absolute' | 'relative')}
 					>
 						<option value="absolute">Absolute</option>
 						<option value="relative">Relative</option>
@@ -460,7 +466,7 @@
 							id="loc-anchor"
 							class="field-input"
 							value={loc.relative_to.anchor}
-							on:change={(e) => applyRelativeField('anchor', e.currentTarget.value)}
+							onchange={(e) => applyRelativeField('anchor', e.currentTarget.value)}
 						>
 							{#each locations.filter((l) => l.id !== loc.id) as option}
 								<option value={option.id}>{option.name}</option>
@@ -475,7 +481,7 @@
 							type="number"
 							step="1"
 							value={loc.relative_to.dnorth_m}
-							on:change={(e) => applyRelativeField('dnorth_m', e.currentTarget.value)}
+							onchange={(e) => applyRelativeField('dnorth_m', e.currentTarget.value)}
 						/>
 						<label class="field-label" for="loc-deast">dEast m</label>
 						<input
@@ -484,7 +490,7 @@
 							type="number"
 							step="1"
 							value={loc.relative_to.deast_m}
-							on:change={(e) => applyRelativeField('deast_m', e.currentTarget.value)}
+							onchange={(e) => applyRelativeField('deast_m', e.currentTarget.value)}
 						/>
 					</div>
 				{:else}
@@ -496,7 +502,7 @@
 							type="number"
 							step="0.00001"
 							value={loc.lat}
-							on:change={(e) => handleFieldChange('lat', parseFloat(e.currentTarget.value))}
+							onchange={(e) => handleFieldChange('lat', parseFloat(e.currentTarget.value))}
 						/>
 						<label class="field-label" for="loc-lon">Lon</label>
 						<input
@@ -505,7 +511,7 @@
 							type="number"
 							step="0.00001"
 							value={loc.lon}
-							on:change={(e) => handleFieldChange('lon', parseFloat(e.currentTarget.value))}
+							onchange={(e) => handleFieldChange('lon', parseFloat(e.currentTarget.value))}
 						/>
 					</div>
 				{/if}
@@ -516,14 +522,14 @@
 						class="field-input"
 						type="text"
 						value={loc.geo_source ?? ''}
-						on:change={(e) => handleFieldChange('geo_source', e.currentTarget.value || null)}
+						onchange={(e) => handleFieldChange('geo_source', e.currentTarget.value || null)}
 					/>
 				</div>
 				<div class="nudge-row">
-					<button class="nudge-btn" on:click={() => nudgeSelected(100, 0)}>N +100m</button>
-					<button class="nudge-btn" on:click={() => nudgeSelected(-100, 0)}>S +100m</button>
-					<button class="nudge-btn" on:click={() => nudgeSelected(0, 100)}>E +100m</button>
-					<button class="nudge-btn" on:click={() => nudgeSelected(0, -100)}>W +100m</button>
+					<button class="nudge-btn" onclick={() => nudgeSelected(100, 0)}>N +100m</button>
+					<button class="nudge-btn" onclick={() => nudgeSelected(-100, 0)}>S +100m</button>
+					<button class="nudge-btn" onclick={() => nudgeSelected(0, 100)}>E +100m</button>
+					<button class="nudge-btn" onclick={() => nudgeSelected(0, -100)}>W +100m</button>
 				</div>
 			</section>
 
@@ -533,7 +539,7 @@
 					<div class="conn-row">
 						<span class="conn-target">{locationName(conn.target)}</span>
 						<span class="conn-desc">{conn.path_description}</span>
-						<button class="nudge-btn" on:click={() => toggleConnection(conn.target)}>Remove</button>
+						<button class="nudge-btn" onclick={() => toggleConnection(conn.target)}>Remove</button>
 					</div>
 				{/each}
 			</section>
@@ -544,7 +550,7 @@
 					class="field-textarea tall"
 					aria-label="Description template"
 					value={loc.description_template}
-					on:change={(e) => handleFieldChange('description_template', e.currentTarget.value)}
+					onchange={(e) => handleFieldChange('description_template', e.currentTarget.value)}
 				></textarea>
 				<p class="field-hint">Placeholders: {'{time}'}, {'{weather}'}, {'{npcs_present}'}</p>
 			</section>
@@ -566,7 +572,7 @@
 					aria-label="Mythological significance"
 					value={loc.mythological_significance ?? ''}
 					placeholder="Fairy fort, holy well, cursed ground…"
-					on:change={(e) =>
+					onchange={(e) =>
 						handleFieldChange(
 							'mythological_significance',
 							e.currentTarget.value.trim() === '' ? null : e.currentTarget.value

--- a/parish/apps/ui/src/components/editor/LocationDetail.svelte
+++ b/parish/apps/ui/src/components/editor/LocationDetail.svelte
@@ -358,28 +358,18 @@
 		};
 	});
 
-	// Tear the MapLibre instance down the moment the selected location
-	// clears (#409). The `{#if loc}` wrapper below unmounts the map-frame
-	// div, but Svelte's `bind:this` does not always reset `mapContainer`
-	// to `undefined` in time for the mapContainer-based watch below to
-	// fire — so we couple the cleanup to `loc` directly. Without this,
-	// each deselect leaks a WebGL context (MapLibre allocates one per
-	// Map instance) and after a few navigations the browser aborts
-	// further WebGL contexts.
+	// Manage the MapLibre instance lifecycle in a single effect so that
+	// create/destroy logic is centralised and ordering is unambiguous.
+	// Background: the `{#if loc}` wrapper unmounts the map-frame div, but
+	// Svelte's `bind:this` does not always reset `mapContainer` to
+	// `undefined` in time — so we couple cleanup to `loc` directly (#409).
+	// Without explicit teardown each deselect leaks a WebGL context
+	// (MapLibre allocates one per Map instance) and after a few navigations
+	// the browser aborts further WebGL contexts.
 	$effect(() => {
-		if (!loc && map) {
-			destroyMap();
-		}
-	});
-	$effect(() => {
-		if (loc && mapContainer && !map) {
-			void ensureMap();
-		}
-	});
-	// Defensive secondary cleanup for any case where the div is
-	// unmounted without `loc` flipping (e.g. future refactors).
-	$effect(() => {
-		if (!mapContainer && map) {
+		if (loc && mapContainer) {
+			if (!map) void ensureMap();
+		} else if (map) {
 			destroyMap();
 		}
 	});

--- a/parish/apps/ui/src/components/editor/LocationList.svelte
+++ b/parish/apps/ui/src/components/editor/LocationList.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { editorLocations, editorSelectedLocationId } from '../../stores/editor';
 
-	let search = '';
+	let search = $state('');
 
-	$: locs = $editorLocations;
-	$: filtered = search
+	const locs = $derived($editorLocations);
+	const filtered = $derived(search
 		? locs.filter((l) => l.name.toLowerCase().includes(search.toLowerCase()))
-		: locs;
+		: locs);
 </script>
 
 <div class="loc-list">
@@ -25,7 +25,7 @@
 			<button
 				class="list-item"
 				class:active={$editorSelectedLocationId === loc.id}
-				on:click={() => editorSelectedLocationId.set(loc.id)}
+				onclick={() => editorSelectedLocationId.set(loc.id)}
 			>
 				<span class="item-name">{loc.name}</span>
 				<span class="item-meta">

--- a/parish/apps/ui/src/components/editor/ModBrowser.svelte
+++ b/parish/apps/ui/src/components/editor/ModBrowser.svelte
@@ -3,8 +3,8 @@
 	import { editorOpenMod } from '$lib/editor-ipc';
 	import type { ModSummary } from '$lib/editor-types';
 
-	let loading = false;
-	let error = '';
+	let loading = $state(false);
+	let error = $state('');
 
 	async function openMod(mod_summary: ModSummary) {
 		loading = true;
@@ -21,7 +21,7 @@
 		}
 	}
 
-	$: mods = $editorMods;
+	const mods = $derived($editorMods);
 </script>
 
 <div class="mod-browser">
@@ -34,7 +34,7 @@
 			{#each mods as mod_item}
 				<button
 					class="mod-card"
-					on:click={() => openMod(mod_item)}
+					onclick={() => openMod(mod_item)}
 					disabled={loading}
 				>
 					<span class="mod-card-name">{mod_item.title ?? mod_item.name}</span>

--- a/parish/apps/ui/src/components/editor/NpcDetail.svelte
+++ b/parish/apps/ui/src/components/editor/NpcDetail.svelte
@@ -131,7 +131,7 @@
 						type="text"
 						value={npc.brief_description ?? ''}
 						placeholder="(auto-generated from occupation)"
-						on:change={(e) => {
+						onchange={(e) => {
 							const val = e.currentTarget.value.trim();
 							handleFieldChange('brief_description', val || null);
 						}}
@@ -170,7 +170,7 @@
 						id="npc-workplace"
 						class="field-select"
 						value={npc.workplace ?? -1}
-						on:change={(e) => {
+						onchange={(e) => {
 							const v = parseInt(e.currentTarget.value);
 							handleFieldChange('workplace', v === -1 ? null : v);
 						}}
@@ -197,7 +197,7 @@
 								min="1"
 								max="5"
 								value={npc.intelligence?.[dim.key] ?? 3}
-								on:change={(e) => {
+								onchange={(e) => {
 									if (!npc?.intelligence) return;
 									const updated = {
 										...npc.intelligence,

--- a/parish/apps/ui/src/components/editor/NpcDetail.svelte
+++ b/parish/apps/ui/src/components/editor/NpcDetail.svelte
@@ -10,9 +10,9 @@
 	import { editorUpdateNpcs, editorSave } from '$lib/editor-ipc';
 	import type { NpcFileEntry, ScheduleVariantFileEntry } from '$lib/editor-types';
 
-	$: npc = $editorSelectedNpc;
-	$: locations = $editorLocations;
-	$: allNpcs = $editorNpcs;
+	const npc = $derived($editorSelectedNpc);
+	const locations = $derived($editorLocations);
+	const allNpcs = $derived($editorNpcs);
 
 	function locationName(id: number): string {
 		return locations.find((l) => l.id === id)?.name ?? `#${id}`;
@@ -76,7 +76,7 @@
 	{#if npc}
 		<div class="detail-header">
 			<h3 class="detail-title">{npc.name}</h3>
-			<button class="save-btn" on:click={handleSave} disabled={!$editorDirty}>Save NPCs</button>
+			<button class="save-btn" onclick={handleSave} disabled={!$editorDirty}>Save NPCs</button>
 		</div>
 
 		<div class="detail-scroll">
@@ -90,7 +90,7 @@
 						class="field-input"
 						type="text"
 						value={npc.name}
-						on:change={(e) => handleFieldChange('name', e.currentTarget.value)}
+						onchange={(e) => handleFieldChange('name', e.currentTarget.value)}
 					/>
 				</div>
 				<div class="field-row">
@@ -100,7 +100,7 @@
 						class="field-input short"
 						type="number"
 						value={npc.age}
-						on:change={(e) => handleFieldChange('age', parseInt(e.currentTarget.value))}
+						onchange={(e) => handleFieldChange('age', parseInt(e.currentTarget.value))}
 					/>
 				</div>
 				<div class="field-row">
@@ -110,7 +110,7 @@
 						class="field-input"
 						type="text"
 						value={npc.occupation}
-						on:change={(e) => handleFieldChange('occupation', e.currentTarget.value)}
+						onchange={(e) => handleFieldChange('occupation', e.currentTarget.value)}
 					/>
 				</div>
 				<div class="field-row">
@@ -120,7 +120,7 @@
 						class="field-input"
 						type="text"
 						value={npc.mood}
-						on:change={(e) => handleFieldChange('mood', e.currentTarget.value)}
+						onchange={(e) => handleFieldChange('mood', e.currentTarget.value)}
 					/>
 				</div>
 				<div class="field-row">
@@ -143,7 +143,7 @@
 						id="npc-personality"
 						class="field-textarea"
 						value={npc.personality}
-						on:change={(e) => handleFieldChange('personality', e.currentTarget.value)}
+						onchange={(e) => handleFieldChange('personality', e.currentTarget.value)}
 					></textarea>
 				</div>
 			</section>
@@ -157,7 +157,7 @@
 						id="npc-home"
 						class="field-select"
 						value={npc.home}
-						on:change={(e) => handleFieldChange('home', parseInt(e.currentTarget.value))}
+						onchange={(e) => handleFieldChange('home', parseInt(e.currentTarget.value))}
 					>
 						{#each locations as loc}
 							<option value={loc.id}>{loc.name}</option>

--- a/parish/apps/ui/src/components/editor/NpcList.svelte
+++ b/parish/apps/ui/src/components/editor/NpcList.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
 	import { editorNpcs, editorSelectedNpcId, editorLocations } from '../../stores/editor';
 
-	let search = '';
+	let search = $state('');
 
-	$: npcs = $editorNpcs;
-	$: locations = $editorLocations;
-	$: filtered = search
+	const npcs = $derived($editorNpcs);
+	const locations = $derived($editorLocations);
+	const filtered = $derived(search
 		? npcs.filter(
 				(n) =>
 					n.name.toLowerCase().includes(search.toLowerCase()) ||
 					n.occupation.toLowerCase().includes(search.toLowerCase())
 			)
-		: npcs;
+		: npcs);
 
 	function locationName(id: number): string {
 		return locations.find((l) => l.id === id)?.name ?? `#${id}`;
@@ -34,7 +34,7 @@
 			<button
 				class="list-item"
 				class:active={$editorSelectedNpcId === npc.id}
-				on:click={() => editorSelectedNpcId.set(npc.id)}
+				onclick={() => editorSelectedNpcId.set(npc.id)}
 			>
 				<span class="item-name">{npc.name}</span>
 				<span class="item-meta">{npc.occupation} &middot; {locationName(npc.home)}</span>

--- a/parish/apps/ui/src/components/editor/SaveInspector.svelte
+++ b/parish/apps/ui/src/components/editor/SaveInspector.svelte
@@ -7,13 +7,13 @@
 	} from '$lib/editor-ipc';
 	import type { SaveFileSummary, BranchSummary, SnapshotDetail } from '$lib/editor-types';
 
-	let saves: SaveFileSummary[] = [];
-	let selectedSave: SaveFileSummary | null = null;
-	let branches: BranchSummary[] = [];
-	let selectedBranch: BranchSummary | null = null;
-	let snapshot: SnapshotDetail | null = null;
-	let loading = false;
-	let error = '';
+	let saves: SaveFileSummary[] = $state([]);
+	let selectedSave: SaveFileSummary | null = $state(null);
+	let branches: BranchSummary[] = $state([]);
+	let selectedBranch: BranchSummary | null = $state(null);
+	let snapshot: SnapshotDetail | null = $state(null);
+	let loading = $state(false);
+	let error = $state('');
 
 	async function refreshSaves() {
 		loading = true;
@@ -86,7 +86,7 @@
 <div class="save-inspector">
 	<div class="panel-header">
 		<h3 class="panel-title">Save Inspector</h3>
-		<button class="refresh-btn" on:click={refreshSaves} disabled={loading}>
+		<button class="refresh-btn" onclick={refreshSaves} disabled={loading}>
 			{loading ? '...' : 'Refresh'}
 		</button>
 	</div>
@@ -100,7 +100,7 @@
 					<button
 						class="col-item"
 						class:active={selectedSave?.path === save.path}
-						on:click={() => selectSave(save)}
+						onclick={() => selectSave(save)}
 					>
 						<span class="item-name">{save.filename}</span>
 						<span class="item-meta">{save.file_size} &middot; {save.branch_count} branches</span>
@@ -120,7 +120,7 @@
 					<button
 						class="col-item"
 						class:active={selectedBranch?.id === branch.id}
-						on:click={() => selectBranch(branch)}
+						onclick={() => selectBranch(branch)}
 					>
 						<span class="item-name">{branch.name}</span>
 						<span class="item-meta">
@@ -145,7 +145,7 @@
 			<div class="snapshot-header">
 				<h4 class="col-title">Latest Snapshot</h4>
 				{#if snapshot}
-					<button class="export-btn" on:click={exportSnapshot}>Export JSON</button>
+					<button class="export-btn" onclick={exportSnapshot}>Export JSON</button>
 				{/if}
 			</div>
 			<div class="col-scroll">

--- a/parish/apps/ui/src/components/editor/ValidatorPanel.svelte
+++ b/parish/apps/ui/src/components/editor/ValidatorPanel.svelte
@@ -8,7 +8,7 @@
 	import { editorValidate } from '$lib/editor-ipc';
 	import type { ValidationIssue } from '$lib/editor-types';
 
-	let running = false;
+	let running = $state(false);
 
 	async function runValidation() {
 		running = true;
@@ -38,17 +38,17 @@
 		}
 	}
 
-	$: report = $editorValidation;
-	$: allIssues = report
+	const report = $derived($editorValidation);
+	const allIssues = $derived(report
 		? [...report.errors.map((e) => ({ ...e, _severity: 'error' as const })),
 		   ...report.warnings.map((w) => ({ ...w, _severity: 'warning' as const }))]
-		: [];
+		: []);
 </script>
 
 <div class="validator-panel">
 	<div class="validator-header">
 		<h3 class="validator-title">Validation</h3>
-		<button class="run-btn" on:click={runValidation} disabled={running}>
+		<button class="run-btn" onclick={runValidation} disabled={running}>
 			{running ? 'Running...' : 'Re-validate'}
 		</button>
 	</div>
@@ -73,7 +73,7 @@
 					class="issue-row"
 					class:is-error={issue._severity === 'error'}
 					class:is-warning={issue._severity === 'warning'}
-					on:click={() => jumpToIssue(issue)}
+					onclick={() => jumpToIssue(issue)}
 				>
 					<span class="issue-severity">{issue._severity === 'error' ? 'ERR' : 'WARN'}</span>
 					<span class="issue-cat">{issue.category}</span>

--- a/parish/apps/ui/src/stores/debug.ts
+++ b/parish/apps/ui/src/stores/debug.ts
@@ -7,7 +7,7 @@ export const debugVisible = writable<boolean>(false);
 /** Latest debug snapshot from the backend. */
 export const debugSnapshot = writable<DebugSnapshot | null>(null);
 
-/** Active debug tab index (0=Overview, 1=NPCs, 2=World, 3=Events, 4=Inference). */
+/** Active debug tab index (0=Overview, 1=NPCs, 2=World, 3=Weather, 4=Gossip, 5=Conv, 6=Events, 7=Inference). */
 export const debugTab = writable<number>(0);
 
 /** Preferred dock position for debug panel on wide screens. */


### PR DESCRIPTION
Migrate DebugPanel, SavePicker, and all 7 editor components from Svelte 4 `$:` + `on:event` syntax to Svelte 5 runes and event attributes. Also fix stale debug tab comment.

Fixes #287, fixes #713.

## Changes

### `$:` → `$derived` / `$effect`
- **DebugPanel**: `snap`, `tab`, `npcId`, `selectedNpc` → `$derived`; `selectedLogId` → `$state`
- **SavePicker**: `loading`, `activeFile`, `files`, `saveState`, `layoutBranches`, `layout` → `$derived`; `loadingCount`, `forkingBranchId`, `forkName`, `forkError`, `showLedgers`, `prevVisible` → `$state`; visibility side-effect block → `$effect`
- **LocationDetail**: `loc`, `locations`, `npcs`, `selectedId` → `$derived`; map lifecycle `$: if` blocks → `$effect`; `mapContainer` → `$state`
- **NpcDetail**: `npc`, `locations`, `allNpcs` → `$derived`
- **NpcList**: `npcs`, `locations`, `filtered` → `$derived`; `search` → `$state`
- **LocationList**: `locs`, `filtered` → `$derived`; `search` → `$state`
- **ModBrowser**: `mods` → `$derived`; `loading`, `error` → `$state`
- **ValidatorPanel**: `report`, `allIssues` → `$derived`; `running` → `$state`
- **SaveInspector**: `saves`, `selectedSave`, `branches`, `selectedBranch`, `snapshot`, `loading`, `error` → `$state`

### `on:event` → event attribute
- All `on:click` → `onclick`, `on:keydown` → `onkeydown`, `on:change` → `onchange`, `on:input` → `oninput`
- `on:event|stopPropagation` → manual `e.stopPropagation()` call inside handler
- `<svelte:window on:keydown>` → `<svelte:window onkeydown>`

### Comment fix
- `stores/debug.ts:10`: updated stale comment from 5-tab list to actual 8 tabs: `['Overview', 'NPCs', 'World', 'Weather', 'Gossip', 'Conv', 'Events', 'Inference']`

## Commands run
- `npx vitest run` — 292 tests, all pass

https://claude.ai/code/session_01H1c7EqJxbFJNrZmbwSG7ud

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1c7EqJxbFJNrZmbwSG7ud)_