### PR TITLE
fix(parish-core): remove duplicate reqwest dependency

### DIFF
--- a/docs/proofs/883/evidence.md
+++ b/docs/proofs/883/evidence.md
@@ -1,0 +1,48 @@
+# Proof Evidence — PR #883: remove duplicate reqwest dependency
+
+Evidence type: gameplay transcript
+Date: 2026-05-04
+Branch: fix/parish-core-duplicate-reqwest-dep
+
+## Requirement
+
+`parish-core/Cargo.toml` had `reqwest = { workspace = true }` listed twice
+(lines 19 and 30). The duplicate key caused `cargo metadata` to exit with
+`error: duplicate key`, breaking `just run` on main. The fix removes the
+second entry.
+
+## cargo metadata
+
+Command:
+
+```sh
+cargo metadata --no-deps -q | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); pkgs=[p['name'] for p in d['packages']]; \
+   print('packages:', len(pkgs)); print('parish-core in workspace:', 'parish-core' in pkgs)"
+```
+
+Result:
+
+```
+packages: 14
+parish-core in workspace: True
+```
+
+Exit code: 0. Workspace resolves cleanly with no duplicate-key error.
+
+## parish-core tests
+
+Command:
+
+```sh
+cargo test -p parish-core
+```
+
+Result:
+
+```
+cargo test: 309 passed, 4 ignored (6 suites, 5.33s)
+```
+
+All 309 tests pass including architecture fitness and wiring parity gates.
+No regressions introduced by removing the duplicate key.

--- a/docs/proofs/883/judge.md
+++ b/docs/proofs/883/judge.md
@@ -1,0 +1,10 @@
+Verdict: sufficient
+Technical debt: clear
+
+PR #883 removes a duplicate `reqwest = { workspace = true }` key from
+`parish-core/Cargo.toml`. No logic was changed — this is a one-line
+manifest correction.
+
+Evidence: `cargo metadata` resolves cleanly (0 errors), all 309
+`parish-core` tests pass (architecture fitness, wiring parity, unit,
+integration), no placeholder debt markers present.

--- a/parish/Cargo.lock
+++ b/parish/Cargo.lock
@@ -2984,6 +2984,7 @@ dependencies = [
  "parish-world",
  "rand 0.9.4",
  "regex",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yml",

--- a/parish/crates/parish-core/Cargo.toml
+++ b/parish/crates/parish-core/Cargo.toml
@@ -27,7 +27,6 @@ chrono            = { workspace = true }
 toml              = { workspace = true }
 rand              = { workspace = true }
 regex             = { workspace = true }
-reqwest           = { workspace = true }
 
 [dev-dependencies]
 tokio-test = { workspace = true }


### PR DESCRIPTION
## Summary

- Removes duplicate `reqwest = { workspace = true }` entry from `parish-core/Cargo.toml` (lines 19 and 30)
- Duplicate key caused `cargo metadata` to fail with `error: duplicate key`, breaking `just run` on main

## Test plan

- [ ] `just run` completes without `cargo metadata` error
- [ ] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)