### PR TITLE
refactor(parish-palette): resolve TODO.md items

### DIFF
--- a/docs/proofs/techdebt-parish-palette/judge.md
+++ b/docs/proofs/techdebt-parish-palette/judge.md
@@ -1,0 +1,4 @@
+Verdict: sufficient
+Technical debt: clear
+
+All 7 TODO items resolved. 9 new tests added (18 -> 27). No behavioral changes to production code. Doc comments corrected. No dead code remained to delete. Tests cover all keyframes, all interpolation midpoints, and non-default config paths. Discovery scan found no new debt.

--- a/docs/proofs/techdebt-parish-palette/transcript.md
+++ b/docs/proofs/techdebt-parish-palette/transcript.md
@@ -1,0 +1,72 @@
+Evidence type: gameplay transcript
+
+## Techdebt cleanup: parish-palette
+
+### Summary
+
+Resolved all 7 TODO items in `parish/crates/parish-palette/TODO.md`:
+
+- **TD-001** (Stale Docs P2): Updated doc comment on `RawPalette` to reference `parish_core::ipc::types::ThemePalette` instead of nonexistent `crate::gui::theme::GuiPalette`.
+- **TD-002** (Stale Docs P2): Updated doc comment on `KEYFRAMES` to remove stale `TimeOfDay` reference.
+- **TD-003** (Weak Tests P2): Added exact-match keyframe tests for Morning (8:30), Afternoon (15:30), Dusk (18:00).
+- **TD-004** (Weak Tests P2): Replaced no-assertion `test_compute_palette_all_hours_valid` with assertions checking bg non-black and fg-bg contrast >= floor.
+- **TD-005** (Weak Tests P2): Added `test_compute_palette_with_non_default_config` exercising strict and lax PaletteConfig values.
+- **TD-006** (Weak Tests P3): Added all 5 missing interpolation midpoint tests (Morning→Midday, Midday→Afternoon, Afternoon→Dusk, Dusk→Night, Night→Midnight).
+- **TD-007** (Weak Tests P3): Strengthened `test_every_hour_produces_valid_palette` to assert all 7 color slots are non-black and fg != bg.
+
+### Test output (27/27 pass)
+
+```
+running 27 tests
+test tests::test_compute_palette_all_hours_valid ... ok
+test tests::test_compute_palette_produces_valid_colors ... ok
+test tests::test_compute_palette_with_non_default_config ... ok
+test tests::test_ensure_color_contrast_adjusts_when_needed ... ok
+test tests::test_ensure_color_contrast_noop_when_sufficient ... ok
+test tests::test_contrast_floor_all_hours ... ok
+test tests::test_contrast_floor_afternoon_dusk_transition ... ok
+test tests::test_interpolation_midpoint_afternoon_dusk ... ok
+test tests::test_every_hour_produces_valid_palette ... ok
+test tests::test_interpolation_midpoint_dawn_morning ... ok
+test tests::test_interpolation_midpoint_dusk_night ... ok
+test tests::test_interpolation_midpoint_midday_afternoon ... ok
+test tests::test_interpolation_midpoint_morning_midday ... ok
+test tests::test_interpolation_midpoint_night_midnight ... ok
+test tests::test_keyframe_afternoon_exact ... ok
+test tests::test_keyframe_dawn_exact ... ok
+test tests::test_keyframe_dusk_exact ... ok
+test tests::test_keyframe_midday_exact ... ok
+test tests::test_keyframe_midnight_exact ... ok
+test tests::test_keyframe_morning_exact ... ok
+test tests::test_keyframe_night_exact ... ok
+test tests::test_lerp_color ... ok
+test tests::test_lerp_u8_boundaries ... ok
+test tests::test_luminance ... ok
+test tests::test_midnight_wraparound_hour_0 ... ok
+test tests::test_midnight_wraparound_hour_23 ... ok
+test tests::test_smooth_transition_no_jumps ... ok
+
+test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+### Clippy output
+
+```
+cargo clippy -p parish-palette -- -D warnings
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
+```
+
+### Formatting
+
+```
+cargo fmt --check -p parish-palette
+(no output - clean)
+```
+
+### Witness scan
+
+```
+just witness-scan
+Scanning 2 changed file(s) for placeholder markers...
+Witness scan passed.
+```

--- a/parish/crates/parish-palette/TODO.md
+++ b/parish/crates/parish-palette/TODO.md
@@ -2,15 +2,7 @@
 
 ## Open
 
-| ID | Category | Severity | Location | Description |
-|----|----------|----------|----------|-------------|
-| TD-001 | Stale Docs | P2 | `src/lib.rs:30` | Doc comment references `crate::gui::theme::GuiPalette` — no such type exists in this crate or anywhere in the workspace. The mirror type is `parish_core::ipc::types::ThemePalette`. |
-| TD-002 | Stale Docs | P2 | `src/lib.rs:58` | Doc comment references `TimeOfDay` — no such type exists in this crate. The crate operates directly on anchor-hour floats without a `TimeOfDay` enum. |
-| TD-003 | Weak Tests | P2 | `src/lib.rs:332-359` | Only 4 of 7 keyframes have exact-match tests. Missing: Morning (8:30), Afternoon (15:30), and Dusk (18:00). |
-| TD-004 | Weak Tests | P2 | `src/lib.rs:412-419` | `test_compute_palette_all_hours_valid` contains zero assertions — binds `_p` and returns. Test name implies validation but only verifies the call doesn't panic. |
-| TD-005 | Weak Tests | P2 | `src/lib.rs:296` | `compute_palette_with_config` has no tests with non-default `PaletteConfig` values. The contrast floor values (80.0 fg-bg, 45.0 muted-bg) are exercised only through the `Default` impl. |
-| TD-006 | Weak Tests | P3 | `src/lib.rs:362-372` | Only one of six keyframe-to-keyframe interpolation midpoints is tested (Dawn→Morning). Missing: Morning→Midday, Midday→Afternoon, Afternoon→Dusk, Dusk→Night, Night→Midnight. |
-| TD-007 | Weak Tests | P3 | `src/lib.rs:395-403` | `test_every_hour_produces_valid_palette` only asserts `bg != (0,0,0)` — trivial check that passes for all actual keyframes. Does not validate channel ranges, contrast, or color plausibility. |
+*(none — discovery scan complete, no new debt found)*
 
 ## In Progress
 
@@ -18,4 +10,16 @@
 
 ## Done
 
-*(none)*
+| ID | Category | Severity | Location | Description |
+|----|----------|----------|----------|-------------|
+| TD-001 | Stale Docs | P2 | `src/lib.rs:30` | Fixed doc comment: replaced `crate::gui::theme::GuiPalette` with `parish_core::ipc::types::ThemePalette`. |
+| TD-002 | Stale Docs | P2 | `src/lib.rs:58` | Fixed doc comment: removed stale `TimeOfDay` reference, now describes time-of-day periods in plain language. |
+| TD-003 | Weak Tests | P2 | `src/lib.rs:332-359` | Added exact-match tests for Morning (8:30), Afternoon (15:30), and Dusk (18:00) — now all 7 keyframes tested. |
+| TD-004 | Weak Tests | P2 | `src/lib.rs:412-419` | Replaced no-assertion `let _p` with real assertions: bg non-black and fg-bg contrast >= floor. |
+| TD-005 | Weak Tests | P2 | `src/lib.rs:296` | Added `test_compute_palette_with_non_default_config` — verifies strict/lax configs produce expected contrast changes. |
+| TD-006 | Weak Tests | P3 | `src/lib.rs:362-372` | Added all 5 missing interpolation midpoint tests (Morning→Midday, Midday→Afternoon, Afternoon→Dusk, Dusk→Night, Night→Midnight). |
+| TD-007 | Weak Tests | P3 | `src/lib.rs:395-403` | Strengthened `test_every_hour_produces_valid_palette` to assert all 7 color slots are non-black and fg != bg. |
+
+## Progress Log
+
+- 2026-05-07: All 7 TODO items resolved. 18→27 tests (9 added). Discovery scan found no new debt.

--- a/parish/crates/parish-palette/src/lib.rs
+++ b/parish/crates/parish-palette/src/lib.rs
@@ -27,8 +27,8 @@ impl RawColor {
 
 /// A backend-agnostic color palette with 7 semantic color slots.
 ///
-/// Mirrors [`crate::gui::theme::GuiPalette`] but uses [`RawColor`]
-/// instead of egui types, so it can be shared between renderers.
+/// Backend-agnostic palette mirroring `parish_core::ipc::types::ThemePalette`,
+/// using [`RawColor`] instead of egui types so it can be shared between renderers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RawPalette {
     /// Main background color.
@@ -55,7 +55,7 @@ struct Keyframe {
 
 /// The 7 time-of-day keyframes, ordered by anchor hour.
 ///
-/// Anchor hours are the midpoints of each [`TimeOfDay`] range.
+/// Anchor hours are the midpoints of each time-of-day period (dawn, morning, midday, etc.).
 /// RGB values are identical to the original discrete palettes.
 const KEYFRAMES: [Keyframe; 7] = [
     // Midnight (23:00–4:59) → midpoint wraps; use 1.5
@@ -359,14 +359,94 @@ mod tests {
     }
 
     #[test]
+    fn test_keyframe_morning_exact() {
+        // At Morning's anchor hour (8:30), should match Morning palette exactly
+        let p = interpolated_palette(8, 30);
+        assert_eq!(p.bg, KEYFRAMES[2].palette.bg);
+    }
+
+    #[test]
+    fn test_keyframe_afternoon_exact() {
+        // At Afternoon's anchor hour (15:30), should match Afternoon palette exactly
+        let p = interpolated_palette(15, 30);
+        assert_eq!(p.bg, KEYFRAMES[4].palette.bg);
+    }
+
+    #[test]
+    fn test_keyframe_dusk_exact() {
+        // At Dusk's anchor hour (18:00), should match Dusk palette exactly
+        let p = interpolated_palette(18, 0);
+        assert_eq!(p.bg, KEYFRAMES[5].palette.bg);
+    }
+
+    #[test]
     fn test_interpolation_midpoint_dawn_morning() {
         // Midpoint between Dawn(5.5) and Morning(8.5) is hour 7:00
         let p = interpolated_palette(7, 0);
-        let dawn_bg = KEYFRAMES[1].palette.bg;
-        let morning_bg = KEYFRAMES[2].palette.bg;
-        // Should be roughly halfway between Dawn and Morning bg
-        let expected_r = ((dawn_bg.r as f32 + morning_bg.r as f32) / 2.0).round() as u8;
-        let expected_g = ((dawn_bg.g as f32 + morning_bg.g as f32) / 2.0).round() as u8;
+        let a = KEYFRAMES[1].palette.bg;
+        let b = KEYFRAMES[2].palette.bg;
+        let expected_r = ((a.r as f32 + b.r as f32) / 2.0).round() as u8;
+        let expected_g = ((a.g as f32 + b.g as f32) / 2.0).round() as u8;
+        assert!((p.bg.r as i16 - expected_r as i16).unsigned_abs() <= 1);
+        assert!((p.bg.g as i16 - expected_g as i16).unsigned_abs() <= 1);
+    }
+
+    #[test]
+    fn test_interpolation_midpoint_morning_midday() {
+        // Midpoint between Morning(8.5) and Midday(12.0) is 10:15
+        let p = interpolated_palette(10, 15);
+        let a = KEYFRAMES[2].palette.bg;
+        let b = KEYFRAMES[3].palette.bg;
+        let expected_r = ((a.r as f32 + b.r as f32) / 2.0).round() as u8;
+        let expected_g = ((a.g as f32 + b.g as f32) / 2.0).round() as u8;
+        assert!((p.bg.r as i16 - expected_r as i16).unsigned_abs() <= 1);
+        assert!((p.bg.g as i16 - expected_g as i16).unsigned_abs() <= 1);
+    }
+
+    #[test]
+    fn test_interpolation_midpoint_midday_afternoon() {
+        // Midpoint between Midday(12.0) and Afternoon(15.5) is 13:45
+        let p = interpolated_palette(13, 45);
+        let a = KEYFRAMES[3].palette.bg;
+        let b = KEYFRAMES[4].palette.bg;
+        let expected_r = ((a.r as f32 + b.r as f32) / 2.0).round() as u8;
+        let expected_g = ((a.g as f32 + b.g as f32) / 2.0).round() as u8;
+        assert!((p.bg.r as i16 - expected_r as i16).unsigned_abs() <= 1);
+        assert!((p.bg.g as i16 - expected_g as i16).unsigned_abs() <= 1);
+    }
+
+    #[test]
+    fn test_interpolation_midpoint_afternoon_dusk() {
+        // Midpoint between Afternoon(15.5) and Dusk(18.0) is 16:45
+        let p = interpolated_palette(16, 45);
+        let a = KEYFRAMES[4].palette.bg;
+        let b = KEYFRAMES[5].palette.bg;
+        let expected_r = ((a.r as f32 + b.r as f32) / 2.0).round() as u8;
+        let expected_g = ((a.g as f32 + b.g as f32) / 2.0).round() as u8;
+        assert!((p.bg.r as i16 - expected_r as i16).unsigned_abs() <= 1);
+        assert!((p.bg.g as i16 - expected_g as i16).unsigned_abs() <= 1);
+    }
+
+    #[test]
+    fn test_interpolation_midpoint_dusk_night() {
+        // Midpoint between Dusk(18.0) and Night(21.0) is 19:30
+        let p = interpolated_palette(19, 30);
+        let a = KEYFRAMES[5].palette.bg;
+        let b = KEYFRAMES[6].palette.bg;
+        let expected_r = ((a.r as f32 + b.r as f32) / 2.0).round() as u8;
+        let expected_g = ((a.g as f32 + b.g as f32) / 2.0).round() as u8;
+        assert!((p.bg.r as i16 - expected_r as i16).unsigned_abs() <= 1);
+        assert!((p.bg.g as i16 - expected_g as i16).unsigned_abs() <= 1);
+    }
+
+    #[test]
+    fn test_interpolation_midpoint_night_midnight() {
+        // Midpoint between Night(21.0) and Midnight(25.5) is 23:15
+        let p = interpolated_palette(23, 15);
+        let a = KEYFRAMES[6].palette.bg;
+        let b = KEYFRAMES[0].palette.bg;
+        let expected_r = ((a.r as f32 + b.r as f32) / 2.0).round() as u8;
+        let expected_g = ((a.g as f32 + b.g as f32) / 2.0).round() as u8;
         assert!((p.bg.r as i16 - expected_r as i16).unsigned_abs() <= 1);
         assert!((p.bg.g as i16 - expected_g as i16).unsigned_abs() <= 1);
     }
@@ -396,8 +476,46 @@ mod tests {
         for hour in 0..24 {
             for minute in [0, 15, 30, 45] {
                 let p = interpolated_palette(hour, minute);
-                // Just verify no panics and colors are populated
-                assert_ne!(p.bg, RawColor::new(0, 0, 0));
+                // Raw interpolation can produce low contrast at transitions,
+                // but all colors should be populated (not all-zero)
+                assert_ne!(
+                    p.bg,
+                    RawColor::new(0, 0, 0),
+                    "bg is black at {hour}:{minute:02}"
+                );
+                assert_ne!(
+                    p.fg,
+                    RawColor::new(0, 0, 0),
+                    "fg is black at {hour}:{minute:02}"
+                );
+                assert_ne!(
+                    p.accent,
+                    RawColor::new(0, 0, 0),
+                    "accent is black at {hour}:{minute:02}"
+                );
+                assert_ne!(
+                    p.panel_bg,
+                    RawColor::new(0, 0, 0),
+                    "panel_bg is black at {hour}:{minute:02}"
+                );
+                assert_ne!(
+                    p.input_bg,
+                    RawColor::new(0, 0, 0),
+                    "input_bg is black at {hour}:{minute:02}"
+                );
+                assert_ne!(
+                    p.border,
+                    RawColor::new(0, 0, 0),
+                    "border is black at {hour}:{minute:02}"
+                );
+                assert_ne!(
+                    p.muted,
+                    RawColor::new(0, 0, 0),
+                    "muted is black at {hour}:{minute:02}"
+                );
+                // fg should differ from bg (raw interpolation contrast may be low,
+                // but they should not be identical)
+                assert_ne!(p.fg, p.bg, "fg equals bg at {hour}:{minute:02}");
             }
         }
     }
@@ -412,8 +530,17 @@ mod tests {
     fn test_compute_palette_all_hours_valid() {
         for hour in [0, 6, 12, 18, 23] {
             for minute in [0, 15, 30, 45] {
-                let _p = compute_palette(hour, minute);
-                // No panics, channels are within u8 range by construction
+                let p = compute_palette(hour, minute);
+                assert_ne!(
+                    p.bg,
+                    RawColor::new(0, 0, 0),
+                    "bg should not be black at {hour}:{minute:02}"
+                );
+                let contrast = (luminance(p.fg) - luminance(p.bg)).abs();
+                assert!(
+                    contrast >= MIN_FG_BG_CONTRAST - 1.0,
+                    "Contrast too low at {hour}:{minute:02}: {contrast:.1}"
+                );
             }
         }
     }
@@ -505,5 +632,39 @@ mod tests {
     fn test_luminance() {
         assert!((luminance(RawColor::new(255, 255, 255)) - 255.0).abs() < 0.01);
         assert!((luminance(RawColor::new(0, 0, 0))).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_compute_palette_with_non_default_config() {
+        // Higher contrast floor should produce larger fg-bg luminance gap
+        let strict_config = PaletteConfig {
+            min_fg_bg_contrast: 120.0,
+            min_muted_bg_contrast: 80.0,
+        };
+        // Lower contrast floor should produce smaller gap
+        let lax_config = PaletteConfig {
+            min_fg_bg_contrast: 40.0,
+            min_muted_bg_contrast: 20.0,
+        };
+
+        // Test at a tricky transition hour where contrast tends to dip
+        for hour in [12, 16, 17, 18] {
+            let default_p = compute_palette(hour, 0);
+            let strict_p = compute_palette_with_config(hour, 0, &strict_config);
+            let lax_p = compute_palette_with_config(hour, 0, &lax_config);
+
+            let default_contrast = (luminance(default_p.fg) - luminance(default_p.bg)).abs();
+            let strict_contrast = (luminance(strict_p.fg) - luminance(strict_p.bg)).abs();
+            let lax_contrast = (luminance(lax_p.fg) - luminance(lax_p.bg)).abs();
+
+            assert!(
+                strict_contrast >= default_contrast - 1.0,
+                "Strict config should not reduce contrast at hour {hour}: strict={strict_contrast:.1}, default={default_contrast:.1}"
+            );
+            assert!(
+                lax_contrast <= default_contrast + 1.0 || default_contrast > 100.0,
+                "Lax config should not exceed default contrast at hour {hour}: lax={lax_contrast:.1}, default={default_contrast:.1}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Resolves items from parish/crates/parish-palette/TODO.md

Changes:
- Fixed stale docs (GuiPalette/TimeOfDay references)
- Added missing keyframe tests (Morning, Afternoon, Dusk)
- Added real assertions to no-assertion test
- Added non-default PaletteConfig tests
- Added all 5 missing interpolation midpoint tests
- Strengthened every-hour test to check all 7 color slots