### PR TITLE
test: fix test quality issues #778 #779 #780 #781

### DIFF
--- a/docs/proofs/778-779-780-781/evidence.md
+++ b/docs/proofs/778-779-780-781/evidence.md
@@ -1,0 +1,112 @@
+Evidence type: gameplay transcript
+Date: 2026-05-04
+Branch: fix/778-779-780-781-test-quality
+
+# Proof Evidence — Fixes #778, #779, #780, #781: Test Quality
+
+## Summary
+
+Four test-quality issues fixed. In each case the production code path is
+unchanged; only the tests were deficient.
+
+## #778 — Exact-count assertions replaced with derived/range checks
+
+### world_graph_integration.rs: test_parish_json_location_count
+
+`assert_eq!(graph.location_count(), 22)` replaced with a derived assertion:
+the test now reads `mods/rundale/world.json` directly, counts the entries in
+the `"locations"` array, and asserts `graph.location_count() == json_count`.
+This will catch any future loader regression that silently drops locations,
+not just a mismatch against a hardcoded literal.
+
+### headless_script_tests.rs: test_all_locations_reachable
+
+The hardcoded list of 14 location names replaced with:
+1. Every resolved destination must appear in the world graph (verifies no
+   phantom locations).
+2. At least 14 distinct locations were visited (`>= 14`), so the test
+   survives graph growth without requiring a fixture update.
+
+Command run:
+
+```sh
+cargo test -p parish --test world_graph_integration
+```
+
+Result: 28 passed
+
+```sh
+cargo test -p parish --test headless_script_tests
+```
+
+Result: 74 passed
+
+## #779 — Gossip retry loops replaced with rate assertions
+
+The three tests in `gossip_integration.rs` that used "find any of 50 seeds
+that propagates" loops were replaced with:
+
+- A loop over 200 deterministic seeds that asserts the transmission rate is
+  between 50% and 70% (the documented ~60%). This directly catches a
+  regression in transmission probability; the previous code would pass even
+  if the rate dropped to 6%.
+- Structural invariants (source recorded, listener in known_by) are verified
+  on the first seed that does transmit, so both correctness and probability
+  are tested.
+
+Command run:
+
+```sh
+cargo test -p parish-npc --test gossip_integration
+```
+
+Result: 3 passed
+
+## #780 — Weather seasonal bias test driven through tick()
+
+`test_weather_seasonal_bias` previously bypassed `tick()` by resetting the
+private `last_check_hour` field and calling `compute_transition()` directly.
+The test now drives the engine through `tick()` over 600 simulated game-hours
+(1 hour per iteration), which exercises the same hourly-gate and
+min-duration logic that production uses.
+
+With 600 hours and a 2-hour min-duration, roughly 150-300 transition checks
+occur — enough for the winter vs summer rain signal to be clearly observable.
+The assertion (`winter_rain > summer_rain` with seed 12345) still holds.
+
+Command run:
+
+```sh
+cargo test -p parish-world test_weather_seasonal_bias
+```
+
+Result: 1 passed
+
+## #781 — focailOpen test exercises the actual handler
+
+The `syncFocailOnViewportChange(matches: boolean)` function was extracted
+from the inline `onChange` handler in `+page.svelte` into `game.ts` as an
+exported function. The handler in `+page.svelte` now delegates to it.
+
+The test now imports and exercises `syncFocailOnViewportChange` directly:
+- `matches=false` (mobile-to-desktop transition) must reset `focailOpen`.
+- `matches=true` (desktop-to-mobile or still mobile) must leave it unchanged.
+
+Previously the test just called `focailOpen.set(false)` directly, which
+would pass even if the entire handler were deleted.
+
+Command run:
+
+```sh
+just ui-test
+```
+
+Result: 304 passed (23 suites)
+
+## Full Rust suite
+
+```sh
+cargo test -p parish -p parish-npc -p parish-world
+```
+
+Result: 840 passed (14 suites)

--- a/docs/proofs/778-779-780-781/judge.md
+++ b/docs/proofs/778-779-780-781/judge.md
@@ -1,0 +1,26 @@
+Verdict: sufficient
+Technical debt: clear
+
+This PR fixes four test-quality issues — no production logic was changed except
+extracting `syncFocailOnViewportChange` from an inline component handler into an
+exported function (which the component immediately calls, preserving behavior).
+
+#778: Both assertions now derive their expected values rather than comparing
+against literals. The world_graph test reads world.json and verifies the loader
+parses every entry; the headless test verifies every visited destination is a
+real graph location and that at least 14 were visited.
+
+#779: The 50-seed "find any propagation" loops are replaced with 200-seed rate
+assertions (50-70%). This directly tests the production transmission probability
+and will fail if it is silently regressed. Structural invariants are also verified
+on the first successful transmission.
+
+#780: The weather seasonal bias test is now driven through tick() over 600
+simulated hours, exercising the same hourly-gate and min-duration logic as
+production rather than bypassing them via field mutation and compute_transition().
+
+#781: The regression test now calls syncFocailOnViewportChange (the extracted
+handler logic) rather than focailOpen.set(false) directly. The test would fail
+if the reset logic were deleted or inverted.
+
+All 840 Rust tests pass; all 304 UI unit tests pass. No debt markers present.

--- a/parish/apps/ui/src/routes/+page.svelte
+++ b/parish/apps/ui/src/routes/+page.svelte
@@ -14,7 +14,7 @@
 	import SavePicker from '../components/SavePicker.svelte';
 	import SetupOverlay from '../components/SetupOverlay.svelte';
 
-	import { worldState, mapData, npcsHere, textLog, streamingActive, loadingPhrase, loadingColor, languageHints, nameHints, uiConfig, fullMapOpen, focailOpen, addReaction, trimTextLog, messageHints, pushErrorLog, formatIpcError } from '../stores/game';
+	import { worldState, mapData, npcsHere, textLog, streamingActive, loadingPhrase, loadingColor, languageHints, nameHints, uiConfig, fullMapOpen, focailOpen, addReaction, trimTextLog, messageHints, pushErrorLog, formatIpcError, syncFocailOnViewportChange } from '../stores/game';
 	import { demoVisible, demoEnabled, demoConfig } from '../stores/demo';
 	import { startDemoLoop, stopDemo } from '../lib/demo-player';
 
@@ -200,9 +200,7 @@
 				// When transitioning from mobile→desktop, close the focail overlay so
 				// the store doesn't stay true while the mobile Sidebar branch is hidden
 				// (the desktop right-col always renders its own Sidebar unconditionally).
-				if (!e.matches) {
-					focailOpen.set(false);
-				}
+				syncFocailOnViewportChange(e.matches);
 			};
 			mq.addEventListener('change', onChange);
 			mobileMediaCleanup = () => mq.removeEventListener('change', onChange);

--- a/parish/apps/ui/src/stores/game.test.ts
+++ b/parish/apps/ui/src/stores/game.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { get } from 'svelte/store';
-import { textLog, pushErrorLog, formatIpcError, loadingColor, focailOpen } from './game';
+import { textLog, pushErrorLog, formatIpcError, loadingColor, focailOpen, syncFocailOnViewportChange } from './game';
 
 describe('pushErrorLog', () => {
 	beforeEach(() => {
@@ -68,28 +68,44 @@ describe('formatIpcError', () => {
 // Regression test for #600: focailOpen must be reset to false when the
 // viewport transitions from mobile to desktop so the Language Hints button
 // doesn't stay in a permanently-pressed-but-invisible state.
-describe('focailOpen store (regression #600)', () => {
+//
+// These tests exercise syncFocailOnViewportChange — the function called by
+// the matchMedia onChange handler in +page.svelte — rather than the writable
+// store directly. A test that calls focailOpen.set(false) manually would pass
+// even if the handler were deleted; these tests fail if the handler logic is
+// removed or inverted.
+describe('syncFocailOnViewportChange (regression #600)', () => {
 	beforeEach(() => {
 		focailOpen.set(false);
 	});
 
-	it('starts as false', () => {
+	it('resets focailOpen to false when transitioning to desktop (matches=false)', () => {
+		// Simulate: user opened the Focail panel on mobile.
+		focailOpen.set(true);
+		expect(get(focailOpen)).toBe(true);
+
+		// Simulate: matchMedia onChange fires with e.matches=false (now desktop).
+		// syncFocailOnViewportChange must reset the store so the button is not
+		// left in a permanently-pressed-but-invisible state.
+		syncFocailOnViewportChange(false);
 		expect(get(focailOpen)).toBe(false);
 	});
 
-	it('can be toggled on (simulating mobile button press)', () => {
+	it('does NOT reset focailOpen when transitioning to mobile (matches=true)', () => {
+		// Simulate: user opened the panel on mobile, viewport shrinks further.
 		focailOpen.set(true);
+		expect(get(focailOpen)).toBe(true);
+
+		// matches=true means the narrow-viewport query still matches; the mobile
+		// branch is still active so focailOpen should be left unchanged.
+		syncFocailOnViewportChange(true);
 		expect(get(focailOpen)).toBe(true);
 	});
 
-	it('is reset to false on mobile→desktop transition (the #600 fix)', () => {
-		// Simulate mobile: user opens the Focail panel
-		focailOpen.set(true);
-		expect(get(focailOpen)).toBe(true);
-
-		// Simulate desktop: the media query onChange handler fires with matches=false
-		// and calls focailOpen.set(false) to avoid a permanently-broken button state.
-		focailOpen.set(false);
+	it('is a no-op when focailOpen is already false and viewport goes desktop', () => {
+		// Store is already false; going to desktop should leave it false.
+		expect(get(focailOpen)).toBe(false);
+		syncFocailOnViewportChange(false);
 		expect(get(focailOpen)).toBe(false);
 	});
 });

--- a/parish/apps/ui/src/stores/game.ts
+++ b/parish/apps/ui/src/stores/game.ts
@@ -55,6 +55,23 @@ export const fullMapOpen = writable<boolean>(false);
 
 export const focailOpen = writable<boolean>(false);
 
+/**
+ * Resets focailOpen to false when the viewport transitions to desktop
+ * (i.e. when the narrow-viewport media query stops matching).
+ *
+ * Extracted from the inline matchMedia onChange handler in +page.svelte so
+ * that the logic can be unit-tested independently of the component lifecycle.
+ * The handler should call this with `e.matches` on every change event.
+ *
+ * See: fix for #600 — focailOpen must be false on desktop so the Language
+ * Hints button doesn't stay in a permanently-pressed-but-invisible state.
+ */
+export function syncFocailOnViewportChange(matches: boolean): void {
+	if (!matches) {
+		focailOpen.set(false);
+	}
+}
+
 /** Maps message ID → Irish word hints for that completed NPC response. */
 export const messageHints = writable<Map<string, LanguageHint[]>>(new Map());
 

--- a/parish/crates/parish-cli/tests/headless_script_tests.rs
+++ b/parish/crates/parish-cli/tests/headless_script_tests.rs
@@ -6,6 +6,7 @@
 //! not just "no crash".
 
 use parish::testing::{ActionResult, GameTestHarness, ScriptResult};
+use parish::world::graph::WorldGraph;
 use parish::world::time::{Season, TimeOfDay};
 use std::path::Path;
 
@@ -14,6 +15,12 @@ fn fixture(name: &str) -> Vec<ScriptResult> {
     let path = Path::new("../../testing/fixtures").join(name);
     assert!(path.exists(), "Fixture {} must exist", name);
     parish::testing::run_script_captured(&path).expect("Script should execute without error")
+}
+
+/// Loads the world graph from the canonical fixture path.
+fn load_world_graph() -> WorldGraph {
+    let path = Path::new("../../../mods/rundale/world.json");
+    WorldGraph::load_from_file(path).expect("mods/rundale/world.json should load")
 }
 
 /// Helper: count results matching a predicate.
@@ -43,11 +50,22 @@ fn looked_results(results: &[ScriptResult]) -> Vec<&ScriptResult> {
 
 #[test]
 fn test_all_locations_reachable() {
+    // Assert that every destination the fixture script visits is a known
+    // location in the world graph (no phantom names), and that at least 14
+    // distinct locations were visited.  Using ">= 14" rather than "== 14"
+    // makes the test resilient to the graph growing without requiring a
+    // fixture update for each new location.
+    let graph = load_world_graph();
+    let all_graph_names: std::collections::HashSet<String> = graph
+        .location_ids()
+        .iter()
+        .filter_map(|id| graph.get(*id).map(|loc| loc.name.clone()))
+        .collect();
+
     let results = fixture("test_all_locations.txt");
     let moves = moved_results(&results);
 
-    // We visit all 14 non-starting locations (Kilteevan is start)
-    let destinations: Vec<&str> = moves
+    let destinations: std::collections::HashSet<&str> = moves
         .iter()
         .filter_map(|r| {
             if let ActionResult::Moved { to, .. } = &r.result {
@@ -58,31 +76,21 @@ fn test_all_locations_reachable() {
         })
         .collect();
 
-    let expected = [
-        "The Crossroads",
-        "Darcy's Pub",
-        "St. Brigid's Church",
-        "The Bog Road",
-        "The Fairy Fort",
-        "Lough Ree Shore",
-        "Hodson Bay",
-        "Murphy's Farm",
-        "O'Brien's Farm",
-        "The Lime Kiln",
-        "The Letter Office",
-        "Connolly's Shop",
-        "The Hedge School",
-        "The Hurling Green",
-    ];
-
-    for loc in &expected {
+    // Every resolved destination must be a real graph location.
+    for dest in &destinations {
         assert!(
-            destinations.contains(loc),
-            "Should have visited {}, destinations: {:?}",
-            loc,
-            destinations
+            all_graph_names.contains(*dest),
+            "Fixture visited '{}' which is not in the world graph",
+            dest
         );
     }
+
+    assert!(
+        destinations.len() >= 14,
+        "Fixture should visit at least 14 distinct locations, got {}: {:?}",
+        destinations.len(),
+        destinations
+    );
 }
 
 #[test]

--- a/parish/crates/parish-cli/tests/world_graph_integration.rs
+++ b/parish/crates/parish-cli/tests/world_graph_integration.rs
@@ -35,8 +35,24 @@ fn test_parish_json_loads() {
 
 #[test]
 fn test_parish_json_location_count() {
+    // Derive the expected count directly from the world.json source so this
+    // test fails if the loader silently drops locations, not just if someone
+    // edits this hardcoded literal.
+    let json_text = std::fs::read_to_string("../../../mods/rundale/world.json")
+        .expect("mods/rundale/world.json must be readable");
+    let world: serde_json::Value =
+        serde_json::from_str(&json_text).expect("world.json must be valid JSON");
+    let json_count = world["locations"]
+        .as_array()
+        .expect("world.json must have a 'locations' array")
+        .len();
     let graph = load_parish_graph();
-    assert_eq!(graph.location_count(), 22);
+    assert_eq!(
+        graph.location_count(),
+        json_count,
+        "loader should parse every location in world.json: json={json_count}, loaded={}",
+        graph.location_count()
+    );
 }
 
 #[test]

--- a/parish/crates/parish-npc/tests/gossip_integration.rs
+++ b/parish/crates/parish-npc/tests/gossip_integration.rs
@@ -26,6 +26,11 @@ fn game_time() -> chrono::DateTime<chrono::Utc> {
 /// must:
 ///   1. Seed the gossip network with A as the source.
 ///   2. Propagate to NPC B when they are co-located during propagation.
+///
+/// This test verifies the structural invariants (source recorded, listener
+/// added to known_by) on a known-transmitting seed, and separately asserts
+/// that the overall transmission rate across 200 seeds is within the expected
+/// ~60% range — catching both wiring breaks and probability regressions.
 #[test]
 fn tier2_event_seeds_gossip_and_propagates_to_colocated_npc() {
     let mut network = GossipNetwork::new();
@@ -62,39 +67,57 @@ fn tier2_event_seeds_gossip_and_propagates_to_colocated_npc() {
         "listener must not know the gossip until propagation runs"
     );
 
-    // Step 2 — Alice and Bob are co-located during a Tier 2 interaction.
-    // Try enough RNG seeds to be overwhelmingly likely to propagate given the
-    // 60% transmission rate — we want a deterministic assertion that the
-    // cross-NPC path works, not a probabilistic one.
+    // Step 2 — verify transmission rate over 200 deterministic seeds.
+    //
+    // propagate_gossip_at_location with {alice, bob} and one alice-owned item
+    // calls gossip_network.propagate(alice, bob, rng) which makes one RNG draw
+    // per item (rng.random::<f64>() < TRANSMISSION_CHANCE = 0.60).
+    // Across 200 independent seeds the rate should fall between 50% and 70%.
+    // If the transmission probability is silently dropped to 0%, this catches it.
     let participants = [alice, bob];
-    let mut propagated_on_seed = None;
-    for seed in 0..50 {
-        let mut network = network.clone();
+    let mut transmitted_count = 0usize;
+    let trials = 200u64;
+
+    // Also check structural invariants on the first seed that does transmit.
+    let mut invariants_verified = false;
+
+    for seed in 0..trials {
+        let mut net = network.clone();
         let mut rng = StdRng::seed_from_u64(seed);
-        let transmitted = propagate_gossip_at_location(&participants, &mut network, &mut rng);
+        let transmitted = propagate_gossip_at_location(&participants, &mut net, &mut rng);
         if transmitted > 0 {
-            // Bob's known_by set must now include the gossip item.
-            let bob_gossip = network.known_by(bob);
-            assert_eq!(
-                bob_gossip.len(),
-                1,
-                "listener should know exactly the one gossip item after propagation"
-            );
-            assert!(
-                bob_gossip[0].known_by.contains(&alice),
-                "original source must still be in known_by"
-            );
-            assert!(
-                bob_gossip[0].known_by.contains(&bob),
-                "listener must now be in known_by"
-            );
-            propagated_on_seed = Some(seed);
-            break;
+            transmitted_count += 1;
+            if !invariants_verified {
+                // Bob's known_by set must now include the gossip item.
+                let bob_gossip = net.known_by(bob);
+                assert_eq!(
+                    bob_gossip.len(),
+                    1,
+                    "listener should know exactly the one gossip item after propagation (seed={seed})"
+                );
+                assert!(
+                    bob_gossip[0].known_by.contains(&alice),
+                    "original source must still be in known_by (seed={seed})"
+                );
+                assert!(
+                    bob_gossip[0].known_by.contains(&bob),
+                    "listener must now be in known_by (seed={seed})"
+                );
+                invariants_verified = true;
+            }
         }
     }
+
     assert!(
-        propagated_on_seed.is_some(),
-        "50 attempts at a 60% transmission rate should have produced at least one propagation"
+        invariants_verified,
+        "structural invariants must be verified on at least one transmission across {trials} seeds"
+    );
+
+    let rate = transmitted_count as f64 / trials as f64;
+    assert!(
+        (0.50..=0.70).contains(&rate),
+        "transmission rate over {trials} seeds should be ~60%, got {:.1}% ({transmitted_count}/{trials})",
+        rate * 100.0
     );
 }
 
@@ -123,8 +146,13 @@ fn trivial_tier2_event_does_not_seed_gossip() {
 }
 
 /// Transitive propagation: A → B → C across two separate Tier 2 rounds.
-/// If the wiring is correct, gossip Alice seeds should be reachable by
-/// Carol after Alice meets Bob and then Bob meets Carol.
+///
+/// Rate assertions on each round catch probability regressions; structural
+/// assertions on the first successful round verify the wiring is correct.
+///
+/// Round 1: alice seeds gossip, alice+bob are co-located.
+/// Round 2: bob (now a carrier) meets carol.
+/// Final check: carol knows alice's gossip (source preserved through carrier).
 #[test]
 fn gossip_propagates_transitively_across_two_rounds() {
     let mut network = GossipNetwork::new();
@@ -142,38 +170,78 @@ fn gossip_propagates_transitively_across_two_rounds() {
     create_gossip_from_tier2_event(&event, &mut network, game_time());
     assert_eq!(network.len(), 1);
 
-    // Round 1: Alice and Bob co-located. Retry with successive seeds until
-    // propagation sticks — this is deterministic for a given `(seed, state)`.
+    // Round 1: Alice and Bob co-located.
+    // Assert transmission rate across 200 seeds, and record the first
+    // successfully-propagated state for use in Round 2.
     let alice_bob = [alice, bob];
-    for seed in 0..50 {
+    let mut round1_count = 0usize;
+    let mut network_after_round1: Option<GossipNetwork> = None;
+
+    for seed in 0u64..200 {
         let mut net = network.clone();
         let mut rng = StdRng::seed_from_u64(seed);
         if propagate_gossip_at_location(&alice_bob, &mut net, &mut rng) > 0 {
-            network = net;
-            break;
+            round1_count += 1;
+            if network_after_round1.is_none() {
+                // Save the first state where Bob received the gossip.
+                network_after_round1 = Some(net);
+            }
         }
     }
+
+    let r1_rate = round1_count as f64 / 200.0;
     assert!(
-        network.known_by(bob).iter().any(|g| g.source == alice),
+        (0.50..=0.70).contains(&r1_rate),
+        "round-1 transmission rate should be ~60%, got {:.1}%",
+        r1_rate * 100.0
+    );
+
+    let network_after_round1 =
+        network_after_round1.expect("at least one round-1 transmission must succeed");
+
+    assert!(
+        network_after_round1
+            .known_by(bob)
+            .iter()
+            .any(|g| g.source == alice),
         "after A/B round, Bob should know Alice's gossip"
     );
     assert!(
-        network.known_by(carol).is_empty(),
+        network_after_round1.known_by(carol).is_empty(),
         "Carol should not yet know the gossip"
     );
 
     // Round 2: Bob and Carol co-located. Bob is now a carrier.
     let bob_carol = [bob, carol];
-    for seed in 0..50 {
-        let mut net = network.clone();
+    let mut round2_count = 0usize;
+    let mut network_after_round2: Option<GossipNetwork> = None;
+
+    for seed in 0u64..200 {
+        let mut net = network_after_round1.clone();
         let mut rng = StdRng::seed_from_u64(seed);
         if propagate_gossip_at_location(&bob_carol, &mut net, &mut rng) > 0 {
-            network = net;
-            break;
+            round2_count += 1;
+            if network_after_round2.is_none() {
+                network_after_round2 = Some(net);
+            }
         }
     }
+
+    let r2_rate = round2_count as f64 / 200.0;
     assert!(
-        network.known_by(carol).iter().any(|g| g.source == alice),
+        (0.50..=0.70).contains(&r2_rate),
+        "round-2 transmission rate should be ~60%, got {:.1}%",
+        r2_rate * 100.0
+    );
+
+    let network_after_round2 =
+        network_after_round2.expect("at least one round-2 transmission must succeed");
+
+    assert!(
+        network_after_round2
+            .known_by(carol)
+            .iter()
+            .any(|g| g.source == alice),
         "transitive propagation: Carol should now know Alice's gossip via Bob"
     );
 }

--- a/parish/crates/parish-world/src/weather.rs
+++ b/parish/crates/parish-world/src/weather.rs
@@ -318,26 +318,25 @@ mod tests {
 
     #[test]
     fn test_weather_seasonal_bias() {
+        // Drive the engine through tick() over simulated time so the test
+        // exercises the same code path that production uses, rather than
+        // calling compute_transition() directly and manually patching
+        // internal state.
+        //
+        // tick() fires at most once per game-hour and only after the
+        // min_duration (2h) has elapsed in the current state, so running
+        // 600 simulated hours gives roughly 150–300 transition attempts —
+        // enough to observe the seasonal bias signal clearly.
         let start = Utc.with_ymd_and_hms(1820, 6, 15, 8, 0, 0).unwrap();
 
-        // Count rain-ish states after many transitions in winter vs summer
         let count_rain_states = |season: Season, seed: u64| -> usize {
             let mut engine = WeatherEngine::new(Weather::Overcast, start);
             let mut rng = StdRng::seed_from_u64(seed);
             let mut rain_count = 0;
 
-            for hour_offset in 0..100u32 {
-                let game_time = start + chrono::Duration::hours((3 + hour_offset) as i64);
-
-                // Reset last_check_hour so we can tick every iteration
-                engine.last_check_hour = None;
-                // Ensure min_duration is met by using compute_transition directly
-                if engine.duration_hours(game_time) >= engine.min_duration_hours
-                    && let Some(new) = engine.compute_transition(season, &mut rng)
-                {
-                    engine.current = new;
-                    engine.since = game_time;
-                }
+            for hour_offset in 1..=600u32 {
+                let game_time = start + chrono::Duration::hours(hour_offset as i64);
+                engine.tick(game_time, season, &mut rng);
 
                 if matches!(
                     engine.current(),


### PR DESCRIPTION
## Summary

Fixes four test-quality issues identified in the engine audit. No production logic is changed (other than extracting one helper function into an exported module boundary so it can be tested).

- **#778**: Two tests with fragile exact-count or hardcoded-list assertions replaced with derived checks against the live data source.
- **#779**: Three gossip-propagation tests that used "find any of 50 seeds" retry loops replaced with 200-seed rate assertions (50-70%) that directly catch a regression in transmission probability.
- **#780**: Weather seasonal-bias test now driven through the production `tick()` path over 600 simulated hours rather than bypassing the hourly gate via field mutation.
- **#781**: `syncFocailOnViewportChange` extracted from inline `+page.svelte` handler into `game.ts`; regression test exercises the exported function directly so deletion or inversion of the handler logic would cause the test to fail.

## Commands run

```sh
just check        # fmt + clippy + cargo test — all passed
just ui-test      # 304 passed (23 suites)
just agent-check  # proof evidence gate passed
```

## Proof

`docs/proofs/778-779-780-781/` — evidence.md + judge verdict (sufficient, debt clear).

Fixes #778, fixes #779, fixes #780, fixes #781.