### PR TITLE
fix(ui): resolve frontend quality issues #702 #705 #712 #772 #773 #774 #776

### DIFF
--- a/parish/apps/ui/src/app.css
+++ b/parish/apps/ui/src/app.css
@@ -102,6 +102,34 @@ body::before {
 	background: var(--color-muted);
 }
 
+/* ── Travel animation dot (HTML marker) ──
+   Animating `transform` would clobber the `translate(…)` MapLibre sets
+   each frame to position the marker, collapsing it to the canvas top-left.
+   Pulse via opacity + box-shadow only.
+   Defined here once and referenced by both MapPanel (minimap) and
+   FullMapOverlay (full map); Svelte scopes :global styles to the mounting
+   component so both components need the class to be reachable. */
+.travel-dot-marker {
+	width: 14px;
+	height: 14px;
+	border-radius: 50%;
+	background: var(--color-accent);
+	border: 2px solid var(--color-fg);
+	animation: travel-pulse 0.6s ease-in-out infinite alternate;
+	pointer-events: none;
+}
+
+@keyframes travel-pulse {
+	from {
+		opacity: 0.85;
+		box-shadow: 0 0 4px var(--color-accent);
+	}
+	to {
+		opacity: 1;
+		box-shadow: 0 0 12px var(--color-accent);
+	}
+}
+
 /* ── Mobile adjustments ── */
 @media (max-width: 768px) {
 	html, body {

--- a/parish/apps/ui/src/components/ChatPanel.test.ts
+++ b/parish/apps/ui/src/components/ChatPanel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, fireEvent } from '@testing-library/svelte';
-import { textLog, streamingActive, loadingSpinner, loadingPhrase, loadingColor } from '../stores/game';
+import { textLog, streamingActive, loadingPhrase, loadingColor } from '../stores/game';
 import ChatPanel from './ChatPanel.svelte';
 
 // Mock the IPC layer
@@ -12,7 +12,6 @@ describe('ChatPanel', () => {
 	beforeEach(() => {
 		textLog.set([]);
 		streamingActive.set(false);
-		loadingSpinner.set('');
 		loadingPhrase.set('');
 		loadingColor.set([72, 199, 142]);
 	});
@@ -33,7 +32,6 @@ describe('ChatPanel', () => {
 	});
 
 	it('shows loading phrase when streaming is active with no streaming entry', () => {
-		loadingSpinner.set('✛');
 		loadingPhrase.set('Consulting the sheep...');
 		streamingActive.set(true);
 		const { container, getByText } = render(ChatPanel);
@@ -43,7 +41,6 @@ describe('ChatPanel', () => {
 	});
 
 	it('applies spinner colour from loadingColor store', () => {
-		loadingSpinner.set('✜');
 		loadingPhrase.set('Pondering the craic...');
 		loadingColor.set([255, 200, 87]);
 		streamingActive.set(true);

--- a/parish/apps/ui/src/components/FullMapOverlay.svelte
+++ b/parish/apps/ui/src/components/FullMapOverlay.svelte
@@ -5,6 +5,7 @@
 	import { tiles, currentTileSource } from '../stores/tiles';
 	import { submitInput } from '$lib/ipc';
 	import { MapController, type LocationHoverInfo } from '$lib/map/controller';
+	import type { MapTooltipInfo } from '$lib/types';
 
 	interface Props {
 		onclose: () => void;
@@ -16,14 +17,7 @@
 	let controller: MapController | null = null;
 	let mounted = $state(false);
 
-	interface TooltipInfo {
-		name: string;
-		indoor?: boolean;
-		travel_minutes?: number;
-		visited?: boolean;
-	}
-
-	let tooltip: TooltipInfo | null = $state(null);
+	let tooltip: MapTooltipInfo | null = $state(null);
 
 	onMount(() => {
 		if (!container) return;
@@ -203,30 +197,7 @@
 		width: 100%;
 	}
 
-	/* ── Travel animation dot (HTML marker) ──
-	   Animating `transform` would clobber the `translate(…)` MapLibre sets
-	   each frame to position the marker, collapsing it to the canvas
-	   top-left. Pulse via opacity + box-shadow only. */
-	:global(.travel-dot-marker) {
-		width: 14px;
-		height: 14px;
-		border-radius: 50%;
-		background: var(--color-accent);
-		border: 2px solid var(--color-fg);
-		animation: travel-pulse 0.6s ease-in-out infinite alternate;
-		pointer-events: none;
-	}
-
-	@keyframes travel-pulse {
-		from {
-			opacity: 0.85;
-			box-shadow: 0 0 4px var(--color-accent);
-		}
-		to {
-			opacity: 1;
-			box-shadow: 0 0 12px var(--color-accent);
-		}
-	}
+	/* .travel-dot-marker and @keyframes travel-pulse are defined once in app.css */
 
 	.tooltip {
 		position: absolute;

--- a/parish/apps/ui/src/components/InputField.svelte
+++ b/parish/apps/ui/src/components/InputField.svelte
@@ -546,16 +546,6 @@
 		}
 	}
 
-	function toggleNpcSelection(realName: string) {
-		if ($streamingActive) return;
-		if (selectedNpcRealNames.includes(realName)) {
-			selectedNpcRealNames = selectedNpcRealNames.filter((name) => name !== realName);
-		} else {
-			selectedNpcRealNames = [...selectedNpcRealNames, realName];
-		}
-		editorEl?.focus();
-	}
-
 	function insertNpcMention(npcName: string) {
 		if ($streamingActive || !editorEl) return;
 

--- a/parish/apps/ui/src/components/MapPanel.svelte
+++ b/parish/apps/ui/src/components/MapPanel.svelte
@@ -5,7 +5,7 @@
 	import { tiles, currentTileSource } from '../stores/tiles';
 	import { submitInput } from '$lib/ipc';
 	import { MapController, type LocationHoverInfo } from '$lib/map/controller';
-	import type { MapLocation } from '$lib/types';
+	import type { MapLocation, MapTooltipInfo } from '$lib/types';
 
 	/** Only show locations within this many hops on the minimap. */
 	const MINIMAP_HOP_RADIUS = 1;
@@ -20,14 +20,7 @@
 		Array<{ x1: number; y1: number; x2: number; y2: number }>
 	>([]);
 
-	interface TooltipInfo {
-		name: string;
-		indoor?: boolean;
-		travel_minutes?: number;
-		visited?: boolean;
-	}
-
-	let tooltip: TooltipInfo | null = $state(null);
+	let tooltip: MapTooltipInfo | null = $state(null);
 
 	/** Computes the set of location IDs visible on the minimap. */
 	function visibleIdSet(locations: MapLocation[]): Set<string> {
@@ -410,32 +403,7 @@
 		stroke-dasharray: 3 2;
 	}
 
-	/* Travel animation dot — also defined in FullMapOverlay.svelte; mirrored
-	   here because Svelte scopes :global styles to the mounting component,
-	   so the minimap needs its own copy when the full map isn't open.
-	   The pulse animates opacity + box-shadow only; animating `transform`
-	   would clobber the `translate(…)` MapLibre sets each frame to position
-	   the marker, collapsing it to the canvas top-left. */
-	:global(.travel-dot-marker) {
-		width: 14px;
-		height: 14px;
-		border-radius: 50%;
-		background: var(--color-accent);
-		border: 2px solid var(--color-fg);
-		animation: travel-pulse 0.6s ease-in-out infinite alternate;
-		pointer-events: none;
-	}
-
-	@keyframes travel-pulse {
-		from {
-			opacity: 0.85;
-			box-shadow: 0 0 4px var(--color-accent);
-		}
-		to {
-			opacity: 1;
-			box-shadow: 0 0 12px var(--color-accent);
-		}
-	}
+	/* .travel-dot-marker and @keyframes travel-pulse are defined once in app.css */
 
 	.tooltip-unexplored {
 		font-style: italic;

--- a/parish/apps/ui/src/components/SavePicker.svelte
+++ b/parish/apps/ui/src/components/SavePicker.svelte
@@ -119,7 +119,7 @@
 			});
 		} catch (e: unknown) {
 			console.error('Branch creation failed:', e);
-			forkError = String(e).substring(0, 60);
+			forkError = (e instanceof Error ? e.message : String(e)).substring(0, 60);
 		}
 		loadingCount--;
 	}

--- a/parish/apps/ui/src/components/SavePicker.svelte
+++ b/parish/apps/ui/src/components/SavePicker.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { tick } from 'svelte';
 	import { savePickerVisible, saveFiles, currentSaveState } from '../stores/save';
-	import { discoverSaveFiles, loadBranch, saveGame, newSaveFile, newGame, createBranch, getSaveState, getWorldSnapshot, getMap, getNpcsHere } from '$lib/ipc';
+	import { discoverSaveFiles, loadBranch, newSaveFile, newGame, createBranch, getSaveState, getWorldSnapshot, getMap, getNpcsHere } from '$lib/ipc';
 	import { worldState, mapData, npcsHere } from '../stores/game';
 	import type { SaveFileInfo, SaveBranchDisplay } from '$lib/types';
 	import { layoutTree, NODE_W, NODE_H, GAP_Y } from '$lib/save-picker/dag';
@@ -12,6 +12,7 @@
 	let forkName = $state('');
 	let forkError = $state('');
 	let showLedgers = $state(false);
+	let modalBodyEl: HTMLDivElement | undefined = $state();
 
 	// ── Handlers ────────────────────────────────────────────────────
 
@@ -105,7 +106,7 @@
 			forkingBranchId = null;
 			forkName = '';
 			// Save scroll position before refresh re-renders the tree
-			const body = document.querySelector('.modal-body');
+			const body = modalBodyEl;
 			const scrollTop = body?.scrollTop ?? 0;
 			const scrollLeft = body?.scrollLeft ?? 0;
 			await refreshSaves();
@@ -116,7 +117,7 @@
 					body.scrollLeft = scrollLeft;
 				}
 			});
-		} catch (e: any) {
+		} catch (e: unknown) {
 			console.error('Branch creation failed:', e);
 			forkError = String(e).substring(0, 60);
 		}
@@ -158,7 +159,7 @@
 		// Scroll the phantom node into view with extra room for scrollbar
 		requestAnimationFrame(() => {
 			const dagNode = node.closest('.dag-node') as HTMLElement | null;
-			const body = document.querySelector('.modal-body');
+			const body = modalBodyEl;
 			if (dagNode && body) {
 				const nodeRect = dagNode.getBoundingClientRect();
 				const bodyRect = body.getBoundingClientRect();
@@ -207,7 +208,7 @@
 
 	async function scrollToCurrentNode() {
 		await tick();
-		const current = document.querySelector('.dag-current');
+		const current = modalBodyEl?.querySelector('.dag-current');
 		if (current) {
 			current.scrollIntoView({ behavior: 'instant', block: 'center', inline: 'center' });
 		}
@@ -266,7 +267,7 @@
 				</span>
 			</div>
 
-			<div class="modal-body">
+			<div class="modal-body" bind:this={modalBodyEl}>
 				{#if loading && files.length === 0}
 					<div class="loading-msg">Scanning save files...</div>
 				{/if}

--- a/parish/apps/ui/src/components/editor/NpcDetail.svelte
+++ b/parish/apps/ui/src/components/editor/NpcDetail.svelte
@@ -100,7 +100,7 @@
 						class="field-input short"
 						type="number"
 						value={npc.age}
-						onchange={(e) => handleFieldChange('age', parseInt(e.currentTarget.value, 10))}
+						onchange={(e) => { const v = parseInt(e.currentTarget.value, 10); if (!isNaN(v)) handleFieldChange('age', v); }}
 					/>
 				</div>
 				<div class="field-row">
@@ -157,7 +157,7 @@
 						id="npc-home"
 						class="field-select"
 						value={npc.home}
-						onchange={(e) => handleFieldChange('home', parseInt(e.currentTarget.value, 10))}
+						onchange={(e) => { const v = parseInt(e.currentTarget.value, 10); if (!isNaN(v)) handleFieldChange('home', v); }}
 					>
 						{#each locations as loc}
 							<option value={loc.id}>{loc.name}</option>
@@ -172,7 +172,7 @@
 						value={npc.workplace ?? -1}
 						onchange={(e) => {
 							const v = parseInt(e.currentTarget.value, 10);
-							handleFieldChange('workplace', v === -1 ? null : v);
+							if (!isNaN(v)) handleFieldChange('workplace', v === -1 ? null : v);
 						}}
 					>
 						<option value={-1}>(none)</option>
@@ -199,11 +199,10 @@
 								value={npc.intelligence?.[dim.key] ?? 3}
 								onchange={(e) => {
 									if (!npc?.intelligence) return;
-									const updated = {
-										...npc.intelligence,
-										[dim.key]: parseInt(e.currentTarget.value, 10)
-									};
-									handleFieldChange('intelligence', updated);
+									const v = parseInt(e.currentTarget.value, 10);
+									if (!isNaN(v)) {
+										handleFieldChange('intelligence', { ...npc.intelligence, [dim.key]: v });
+									}
 								}}
 							/>
 							<span class="range-value">{npc.intelligence?.[dim.key] ?? 3}</span>

--- a/parish/apps/ui/src/components/editor/NpcDetail.svelte
+++ b/parish/apps/ui/src/components/editor/NpcDetail.svelte
@@ -100,7 +100,7 @@
 						class="field-input short"
 						type="number"
 						value={npc.age}
-						onchange={(e) => handleFieldChange('age', parseInt(e.currentTarget.value))}
+						onchange={(e) => handleFieldChange('age', parseInt(e.currentTarget.value, 10))}
 					/>
 				</div>
 				<div class="field-row">
@@ -157,7 +157,7 @@
 						id="npc-home"
 						class="field-select"
 						value={npc.home}
-						onchange={(e) => handleFieldChange('home', parseInt(e.currentTarget.value))}
+						onchange={(e) => handleFieldChange('home', parseInt(e.currentTarget.value, 10))}
 					>
 						{#each locations as loc}
 							<option value={loc.id}>{loc.name}</option>
@@ -171,7 +171,7 @@
 						class="field-select"
 						value={npc.workplace ?? -1}
 						onchange={(e) => {
-							const v = parseInt(e.currentTarget.value);
+							const v = parseInt(e.currentTarget.value, 10);
 							handleFieldChange('workplace', v === -1 ? null : v);
 						}}
 					>
@@ -201,7 +201,7 @@
 									if (!npc?.intelligence) return;
 									const updated = {
 										...npc.intelligence,
-										[dim.key]: parseInt(e.currentTarget.value)
+										[dim.key]: parseInt(e.currentTarget.value, 10)
 									};
 									handleFieldChange('intelligence', updated);
 								}}

--- a/parish/apps/ui/src/components/editor/ValidatorPanel.svelte
+++ b/parish/apps/ui/src/components/editor/ValidatorPanel.svelte
@@ -29,11 +29,11 @@
 		if (npcMatch && issue.context) {
 			editorTab.set('npcs');
 			// context usually has the id; try to use it
-			const id = parseInt(issue.context);
+			const id = parseInt(issue.context, 10);
 			if (!isNaN(id)) editorSelectedNpcId.set(id);
 		} else if (locMatch && issue.context) {
 			editorTab.set('locations');
-			const id = parseInt(issue.context);
+			const id = parseInt(issue.context, 10);
 			if (!isNaN(id)) editorSelectedLocationId.set(id);
 		}
 	}

--- a/parish/apps/ui/src/lib/editor-ipc.ts
+++ b/parish/apps/ui/src/lib/editor-ipc.ts
@@ -16,7 +16,6 @@ import type {
 	LocationData,
 	SaveFileSummary,
 	BranchSummary,
-	SnapshotSummary,
 	SnapshotDetail
 } from './editor-types';
 
@@ -24,8 +23,6 @@ export const editorListMods = () => command<ModSummary[]>('editor_list_mods');
 
 export const editorOpenMod = (modPath: string) =>
 	command<EditorModSnapshot>('editor_open_mod', { modPath });
-
-export const editorGetSnapshot = () => command<EditorModSnapshot>('editor_get_snapshot');
 
 export const editorValidate = () => command<ValidationReport>('editor_validate');
 
@@ -38,19 +35,12 @@ export const editorUpdateLocations = (locations: LocationData[]) =>
 export const editorSave = (docs: EditorDoc[]) =>
 	command<EditorSaveResponse>('editor_save', { docs });
 
-export const editorReload = () => command<EditorModSnapshot>('editor_reload');
-
-export const editorClose = () => command<void>('editor_close');
-
 // ── Save inspector (read-only) ───────────────────────────────────────────────
 
 export const editorListSaves = () => command<SaveFileSummary[]>('editor_list_saves');
 
 export const editorListBranches = (savePath: string) =>
 	command<BranchSummary[]>('editor_list_branches', { savePath });
-
-export const editorListSnapshots = (savePath: string, branchId: number) =>
-	command<SnapshotSummary[]>('editor_list_snapshots', { savePath, branchId });
 
 export const editorReadSnapshot = (savePath: string, branchId: number) =>
 	command<SnapshotDetail | null>('editor_read_snapshot', { savePath, branchId });

--- a/parish/apps/ui/src/lib/types.ts
+++ b/parish/apps/ui/src/lib/types.ts
@@ -44,6 +44,15 @@ export interface MapData {
 	transport_id?: string;
 }
 
+/** Tooltip data shown when hovering a map location marker.
+ *  Used by both MapPanel (minimap) and FullMapOverlay (full map). */
+export interface MapTooltipInfo {
+	name: string;
+	indoor?: boolean;
+	travel_minutes?: number;
+	visited?: boolean;
+}
+
 /** A waypoint along a travel path. */
 export interface TravelWaypoint {
 	id: string;
@@ -84,8 +93,6 @@ export interface LanguageHint {
 	meaning: string | null;
 }
 
-/** Backward-compatible alias. */
-export type IrishWordHint = LanguageHint;
 
 export interface UiConfig {
 	hints_label: string;
@@ -139,7 +146,7 @@ export interface StreamTurnEndPayload {
 }
 
 export interface StreamEndPayload {
-	hints: IrishWordHint[];
+	hints: LanguageHint[];
 }
 
 export interface TextLogPayload {

--- a/parish/apps/ui/src/routes/+page.svelte
+++ b/parish/apps/ui/src/routes/+page.svelte
@@ -13,7 +13,7 @@
 	import DemoPanel from '../components/DemoPanel.svelte';
 	import SavePicker from '../components/SavePicker.svelte';
 
-	import { worldState, mapData, npcsHere, textLog, streamingActive, loadingSpinner, loadingPhrase, loadingColor, languageHints, nameHints, uiConfig, fullMapOpen, focailOpen, addReaction, trimTextLog, messageHints, pushErrorLog, formatIpcError } from '../stores/game';
+	import { worldState, mapData, npcsHere, textLog, streamingActive, loadingPhrase, loadingColor, languageHints, nameHints, uiConfig, fullMapOpen, focailOpen, addReaction, trimTextLog, messageHints, pushErrorLog, formatIpcError } from '../stores/game';
 	import { demoVisible, demoEnabled, demoConfig } from '../stores/demo';
 	import { startDemoLoop, stopDemo } from '../lib/demo-player';
 
@@ -563,7 +563,6 @@
 				if (payload.active) {
 					// Loading started: mark streaming active and update spinner UI.
 					streamingActive.set(true);
-					if (payload.spinner) loadingSpinner.set(payload.spinner);
 					if (payload.phrase) loadingPhrase.set(payload.phrase);
 					if (payload.color) loadingColor.set(payload.color);
 				} else if (pendingNpcTurns.size === 0 && pendingStreamEndHints === null) {

--- a/parish/apps/ui/src/routes/editor/+page.svelte
+++ b/parish/apps/ui/src/routes/editor/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { editorListMods, editorOpenMod } from '$lib/editor-ipc';
+	import { editorListMods } from '$lib/editor-ipc';
 	import {
 		editorMods,
 		editorSnapshot,
@@ -44,9 +44,9 @@
 		}
 	});
 
-	$: snap = $editorSnapshot;
-	$: tab = $editorTab;
-	$: issueCount = $editorIssueCount;
+	const snap = $derived($editorSnapshot);
+	const tab = $derived($editorTab);
+	const issueCount = $derived($editorIssueCount);
 </script>
 
 <div class="editor-page">
@@ -67,7 +67,7 @@
 				<button
 					class="tab-btn"
 					class:active={tab === t.id}
-					on:click={() => selectTab(t.id)}
+					onclick={() => selectTab(t.id)}
 				>
 					{t.label}
 					{#if t.id === 'validator' && issueCount > 0}

--- a/parish/apps/ui/src/stores/game.ts
+++ b/parish/apps/ui/src/stores/game.ts
@@ -20,9 +20,6 @@ export function trimTextLog(log: TextLogEntry[]): TextLogEntry[] {
 
 export const streamingActive = writable<boolean>(false);
 
-/// Current loading spinner character (e.g. "✛").
-export const loadingSpinner = writable<string>('');
-
 /// Current fun loading phrase (e.g. "Consulting the sheep...").
 export const loadingPhrase = writable<string>('');
 

--- a/parish/apps/ui/src/stores/travel.ts
+++ b/parish/apps/ui/src/stores/travel.ts
@@ -1,4 +1,4 @@
-import { writable, derived } from 'svelte/store';
+import { writable } from 'svelte/store';
 import type { TravelStartPayload, TravelWaypoint } from '$lib/types';
 
 /** Current travel animation state (null when not traveling). */
@@ -24,9 +24,6 @@ const MAX_ANIMATION_MS = 3000;
 
 /** The active travel animation, or null if idle. */
 export const travelState = writable<TravelState | null>(null);
-
-/** Whether a travel animation is currently playing. */
-export const isTraveling = derived(travelState, ($t) => $t !== null);
 
 /** Outstanding auto-clear timer for the active travel animation.
  *
@@ -94,36 +91,3 @@ export function cancelTravel(): void {
 	travelState.set(null);
 }
 
-/**
- * Computes the current interpolated position along the travel path.
- *
- * Returns `{ lat, lon, progress, segmentIndex }` where progress is 0–1
- * and segmentIndex is which edge segment the dot is currently on.
- * Returns null if not traveling.
- */
-export function getTravelPosition(
-	state: TravelState,
-	now: number
-): { lat: number; lon: number; progress: number; segmentIndex: number } | null {
-	const elapsed = now - state.startedAt;
-	const progress = Math.min(1, Math.max(0, elapsed / state.animationMs));
-
-	const wps = state.waypoints;
-	const segCount = wps.length - 1;
-	if (segCount < 1) return null;
-
-	// Map progress to segment
-	const segFloat = progress * segCount;
-	const segIndex = Math.min(Math.floor(segFloat), segCount - 1);
-	const segProgress = segFloat - segIndex;
-
-	const from = wps[segIndex];
-	const to = wps[segIndex + 1];
-
-	return {
-		lat: from.lat + (to.lat - from.lat) * segProgress,
-		lon: from.lon + (to.lon - from.lon) * segProgress,
-		progress,
-		segmentIndex: segIndex
-	};
-}


### PR DESCRIPTION
## Summary

- **#702 / #773 — dead code:** Remove unused exports (`isTraveling`, `getTravelPosition`, `editorGetSnapshot`, `editorReload`, `editorClose`, `editorListSnapshots`), unused imports (`saveGame` in SavePicker, `editorOpenMod` in editor page), dead `loadingSpinner` store and its write-path in `+page.svelte`, `IrishWordHint` backward-compat alias (replaced with `LanguageHint` at its single use-site), and `toggleNpcSelection` function that had no call sites.
- **#772 — parseInt radix:** Added explicit radix `10` to all six `parseInt()` calls across `NpcDetail.svelte` (lines 103, 160, 174, 204) and `ValidatorPanel.svelte` (lines 32, 36).
- **#774 — TypeScript strict:** Changed `catch (e: any)` → `catch (e: unknown)` in `SavePicker.svelte`; `String(e)` already handles `unknown` cleanly.
- **#776 — document.querySelector scope:** Added `let modalBodyEl: HTMLDivElement | undefined = $state()` and `bind:this={modalBodyEl}` to the `.modal-body` div. Replaced all three `document.querySelector('.modal-body')` calls with the bound ref, and replaced `document.querySelector('.dag-current')` with `modalBodyEl?.querySelector('.dag-current')`.
- **#712 — CSS and type duplication:** Moved `.travel-dot-marker` styles and `@keyframes travel-pulse` from both `MapPanel.svelte` and `FullMapOverlay.svelte` into `app.css` (single source of truth). Extracted identical `TooltipInfo` interface into `MapTooltipInfo` in `$lib/types.ts` and replaced local definitions in both map components.
- **Editor page Svelte 4 → 5:** While fixing #702, migrated the three reactive declarations (`$:`) to `$derived` and `on:click` to `onclick` in `editor/+page.svelte`.

## Test plan

- [x] `cd parish/apps/ui && npm run check` — 0 errors (1 pre-existing `user-select` warning)
- [x] `cd parish/apps/ui && npm run build` — clean build
- [x] `cd parish/apps/ui && npx vitest run` — 292 tests pass
- [x] `cd parish && cargo fmt --check` — clean
- [x] `cd parish && cargo clippy -- -D warnings` — clean
- [x] `cd parish && cargo test` — all tests pass

Fixes #702, fixes #705, fixes #712, fixes #772, fixes #773, fixes #774, fixes #776.

https://claude.ai/code/session_01H1c7EqJxbFJNrZmbwSG7ud

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1c7EqJxbFJNrZmbwSG7ud)_