### PR TITLE
fix(ui): register WS event listeners before fetching demo config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ parish/node_modules/
 logs/
 .claude/worktrees
 parish/apps/ui/dist/
+test-results/
 claude/*
 .worktrees
 saves

--- a/parish/apps/ui/src/routes/+page.svelte
+++ b/parish/apps/ui/src/routes/+page.svelte
@@ -311,21 +311,6 @@
 			}
 		} catch (_) {}
 
-		// Fetch demo config and auto-start if requested.
-		try {
-			const dc = await getDemoConfig();
-			demoConfig.set({
-				auto_start: dc.auto_start,
-				extra_prompt: dc.extra_prompt,
-				turn_pause_secs: dc.turn_pause_secs,
-				max_turns: dc.max_turns
-			});
-			if (dc.auto_start) {
-				startDemoLoop();
-			}
-		} catch (_) {}
-
-		// Subscribe to events
 		// Fetch initial debug snapshot
 		try {
 			const debugSnap = await getDebugSnapshot();
@@ -613,6 +598,24 @@
 		} catch (e) {
 			console.warn('Failed to set up some event listeners:', e);
 		}
+
+		// Fetch demo config after event listeners are registered so that
+		// WebSocket is open before any potentially-slow optional API calls.
+		// In web mode /api/demo-config returns 404 (not implemented), causing
+		// a network round-trip that previously delayed listener registration
+		// and caused the smoke test player-echo event to be dropped.
+		try {
+			const dc = await getDemoConfig();
+			demoConfig.set({
+				auto_start: dc.auto_start,
+				extra_prompt: dc.extra_prompt,
+				turn_pause_secs: dc.turn_pause_secs,
+				max_turns: dc.max_turns
+			});
+			if (dc.auto_start) {
+				startDemoLoop();
+			}
+		} catch (_) {}
 
 		return () => {
 			window.removeEventListener('keydown', onTrackerKey);


### PR DESCRIPTION
## Summary

- `getDemoConfig()` was awaited **before** event listeners were registered in `+page.svelte`
- In web mode `/api/demo-config` returns 404, adding a network round-trip that delayed `ensureWebSocket()` being called (which only fires on the first `onEvent()` registration)
- The Playwright smoke test "player can type a command" submits `look` as soon as the status bar is visible — which happens early, before listeners were registered — so the player-echo `text-log` WebSocket event was emitted by the server and silently dropped
- Moving `getDemoConfig()` to **after** the event-listener `try/catch` block ensures the WebSocket is open and all listeners are subscribed before any optional slow API call runs

## Test plan

- [ ] `just ui-e2e` — smoke test "player can type a command" should pass
- [ ] `just check` — fmt + clippy + tests
- [ ] Demo auto-start (`auto_start: true`) still works in Tauri mode (getDemoConfig resolves immediately, startDemoLoop fires as before)

https://claude.ai/code/session_01FP7KHaC4yLthaq4fu6f4mU

---
_Generated by [Claude Code](https://claude.ai/code/session_01FP7KHaC4yLthaq4fu6f4mU)_