### PR TITLE
fix: graceful shutdown for background task ticks (#104, #228)

### DIFF
--- a/parish/crates/parish-server/src/session.rs
+++ b/parish/crates/parish-server/src/session.rs
@@ -79,8 +79,21 @@ pub struct SessionEntry {
     pub app_state: Arc<AppState>,
     /// Unix timestamp of the last API request from this session.
     pub last_active: AtomicU64,
+    /// Cancellation token — cancelled when the session is evicted so background
+    /// tick tasks shut down gracefully instead of running until the JoinHandle
+    /// is aborted (#228).
+    _shutdown_token: tokio_util::sync::CancellationToken,
     /// Background tick task handles — dropped when the session is evicted.
     _tick_handles: Vec<JoinHandle<()>>,
+}
+
+impl Drop for SessionEntry {
+    fn drop(&mut self) {
+        // Signal all background tasks to stop gracefully before their handles
+        // are dropped.  Tasks observe the token in their select! loops and exit
+        // cleanly, completing any in-flight autosave iteration first (#228).
+        self._shutdown_token.cancel();
+    }
 }
 
 // ── SessionRegistry ──────────────────────────────────────────────────────────
@@ -548,11 +561,13 @@ async fn create_session(global: &Arc<GlobalState>, session_id: &str) -> Arc<Sess
         tracing::warn!("Session initial save failed: {}", e);
     }
 
-    let handles = spawn_session_ticks(Arc::clone(&app_state));
+    let shutdown_token = tokio_util::sync::CancellationToken::new();
+    let handles = spawn_session_ticks(Arc::clone(&app_state), shutdown_token.clone());
 
     Arc::new(SessionEntry {
         app_state,
         last_active: AtomicU64::new(SessionRegistry::now_unix()),
+        _shutdown_token: shutdown_token,
         _tick_handles: handles,
     })
 }
@@ -660,11 +675,13 @@ async fn restore_session(
     *app_state.current_branch_id.lock().await = Some(branch_id);
     *app_state.current_branch_name.lock().await = Some(branch_name);
 
-    let handles = spawn_session_ticks(Arc::clone(&app_state));
+    let shutdown_token = tokio_util::sync::CancellationToken::new();
+    let handles = spawn_session_ticks(Arc::clone(&app_state), shutdown_token.clone());
 
     Ok(Arc::new(SessionEntry {
         app_state,
         last_active: AtomicU64::new(SessionRegistry::now_unix()),
+        _shutdown_token: shutdown_token,
         _tick_handles: handles,
     }))
 }
@@ -797,17 +814,28 @@ where
 }
 
 /// Spawns the three per-session background tasks and returns their handles.
-fn spawn_session_ticks(state: Arc<AppState>) -> Vec<JoinHandle<()>> {
+///
+/// Each task observes `shutdown_token` via `tokio::select!` so it exits
+/// cleanly when the token is cancelled (e.g. on session eviction) rather than
+/// running until its `JoinHandle` is aborted (#228).
+fn spawn_session_ticks(
+    state: Arc<AppState>,
+    shutdown_token: tokio_util::sync::CancellationToken,
+) -> Vec<JoinHandle<()>> {
     let mut handles = Vec::with_capacity(3);
 
     // ── World tick (5 s) ─────────────────────────────────────────────────────
     {
         let s = Arc::clone(&state);
+        let token = shutdown_token.clone();
         handles.push(tokio::spawn(async move {
             // Round-robin cursor for budgeted gossip propagation (#466).
             let mut gossip_cursor: usize = 0;
             loop {
-                tokio::time::sleep(Duration::from_secs(5)).await;
+                tokio::select! {
+                    _ = token.cancelled() => break,
+                    _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+                }
 
                 {
                     let world = s.world.lock().await;
@@ -889,9 +917,13 @@ fn spawn_session_ticks(state: Arc<AppState>) -> Vec<JoinHandle<()>> {
     // ── Inactivity tick (1 s) ────────────────────────────────────────────────
     {
         let s = Arc::clone(&state);
+        let token = shutdown_token.clone();
         handles.push(tokio::spawn(async move {
             loop {
-                tokio::time::sleep(Duration::from_secs(1)).await;
+                tokio::select! {
+                    _ = token.cancelled() => break,
+                    _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                }
                 crate::routes::tick_inactivity(&s).await;
             }
         }));
@@ -906,6 +938,7 @@ fn spawn_session_ticks(state: Arc<AppState>) -> Vec<JoinHandle<()>> {
     // inside `AsyncDatabase`, so a slow fsync can never stall the Tokio runtime.
     {
         let s = Arc::clone(&state);
+        let token = shutdown_token.clone();
         handles.push(tokio::spawn(async move {
             use parish_core::persistence::snapshot::GameSnapshot;
             use parish_core::persistence::{AsyncDatabase, Database};
@@ -913,7 +946,13 @@ fn spawn_session_ticks(state: Arc<AppState>) -> Vec<JoinHandle<()>> {
             // one user-visible warning per failure run, not one per tick.
             let mut last_autosave_failed = false;
             loop {
-                tokio::time::sleep(Duration::from_secs(AUTOSAVE_INTERVAL_SECS)).await;
+                // Wait for the interval or cancellation.  Cancellation exits
+                // only after the *sleep* fires, so any in-flight autosave
+                // iteration completes before the task stops (#228).
+                tokio::select! {
+                    _ = token.cancelled() => break,
+                    _ = tokio::time::sleep(Duration::from_secs(AUTOSAVE_INTERVAL_SECS)) => {}
+                }
 
                 let save_path = s.save_path.lock().await.clone();
                 let branch_id = *s.current_branch_id.lock().await;

--- a/parish/crates/parish-tauri/src/lib.rs
+++ b/parish/crates/parish-tauri/src/lib.rs
@@ -18,6 +18,7 @@ use std::time::Instant;
 use tauri::Emitter;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use parish_core::config::{FeatureFlags, Provider, ProviderConfig};
 use parish_core::debug_snapshot::{DebugEvent, InferenceDebug};
@@ -310,6 +311,9 @@ pub struct AppState {
     pub inference_config: parish_core::config::InferenceConfig,
     /// Demo / auto-player configuration. Read-only after startup.
     pub demo_config: DemoConfig,
+    /// Cancellation token — cancelled during app shutdown to stop background ticks
+    /// gracefully. Clones are passed into each spawned tick task (#104).
+    pub shutdown_token: CancellationToken,
 }
 
 // ── Data path resolution ─────────────────────────────────────────────────────
@@ -727,6 +731,9 @@ pub fn run() {
     // commands read `state.saves_dir` instead of re-probing the cwd.
     let saves_dir = parish_core::persistence::picker::resolve_project_saves_dir_from_cwd();
 
+    // Cancellation token for graceful background-task shutdown (#104).
+    let shutdown_token = CancellationToken::new();
+
     let state = Arc::new(AppState {
         world: Mutex::new(world),
         npc_manager: Mutex::new(npc_manager),
@@ -758,6 +765,7 @@ pub fn run() {
         inference_config: engine_config.inference, // (#417) store TOML-configured timeouts
         config: Mutex::new(game_config),
         demo_config,
+        shutdown_token: shutdown_token.clone(),
     });
 
     tauri::Builder::default()
@@ -1016,25 +1024,31 @@ pub fn run() {
                 // last N events in AppState.game_events for the debug panel.
                 {
                     let state_events = Arc::clone(&state_setup);
+                    let token_events = state_setup.shutdown_token.clone();
                     let mut rx = {
                         let world = state_events.world.lock().await;
                         world.event_bus.subscribe()
                     };
                     tokio::spawn(async move {
                         loop {
-                            match rx.recv().await {
-                                Ok(evt) => {
-                                    let mut buf = state_events.game_events.lock().await;
-                                    if buf.len() >= DEBUG_EVENT_CAPACITY {
-                                        buf.pop_front();
+                            tokio::select! {
+                                _ = token_events.cancelled() => break,
+                                result = rx.recv() => {
+                                    match result {
+                                        Ok(evt) => {
+                                            let mut buf = state_events.game_events.lock().await;
+                                            if buf.len() >= DEBUG_EVENT_CAPACITY {
+                                                buf.pop_front();
+                                            }
+                                            buf.push_back(evt);
+                                        }
+                                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                                            continue;
+                                        }
+                                        Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                                            break;
+                                        }
                                     }
-                                    buf.push_back(evt);
-                                }
-                                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                                    continue;
-                                }
-                                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                                    break;
                                 }
                             }
                         }
@@ -1051,10 +1065,14 @@ pub fn run() {
                 // the tick (see the AppState lock ordering contract).
                 let state_tick = Arc::clone(&state_setup);
                 let handle_tick = handle.clone();
+                let token_tick = state_setup.shutdown_token.clone();
                 tokio::spawn(async move {
                     let mut last_palette: Option<parish_palette::RawPalette> = None;
                     loop {
-                        tokio::time::sleep(Duration::from_secs(5)).await;
+                        tokio::select! {
+                            _ = token_tick.cancelled() => break,
+                            _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+                        }
 
                         let mut world = state_tick.world.lock().await;
                         let mut npc_mgr = state_tick.npc_manager.lock().await;
@@ -1575,9 +1593,13 @@ pub fn run() {
                 // Inactivity tick: drive idle banter and auto-pause.
                 let state_idle = Arc::clone(&state_setup);
                 let handle_idle = handle.clone();
+                let token_idle = state_setup.shutdown_token.clone();
                 tokio::spawn(async move {
                     loop {
-                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        tokio::select! {
+                            _ = token_idle.cancelled() => break,
+                            _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                        }
                         crate::commands::tick_inactivity(&state_idle, &handle_idle).await;
                     }
                 });
@@ -1590,9 +1612,13 @@ pub fn run() {
                 // inference_log (#483).
                 let state_debug = Arc::clone(&state_setup);
                 let handle_debug = handle.clone();
+                let token_debug = state_setup.shutdown_token.clone();
                 tokio::spawn(async move {
                     loop {
-                        tokio::time::sleep(Duration::from_secs(2)).await;
+                        tokio::select! {
+                            _ = token_debug.cancelled() => break,
+                            _ = tokio::time::sleep(Duration::from_secs(2)) => {}
+                        }
 
                         // 1. Peek inference_queue presence first (#483).
                         let has_inference_queue =
@@ -1688,9 +1714,13 @@ pub fn run() {
 
                 // Autosave tick: save snapshot every AUTOSAVE_INTERVAL_SECS (if a save file is active)
                 let state_autosave = Arc::clone(&state_setup);
+                let token_autosave = state_setup.shutdown_token.clone();
                 tokio::spawn(async move {
                     loop {
-                        tokio::time::sleep(Duration::from_secs(AUTOSAVE_INTERVAL_SECS)).await;
+                        tokio::select! {
+                            _ = token_autosave.cancelled() => break,
+                            _ = tokio::time::sleep(Duration::from_secs(AUTOSAVE_INTERVAL_SECS)) => {}
+                        }
 
                         // Only autosave if a save file and branch are active
                         let save_path = state_autosave.save_path.lock().await.clone();
@@ -1720,6 +1750,14 @@ pub fn run() {
             });
 
             Ok(())
+        })
+        .on_window_event({
+            let token = shutdown_token.clone();
+            move |_window, event| {
+                if let tauri::WindowEvent::Destroyed = event {
+                    token.cancel();
+                }
+            }
         })
         .run(tauri::generate_context!())
         .expect("error while running Parish application");


### PR DESCRIPTION
Add `CancellationToken` to background tick tasks in both Tauri and web server paths so they exit cleanly on shutdown rather than running until aborted.

## Summary

- **Tauri (#104):** Added `shutdown_token: CancellationToken` to `AppState`. All five background tasks (event-bus fan-in, world/idle tick, inactivity tick, debug tick, autosave tick) now use `tokio::select!` with the token. Cancellation is triggered via `on_window_event(WindowEvent::Destroyed)`.

- **Server (#228):** `spawn_session_ticks` now accepts a `CancellationToken`. Each of the three per-session tasks (world tick, inactivity tick, autosave tick) selects on it. `SessionEntry` stores the token and cancels it in `Drop` so tasks begin their clean exit as soon as the session is evicted from the `DashMap`. The autosave task completes any in-flight snapshot before exiting.

## Commands run

```
cargo fmt --all --check   # clean
cargo clippy --all-targets --all-features   # clean
cargo test --workspace --exclude parish-tauri   # 0 failures
```

Fixes #104, fixes #228.

https://claude.ai/code/session_01H1c7EqJxbFJNrZmbwSG7ud

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1c7EqJxbFJNrZmbwSG7ud)_