### PR TITLE
fix(preview): correct cwd paths in .claude/launch.json

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,7 @@
       "name": "vite-dev",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "cwd": "apps/ui",
+      "cwd": "parish/apps/ui",
       "port": 5173,
       "autoPort": true
     },
@@ -13,12 +13,14 @@
       "name": "parish-web",
       "runtimeExecutable": "/bin/sh",
       "runtimeArgs": ["-c", "source $HOME/.cargo/env && cargo run -- --web"],
+      "cwd": "parish",
       "port": 3001
     },
     {
       "name": "parish-e2e",
       "runtimeExecutable": "/bin/sh",
       "runtimeArgs": ["-c", "source $HOME/.cargo/env && cargo run -- --web 3099"],
+      "cwd": "parish",
       "port": 3099
     }
   ]


### PR DESCRIPTION
## Summary
- Add `cwd: parish` to the `parish-web` and `parish-e2e` configurations so `cargo run` finds the workspace `Cargo.toml`.
- Fix `vite-dev` cwd from `apps/ui` (does not exist at repo root) to `parish/apps/ui`.

Without these, `preview_start` fails immediately:
```
error: could not find `Cargo.toml` in `<worktree>` or any parent directory
```

## Test plan
- [x] `preview_start parish-web` compiles and serves the UI on :3001 (verified — Kilteevan Village renders, NPCs and travel options listed).
- [ ] `preview_start vite-dev` starts Vite on :5173.
- [ ] `preview_start parish-e2e` starts the e2e server on :3099.