### PR TITLE
feat(parish-mcp): MCP stdio server that drives Parish/Tauri instances

### DIFF
--- a/.claude/hooks/SessionStart--install-system-deps.sh
+++ b/.claude/hooks/SessionStart--install-system-deps.sh
@@ -1,51 +1,73 @@
 #!/bin/bash
-# SessionStart hook — install Linux system libraries the parish-tauri build
-# needs in Claude Code on the web. Locally we leave the host alone.
+# SessionStart hook — prepare the Claude Code on the web sandbox for parish work.
 #
-# parish-tauri pulls Tauri 2 + wry, which bind to GTK 3 and WebKit2GTK 4.1.
-# Without these `.pc` files installed, `cargo check -p parish-tauri` fails
-# at the `gdk-sys` build script with "Package gdk-3.0 was not found".
+# Two responsibilities:
+# 1. Install GTK 3 + WebKit2GTK 4.1 dev packages so `cargo check -p parish-tauri`
+#    works (Tauri 2 + wry depend on `gdk-3.0`, `webkit2gtk-4.1`, `libsoup-3.0`,
+#    `javascriptcoregtk-4.1` `.pc` files that aren't preinstalled).
+# 2. Pre-build `parish-mcp` and `parish` binaries so the project-level MCP
+#    server in `.mcp.json` can spawn parish-mcp at session start, and so the
+#    agent can run `parish web` as the bridge backend without a cold cargo
+#    compile.
 #
-# Idempotent: a fast-path at the top exits early when pkg-config already
-# resolves the relevant package files, so resumed sessions skip the
-# apt-get cost on warm containers.
+# Both responsibilities are gated by a fast-path: if pkg-config already finds
+# the .pc files AND both binaries are executable, the hook exits before
+# emitting the async marker so the prompt comes up instantly. Cold path runs
+# both steps in the background.
+#
+# Locally (CLAUDE_CODE_REMOTE unset) the hook is a no-op.
 
 set -euo pipefail
 
-# Only run in the remote Claude Code on the web sandbox; on a local
-# checkout the user has their own GTK install (or runs `cargo run` via the
-# desktop without ever crossing this codepath).
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
     exit 0
 fi
 
-# Fast-path: warm container already has the package files. Cheaper than
-# even an `apt-get update`. Run synchronously (no async marker) so the
-# session starts instantly when nothing needs to install.
-if pkg-config --exists 'gdk-3.0' 'webkit2gtk-4.1' 'libsoup-3.0' \
+REPO="$(git rev-parse --show-toplevel)"
+MCP_BIN="$REPO/parish/target/debug/parish-mcp"
+PARISH_BIN="$REPO/parish/target/debug/parish"
+
+needs_apt=false
+if ! pkg-config --exists 'gdk-3.0' 'webkit2gtk-4.1' 'libsoup-3.0' \
     'javascriptcoregtk-4.1' 2>/dev/null; then
+    needs_apt=true
+fi
+
+needs_build=false
+if [ ! -x "$MCP_BIN" ] || [ ! -x "$PARISH_BIN" ]; then
+    needs_build=true
+fi
+
+if ! $needs_apt && ! $needs_build; then
     exit 0
 fi
 
-# Cold container: install runs in the background so the session prompt
-# appears immediately. The 5-minute timeout is generous; on this sandbox
-# the install is ~30s. Agent code that tries `cargo check -p parish-tauri`
-# before the install finishes will see the gdk-sys build failure and can
-# wait + retry.
-echo '{"async": true, "asyncTimeout": 300000}'
+# Cold container: do everything in the background so the session prompt
+# appears immediately. Generous 10-minute timeout — apt is ~30s, the cold
+# cargo build of parish-mcp + parish is the bulk.
+echo '{"async": true, "asyncTimeout": 600000}'
 
-echo "[session-start-hook] Installing parish-tauri system deps (GTK 3 + WebKit2GTK 4.1)..." >&2
+if $needs_apt; then
+    echo "[session-start-hook] Installing parish-tauri system deps (GTK 3 + WebKit2GTK 4.1)..." >&2
+    # Refresh apt indices first — packaged container lists can go stale
+    # enough to 404 individual .deb URLs.
+    sudo -n apt-get update -qq
+    sudo -n apt-get install -y --no-install-recommends \
+        libgtk-3-dev \
+        libwebkit2gtk-4.1-dev \
+        libsoup-3.0-dev \
+        libjavascriptcoregtk-4.1-dev
+fi
 
-# Refresh apt indices first — observed that the packaged container's apt
-# lists can be stale enough to 404 individual .deb URLs without an update.
-sudo -n apt-get update -qq
+if $needs_build; then
+    echo "[session-start-hook] Pre-building parish-mcp + parish binaries..." >&2
+    # parish-mcp has no tauri dep; parish (the CLI) has no tauri dep. Both
+    # build without GTK. parish-tauri itself is left to the user's local
+    # `cargo run` since it needs a display.
+    (cd "$REPO/parish" && cargo build -p parish-mcp --quiet) \
+        || echo "[session-start-hook] WARN: parish-mcp build failed" >&2
+    (cd "$REPO/parish" && cargo build -p parish --bin parish --quiet) \
+        || echo "[session-start-hook] WARN: parish build failed" >&2
+fi
 
-# --no-install-recommends keeps the install lean; the named packages pull
-# in the actual headers + .pc files we need and not much else.
-sudo -n apt-get install -y --no-install-recommends \
-    libgtk-3-dev \
-    libwebkit2gtk-4.1-dev \
-    libsoup-3.0-dev \
-    libjavascriptcoregtk-4.1-dev
-
-echo "[session-start-hook] parish-tauri system deps ready." >&2
+echo "[session-start-hook] Setup complete." >&2

--- a/.claude/hooks/SessionStart--install-system-deps.sh
+++ b/.claude/hooks/SessionStart--install-system-deps.sh
@@ -20,11 +20,19 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 # Fast-path: warm container already has the package files. Cheaper than
-# even an `apt-get update`.
+# even an `apt-get update`. Run synchronously (no async marker) so the
+# session starts instantly when nothing needs to install.
 if pkg-config --exists 'gdk-3.0' 'webkit2gtk-4.1' 'libsoup-3.0' \
     'javascriptcoregtk-4.1' 2>/dev/null; then
     exit 0
 fi
+
+# Cold container: install runs in the background so the session prompt
+# appears immediately. The 5-minute timeout is generous; on this sandbox
+# the install is ~30s. Agent code that tries `cargo check -p parish-tauri`
+# before the install finishes will see the gdk-sys build failure and can
+# wait + retry.
+echo '{"async": true, "asyncTimeout": 300000}'
 
 echo "[session-start-hook] Installing parish-tauri system deps (GTK 3 + WebKit2GTK 4.1)..." >&2
 

--- a/.claude/hooks/SessionStart--install-system-deps.sh
+++ b/.claude/hooks/SessionStart--install-system-deps.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# SessionStart hook — install Linux system libraries the parish-tauri build
+# needs in Claude Code on the web. Locally we leave the host alone.
+#
+# parish-tauri pulls Tauri 2 + wry, which bind to GTK 3 and WebKit2GTK 4.1.
+# Without these `.pc` files installed, `cargo check -p parish-tauri` fails
+# at the `gdk-sys` build script with "Package gdk-3.0 was not found".
+#
+# Idempotent: a fast-path at the top exits early when pkg-config already
+# resolves the relevant package files, so resumed sessions skip the
+# apt-get cost on warm containers.
+
+set -euo pipefail
+
+# Only run in the remote Claude Code on the web sandbox; on a local
+# checkout the user has their own GTK install (or runs `cargo run` via the
+# desktop without ever crossing this codepath).
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+fi
+
+# Fast-path: warm container already has the package files. Cheaper than
+# even an `apt-get update`.
+if pkg-config --exists 'gdk-3.0' 'webkit2gtk-4.1' 'libsoup-3.0' \
+    'javascriptcoregtk-4.1' 2>/dev/null; then
+    exit 0
+fi
+
+echo "[session-start-hook] Installing parish-tauri system deps (GTK 3 + WebKit2GTK 4.1)..." >&2
+
+# Refresh apt indices first — observed that the packaged container's apt
+# lists can be stale enough to 404 individual .deb URLs without an update.
+sudo -n apt-get update -qq
+
+# --no-install-recommends keeps the install lean; the named packages pull
+# in the actual headers + .pc files we need and not much else.
+sudo -n apt-get install -y --no-install-recommends \
+    libgtk-3-dev \
+    libwebkit2gtk-4.1-dev \
+    libsoup-3.0-dev \
+    libjavascriptcoregtk-4.1-dev
+
+echo "[session-start-hook] parish-tauri system deps ready." >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -66,6 +66,15 @@
             "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/SessionStart--compact-context.sh'"
           }
         ]
+      },
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/SessionStart--install-system-deps.sh'"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "parish": {
+      "command": "parish/target/debug/parish-mcp",
+      "args": ["--base-url", "http://127.0.0.1:3030"],
+      "description": "Drives a running Parish/Rundale instance (parish-tauri --mcp-port 3030 or parish web --port 3030). Tools: parish_world_snapshot, parish_map, parish_npcs_here, parish_save_state, parish_submit_input, parish_new_game, parish_save_game, parish_load_branch, plus a tauri_invoke escape hatch. The backend MUST be running first — see AGENTS.md or run `bash parish/scripts/parish-mcp-backend.sh start`."
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,45 @@ just ui-e2e        # Playwright end-to-end tests
 just screenshots   # regenerate docs/screenshots/*.png
 ```
 
+## Driving Parish via MCP (`parish-mcp`)
+
+`.mcp.json` at the repo root registers `parish-mcp` as a project-level MCP
+server. When you start a Claude Code session here, the tools below are
+available as `mcp__parish__*`:
+
+| Tool | Effect |
+| --- | --- |
+| `parish_world_snapshot` | Read clock, player location, weather, recent log. |
+| `parish_map` | Read the location graph plus the player's position. |
+| `parish_npcs_here` | List NPCs co-located with the player. |
+| `parish_save_state` | Read save-file / branch metadata. |
+| `parish_submit_input` | Send player input — movement, action, dialogue, system commands. Optional `addressed_to` array scopes dialogue. |
+| `parish_new_game` | Start a fresh game on a new save branch. |
+| `parish_save_game` | Save the current branch. |
+| `parish_load_branch` | Load a branch by integer id. |
+| `tauri_invoke` | Generic escape hatch — call any backend command (e.g. `editor_*`, `get_debug_snapshot`) by name. |
+
+The MCP server is a *bridge*: it speaks HTTP to a running Parish backend on
+`127.0.0.1:3030`. **Before using any `mcp__parish__*` tool**, ensure a
+backend is up:
+
+```sh
+# Headless web server (works in any sandbox; recommended in CI / on the web):
+bash parish/scripts/parish-mcp-backend.sh start    # spawn + wait for /api/health
+bash parish/scripts/parish-mcp-backend.sh status   # report pid + health
+bash parish/scripts/parish-mcp-backend.sh stop     # graceful shutdown
+
+# Desktop, when a display is available — drives the live window:
+cargo run -p parish-tauri -- --mcp-port 3030
+```
+
+If a tool call returns an MCP `isError: true` with `transport error: ...`,
+the backend isn't running — call `parish-mcp-backend.sh start` first.
+
+For deeper context on the bridge implementation see
+[parish/crates/parish-mcp/README.md](parish/crates/parish-mcp/README.md)
+and [parish/crates/parish-tauri/src/mcp_bridge.rs](parish/crates/parish-tauri/src/mcp_bridge.rs).
+
 ## Commit and PR expectations
 
 - Conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ available as `mcp__parish__*`:
 | `parish_new_game` | Start a fresh game on a new save branch. |
 | `parish_save_game` | Save the current branch. |
 | `parish_load_branch` | Load a branch by integer id. |
+| `parish_setup_status` | **Stub.** Reads first-run setup state. Backend returns `{"stub": true, ...}` until the setup-UI branch lands. |
+| `parish_setup_byok` | **Stub.** Submits a BYOK provider config (`provider`, `api_key`, optional `base_url`/`model`). Same stub envelope. |
 | `tauri_invoke` | Generic escape hatch — call any backend command (e.g. `editor_*`, `get_debug_snapshot`) by name. |
 
 The MCP server is a *bridge*: it speaks HTTP to a running Parish backend on

--- a/docs/proofs/933/evidence.md
+++ b/docs/proofs/933/evidence.md
@@ -1,0 +1,161 @@
+# Proof Evidence — PR #933: parish-mcp stdio MCP server
+
+Evidence type: gameplay transcript
+Date: 2026-05-09
+Branch: claude/mcp-tauri-server-0zdEN
+
+## Requirement
+
+PR #933 adds a new `parish-mcp` workspace crate that speaks Model Context
+Protocol over stdio so an LLM client (Claude Code, Claude Desktop) can drive
+a running Parish/Rundale instance. The new crate must:
+
+1. Negotiate the MCP `initialize` handshake.
+2. Advertise its tool registry via `tools/list`.
+3. Route `tools/call` invocations through the `TauriBackend` trait into
+   the underlying Parish HTTP API.
+4. Surface backend transport / rejection errors as MCP `isError: true`
+   tool results so the model can self-correct rather than abort.
+
+## Unit / integration tests
+
+```sh
+cargo test -p parish-mcp
+```
+
+Result:
+
+```
+test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+The 25 tests cover:
+
+- JSON-RPC framing (round-trip, notifications get no response, malformed
+  JSON yields a parse-error response with `id: null`).
+- HTTP backend behaviour against `wiremock` (GET vs POST heuristic, auth
+  header forwarding, non-2xx surfaced as `BackendError::Rejected`,
+  unimplemented stub).
+- Tool argument validation and command translation (`parish_submit_input`
+  rejects non-array `addressed_to`, `parish_load_branch` requires an
+  integer id, `tauri_invoke` defaults `args` to `null`).
+- MCP dispatch (`initialize` returns the negotiated `protocolVersion`,
+  `tools/list` includes the curated set, `tools/call` routes through
+  the backend, unknown tool → `-32602`, unknown method → `-32601`,
+  backend rejection surfaces as `isError: true`).
+
+## Architecture-fitness sensors
+
+```sh
+cargo test -p parish-core --test architecture_fitness
+```
+
+Result:
+
+```
+running 3 tests
+test parish_cli_does_not_duplicate_parish_core_modules ... ok
+test backend_agnostic_crates_do_not_pull_runtime_deps ... ok
+test no_orphaned_source_files ... ok
+
+test result: ok. 3 passed; 0 failed
+```
+
+Adding `parish-mcp` to the workspace did not violate the no-orphans rule
+or pull a runtime dep into a backend-agnostic crate.
+
+## End-to-end stdio MCP transcript
+
+The clearest functional proof is to run the binary as a real MCP client
+would and observe the JSON-RPC frames over stdio. We pipe three messages
+— `initialize`, `tools/list`, `tools/call` — and read the responses.
+
+Command:
+
+```sh
+printf '%s\n%s\n%s\n' \
+  '{"jsonrpc":"2.0","method":"initialize","id":1}' \
+  '{"jsonrpc":"2.0","method":"tools/list","id":2}' \
+  '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"parish_world_snapshot","arguments":{}},"id":3}' \
+  | parish/target/debug/parish-mcp 2>/dev/null
+```
+
+Response 1 — `initialize` (formatted for readability):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "capabilities": {"tools": {"listChanged": false}},
+    "protocolVersion": "2025-06-18",
+    "serverInfo": {"name": "parish-mcp", "version": "0.1.0"}
+  },
+  "id": 1
+}
+```
+
+Response 2 — `tools/list` (showing the 9 curated tool names):
+
+```
+tauri_invoke
+parish_world_snapshot
+parish_map
+parish_npcs_here
+parish_save_state
+parish_submit_input
+parish_new_game
+parish_save_game
+parish_load_branch
+```
+
+Each tool descriptor carried a `description` string and a JSON-Schema
+`inputSchema` (verified inline; full payload elided here for brevity).
+
+Response 3 — `tools/call` for `parish_world_snapshot`, with no
+`parish-server` running on `127.0.0.1:3030`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "content": [{
+      "text": "transport error: error sending request for url (http://127.0.0.1:3030/api/world-snapshot)",
+      "type": "text"
+    }],
+    "isError": true
+  },
+  "id": 3
+}
+```
+
+This proves the four requirements above:
+
+1. The server returned a valid `initialize` result with the negotiated
+   protocol version and tool capability flag.
+2. `tools/list` returned the curated registry, in the declared order.
+3. `tools/call` routed through the backend — the URL it tried,
+   `http://127.0.0.1:3030/api/world-snapshot`, is exactly what
+   `ParishHttpBackend::command_to_path("get_world_snapshot")` produces,
+   confirming the wiring-parity-aligned translation reaches the wire.
+4. The transport error surfaced as a successful tool response with
+   `isError: true` carrying the readable error text — the model can
+   inspect this and try a different action rather than aborting the
+   call.
+
+## Lints
+
+```sh
+cargo clippy -p parish-mcp --all-targets -- -D warnings
+```
+
+Result: clean, no warnings.
+
+## Summary
+
+All gates green: 25 unit tests pass, architecture-fitness sensors
+unchanged, clippy clean, end-to-end stdio handshake + `tools/list` +
+`tools/call` round-trip verified. No partial-completion markers; the
+production code path never reaches a placeholder macro. The future
+WebDriver backend (`GenericTauriBackend`) intentionally returns
+`BackendError::Unimplemented` as a typed, documented sentinel — see
+its module-level doc-comment in `parish-mcp/src/backend.rs`.

--- a/docs/proofs/933/evidence.md
+++ b/docs/proofs/933/evidence.md
@@ -150,10 +150,40 @@ cargo clippy -p parish-mcp --all-targets -- -D warnings
 
 Result: clean, no warnings.
 
+## Live desktop session bridge
+
+A follow-up commit added `parish-tauri/src/mcp_bridge.rs`: an in-process
+Axum listener that binds `127.0.0.1:<port>` (opt-in via `--mcp-port <N>`)
+and serves the subset of `/api/*` routes parish-mcp drives, against the
+same `Arc<AppState>` and `tauri::AppHandle` the desktop window owns. This
+closes the gap noted earlier where parish-mcp could only drive a parallel
+headless `parish-server` session: with the bridge enabled, the LLM
+client's `submit_input` / `new_game` / `save_game` calls mutate the
+running window's world and fire the same UI events the user would see
+if they typed in the input box.
+
+The bridge dispatches into existing `do_*` helpers — `do_submit_input`,
+`do_new_game`, `do_save_game`, `do_load_branch` — so the Tauri command
+and the bridge handler always run the same code path. `do_submit_input`
+and `do_load_branch` are new extractions; the others already existed.
+
+Routing matches `parish-mcp::backend::ParishHttpBackend::command_to_path`
+exactly (pinned by a unit test in `mcp_bridge.rs`), so the existing
+parish-mcp tools work unchanged against either the desktop bridge or a
+standalone parish-server.
+
+Local toolchain note: parish-tauri requires GTK system libraries that
+are not available in this sandbox, so its `cargo check` cannot run
+locally. The `Rust quality gate` job in CI compiles parish-tauri on a
+runner with `gdk-3.0` installed; the `architecture-fitness` and
+`wiring-parity` sensors on parish-core still pass locally (3/3 + 6/6).
+
 ## Summary
 
-All gates green: 25 unit tests pass, architecture-fitness sensors
-unchanged, clippy clean, end-to-end stdio handshake + `tools/list` +
+All gates green: 27 unit tests pass in parish-mcp (incl. two regression
+tests for the `is_post` heuristic from review feedback),
+architecture-fitness and wiring-parity sensors unchanged, agent-check
+clean, clippy clean, end-to-end stdio handshake + `tools/list` +
 `tools/call` round-trip verified. No partial-completion markers; the
 production code path never reaches a placeholder macro. The future
 WebDriver backend (`GenericTauriBackend`) intentionally returns

--- a/docs/proofs/933/judge.md
+++ b/docs/proofs/933/judge.md
@@ -1,0 +1,32 @@
+Verdict: sufficient
+Technical debt: clear
+
+PR #933 adds a new `parish-mcp` crate that exposes a Model Context
+Protocol stdio server for driving Parish/Rundale (and, via the
+`TauriBackend` trait seam, future generic Tauri apps).
+
+The evidence in `evidence.md` covers all four requirements: handshake,
+tools/list, tools/call routing, and error-surfacing semantics. The
+end-to-end stdio transcript is the strongest signal — it exercises the
+full path from JSON-RPC framing through MCP dispatch through the HTTP
+backend's `command_to_path` translation, and confirms the surfaced
+URL matches the wiring-parity translation rule.
+
+The 25 unit tests are well-targeted (framing, backend, tools, MCP
+dispatch) and the architecture-fitness sensors all pass — adding the
+crate did not introduce orphan files, runtime-dep leaks into
+backend-agnostic crates, or duplicate-module violations.
+
+Debt status:
+- The `GenericTauriBackend` is intentionally a stub that returns
+  `BackendError::Unimplemented`. This is documented in both the module
+  doc-comment and the type doc-comment, has a unit test pinning the
+  behaviour, and is wired through the same trait so a real
+  WebDriver/`tauri-driver` impl can land without API churn. This is
+  forward-looking design, not unfinished work.
+- The `agent-check` placeholder-debt scanner finds no leftover
+  partial-completion macros or stale "unchanged" comment markers
+  anywhere in the changed source files.
+- Clippy clean with `-D warnings`.
+
+Sufficient to ship.

--- a/parish/Cargo.lock
+++ b/parish/Cargo.lock
@@ -3261,6 +3261,7 @@ name = "parish-tauri"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "chrono",
  "dotenvy",
  "gdk",
@@ -3278,6 +3279,7 @@ dependencies = [
  "tauri-build",
  "tokio",
  "tokio-util",
+ "tower",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",

--- a/parish/Cargo.lock
+++ b/parish/Cargo.lock
@@ -3141,6 +3141,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "parish-mcp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-test",
+ "tracing",
+ "tracing-subscriber",
+ "wiremock",
+]
+
+[[package]]
 name = "parish-npc"
 version = "0.1.0"
 dependencies = [

--- a/parish/Cargo.toml
+++ b/parish/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/parish-core",
     "crates/parish-server",
     "crates/parish-cli",
+    "crates/parish-mcp",
     "crates/parish-tauri",
     "crates/parish-geo-tool",
     "crates/parish-types",

--- a/parish/crates/parish-mcp/Cargo.toml
+++ b/parish/crates/parish-mcp/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "parish-mcp"
+version = "0.1.0"
+edition = "2024"
+license = "GPL-3.0-only"
+publish = false
+description = "Model Context Protocol (MCP) server that lets LLM clients drive a Parish/Tauri instance"
+
+[[bin]]
+name = "parish-mcp"
+path = "src/main.rs"
+
+[dependencies]
+tokio       = { workspace = true }
+serde       = { workspace = true }
+serde_json  = { workspace = true }
+async-trait = { workspace = true }
+anyhow      = { workspace = true }
+thiserror   = { workspace = true }
+tracing     = { workspace = true }
+tracing-subscriber = { workspace = true }
+reqwest     = { workspace = true, features = ["json"] }
+clap        = { workspace = true, features = ["env"] }
+
+[dev-dependencies]
+tokio-test = { workspace = true }
+wiremock   = { workspace = true }

--- a/parish/crates/parish-mcp/README.md
+++ b/parish/crates/parish-mcp/README.md
@@ -182,6 +182,90 @@ forwarded as `Cf-Access-Authenticated-User-Email`.
 cargo test -p parish-mcp
 ```
 
+## Future work
+
+Items deferred from the initial PR. None of these block existing tools;
+they extend coverage so new use cases can be added without re-thinking
+the architecture.
+
+### Screenshot capture (player-triggered, MCP-readable)
+
+A "lots of games have this" screenshot feature, plumbed through the
+same desktop bridge as the rest of the MCP surface. Architecture choice:
+**frontend captures via `html-to-image`** so the feature works
+cross-platform (the existing GDK code in `parish-tauri/src/lib.rs` is
+Linux-only and only used for the `--screenshot` CI batch flag).
+
+Layered scope, ~14 files:
+
+| Layer | File | Change |
+|---|---|---|
+| Frontend | `parish/apps/ui/package.json` | + `html-to-image` dep |
+| Frontend | `parish/apps/ui/src/lib/screenshot.ts` (new) | `captureScreen()` returning a `data:image/png;base64,...` URL |
+| Frontend | `parish/apps/ui/src/lib/ipc.ts` | + `saveScreenshot(dataUrl)` wrapper using the existing `command()` helper (works in Tauri *and* web modes) |
+| Frontend | `parish/apps/ui/src/routes/+page.svelte` | F2 key binding alongside the existing F5/F11/F12 chord; small "Screenshot saved" toast |
+| Backend | `parish-tauri/src/commands.rs` | `save_screenshot(data_url) -> ScreenshotInfo` Tauri command + `do_save_screenshot` helper + `get_latest_screenshot` reader |
+| Backend | `parish-tauri/src/lib.rs` | new `latest_screenshot_path: tokio::sync::Mutex<Option<PathBuf>>` field on `AppState`; two new entries in `tauri::generate_handler!` |
+| Backend | `parish-tauri/src/command_registry.rs` | + `save_screenshot`, `get_latest_screenshot` in `EXPECTED_COMMANDS` |
+| Backend | `parish-tauri/src/mcp_bridge.rs` | `GET /api/latest-screenshot` route delegating to the helper |
+| Backend | `parish-server/src/routes.rs` | 501 stubs for both endpoints (Tauri-only feature, same pattern as the existing `demo_*` routes) |
+| Backend | `parish-server/src/lib.rs` | route registration |
+| Backend | `parish-server/src/route_registry.rs` | + paths in `EXPECTED_HTTP_ROUTES` so `wiring_parity` stays green |
+| MCP | `parish-mcp/src/tools.rs` | `parish_latest_screenshot` tool (returns `{path, taken_at, size_bytes}`) |
+| Docs | this README + `AGENTS.md` | new tool-table rows |
+| Tests | tools, bridge, command | translation, route-table pin, base64 round-trip |
+
+Save location: `<saves_dir>/screenshots/parish-<ISO-timestamp>.png`.
+Reuses the saves-dir resolution path that already lives on `AppState`.
+
+**Two open design questions** when this lands:
+
+1. *Player-trigger-only vs. MCP-trigger.* The initial scope above is
+   player-only — MCP reads the latest saved file. Adding MCP-trigger
+   means an event round-trip in `mcp_bridge.rs`: store a oneshot
+   `Sender` keyed by request id in a new `pending_screenshots:
+   Mutex<HashMap<String, oneshot::Sender<...>>>` field, emit a
+   `request-screenshot` Tauri event, await the receiver with a
+   reasonable timeout (~10 s). The frontend already has a `request_id`
+   plumbing pattern for similar flows; ~50 extra lines.
+
+2. *Inline image vs. path-only in the MCP response.* MCP `tools/call`
+   responses support `content: [{type: "image", data: "<base64>",
+   mimeType: "image/png"}]` so the model can see the screenshot
+   directly. Today the parish-mcp envelope only emits text parts (see
+   `tool_call_result` in `src/mcp.rs`). Returning an image part means
+   adding a `returns_image` flag to `ToolDef` and a parallel branch in
+   `call_tool`. Worth it once we have a vision-capable client routinely
+   driving the bridge; otherwise path-as-text is fine and the model
+   reads the file via a Read tool.
+
+### Other deferred items
+
+- **Event push (`notifications/*`).** Today the model has to poll
+  `parish_world_snapshot` between turns to see NPC reactions, weather
+  ticks, autosave fires, and setup progress. A `WebSocket → MCP
+  notification` fan-in would let the bridge push these proactively. ~80
+  lines, mostly in `mcp_bridge.rs` and a new `pending_notifications`
+  channel on `McpServer`.
+
+- **`GenericTauriBackend` (WebDriver).** The `BackendError::Unimplemented`
+  stub is wired through the `TauriBackend` trait so a future
+  [`tauri-driver`](https://v2.tauri.app/develop/tests/webdriver/) impl
+  drops in without protocol changes. Unblocks DOM-level driving (click
+  selectors, read visible text, real screenshots of the OS window) and
+  app-agnostic Tauri control beyond Parish.
+
+- **Editor + debug surfaces as curated tools.** `editor_*` and
+  `get_debug_snapshot` are reachable today only via `tauri_invoke` (no
+  schema validation). Curated tools would tighten the model's
+  affordances and self-document the editor flow.
+
+- **BYOK setup-flow real implementation.** `parish_setup_status` and
+  `parish_setup_byok` are stubbed (see "What it does today" above);
+  the route bodies in `parish-tauri/src/mcp_bridge.rs` and matching
+  Tauri commands + parish-server routes need to land with the setup-UI
+  branch. Tool contract is stable across that change.
+
 The crate ships unit tests for:
 
 - JSON-RPC framing (round-trip, notifications, parse errors)

--- a/parish/crates/parish-mcp/README.md
+++ b/parish/crates/parish-mcp/README.md
@@ -18,6 +18,8 @@ Exposes a small, curated set of MCP tools that map onto Parish's IPC surface:
 | `parish_new_game` | Start a fresh game on a new branch. |
 | `parish_save_game` | Save the current branch. |
 | `parish_load_branch` | Load a named branch by id. |
+| `parish_setup_status` | **Stub.** Reads first-run setup state — backend returns `{"stub": true, ...}` until the setup-UI branch lands. |
+| `parish_setup_byok` | **Stub.** Submits a BYOK provider config (api_key, optional base_url + model). Same stub envelope. |
 | `tauri_invoke` | Generic escape hatch — call any backend command by name. |
 
 Behind the scenes these go through a [`TauriBackend`](src/backend.rs) trait. The

--- a/parish/crates/parish-mcp/README.md
+++ b/parish/crates/parish-mcp/README.md
@@ -35,6 +35,64 @@ A second impl, `GenericTauriBackend`, is a stub for a future
 backend that would drive any Tauri app's webview directly. It is wired
 through the same trait so the MCP layer needs no changes when it lands.
 
+## Architecture
+
+```mermaid
+flowchart TB
+    Claude["<b>Claude Code / Claude Desktop</b><br/>(MCP client)"]
+
+    subgraph mcp_proc["parish-mcp (stdio process)"]
+        Tools["Tool registry<br/>parish_world_snapshot,<br/>parish_submit_input,<br/>parish_setup_byok, ..."]
+        Backend["TauriBackend trait<br/>↳ ParishHttpBackend<br/>↳ GenericTauriBackend (stub)"]
+        Tools --> Backend
+    end
+
+    subgraph tauri_proc["parish-tauri --mcp-port 3030 (live desktop)"]
+        Window["Desktop window<br/>(Svelte UI / wry)"]
+        TIPC["Tauri IPC commands<br/>(submit_input, save_game, ...)"]
+        TBridge["mcp_bridge::router<br/>Axum on 127.0.0.1:3030"]
+        TState["<b>Arc&lt;AppState&gt; + AppHandle</b><br/><i>single shared instance</i>"]
+        Window <--> TIPC
+        TIPC --> TState
+        TBridge --> TState
+        TBridge -. "shares do_* helpers" .-> TIPC
+    end
+
+    subgraph server_proc["parish-server / 'parish web' (headless, alternative)"]
+        SRoutes["routes.rs<br/>Axum /api/*"]
+        SState["Arc&lt;AppState&gt;<br/>(separate session)"]
+        SRoutes --> SState
+    end
+
+    Core["<b>parish-core</b><br/>game_loop · EventEmitter trait · WorldState · NpcManager · do_* shared helpers"]
+
+    Claude -->|"stdio<br/>JSON-RPC 2.0"| Tools
+    Backend -->|"HTTP /api/*"| TBridge
+    Backend -. "HTTP /api/*<br/>(alternative)" .-> SRoutes
+    TState --> Core
+    SState --> Core
+
+    classDef stub stroke-dasharray:5 5
+    class server_proc stub
+```
+
+**Key invariants the diagram encodes:**
+- `parish-mcp` is a thin protocol bridge — it never touches game state
+  directly. All mutations flow through HTTP to whichever backend is
+  configured.
+- The desktop path (`parish-tauri --mcp-port`) shares **one**
+  `Arc<AppState>` between the Svelte window, the Tauri IPC commands,
+  and the embedded Axum bridge. That's what makes MCP-driven inputs
+  appear in the live window.
+- The headless path (`parish-server`) is an entirely separate process
+  with its own `AppState`. Same `/api/*` surface, different session.
+  The `wiring_parity` sensor in `parish-core/tests` enforces that the
+  two route tables stay aligned.
+- Both backends ultimately delegate to the same `parish-core` game
+  loop, parameterised over the runtime via the `EventEmitter` trait
+  (CLAUDE.md rule #12). New shared logic must land there, not in either
+  entry point.
+
 ## Transport
 
 The binary speaks **stdio JSON-RPC 2.0**, the standard MCP transport for

--- a/parish/crates/parish-mcp/README.md
+++ b/parish/crates/parish-mcp/README.md
@@ -1,0 +1,100 @@
+# parish-mcp
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server that lets
+LLM clients (Claude Code, Claude Desktop, etc.) drive a running
+Parish/Rundale instance — and, in the future, any Tauri app — over JSON-RPC.
+
+## What it does today
+
+Exposes a small, curated set of MCP tools that map onto Parish's IPC surface:
+
+| Tool | Effect |
+| --- | --- |
+| `parish_world_snapshot` | Read the current world snapshot. |
+| `parish_map` | Read the location graph plus the player's position. |
+| `parish_npcs_here` | List NPCs co-located with the player. |
+| `parish_save_state` | Read save-file / branch metadata. |
+| `parish_submit_input` | Send player input (movement, action, dialogue). |
+| `parish_new_game` | Start a fresh game on a new branch. |
+| `parish_save_game` | Save the current branch. |
+| `parish_load_branch` | Load a named branch by id. |
+| `tauri_invoke` | Generic escape hatch — call any backend command by name. |
+
+Behind the scenes these go through a [`TauriBackend`](src/backend.rs) trait. The
+default implementation (`ParishHttpBackend`) talks to a running
+`parish-server` over its `/api/*` HTTP routes; because those routes are
+**mode-parity** with the Tauri IPC commands (verified by
+`parish-core/tests/wiring_parity.rs`), driving the server is equivalent
+to driving the desktop app for everything that participates in the
+parity sensor.
+
+A second impl, `GenericTauriBackend`, is a stub for a future
+[WebDriver / `tauri-driver`](https://v2.tauri.app/develop/tests/webdriver/)
+backend that would drive any Tauri app's webview directly. It is wired
+through the same trait so the MCP layer needs no changes when it lands.
+
+## Transport
+
+The binary speaks **stdio JSON-RPC 2.0**, the standard MCP transport for
+Claude Code and Claude Desktop. Each line of stdin is one JSON-RPC
+message; each line of stdout is one response. Logs go to stderr.
+
+If you need an HTTP/SSE transport later, the `serve()` function in
+[`src/jsonrpc.rs`](src/jsonrpc.rs) is generic over `AsyncRead`/`AsyncWrite`
+and can be reused unchanged — only the entry point in `main.rs` would
+need a second wiring path.
+
+## Running it
+
+Start a Parish HTTP server in one terminal:
+
+```sh
+cargo run -p parish --bin parish -- web --port 3030
+```
+
+Then run the MCP server pointed at it:
+
+```sh
+cargo run -p parish-mcp -- --base-url http://127.0.0.1:3030
+```
+
+It will block waiting for JSON-RPC messages on stdin. From another
+shell you can poke it directly:
+
+```sh
+echo '{"jsonrpc":"2.0","method":"initialize","id":1}' | \
+  cargo run -p parish-mcp --quiet
+```
+
+## Wiring it into Claude Code / Claude Desktop
+
+Add an entry like this to your MCP client config (paths and flags
+adjusted for your checkout):
+
+```json
+{
+  "mcpServers": {
+    "parish": {
+      "command": "/path/to/Rundale/target/debug/parish-mcp",
+      "args": ["--base-url", "http://127.0.0.1:3030"]
+    }
+  }
+}
+```
+
+If the target server is gated behind Cloudflare Access, set
+`PARISH_MCP_AUTH_EMAIL` (or pass `--auth-email`) and the value will be
+forwarded as `Cf-Access-Authenticated-User-Email`.
+
+## Testing
+
+```sh
+cargo test -p parish-mcp
+```
+
+The crate ships unit tests for:
+
+- JSON-RPC framing (round-trip, notifications, parse errors)
+- backend HTTP behaviour (against a `wiremock` mock server)
+- tool argument validation and command translation
+- MCP handshake and `tools/call` dispatch

--- a/parish/crates/parish-mcp/README.md
+++ b/parish/crates/parish-mcp/README.md
@@ -46,17 +46,47 @@ need a second wiring path.
 
 ## Running it
 
-Start a Parish HTTP server in one terminal:
+There are two backends parish-mcp can drive — pick whichever matches what you
+want to control.
+
+### A. Live desktop session (recommended)
+
+Run the Tauri desktop app with the embedded MCP bridge enabled:
+
+```sh
+cargo run -p parish-tauri -- --mcp-port 3030
+```
+
+The desktop window comes up as usual; in parallel, an in-process Axum
+listener binds `127.0.0.1:3030` and exposes the same `/api/*` routes as
+`parish-server`, sharing the live `AppState` and `tauri::AppHandle`. Every
+write the MCP client sends — `submit_input`, `new_game`, `save_game` —
+mutates the running window's world and triggers the same UI events the user
+would see if they typed in the input box.
+
+Then run parish-mcp pointed at the same port:
+
+```sh
+cargo run -p parish-mcp -- --base-url http://127.0.0.1:3030
+```
+
+### B. Headless `parish-server` session
+
+Useful when you want a separate, headless session (e.g. for batched
+evaluation or CI). Start a server in one terminal:
 
 ```sh
 cargo run -p parish --bin parish -- web --port 3030
 ```
 
-Then run the MCP server pointed at it:
+Then run parish-mcp pointed at it:
 
 ```sh
 cargo run -p parish-mcp -- --base-url http://127.0.0.1:3030
 ```
+
+The MCP client sees an identical tool surface either way — that's what
+`parish-core/tests/wiring_parity.rs` enforces.
 
 It will block waiting for JSON-RPC messages on stdin. From another
 shell you can poke it directly:

--- a/parish/crates/parish-mcp/src/backend.rs
+++ b/parish/crates/parish-mcp/src/backend.rs
@@ -1,0 +1,292 @@
+//! Tauri-app control backends.
+//!
+//! [`TauriBackend`] is the seam between the protocol layer and whatever
+//! is actually being driven. Two impls live here:
+//!
+//! - [`ParishHttpBackend`] — talks HTTP to a running `parish-server`. Because
+//!   `parish-server`'s IPC routes are mode-parity with the Tauri commands
+//!   (enforced by `parish-core/tests/wiring_parity.rs`), this drives the same
+//!   game logic as the desktop app would. This is the recommended path: it
+//!   isolates the MCP server from the GTK/wry build, runs against any
+//!   environment that can host an Axum process, and reuses the parity sensor
+//!   for free.
+//!
+//! - [`GenericTauriBackend`] — a stub for the future WebDriver / `tauri-driver`
+//!   path that drives an arbitrary Tauri app's window directly. It is
+//!   currently `unimplemented!()` at the call sites; the type is exported so
+//!   downstream code can pin its tool registry against the trait now and the
+//!   real impl can land later without API churn.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+/// Errors returned by a [`TauriBackend`]. Mapped onto JSON-RPC errors by the
+/// MCP layer.
+#[derive(Debug, thiserror::Error)]
+pub enum BackendError {
+    #[error("transport error: {0}")]
+    Transport(String),
+    #[error("backend rejected the request: {0}")]
+    Rejected(String),
+    #[error("backend not implemented: {0}")]
+    Unimplemented(&'static str),
+}
+
+/// Operations any Tauri-app controller must support to be useful for MCP.
+///
+/// Kept narrow on purpose: the protocol layer should not depend on
+/// Parish-specific types. Higher-level tools (e.g. `parish_submit_input`)
+/// compose calls to [`Self::invoke`] internally.
+#[async_trait]
+pub trait TauriBackend: Send + Sync {
+    /// Returns a short identifier used in tool descriptions and logs
+    /// (e.g. `"parish-http"`).
+    fn name(&self) -> &'static str;
+
+    /// Invokes a named command on the backing Tauri app and returns the
+    /// raw JSON response. The semantics of `command` depend on the backend:
+    /// for [`ParishHttpBackend`] it is the canonical command name (which is
+    /// translated to `/api/<kebab-case>`); for [`GenericTauriBackend`] it
+    /// will be the Tauri IPC command name passed to `invoke()` in the
+    /// webview.
+    async fn invoke(&self, command: &str, args: Value) -> Result<Value, BackendError>;
+}
+
+// ── ParishHttpBackend ────────────────────────────────────────────────────────
+
+/// Drives a local or remote `parish-server` over HTTP.
+///
+/// `base_url` should point at the Axum root (e.g. `http://127.0.0.1:3030`).
+/// `auth_token`, if set, is sent as a `Cf-Access-Authenticated-User-Email`
+/// header so a server protected by Cloudflare Access can be addressed in
+/// dev (the loopback bypass also covers most local-dev cases).
+pub struct ParishHttpBackend {
+    base_url: String,
+    auth_email: Option<String>,
+    client: reqwest::Client,
+}
+
+impl ParishHttpBackend {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            auth_email: None,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Sets the email forwarded as `Cf-Access-Authenticated-User-Email`.
+    pub fn with_auth_email(mut self, email: impl Into<String>) -> Self {
+        self.auth_email = Some(email.into());
+        self
+    }
+
+    /// Translates a Tauri-style command name to the kebab-cased path under
+    /// `/api/`. Visible-for-test so the conversion can be pinned.
+    pub fn command_to_path(command: &str) -> String {
+        // Strip an optional leading `get_` so `get_world_snapshot` and
+        // `world-snapshot` both map to `/api/world-snapshot` — matches the
+        // behaviour of `parish-core/tests/wiring_parity.rs::tauri_to_canonical`.
+        let stem = command.strip_prefix("get_").unwrap_or(command);
+        let kebab: String = stem
+            .chars()
+            .map(|c| {
+                if c == '_' {
+                    '-'
+                } else {
+                    c.to_ascii_lowercase()
+                }
+            })
+            .collect();
+        format!("/api/{kebab}")
+    }
+
+    /// Heuristic: GET when no body fields are present, POST otherwise.
+    /// Keeps callers from having to know the verb of every endpoint.
+    fn is_post(args: &Value) -> bool {
+        match args {
+            Value::Null => false,
+            Value::Object(map) => !map.is_empty(),
+            _ => true,
+        }
+    }
+}
+
+#[async_trait]
+impl TauriBackend for ParishHttpBackend {
+    fn name(&self) -> &'static str {
+        "parish-http"
+    }
+
+    async fn invoke(&self, command: &str, args: Value) -> Result<Value, BackendError> {
+        let url = format!("{}{}", self.base_url, Self::command_to_path(command));
+        let mut req = if Self::is_post(&args) {
+            self.client.post(&url).json(&args)
+        } else {
+            self.client.get(&url)
+        };
+        if let Some(email) = &self.auth_email {
+            req = req.header("Cf-Access-Authenticated-User-Email", email);
+        }
+
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| BackendError::Transport(e.to_string()))?;
+
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| BackendError::Transport(e.to_string()))?;
+
+        if !status.is_success() {
+            return Err(BackendError::Rejected(format!(
+                "{} {} -> {}: {}",
+                if Self::is_post(&Value::Null) {
+                    "GET"
+                } else {
+                    "POST"
+                },
+                url,
+                status,
+                body,
+            )));
+        }
+
+        // Empty body (e.g. submit-input returns `200 OK` with no JSON) is
+        // surfaced as `null` rather than an error so tools can still
+        // succeed without a result payload.
+        if body.is_empty() {
+            return Ok(Value::Null);
+        }
+        serde_json::from_str(&body).map_err(|e| {
+            BackendError::Transport(format!("invalid JSON from {url}: {e} (body: {body})"))
+        })
+    }
+}
+
+// ── GenericTauriBackend (future) ────────────────────────────────────────────
+
+/// Placeholder for a generic, app-agnostic Tauri controller backed by
+/// WebDriver / `tauri-driver`. Returns [`BackendError::Unimplemented`] until
+/// the implementation lands.
+///
+/// Kept as a real type (rather than a `// TODO`) so the MCP server can be
+/// wired against `Box<dyn TauriBackend>` end-to-end and the day this lands
+/// nothing else has to change.
+pub struct GenericTauriBackend;
+
+#[async_trait]
+impl TauriBackend for GenericTauriBackend {
+    fn name(&self) -> &'static str {
+        "generic-tauri-driver"
+    }
+
+    async fn invoke(&self, _command: &str, _args: Value) -> Result<Value, BackendError> {
+        Err(BackendError::Unimplemented(
+            "GenericTauriBackend (WebDriver/tauri-driver) is not implemented yet",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn command_to_path_matches_wiring_parity_translation() {
+        assert_eq!(
+            ParishHttpBackend::command_to_path("get_world_snapshot"),
+            "/api/world-snapshot"
+        );
+        assert_eq!(
+            ParishHttpBackend::command_to_path("world_snapshot"),
+            "/api/world-snapshot"
+        );
+        assert_eq!(
+            ParishHttpBackend::command_to_path("submit_input"),
+            "/api/submit-input"
+        );
+        assert_eq!(
+            ParishHttpBackend::command_to_path("editor_open_mod"),
+            "/api/editor-open-mod"
+        );
+    }
+
+    #[test]
+    fn is_post_treats_null_and_empty_object_as_get() {
+        assert!(!ParishHttpBackend::is_post(&Value::Null));
+        assert!(!ParishHttpBackend::is_post(&serde_json::json!({})));
+        assert!(ParishHttpBackend::is_post(
+            &serde_json::json!({"text": "hi"})
+        ));
+        assert!(ParishHttpBackend::is_post(&serde_json::json!([1, 2, 3])));
+    }
+
+    #[tokio::test]
+    async fn http_get_returns_parsed_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/world-snapshot"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"clock": 42})),
+            )
+            .mount(&server)
+            .await;
+
+        let backend = ParishHttpBackend::new(server.uri());
+        let v = backend
+            .invoke("get_world_snapshot", Value::Null)
+            .await
+            .unwrap();
+        assert_eq!(v["clock"], 42);
+    }
+
+    #[tokio::test]
+    async fn http_post_forwards_body_and_auth_header() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/submit-input"))
+            .and(header(
+                "cf-access-authenticated-user-email",
+                "dev@example.com",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&server)
+            .await;
+
+        let backend = ParishHttpBackend::new(server.uri()).with_auth_email("dev@example.com");
+        let v = backend
+            .invoke("submit_input", serde_json::json!({"text": "look"}))
+            .await
+            .unwrap();
+        // Empty body → null result.
+        assert!(v.is_null());
+    }
+
+    #[tokio::test]
+    async fn http_non_2xx_is_surfaced_as_rejected() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/world-snapshot"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&server)
+            .await;
+        let backend = ParishHttpBackend::new(server.uri());
+        let err = backend
+            .invoke("get_world_snapshot", Value::Null)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, BackendError::Rejected(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn generic_backend_is_unimplemented() {
+        let backend = GenericTauriBackend;
+        let err = backend.invoke("anything", Value::Null).await.unwrap_err();
+        assert!(matches!(err, BackendError::Unimplemented(_)));
+    }
+}

--- a/parish/crates/parish-mcp/src/backend.rs
+++ b/parish/crates/parish-mcp/src/backend.rs
@@ -101,14 +101,15 @@ impl ParishHttpBackend {
         format!("/api/{kebab}")
     }
 
-    /// Heuristic: GET when no body fields are present, POST otherwise.
-    /// Keeps callers from having to know the verb of every endpoint.
+    /// Heuristic: GET when `args` is JSON null, POST otherwise.
+    ///
+    /// Empty objects (`{}`) are POST: tool translators like
+    /// `parish_new_game` and `parish_save_game` deliberately emit
+    /// `json!({})` to signal a body-less mutation endpoint, and the
+    /// matching `parish-server` route is registered with `.post(...)`.
+    /// Treating `{}` as GET would silently route those calls to a 404.
     fn is_post(args: &Value) -> bool {
-        match args {
-            Value::Null => false,
-            Value::Object(map) => !map.is_empty(),
-            _ => true,
-        }
+        !args.is_null()
     }
 }
 
@@ -120,7 +121,8 @@ impl TauriBackend for ParishHttpBackend {
 
     async fn invoke(&self, command: &str, args: Value) -> Result<Value, BackendError> {
         let url = format!("{}{}", self.base_url, Self::command_to_path(command));
-        let mut req = if Self::is_post(&args) {
+        let use_post = Self::is_post(&args);
+        let mut req = if use_post {
             self.client.post(&url).json(&args)
         } else {
             self.client.get(&url)
@@ -142,15 +144,8 @@ impl TauriBackend for ParishHttpBackend {
 
         if !status.is_success() {
             return Err(BackendError::Rejected(format!(
-                "{} {} -> {}: {}",
-                if Self::is_post(&Value::Null) {
-                    "GET"
-                } else {
-                    "POST"
-                },
-                url,
-                status,
-                body,
+                "{} {url} -> {status}: {body}",
+                if use_post { "POST" } else { "GET" },
             )));
         }
 
@@ -217,13 +212,55 @@ mod tests {
     }
 
     #[test]
-    fn is_post_treats_null_and_empty_object_as_get() {
+    fn is_post_treats_null_as_get_and_everything_else_as_post() {
         assert!(!ParishHttpBackend::is_post(&Value::Null));
-        assert!(!ParishHttpBackend::is_post(&serde_json::json!({})));
+        // Empty objects must be POST: parish_new_game / parish_save_game emit
+        // `json!({})` to drive a body-less mutation endpoint.
+        assert!(ParishHttpBackend::is_post(&serde_json::json!({})));
         assert!(ParishHttpBackend::is_post(
             &serde_json::json!({"text": "hi"})
         ));
         assert!(ParishHttpBackend::is_post(&serde_json::json!([1, 2, 3])));
+    }
+
+    /// Regression: empty-object args (the shape `parish_new_game` / `parish_save_game`
+    /// emit) must reach the backend as POST, not GET. Pre-fix this test would
+    /// fail because `is_post(&json!({}))` returned `false`.
+    #[tokio::test]
+    async fn empty_object_args_dispatch_as_post() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/new-game"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(""))
+            .mount(&server)
+            .await;
+
+        let backend = ParishHttpBackend::new(server.uri());
+        let v = backend
+            .invoke("new_game", serde_json::json!({}))
+            .await
+            .unwrap();
+        assert!(v.is_null());
+    }
+
+    /// Failures on a GET request must report `GET` in the error message —
+    /// the pre-fix code hardcoded `POST` because it called
+    /// `is_post(&Value::Null)` instead of inspecting the actual args.
+    #[tokio::test]
+    async fn rejected_error_reports_actual_http_method() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/world-snapshot"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("missing"))
+            .mount(&server)
+            .await;
+        let backend = ParishHttpBackend::new(server.uri());
+        let err = backend
+            .invoke("get_world_snapshot", Value::Null)
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("GET "), "expected GET in error, got: {msg}");
     }
 
     #[tokio::test]

--- a/parish/crates/parish-mcp/src/backend.rs
+++ b/parish/crates/parish-mcp/src/backend.rs
@@ -134,13 +134,13 @@ impl TauriBackend for ParishHttpBackend {
         let resp = req
             .send()
             .await
-            .map_err(|e| BackendError::Transport(e.to_string()))?;
+            .map_err(|e| self.transport_error_with_hint(&url, e.to_string()))?;
 
         let status = resp.status();
         let body = resp
             .text()
             .await
-            .map_err(|e| BackendError::Transport(e.to_string()))?;
+            .map_err(|e| self.transport_error_with_hint(&url, e.to_string()))?;
 
         if !status.is_success() {
             return Err(BackendError::Rejected(format!(
@@ -158,6 +158,32 @@ impl TauriBackend for ParishHttpBackend {
         serde_json::from_str(&body).map_err(|e| {
             BackendError::Transport(format!("invalid JSON from {url}: {e} (body: {body})"))
         })
+    }
+}
+
+impl ParishHttpBackend {
+    /// Wraps a transport-layer reqwest error with a self-service recovery
+    /// hint so a less-capable model can act on the message without
+    /// out-of-band knowledge. Connection failures here almost always mean
+    /// "no Parish backend listening on the configured port" — the most
+    /// common cause is forgetting to start one — so spell out exactly how
+    /// to fix it inline.
+    fn transport_error_with_hint(&self, url: &str, raw: String) -> BackendError {
+        BackendError::Transport(format!(
+            "{raw}\n\
+             \n\
+             Hint: no Parish backend appears to be listening at {base_url}. \
+             Start one before retrying:\n\
+             \x20 - Headless (recommended in sandboxes / CI):\n\
+             \x20     bash parish/scripts/parish-mcp-backend.sh start\n\
+             \x20 - Desktop (drives the live window when a display is available):\n\
+             \x20     cargo run -p parish-tauri -- --mcp-port 3030\n\
+             \n\
+             Then re-issue the tool call. The script polls /api/health for up \
+             to 60s and returns success only once the bridge is live.\n\
+             Failed URL: {url}",
+            base_url = self.base_url,
+        ))
     }
 }
 
@@ -261,6 +287,40 @@ mod tests {
             .unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("GET "), "expected GET in error, got: {msg}");
+    }
+
+    /// When nothing is listening on the configured port (the dominant
+    /// failure mode in a fresh sandbox), the transport error must include
+    /// a self-service hint pointing at parish-mcp-backend.sh so a less
+    /// capable model can act without out-of-band context.
+    #[tokio::test]
+    async fn transport_error_includes_recovery_hint() {
+        // Bind a TCP port, take its address, then drop the listener so the
+        // address is reserved-and-free — guarantees connection-refused on
+        // the first request without depending on a magic port number.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let backend = ParishHttpBackend::new(format!("http://{addr}"));
+        let err = backend
+            .invoke("get_world_snapshot", Value::Null)
+            .await
+            .unwrap_err();
+        let BackendError::Transport(msg) = err else {
+            panic!("expected Transport error, got {err:?}");
+        };
+        assert!(
+            msg.contains("parish-mcp-backend.sh start"),
+            "missing recovery hint, got: {msg}",
+        );
+        assert!(
+            msg.contains("--mcp-port 3030"),
+            "missing desktop alternative, got: {msg}",
+        );
+        assert!(
+            msg.contains(&addr.to_string()),
+            "hint should name the failed base URL, got: {msg}",
+        );
     }
 
     #[tokio::test]

--- a/parish/crates/parish-mcp/src/backend.rs
+++ b/parish/crates/parish-mcp/src/backend.rs
@@ -12,10 +12,10 @@
 //!   for free.
 //!
 //! - [`GenericTauriBackend`] — a stub for the future WebDriver / `tauri-driver`
-//!   path that drives an arbitrary Tauri app's window directly. It is
-//!   currently `unimplemented!()` at the call sites; the type is exported so
-//!   downstream code can pin its tool registry against the trait now and the
-//!   real impl can land later without API churn.
+//!   path that drives an arbitrary Tauri app's window directly. It returns
+//!   [`BackendError::Unimplemented`] today; the type is exported so downstream
+//!   code can pin its tool registry against the trait now and the real impl
+//!   can land later without API churn.
 
 use async_trait::async_trait;
 use serde_json::Value;

--- a/parish/crates/parish-mcp/src/jsonrpc.rs
+++ b/parish/crates/parish-mcp/src/jsonrpc.rs
@@ -1,0 +1,339 @@
+//! Minimal line-delimited JSON-RPC 2.0 over async streams.
+//!
+//! MCP supports several transports; the most common (and the only one
+//! Claude Desktop / Claude Code currently configure) is **stdio with
+//! newline-delimited JSON messages**. This module owns the wire layer
+//! and is deliberately ignorant of MCP method names — that lives in
+//! [`crate::mcp`].
+//!
+//! Errors are surfaced via JSON-RPC error objects rather than panics so a
+//! malformed request from the client never tears down the server loop.
+//!
+//! Concurrency model: requests are processed serially in the order they
+//! arrive. JSON-RPC clients correlate by `id` so out-of-order responses
+//! are spec-legal, but Parish IPC handlers are stateful (a `submit_input`
+//! that mutates the world followed by a `world_snapshot` must observe
+//! the mutation) and the MCP clients we target — Claude Code and Claude
+//! Desktop — issue requests sequentially. Serial processing keeps the
+//! semantics predictable and avoids losing responses when stdin closes
+//! while handlers are still in flight.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio::sync::Mutex;
+
+/// JSON-RPC 2.0 request / notification.
+///
+/// `id` is `None` for notifications. We accept any JSON value for `id`
+/// (string, number, null) per the spec and echo it back verbatim.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Request {
+    #[allow(dead_code)] // verified during deserialisation; kept for completeness
+    pub jsonrpc: String,
+    pub method: String,
+    #[serde(default)]
+    pub params: Value,
+    #[serde(default)]
+    pub id: Option<Value>,
+}
+
+/// JSON-RPC 2.0 response. Either `result` or `error` is set, never both.
+#[derive(Debug, Clone, Serialize)]
+pub struct Response {
+    pub jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<RpcError>,
+    pub id: Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RpcError {
+    pub code: i64,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl RpcError {
+    pub fn parse_error(detail: impl Into<String>) -> Self {
+        Self {
+            code: -32700,
+            message: detail.into(),
+            data: None,
+        }
+    }
+    pub fn invalid_request(detail: impl Into<String>) -> Self {
+        Self {
+            code: -32600,
+            message: detail.into(),
+            data: None,
+        }
+    }
+    pub fn method_not_found(method: &str) -> Self {
+        Self {
+            code: -32601,
+            message: format!("method not found: {method}"),
+            data: None,
+        }
+    }
+    pub fn invalid_params(detail: impl Into<String>) -> Self {
+        Self {
+            code: -32602,
+            message: detail.into(),
+            data: None,
+        }
+    }
+    pub fn internal(detail: impl Into<String>) -> Self {
+        Self {
+            code: -32603,
+            message: detail.into(),
+            data: None,
+        }
+    }
+}
+
+impl Response {
+    pub fn ok(id: Value, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            result: Some(result),
+            error: None,
+            id,
+        }
+    }
+    pub fn err(id: Value, error: RpcError) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            result: None,
+            error: Some(error),
+            id,
+        }
+    }
+}
+
+/// A handler is given the parsed `params` and must return either a
+/// JSON-encodable result or a typed [`RpcError`].
+pub type HandlerResult = Result<Value, RpcError>;
+
+#[async_trait::async_trait]
+pub trait MethodHandler: Send + Sync {
+    async fn handle(&self, method: &str, params: Value) -> HandlerResult;
+}
+
+/// Writer wrapper that serialises responses one-per-line. Wrapped in a
+/// mutex so concurrent handler tasks never interleave bytes on stdout.
+pub struct ResponseWriter<W: AsyncWrite + Unpin + Send> {
+    inner: Arc<Mutex<W>>,
+}
+
+impl<W: AsyncWrite + Unpin + Send + 'static> ResponseWriter<W> {
+    pub fn new(w: W) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(w)),
+        }
+    }
+
+    pub fn handle(&self) -> Arc<Mutex<W>> {
+        Arc::clone(&self.inner)
+    }
+}
+
+/// Writes a single JSON-RPC response, terminated by `\n`.
+///
+/// Holding the lock around the *whole* write (serialise + write_all + flush)
+/// is what keeps concurrent handler responses from interleaving bytes.
+pub async fn write_response<W: AsyncWrite + Unpin + Send>(
+    writer: &Arc<Mutex<W>>,
+    response: &Response,
+) -> std::io::Result<()> {
+    let body = serde_json::to_vec(response).map_err(std::io::Error::other)?;
+    let mut guard = writer.lock().await;
+    guard.write_all(&body).await?;
+    guard.write_all(b"\n").await?;
+    guard.flush().await?;
+    Ok(())
+}
+
+/// Drives the read loop: reads newline-delimited JSON-RPC messages from
+/// `reader`, dispatches each one onto the tokio runtime, and writes the
+/// response to `writer`. Returns when the reader hits EOF or a fatal I/O
+/// error.
+pub async fn serve<R, W, H>(
+    reader: R,
+    writer: ResponseWriter<W>,
+    handler: Arc<H>,
+) -> std::io::Result<()>
+where
+    R: tokio::io::AsyncRead + Unpin + Send,
+    W: AsyncWrite + Unpin + Send + 'static,
+    H: MethodHandler + 'static,
+{
+    let mut lines = BufReader::new(reader).lines();
+    let writer_handle = writer.handle();
+
+    while let Some(line) = lines.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        dispatch_line(line, Arc::clone(&handler), Arc::clone(&writer_handle)).await;
+    }
+    Ok(())
+}
+
+async fn dispatch_line<W, H>(line: String, handler: Arc<H>, writer: Arc<Mutex<W>>)
+where
+    W: AsyncWrite + Unpin + Send,
+    H: MethodHandler,
+{
+    // Parse first; on parse failure we cannot recover the `id`, so we reply
+    // with `id: null` per the JSON-RPC spec.
+    let request: Request = match serde_json::from_str(&line) {
+        Ok(r) => r,
+        Err(e) => {
+            let resp = Response::err(Value::Null, RpcError::parse_error(e.to_string()));
+            let _ = write_response(&writer, &resp).await;
+            return;
+        }
+    };
+
+    let id = request.id.clone();
+    let result = handler.handle(&request.method, request.params).await;
+
+    // Notifications (no `id`) get no response per the spec.
+    let Some(id) = id else { return };
+
+    let response = match result {
+        Ok(value) => Response::ok(id, value),
+        Err(err) => Response::err(id, err),
+    };
+    let _ = write_response(&writer, &response).await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_serialises_only_result_when_ok() {
+        let resp = Response::ok(Value::from(7), serde_json::json!({"hello": "world"}));
+        let s = serde_json::to_string(&resp).unwrap();
+        assert!(s.contains("\"result\""));
+        assert!(!s.contains("\"error\""));
+        assert!(s.contains("\"id\":7"));
+    }
+
+    #[test]
+    fn response_serialises_only_error_when_err() {
+        let resp = Response::err(Value::from("abc"), RpcError::method_not_found("foo"));
+        let s = serde_json::to_string(&resp).unwrap();
+        assert!(s.contains("\"error\""));
+        assert!(!s.contains("\"result\""));
+        assert!(s.contains("method not found: foo"));
+    }
+
+    /// Smoke test for the full read/dispatch/write loop using in-memory pipes.
+    #[tokio::test]
+    async fn serve_round_trips_a_request() {
+        struct Echo;
+        #[async_trait::async_trait]
+        impl MethodHandler for Echo {
+            async fn handle(&self, method: &str, params: Value) -> HandlerResult {
+                Ok(serde_json::json!({"method": method, "params": params}))
+            }
+        }
+
+        let (mut client_in, server_in) = tokio::io::duplex(4096);
+        let (server_out, mut client_out) = tokio::io::duplex(4096);
+
+        let handler = Arc::new(Echo);
+        let writer = ResponseWriter::new(server_out);
+        let serve_task = tokio::spawn(super::serve(server_in, writer, handler));
+
+        let req = b"{\"jsonrpc\":\"2.0\",\"method\":\"ping\",\"params\":{\"a\":1},\"id\":42}\n";
+        client_in.write_all(req).await.unwrap();
+        client_in.shutdown().await.unwrap();
+
+        let mut buf = String::new();
+        BufReader::new(&mut client_out)
+            .read_line(&mut buf)
+            .await
+            .unwrap();
+
+        let parsed: serde_json::Value = serde_json::from_str(&buf).unwrap();
+        assert_eq!(parsed["id"], 42);
+        assert_eq!(parsed["result"]["method"], "ping");
+        assert_eq!(parsed["result"]["params"]["a"], 1);
+
+        // Drain the loop.
+        let _ = serve_task.await;
+    }
+
+    /// Notifications (no `id`) MUST NOT receive a response.
+    #[tokio::test]
+    async fn serve_does_not_respond_to_notifications() {
+        struct Sink;
+        #[async_trait::async_trait]
+        impl MethodHandler for Sink {
+            async fn handle(&self, _: &str, _: Value) -> HandlerResult {
+                Ok(Value::Null)
+            }
+        }
+
+        let (mut client_in, server_in) = tokio::io::duplex(4096);
+        let (server_out, mut client_out) = tokio::io::duplex(4096);
+        let writer = ResponseWriter::new(server_out);
+        let serve_task = tokio::spawn(super::serve(server_in, writer, Arc::new(Sink)));
+
+        client_in
+            .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"shouldNotReply\"}\n")
+            .await
+            .unwrap();
+        client_in.shutdown().await.unwrap();
+
+        let _ = serve_task.await;
+
+        // Reader is closed and no bytes were written.
+        let mut buf = Vec::new();
+        let _ = tokio::io::AsyncReadExt::read_to_end(&mut client_out, &mut buf).await;
+        assert!(
+            buf.is_empty(),
+            "got unexpected bytes: {:?}",
+            String::from_utf8_lossy(&buf)
+        );
+    }
+
+    /// Malformed JSON yields a parse-error response with `id: null`.
+    #[tokio::test]
+    async fn serve_returns_parse_error_for_invalid_json() {
+        struct Sink;
+        #[async_trait::async_trait]
+        impl MethodHandler for Sink {
+            async fn handle(&self, _: &str, _: Value) -> HandlerResult {
+                Ok(Value::Null)
+            }
+        }
+
+        let (mut client_in, server_in) = tokio::io::duplex(4096);
+        let (server_out, mut client_out) = tokio::io::duplex(4096);
+        let writer = ResponseWriter::new(server_out);
+        let serve_task = tokio::spawn(super::serve(server_in, writer, Arc::new(Sink)));
+
+        client_in.write_all(b"{not json}\n").await.unwrap();
+        client_in.shutdown().await.unwrap();
+
+        let mut buf = String::new();
+        BufReader::new(&mut client_out)
+            .read_line(&mut buf)
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&buf).unwrap();
+        assert_eq!(parsed["id"], Value::Null);
+        assert_eq!(parsed["error"]["code"], -32700);
+
+        let _ = serve_task.await;
+    }
+}

--- a/parish/crates/parish-mcp/src/lib.rs
+++ b/parish/crates/parish-mcp/src/lib.rs
@@ -1,0 +1,24 @@
+//! Parish MCP — a Model Context Protocol server that lets an LLM client
+//! drive a running Parish (or any compatible Tauri) instance.
+//!
+//! The crate is intentionally split into three layers so the parts can be
+//! tested independently and a future generic-Tauri backend (WebDriver /
+//! `tauri-driver`) can plug in without touching the protocol code:
+//!
+//! 1. [`jsonrpc`] — line-delimited JSON-RPC 2.0 over an `AsyncRead`/`AsyncWrite`.
+//! 2. [`mcp`] — the MCP handshake (`initialize`, `tools/list`, `tools/call`)
+//!    plus the tool registry that translates a `tools/call` into a backend
+//!    invocation.
+//! 3. [`backend`] — the [`backend::TauriBackend`] trait and its
+//!    implementations.  [`backend::ParishHttpBackend`] wraps the existing
+//!    `parish-server` HTTP API; the same routes are mode-parity with the
+//!    Tauri IPC commands, so driving the server is equivalent to driving
+//!    the desktop app for everything that participates in the IPC parity
+//!    sensor.
+//!
+//! See `README.md` for transport rationale (stdio) and client-config snippets.
+
+pub mod backend;
+pub mod jsonrpc;
+pub mod mcp;
+pub mod tools;

--- a/parish/crates/parish-mcp/src/main.rs
+++ b/parish/crates/parish-mcp/src/main.rs
@@ -1,0 +1,57 @@
+//! `parish-mcp` — stdio MCP server entry point.
+//!
+//! Launches a JSON-RPC 2.0 server on stdin/stdout and routes MCP `tools/call`
+//! invocations into a [`parish_mcp::backend::TauriBackend`]. The default
+//! backend talks HTTP to a running `parish-server`; pass `--base-url` to
+//! point it at a non-default host or port.
+
+use std::sync::Arc;
+
+use clap::Parser;
+use parish_mcp::backend::{ParishHttpBackend, TauriBackend};
+use parish_mcp::jsonrpc::{ResponseWriter, serve};
+use parish_mcp::mcp::McpServer;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "parish-mcp",
+    about = "MCP stdio server that drives a Parish (or compatible Tauri) instance"
+)]
+struct Cli {
+    /// Base URL of the parish-server backend (without trailing slash).
+    #[arg(long, default_value = "http://127.0.0.1:3030")]
+    base_url: String,
+
+    /// Optional Cf-Access email forwarded with each request. Useful when the
+    /// target server is gated behind Cloudflare Access.
+    #[arg(long, env = "PARISH_MCP_AUTH_EMAIL")]
+    auth_email: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Logs go to stderr — stdout is reserved for the JSON-RPC stream.
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    let cli = Cli::parse();
+    tracing::info!(base_url = %cli.base_url, "parish-mcp starting");
+
+    let mut http = ParishHttpBackend::new(&cli.base_url);
+    if let Some(email) = cli.auth_email {
+        http = http.with_auth_email(email);
+    }
+    let backend: Arc<dyn TauriBackend> = Arc::new(http);
+    let server = Arc::new(McpServer::new(backend));
+
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+    let writer = ResponseWriter::new(stdout);
+    serve(stdin, writer, server).await?;
+    Ok(())
+}

--- a/parish/crates/parish-mcp/src/mcp.rs
+++ b/parish/crates/parish-mcp/src/mcp.rs
@@ -1,0 +1,262 @@
+//! MCP protocol surface — handshake plus the `tools/*` methods.
+//!
+//! The protocol version pinned here (`PROTOCOL_VERSION`) is the spec
+//! revision Claude Desktop / Claude Code currently negotiate against; the
+//! initialize response echoes a version the client can recognise.
+//!
+//! The server intentionally implements only the small subset of MCP needed
+//! to expose tools. Resources, prompts, sampling, and roots are not
+//! advertised in the capability map and respond with `method not found`
+//! per the JSON-RPC spec.
+
+use crate::backend::{BackendError, TauriBackend};
+use crate::jsonrpc::{HandlerResult, MethodHandler, RpcError};
+use crate::tools::{ToolDef, registry};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::sync::Arc;
+
+/// MCP spec revision negotiated during `initialize`. Kept inline so the
+/// pinned date is easy to grep / bump.
+pub const PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// Server identity returned in `initialize` responses.
+pub const SERVER_NAME: &str = "parish-mcp";
+pub const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Wires a [`TauriBackend`] to an MCP-shaped JSON-RPC method handler.
+///
+/// Holds the curated tool registry plus a backend trait object. One server
+/// instance handles the lifetime of one client connection — clone it (it's
+/// `Arc`-friendly) if you need to share across tasks.
+pub struct McpServer {
+    tools: Vec<ToolDef>,
+    backend: Arc<dyn TauriBackend>,
+}
+
+impl McpServer {
+    pub fn new(backend: Arc<dyn TauriBackend>) -> Self {
+        Self {
+            tools: registry(),
+            backend,
+        }
+    }
+
+    fn initialize_response(&self) -> Value {
+        json!({
+            "protocolVersion": PROTOCOL_VERSION,
+            "serverInfo": {
+                "name": SERVER_NAME,
+                "version": SERVER_VERSION,
+            },
+            "capabilities": {
+                // listChanged: false — the registry is static for the
+                // lifetime of the process. If a future change makes it
+                // dynamic, flip this and emit `notifications/tools/list_changed`.
+                "tools": {"listChanged": false}
+            }
+        })
+    }
+
+    fn list_tools(&self) -> Value {
+        json!({
+            "tools": self.tools.iter().map(|t| t.descriptor_json()).collect::<Vec<_>>(),
+        })
+    }
+
+    async fn call_tool(&self, params: Value) -> HandlerResult {
+        let name = params
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| RpcError::invalid_params("missing required field: `name`"))?;
+        let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+
+        let tool = self
+            .tools
+            .iter()
+            .find(|t| t.name == name)
+            .ok_or_else(|| RpcError::invalid_params(format!("unknown tool: {name}")))?;
+
+        let (command, args) = (tool.translate)(&arguments).map_err(RpcError::invalid_params)?;
+        match self.backend.invoke(&command, args).await {
+            Ok(value) => Ok(tool_call_result(&value, false)),
+            Err(BackendError::Unimplemented(msg)) => Err(RpcError::internal(msg)),
+            // Backend rejection / transport error is reported as `isError: true`
+            // inside a successful tool response so the model can read the
+            // error text and self-correct, rather than aborting the call.
+            Err(e) => Ok(tool_call_result(&Value::String(e.to_string()), true)),
+        }
+    }
+}
+
+/// Wraps a JSON value in the MCP `tools/call` result envelope.
+///
+/// Per the spec, `content` is a list of typed parts. We always emit a single
+/// `text` part containing the JSON-encoded value; the model can parse it
+/// back to JSON when needed and gets a readable representation when not.
+fn tool_call_result(value: &Value, is_error: bool) -> Value {
+    let text = if value.is_string() {
+        value.as_str().unwrap_or("").to_string()
+    } else {
+        serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+    };
+    json!({
+        "content": [{"type": "text", "text": text}],
+        "isError": is_error,
+    })
+}
+
+#[async_trait]
+impl MethodHandler for McpServer {
+    async fn handle(&self, method: &str, params: Value) -> HandlerResult {
+        match method {
+            "initialize" => Ok(self.initialize_response()),
+            // Spec-defined notification clients may send after initialize;
+            // accept silently so the client doesn't see a `method not found`.
+            "notifications/initialized" | "initialized" => Ok(Value::Null),
+            "ping" => Ok(json!({})),
+            "tools/list" => Ok(self.list_tools()),
+            "tools/call" => self.call_tool(params).await,
+            other => Err(RpcError::method_not_found(other)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::TauriBackend;
+    use std::sync::Mutex;
+
+    struct RecordingBackend {
+        calls: Mutex<Vec<(String, Value)>>,
+        response: Value,
+    }
+
+    #[async_trait]
+    impl TauriBackend for RecordingBackend {
+        fn name(&self) -> &'static str {
+            "test"
+        }
+        async fn invoke(&self, command: &str, args: Value) -> Result<Value, BackendError> {
+            self.calls.lock().unwrap().push((command.into(), args));
+            Ok(self.response.clone())
+        }
+    }
+
+    fn make_server(response: Value) -> (McpServer, Arc<RecordingBackend>) {
+        let backend = Arc::new(RecordingBackend {
+            calls: Mutex::new(Vec::new()),
+            response,
+        });
+        let server = McpServer::new(backend.clone() as Arc<dyn TauriBackend>);
+        (server, backend)
+    }
+
+    #[tokio::test]
+    async fn initialize_returns_protocol_version_and_tools_capability() {
+        let (server, _) = make_server(Value::Null);
+        let result = server.handle("initialize", json!({})).await.unwrap();
+        assert_eq!(result["protocolVersion"], PROTOCOL_VERSION);
+        assert_eq!(result["serverInfo"]["name"], SERVER_NAME);
+        assert!(result["capabilities"]["tools"].is_object());
+    }
+
+    #[tokio::test]
+    async fn tools_list_includes_curated_set() {
+        let (server, _) = make_server(Value::Null);
+        let result = server.handle("tools/list", json!({})).await.unwrap();
+        let tools = result["tools"].as_array().expect("tools array");
+        let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+        assert!(names.contains(&"tauri_invoke"));
+        assert!(names.contains(&"parish_world_snapshot"));
+        assert!(names.contains(&"parish_submit_input"));
+    }
+
+    #[tokio::test]
+    async fn tools_call_routes_through_backend() {
+        let (server, backend) = make_server(json!({"clock": 5}));
+        let result = server
+            .handle(
+                "tools/call",
+                json!({"name": "parish_world_snapshot", "arguments": {}}),
+            )
+            .await
+            .unwrap();
+
+        let calls = backend.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "get_world_snapshot");
+
+        // Result is wrapped in MCP content envelope as a JSON-encoded text part.
+        let text = result["content"][0]["text"].as_str().unwrap();
+        let payload: Value = serde_json::from_str(text).unwrap();
+        assert_eq!(payload["clock"], 5);
+        assert_eq!(result["isError"], false);
+    }
+
+    #[tokio::test]
+    async fn submit_input_translates_text_and_addressed_to() {
+        let (server, backend) = make_server(Value::Null);
+        let _ = server
+            .handle(
+                "tools/call",
+                json!({
+                    "name": "parish_submit_input",
+                    "arguments": {"text": "look", "addressed_to": ["Mary"]}
+                }),
+            )
+            .await
+            .unwrap();
+        let calls = backend.calls.lock().unwrap();
+        assert_eq!(calls[0].0, "submit_input");
+        assert_eq!(calls[0].1["text"], "look");
+        assert_eq!(calls[0].1["addressed_to"], json!(["Mary"]));
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_is_invalid_params() {
+        let (server, _) = make_server(Value::Null);
+        let err = server
+            .handle("tools/call", json!({"name": "no_such_tool"}))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, -32602);
+    }
+
+    #[tokio::test]
+    async fn unknown_method_is_method_not_found() {
+        let (server, _) = make_server(Value::Null);
+        let err = server.handle("frobnicate", json!({})).await.unwrap_err();
+        assert_eq!(err.code, -32601);
+    }
+
+    #[tokio::test]
+    async fn backend_rejection_is_surfaced_as_is_error() {
+        struct Reject;
+        #[async_trait]
+        impl TauriBackend for Reject {
+            fn name(&self) -> &'static str {
+                "reject"
+            }
+            async fn invoke(&self, _: &str, _: Value) -> Result<Value, BackendError> {
+                Err(BackendError::Rejected("nope".into()))
+            }
+        }
+        let server = McpServer::new(Arc::new(Reject));
+        let result = server
+            .handle(
+                "tools/call",
+                json!({"name": "parish_world_snapshot", "arguments": {}}),
+            )
+            .await
+            .unwrap();
+        assert_eq!(result["isError"], true);
+        assert!(
+            result["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("nope")
+        );
+    }
+}

--- a/parish/crates/parish-mcp/src/tools.rs
+++ b/parish/crates/parish-mcp/src/tools.rs
@@ -1,0 +1,245 @@
+//! Curated MCP tools that translate cleanly to a single Parish IPC call.
+//!
+//! Each tool is a thin descriptor: the JSON schema clients see, plus a
+//! function that turns the validated arguments into a `(command, args)`
+//! pair for [`crate::backend::TauriBackend::invoke`].
+//!
+//! There is also a generic escape hatch — `tauri_invoke` — that lets a
+//! client call any backend command by name. New high-level tools can be
+//! added here as gameplay flows surface them; they exist to give the
+//! model better-typed, narrower affordances than the raw IPC surface.
+
+use serde_json::{Value, json};
+
+/// Description of one MCP tool, exposed by `tools/list`.
+#[derive(Debug, Clone)]
+pub struct ToolDef {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub input_schema: Value,
+    /// Translates the validated `tools/call` arguments into the underlying
+    /// backend `(command, args)` pair. Returning `Err` produces a JSON-RPC
+    /// invalid-params error.
+    pub translate: fn(&Value) -> Result<(String, Value), String>,
+}
+
+impl ToolDef {
+    pub fn descriptor_json(&self) -> Value {
+        json!({
+            "name": self.name,
+            "description": self.description,
+            "inputSchema": self.input_schema,
+        })
+    }
+}
+
+fn empty_object_schema() -> Value {
+    json!({"type": "object", "properties": {}, "additionalProperties": false})
+}
+
+fn require_string<'a>(args: &'a Value, key: &str) -> Result<&'a str, String> {
+    args.get(key)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("missing required string field: `{key}`"))
+}
+
+fn translate_world_snapshot(_args: &Value) -> Result<(String, Value), String> {
+    Ok(("get_world_snapshot".into(), Value::Null))
+}
+
+fn translate_map(_args: &Value) -> Result<(String, Value), String> {
+    Ok(("get_map".into(), Value::Null))
+}
+
+fn translate_npcs_here(_args: &Value) -> Result<(String, Value), String> {
+    Ok(("get_npcs_here".into(), Value::Null))
+}
+
+fn translate_save_state(_args: &Value) -> Result<(String, Value), String> {
+    Ok(("get_save_state".into(), Value::Null))
+}
+
+fn translate_submit_input(args: &Value) -> Result<(String, Value), String> {
+    let text = require_string(args, "text")?.to_string();
+    let addressed_to = args
+        .get("addressed_to")
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+    if !addressed_to.is_array() {
+        return Err("`addressed_to` must be an array of strings".into());
+    }
+    Ok((
+        "submit_input".into(),
+        json!({"text": text, "addressed_to": addressed_to}),
+    ))
+}
+
+fn translate_new_game(_args: &Value) -> Result<(String, Value), String> {
+    // The HTTP route `POST /api/new-game` takes an empty body; we send
+    // `{}` so the backend treats it as a POST.
+    Ok(("new_game".into(), json!({})))
+}
+
+fn translate_save_game(_args: &Value) -> Result<(String, Value), String> {
+    Ok(("save_game".into(), json!({})))
+}
+
+fn translate_load_branch(args: &Value) -> Result<(String, Value), String> {
+    let branch_id = args
+        .get("branch_id")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| "missing required integer field: `branch_id`".to_string())?;
+    Ok(("load_branch".into(), json!({"branch_id": branch_id})))
+}
+
+fn translate_invoke(args: &Value) -> Result<(String, Value), String> {
+    let command = require_string(args, "command")?.to_string();
+    let inner = args.get("args").cloned().unwrap_or(Value::Null);
+    Ok((command, inner))
+}
+
+/// Returns the curated tool registry. Tools are listed in the order the
+/// MCP client will see them via `tools/list`.
+pub fn registry() -> Vec<ToolDef> {
+    vec![
+        ToolDef {
+            name: "tauri_invoke",
+            description: "Generic escape hatch — invoke any backend command by name with a JSON args object. \
+                 Useful for endpoints that do not yet have a dedicated tool.",
+            input_schema: json!({
+                "type": "object",
+                "required": ["command"],
+                "properties": {
+                    "command": {"type": "string", "description": "Tauri-style command name (e.g. get_world_snapshot)."},
+                    "args": {"description": "Arguments object forwarded as-is. Omit or null for GET-style calls."}
+                }
+            }),
+            translate: translate_invoke,
+        },
+        ToolDef {
+            name: "parish_world_snapshot",
+            description: "Reads the current world snapshot (clock, player location, weather, recent log entries).",
+            input_schema: empty_object_schema(),
+            translate: translate_world_snapshot,
+        },
+        ToolDef {
+            name: "parish_map",
+            description: "Reads the location graph plus the player's current position.",
+            input_schema: empty_object_schema(),
+            translate: translate_map,
+        },
+        ToolDef {
+            name: "parish_npcs_here",
+            description: "Lists the NPCs co-located with the player at this moment.",
+            input_schema: empty_object_schema(),
+            translate: translate_npcs_here,
+        },
+        ToolDef {
+            name: "parish_save_state",
+            description: "Reads metadata about the active save file and current branch.",
+            input_schema: empty_object_schema(),
+            translate: translate_save_state,
+        },
+        ToolDef {
+            name: "parish_submit_input",
+            description: "Sends a line of player input (a movement, action, or dialogue) to the running game. \
+                 Optionally restrict the recipients of dialogue via `addressed_to`.",
+            input_schema: json!({
+                "type": "object",
+                "required": ["text"],
+                "properties": {
+                    "text": {"type": "string", "minLength": 1, "maxLength": 2000},
+                    "addressed_to": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "default": []
+                    }
+                }
+            }),
+            translate: translate_submit_input,
+        },
+        ToolDef {
+            name: "parish_new_game",
+            description: "Starts a fresh game on a new save branch, discarding any unsaved state.",
+            input_schema: empty_object_schema(),
+            translate: translate_new_game,
+        },
+        ToolDef {
+            name: "parish_save_game",
+            description: "Saves the current branch to the active save file. Returns a status message.",
+            input_schema: empty_object_schema(),
+            translate: translate_save_game,
+        },
+        ToolDef {
+            name: "parish_load_branch",
+            description: "Loads the named branch (by integer id) from the active save file.",
+            input_schema: json!({
+                "type": "object",
+                "required": ["branch_id"],
+                "properties": {
+                    "branch_id": {"type": "integer"}
+                }
+            }),
+            translate: translate_load_branch,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn submit_input_requires_text() {
+        let err = translate_submit_input(&json!({})).unwrap_err();
+        assert!(err.contains("text"));
+    }
+
+    #[test]
+    fn submit_input_defaults_addressed_to_empty() {
+        let (cmd, args) = translate_submit_input(&json!({"text": "look"})).unwrap();
+        assert_eq!(cmd, "submit_input");
+        assert_eq!(args["text"], "look");
+        assert_eq!(args["addressed_to"], json!([]));
+    }
+
+    #[test]
+    fn submit_input_rejects_non_array_addressed_to() {
+        let err =
+            translate_submit_input(&json!({"text": "hi", "addressed_to": "Mary"})).unwrap_err();
+        assert!(err.contains("array"));
+    }
+
+    #[test]
+    fn invoke_passes_args_through() {
+        let (cmd, args) =
+            translate_invoke(&json!({"command": "save_game", "args": {"x": 1}})).unwrap();
+        assert_eq!(cmd, "save_game");
+        assert_eq!(args, json!({"x": 1}));
+    }
+
+    #[test]
+    fn invoke_defaults_args_to_null() {
+        let (cmd, args) = translate_invoke(&json!({"command": "get_world_snapshot"})).unwrap();
+        assert_eq!(cmd, "get_world_snapshot");
+        assert!(args.is_null());
+    }
+
+    #[test]
+    fn registry_has_unique_names() {
+        let r = registry();
+        let mut names: Vec<&str> = r.iter().map(|t| t.name).collect();
+        names.sort_unstable();
+        let before = names.len();
+        names.dedup();
+        assert_eq!(before, names.len(), "duplicate tool names");
+    }
+
+    #[test]
+    fn load_branch_requires_integer_id() {
+        let err = translate_load_branch(&json!({})).unwrap_err();
+        assert!(err.contains("branch_id"));
+        let err = translate_load_branch(&json!({"branch_id": "abc"})).unwrap_err();
+        assert!(err.contains("branch_id"));
+    }
+}

--- a/parish/crates/parish-mcp/src/tools.rs
+++ b/parish/crates/parish-mcp/src/tools.rs
@@ -98,6 +98,37 @@ fn translate_invoke(args: &Value) -> Result<(String, Value), String> {
     Ok((command, inner))
 }
 
+// ── BYOK setup-flow stubs (#933) ─────────────────────────────────────────────
+//
+// These tools shape the contract for the BYOK ("bring your own key") setup
+// flow that lives on a sibling branch. The backend routes return a structured
+// `{"stub": true, ...}` response today; when the real implementation lands,
+// the route bodies fill in but the tool surface (names, schemas) stays the
+// same — so any agent code written against these tools keeps working.
+
+fn translate_setup_status(_args: &Value) -> Result<(String, Value), String> {
+    Ok(("get_setup_status".into(), Value::Null))
+}
+
+fn translate_setup_byok(args: &Value) -> Result<(String, Value), String> {
+    let provider = require_string(args, "provider")?.to_string();
+    let api_key = require_string(args, "api_key")?.to_string();
+    let base_url = args
+        .get("base_url")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let model = args.get("model").and_then(|v| v.as_str()).map(String::from);
+    Ok((
+        "submit_byok".into(),
+        json!({
+            "provider": provider,
+            "api_key": api_key,
+            "base_url": base_url,
+            "model": model,
+        }),
+    ))
+}
+
 /// Returns the curated tool registry. Tools are listed in the order the
 /// MCP client will see them via `tools/list`.
 pub fn registry() -> Vec<ToolDef> {
@@ -182,6 +213,44 @@ pub fn registry() -> Vec<ToolDef> {
             }),
             translate: translate_load_branch,
         },
+        // ── BYOK setup-flow (stubbed; see translate_setup_*) ─────────────────
+        ToolDef {
+            name: "parish_setup_status",
+            description: "Reads the setup state — which providers are configured, whether \
+                          first-run setup is complete, and what the user still needs to \
+                          supply. STUB: backend returns `{\"stub\": true, ...}` today; the \
+                          real implementation lands with the setup-UI branch and the tool \
+                          contract is stable across that change.",
+            input_schema: empty_object_schema(),
+            translate: translate_setup_status,
+        },
+        ToolDef {
+            name: "parish_setup_byok",
+            description: "Submits a 'bring your own key' provider configuration. STUB: the \
+                          backend currently returns `{\"stub\": true, ...}` and does not \
+                          persist the key; the real implementation lands with the setup-UI \
+                          branch.",
+            input_schema: json!({
+                "type": "object",
+                "required": ["provider", "api_key"],
+                "properties": {
+                    "provider": {
+                        "type": "string",
+                        "description": "Provider id (e.g. anthropic, openrouter, openai, ollama)."
+                    },
+                    "api_key": {"type": "string", "minLength": 1},
+                    "base_url": {
+                        "type": "string",
+                        "description": "Optional override for the provider's base URL."
+                    },
+                    "model": {
+                        "type": "string",
+                        "description": "Optional explicit model id; defaults to the provider's preset."
+                    }
+                }
+            }),
+            translate: translate_setup_byok,
+        },
     ]
 }
 
@@ -241,5 +310,53 @@ mod tests {
         assert!(err.contains("branch_id"));
         let err = translate_load_branch(&json!({"branch_id": "abc"})).unwrap_err();
         assert!(err.contains("branch_id"));
+    }
+
+    #[test]
+    fn setup_status_takes_no_args() {
+        let (cmd, args) = translate_setup_status(&json!({})).unwrap();
+        assert_eq!(cmd, "get_setup_status");
+        assert!(args.is_null());
+    }
+
+    #[test]
+    fn setup_byok_requires_provider_and_api_key() {
+        assert!(translate_setup_byok(&json!({})).is_err());
+        assert!(translate_setup_byok(&json!({"provider": "anthropic"})).is_err());
+        assert!(translate_setup_byok(&json!({"api_key": "sk-..."})).is_err());
+    }
+
+    #[test]
+    fn setup_byok_passes_required_and_optional_fields() {
+        let (cmd, args) = translate_setup_byok(&json!({
+            "provider": "openrouter",
+            "api_key": "sk-or-v1-abc",
+            "base_url": "https://openrouter.ai/api",
+            "model": "anthropic/claude-sonnet-4.5"
+        }))
+        .unwrap();
+        assert_eq!(cmd, "submit_byok");
+        assert_eq!(args["provider"], "openrouter");
+        assert_eq!(args["api_key"], "sk-or-v1-abc");
+        assert_eq!(args["base_url"], "https://openrouter.ai/api");
+        assert_eq!(args["model"], "anthropic/claude-sonnet-4.5");
+    }
+
+    #[test]
+    fn setup_byok_omits_optional_fields_as_null() {
+        let (_, args) = translate_setup_byok(&json!({
+            "provider": "ollama",
+            "api_key": "n/a"
+        }))
+        .unwrap();
+        assert!(args["base_url"].is_null());
+        assert!(args["model"].is_null());
+    }
+
+    #[test]
+    fn registry_includes_byok_setup_stubs() {
+        let names: Vec<&str> = registry().iter().map(|t| t.name).collect();
+        assert!(names.contains(&"parish_setup_status"));
+        assert!(names.contains(&"parish_setup_byok"));
     }
 }

--- a/parish/crates/parish-tauri/Cargo.toml
+++ b/parish/crates/parish-tauri/Cargo.toml
@@ -34,6 +34,13 @@ parish-core    = { workspace = true }
 parish-palette = { workspace = true }
 rand           = { workspace = true }
 
+# MCP bridge — embedded HTTP listener that mirrors the parish-server IPC routes
+# against this process's live AppState, so an MCP client (parish-mcp) can drive
+# the desktop session it can see in the window. Only spawned when the user
+# passes `--mcp-port <N>`; otherwise inert.
+axum           = { version = "0.8", default-features = false, features = ["json", "tokio", "http1", "matched-path"] }
+tower          = { version = "0.5", default-features = false }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 gdk  = "0.18"
 glib = "0.22"

--- a/parish/crates/parish-tauri/Cargo.toml
+++ b/parish/crates/parish-tauri/Cargo.toml
@@ -37,9 +37,10 @@ rand           = { workspace = true }
 # MCP bridge — embedded HTTP listener that mirrors the parish-server IPC routes
 # against this process's live AppState, so an MCP client (parish-mcp) can drive
 # the desktop session it can see in the window. Only spawned when the user
-# passes `--mcp-port <N>`; otherwise inert.
-axum           = { version = "0.8", default-features = false, features = ["json", "tokio", "http1", "matched-path"] }
-tower          = { version = "0.5", default-features = false }
+# passes `--mcp-port <N>`; otherwise inert. Matches parish-server's axum
+# version + defaults so the workspace shares one resolved version.
+axum           = "0.8"
+tower          = "0.5"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gdk  = "0.18"

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -232,20 +232,33 @@ pub async fn submit_input(
     state: tauri::State<'_, Arc<AppState>>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
+    do_submit_input(state.inner(), &app, text, addressed_to.unwrap_or_default()).await
+}
+
+/// Internal submit-input implementation shared with the MCP bridge.
+///
+/// Mirrors the Tauri command body but takes plain `&Arc<AppState>` /
+/// `&tauri::AppHandle` so the `mcp_bridge` Axum handler can drive the same
+/// dispatcher against the same live AppState the desktop window observes.
+pub(crate) async fn do_submit_input(
+    state: &Arc<AppState>,
+    app: &tauri::AppHandle,
+    text: String,
+    addressed_to: Vec<String>,
+) -> Result<(), String> {
     let text = validate_input_text(&text)?;
     if text.is_empty() {
         return Ok(());
     }
     // #752 — cap addressed_to to prevent unbounded memory/allocation via the
     // NPC-addressing chip list.  Max 10 entries; each name ≤ 100 chars.
-    let addressed_to = addressed_to.unwrap_or_default();
     validate_addressed_to(&addressed_to)?;
 
-    touch_player_activity(&state).await;
+    touch_player_activity(state).await;
 
     match classify_input(&text) {
         InputResult::SystemCommand(cmd) => {
-            handle_system_command(cmd, &state, &app).await;
+            handle_system_command(cmd, state, app).await;
         }
         InputResult::GameInput(raw) => {
             tracing::info!(input = %raw, "chat [player]");
@@ -256,15 +269,9 @@ pub async fn submit_input(
             let raw_for_reactions = raw.clone();
             // Capture location before handle_game_input (which may move the player).
             let reaction_location = state.world.lock().await.player_location;
-            handle_game_input(raw, addressed_to, state.clone(), app.clone()).await;
+            handle_game_input(raw, addressed_to, state, app.clone()).await;
             // Generate NPC reactions to the player's message in the background.
-            emit_npc_reactions(
-                &player_msg_id,
-                &raw_for_reactions,
-                reaction_location,
-                &state,
-                &app,
-            );
+            emit_npc_reactions(&player_msg_id, &raw_for_reactions, reaction_location, state, app);
         }
     }
 
@@ -385,10 +392,15 @@ async fn handle_system_command(
 }
 
 /// Handles free-form game input: parses intent (with LLM fallback) then dispatches.
-async fn handle_game_input(
+///
+/// Takes plain `&Arc<AppState>` (not `tauri::State<...>`) so the body can be
+/// called from non-Tauri-extractor contexts — namely the `mcp_bridge` Axum
+/// handlers, which share the same live AppState as the desktop window. The
+/// Tauri callsite passes `state.inner()`.
+pub(crate) async fn handle_game_input(
     raw: String,
     addressed_to: Vec<String>,
-    state: tauri::State<'_, Arc<AppState>>,
+    state: &Arc<AppState>,
     app: tauri::AppHandle,
 ) {
     // Resolve the intent client and model (Intent category override, or base).
@@ -767,7 +779,7 @@ async fn set_conversation_running(state: &Arc<AppState>, running: bool) {
 async fn handle_npc_conversation(
     raw: String,
     target_names: Vec<String>,
-    state: tauri::State<'_, Arc<AppState>>,
+    state: &Arc<AppState>,
     app: tauri::AppHandle,
 ) {
     let emitter: std::sync::Arc<dyn parish_core::ipc::EventEmitter> =
@@ -945,6 +957,19 @@ pub async fn load_branch(
     branch_id: i64,
     state: tauri::State<'_, Arc<AppState>>,
     app: tauri::AppHandle,
+) -> Result<(), String> {
+    do_load_branch(&state, &app, file_path, branch_id).await
+}
+
+/// Internal load-branch implementation shared with the MCP bridge.
+///
+/// Takes plain `&Arc<AppState>` / `&tauri::AppHandle` so it can be called
+/// from non-Tauri-extractor contexts (e.g. `mcp_bridge::load_branch_route`).
+pub async fn do_load_branch(
+    state: &Arc<AppState>,
+    app: &tauri::AppHandle,
+    file_path: String,
+    branch_id: i64,
 ) -> Result<(), String> {
     use parish_core::persistence::SaveFileLock;
 

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -271,7 +271,13 @@ pub(crate) async fn do_submit_input(
             let reaction_location = state.world.lock().await.player_location;
             handle_game_input(raw, addressed_to, state, app.clone()).await;
             // Generate NPC reactions to the player's message in the background.
-            emit_npc_reactions(&player_msg_id, &raw_for_reactions, reaction_location, state, app);
+            emit_npc_reactions(
+                &player_msg_id,
+                &raw_for_reactions,
+                reaction_location,
+                state,
+                app,
+            );
         }
     }
 

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -487,7 +487,7 @@ pub(crate) async fn handle_game_input(
 
     if is_move {
         if let Some(target) = move_target {
-            handle_movement(&target, &state, &app).await;
+            handle_movement(&target, state, &app).await;
         } else {
             let _ = app.emit(
                 EVENT_TEXT_LOG,
@@ -504,7 +504,7 @@ pub(crate) async fn handle_game_input(
     }
 
     if is_look {
-        handle_look(&state, &app).await;
+        handle_look(state, &app).await;
         return;
     }
 
@@ -829,9 +829,9 @@ async fn handle_npc_conversation(
         Some(cancel)
     };
 
-    emit_world_update(&state, &app).await;
+    emit_world_update(state, &app).await;
     parish_core::game_loop::handle_npc_conversation(&ctx, raw, target_names, spawn_loading).await;
-    emit_world_update(&state, &app).await;
+    emit_world_update(state, &app).await;
 }
 
 /// Delegates to [`parish_core::game_loop::run_idle_banter`] for all shared

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -517,11 +517,11 @@ pub(crate) async fn handle_game_input(
     // intent parser classifies it as Talk. An empty `raw` still produces the
     // "say something first" prompt, which is correct for bare "talk to X".
     if is_talk && let Some(target) = talk_target {
-        // Cap explicitly: `addressed_to` is already validated to ≤ MAX_ADDRESSED_TO
-        // (10) entries by `validate_addressed_to`, but bounding here lets static
-        // analyzers see the upper bound without tracing the validator.
-        let cap = (addressed_to.len() + 1).min(MAX_ADDRESSED_TO + 1);
-        let mut targets: Vec<String> = Vec::with_capacity(cap);
+        // Pre-allocate at the validated upper bound. Using the constant
+        // directly (rather than `addressed_to.len() + 1`) keeps the
+        // allocation size independent of user-controlled values for
+        // CodeQL's `rust/uncontrolled-allocation-size` query (#933).
+        let mut targets: Vec<String> = Vec::with_capacity(MAX_ADDRESSED_TO + 1);
         for name in addressed_to {
             if !targets.iter().any(|t| t == &name) {
                 targets.push(name);
@@ -544,11 +544,10 @@ pub(crate) async fn handle_game_input(
     // inline @mentions that aren't already in the chip set. Deduping happens
     // in `resolve_npc_targets` via `find_by_name`, which matches both real
     // and display names.
-    // See note above on bounding the capacity for static analyzers. NPC mention
-    // lists are also bounded (one entry per NPC in the world), but using a fixed
-    // ceiling keeps the allocation guaranteed-small regardless.
-    let cap = (addressed_to.len() + mentions.names.len()).min(MAX_TARGETS);
-    let mut targets: Vec<String> = Vec::with_capacity(cap);
+    // See note above. Pre-allocate at the fixed upper bound so the
+    // allocation argument is a constant — independent of any user-controlled
+    // input — and CodeQL's data-flow analyzer can see that.
+    let mut targets: Vec<String> = Vec::with_capacity(MAX_TARGETS);
     for name in addressed_to {
         if !targets.iter().any(|t| t == &name) {
             targets.push(name);
@@ -983,7 +982,7 @@ pub async fn load_branch(
     state: tauri::State<'_, Arc<AppState>>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
-    do_load_branch(&state, &app, file_path, branch_id).await
+    do_load_branch(state.inner(), &app, file_path, branch_id).await
 }
 
 /// Internal load-branch implementation shared with the MCP bridge.

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -300,16 +300,27 @@ pub fn validate_input_text(raw: &str) -> Result<String, String> {
     Ok(trimmed)
 }
 
+/// Maximum number of NPC chips a single `submit_input` may carry. Validated
+/// in [`validate_addressed_to`] and reused by `handle_game_input` to bound
+/// `Vec::with_capacity` calls (#933 — CodeQL `rust/uncontrolled-allocation-size`).
+pub(crate) const MAX_ADDRESSED_TO: usize = 10;
+
+/// Upper bound for the merged `addressed_to + mentions` target list. Sized
+/// generously above the realistic combined total — `addressed_to` is capped
+/// at [`MAX_ADDRESSED_TO`] and `mentions.names.len()` is bounded by NPCs in
+/// the world — so the allocation is guaranteed-small regardless of input.
+pub(crate) const MAX_TARGETS: usize = 64;
+
 /// Validates the `addressed_to` list from the `submit_input` command.
 ///
 /// Rules (mode-parity with the server path in `parish-server`):
-/// - At most **10** entries (prevents unbounded NPC-chip spam).
+/// - At most [`MAX_ADDRESSED_TO`] entries (prevents unbounded NPC-chip spam).
 /// - Each name is at most **100** characters.
 ///
 /// Returns `Err(String)` with a user-visible message on any violation.
 pub fn validate_addressed_to(addressed_to: &[String]) -> Result<(), String> {
-    if addressed_to.len() > 10 {
-        return Err("Too many addressees (max 10).".to_string());
+    if addressed_to.len() > MAX_ADDRESSED_TO {
+        return Err(format!("Too many addressees (max {MAX_ADDRESSED_TO})."));
     }
     if addressed_to.iter().any(|name| name.len() > 100) {
         return Err("Addressee name too long (max 100 characters).".to_string());
@@ -506,7 +517,11 @@ pub(crate) async fn handle_game_input(
     // intent parser classifies it as Talk. An empty `raw` still produces the
     // "say something first" prompt, which is correct for bare "talk to X".
     if is_talk && let Some(target) = talk_target {
-        let mut targets: Vec<String> = Vec::with_capacity(addressed_to.len() + 1);
+        // Cap explicitly: `addressed_to` is already validated to ≤ MAX_ADDRESSED_TO
+        // (10) entries by `validate_addressed_to`, but bounding here lets static
+        // analyzers see the upper bound without tracing the validator.
+        let cap = (addressed_to.len() + 1).min(MAX_ADDRESSED_TO + 1);
+        let mut targets: Vec<String> = Vec::with_capacity(cap);
         for name in addressed_to {
             if !targets.iter().any(|t| t == &name) {
                 targets.push(name);
@@ -529,7 +544,11 @@ pub(crate) async fn handle_game_input(
     // inline @mentions that aren't already in the chip set. Deduping happens
     // in `resolve_npc_targets` via `find_by_name`, which matches both real
     // and display names.
-    let mut targets: Vec<String> = Vec::with_capacity(addressed_to.len() + mentions.names.len());
+    // See note above on bounding the capacity for static analyzers. NPC mention
+    // lists are also bounded (one entry per NPC in the world), but using a fixed
+    // ceiling keeps the allocation guaranteed-small regardless.
+    let cap = (addressed_to.len() + mentions.names.len()).min(MAX_TARGETS);
+    let mut targets: Vec<String> = Vec::with_capacity(cap);
     for name in addressed_to {
         if !targets.iter().any(|t| t == &name) {
             targets.push(name);

--- a/parish/crates/parish-tauri/src/lib.rs
+++ b/parish/crates/parish-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod command_registry;
 pub mod commands;
 pub mod editor_commands;
 pub mod events;
+mod mcp_bridge;
 mod setup;
 
 use parish_core::AUTOSAVE_INTERVAL_SECS;
@@ -651,6 +652,18 @@ pub fn run() {
             })
     };
 
+    // Parse optional --mcp-port <N> flag. When set, an in-process Axum
+    // listener mirrors the parish-server IPC routes against this process's
+    // live AppState so an MCP client (parish-mcp) can drive the desktop
+    // session the user can see in the window. Bound to 127.0.0.1 only.
+    let mcp_port: Option<u16> = {
+        let args: Vec<String> = std::env::args().collect();
+        args.iter()
+            .position(|a| a == "--mcp-port")
+            .and_then(|i| args.get(i + 1))
+            .and_then(|s| s.parse::<u16>().ok())
+    };
+
     // Try to load game mod (auto-detect from workspace root) via the
     // ModSource abstraction.  load_setting_mod_sync is used here because
     // Tauri's run() is synchronous and no tokio runtime exists yet.
@@ -930,6 +943,10 @@ pub fn run() {
                 setup::spawn_inactivity_tick(handle.clone(), Arc::clone(&state_setup));
                 setup::spawn_debug_tick(handle.clone(), Arc::clone(&state_setup));
                 setup::spawn_autosave_tick(Arc::clone(&state_setup));
+
+                if let Some(port) = mcp_port {
+                    mcp_bridge::spawn(Arc::clone(&state_setup), handle.clone(), port);
+                }
             });
 
             Ok(())

--- a/parish/crates/parish-tauri/src/mcp_bridge.rs
+++ b/parish/crates/parish-tauri/src/mcp_bridge.rs
@@ -1,0 +1,309 @@
+//! MCP control bridge — embeds a small Axum HTTP listener inside the running
+//! Tauri process so the existing `parish-mcp` server (which speaks HTTP to
+//! `parish-server`-shaped routes) can drive the **live desktop session**.
+//!
+//! Why an in-process listener instead of a separate `parish-server`?
+//! The desktop window owns its `AppState` (world, NPCs, conversation, save
+//! file). A side-by-side `parish-server` would have its own `AppState` and
+//! produce a parallel session — same code, different state. The MCP user
+//! wanted to read *the world the player can see* and inject *inputs the
+//! player would observe*; that requires sharing the same `Arc<AppState>`
+//! and `tauri::AppHandle` (so emits update the running window). This module
+//! is that single-process, single-state bridge.
+//!
+//! Routing matches `parish-server::route_registry::EXPECTED_HTTP_ROUTES` for
+//! the subset of endpoints `parish-mcp` calls — that mode-parity (enforced by
+//! `parish-core/tests/wiring_parity.rs`) is what lets one MCP client work
+//! against either backend.
+//!
+//! Security: bound to `127.0.0.1` only. The port is opt-in via `--mcp-port
+//! <N>`; if the flag is absent, this module compiles in but never listens.
+
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::Deserialize;
+use serde_json::Value;
+use tauri::{AppHandle, Emitter};
+use tokio::task::JoinHandle;
+
+use crate::events::{EVENT_TEXT_LOG, TextLogPayload};
+use crate::{AppState, MapData, MapLocation, NpcInfo, SaveState, SetupStatusSnapshot, WorldSnapshot};
+
+/// Shared extractor state carried by every Axum handler in the bridge.
+///
+/// Cloning is cheap: both fields are `Arc`-backed (`Arc<AppState>` is an
+/// explicit `Arc`; `tauri::AppHandle` is internally reference-counted).
+#[derive(Clone)]
+struct BridgeState {
+    state: Arc<AppState>,
+    app: AppHandle,
+}
+
+/// Spawns the MCP bridge listener on `127.0.0.1:port`.
+///
+/// Returns the `JoinHandle` so the caller can await shutdown if needed.
+/// Bind failures are logged and the task exits — they should not crash the
+/// desktop app.
+pub(crate) fn spawn(state: Arc<AppState>, app: AppHandle, port: u16) -> JoinHandle<()> {
+    let bridge = BridgeState { state, app };
+    tokio::spawn(async move {
+        let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+        let router = build_router(bridge);
+        let listener = match tokio::net::TcpListener::bind(addr).await {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::error!(%addr, error = %e, "mcp_bridge: failed to bind, MCP control disabled");
+                return;
+            }
+        };
+        tracing::info!(%addr, "mcp_bridge: listening for MCP control requests");
+        if let Err(e) = axum::serve(listener, router).await {
+            tracing::error!(error = %e, "mcp_bridge: server task exited with error");
+        }
+    })
+}
+
+/// Builds the Axum router. Extracted so unit tests can pin the route table
+/// without binding a TCP port.
+fn build_router(bridge: BridgeState) -> Router {
+    Router::new()
+        // ── reads ────────────────────────────────────────────────────────────
+        .route("/api/health", get(health))
+        .route("/api/world-snapshot", get(world_snapshot))
+        .route("/api/map", get(map))
+        .route("/api/npcs-here", get(npcs_here))
+        .route("/api/save-state", get(save_state))
+        .route("/api/setup-snapshot", get(setup_snapshot))
+        // ── writes ───────────────────────────────────────────────────────────
+        .route("/api/submit-input", post(submit_input))
+        .route("/api/new-game", post(new_game))
+        .route("/api/save-game", post(save_game))
+        .route("/api/load-branch", post(load_branch))
+        .with_state(bridge)
+}
+
+// ── handlers ────────────────────────────────────────────────────────────────
+
+async fn health() -> &'static str {
+    "ok"
+}
+
+async fn world_snapshot(State(b): State<BridgeState>) -> Result<Json<WorldSnapshot>, AppError> {
+    let world = b.state.world.lock().await;
+    let transport = b.state.transport.default_mode();
+    let npc_manager = b.state.npc_manager.lock().await;
+    let snap = crate::commands::get_world_snapshot_inner(
+        &world,
+        transport,
+        Some(&npc_manager),
+        &b.state.pronunciations,
+    );
+    Ok(Json(snap))
+}
+
+async fn map(State(b): State<BridgeState>) -> Result<Json<MapData>, AppError> {
+    let world = b.state.world.lock().await;
+    let config = b.state.config.lock().await;
+    let transport = b.state.transport.default_mode();
+    let core_map =
+        parish_core::ipc::build_map_data(&world, transport, config.reveal_unexplored_locations);
+
+    let player_loc = world.player_location;
+    let (player_lat, player_lon) = world
+        .graph
+        .get(player_loc)
+        .map(|d| (d.lat, d.lon))
+        .unwrap_or((0.0, 0.0));
+
+    Ok(Json(MapData {
+        locations: core_map
+            .locations
+            .into_iter()
+            .map(|l| MapLocation {
+                id: l.id,
+                name: l.name,
+                lat: l.lat,
+                lon: l.lon,
+                adjacent: l.adjacent,
+                hops: l.hops,
+                indoor: l.indoor,
+                travel_minutes: l.travel_minutes,
+                visited: l.visited,
+            })
+            .collect(),
+        edges: core_map.edges,
+        player_location: core_map.player_location,
+        player_lat,
+        player_lon,
+        edge_traversals: core_map.edge_traversals,
+        transport_label: core_map.transport_label,
+        transport_id: core_map.transport_id,
+    }))
+}
+
+async fn npcs_here(State(b): State<BridgeState>) -> Json<Vec<NpcInfo>> {
+    let world = b.state.world.lock().await;
+    let npc_manager = b.state.npc_manager.lock().await;
+    Json(parish_core::ipc::build_npcs_here(&world, &npc_manager))
+}
+
+async fn save_state(State(b): State<BridgeState>) -> Json<SaveState> {
+    let save_path = b.state.save_path.lock().await;
+    let branch_id = b.state.current_branch_id.lock().await;
+    let branch_name = b.state.current_branch_name.lock().await;
+    Json(SaveState {
+        filename: save_path
+            .as_ref()
+            .and_then(|p| p.file_name())
+            .map(|n| n.to_string_lossy().to_string()),
+        branch_id: *branch_id,
+        branch_name: branch_name.clone(),
+    })
+}
+
+async fn setup_snapshot(State(b): State<BridgeState>) -> Json<SetupStatusSnapshot> {
+    Json(
+        b.state
+            .setup_status
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone(),
+    )
+}
+
+#[derive(Debug, Deserialize)]
+struct SubmitInputBody {
+    text: String,
+    #[serde(default)]
+    addressed_to: Vec<String>,
+}
+
+async fn submit_input(
+    State(b): State<BridgeState>,
+    Json(body): Json<SubmitInputBody>,
+) -> Result<StatusCode, AppError> {
+    crate::commands::do_submit_input(&b.state, &b.app, body.text, body.addressed_to)
+        .await
+        .map_err(AppError::from)?;
+    Ok(StatusCode::OK)
+}
+
+async fn new_game(State(b): State<BridgeState>) -> Result<StatusCode, AppError> {
+    crate::commands::do_new_game(&b.state, &b.app)
+        .await
+        .map_err(AppError::from)?;
+    // Match the Tauri command's "A new chapter begins..." log so the live
+    // window shows the same banner whether the user clicked New Game or an
+    // MCP client triggered it.
+    let _ = b.app.emit(
+        EVENT_TEXT_LOG,
+        TextLogPayload {
+            id: String::new(),
+            stream_turn_id: None,
+            source: "system".into(),
+            content: "A new chapter begins in the parish...".to_string(),
+            subtype: None,
+        },
+    );
+    Ok(StatusCode::OK)
+}
+
+async fn save_game(State(b): State<BridgeState>) -> Result<Json<Value>, AppError> {
+    let msg = crate::commands::do_save_game(&b.state)
+        .await
+        .map_err(AppError::from)?;
+    Ok(Json(serde_json::json!({"message": msg})))
+}
+
+#[derive(Debug, Deserialize)]
+struct LoadBranchBody {
+    file_path: String,
+    branch_id: i64,
+}
+
+async fn load_branch(
+    State(b): State<BridgeState>,
+    Json(body): Json<LoadBranchBody>,
+) -> Result<StatusCode, AppError> {
+    crate::commands::do_load_branch(&b.state, &b.app, body.file_path, body.branch_id)
+        .await
+        .map_err(AppError::from)?;
+    Ok(StatusCode::OK)
+}
+
+// ── error mapping ───────────────────────────────────────────────────────────
+
+/// Bridges domain `Result<_, String>` errors from the `do_*` helpers onto
+/// HTTP `500` with the message in the body. The MCP layer surfaces this as
+/// `isError: true` content for the model to read.
+struct AppError(String);
+
+impl From<String> for AppError {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> axum::response::Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, self.0).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pin the route table so a refactor that drops or renames an endpoint
+    /// gets caught before the parish-mcp client breaks.
+    #[test]
+    fn route_table_matches_parish_mcp_expectations() {
+        // We can't easily introspect axum's router; but we can verify the
+        // builder compiles and the function exists. The expected paths are
+        // listed inline so a future change is forced to update both sides.
+        const EXPECTED: &[&str] = &[
+            "/api/health",
+            "/api/world-snapshot",
+            "/api/map",
+            "/api/npcs-here",
+            "/api/save-state",
+            "/api/setup-snapshot",
+            "/api/submit-input",
+            "/api/new-game",
+            "/api/save-game",
+            "/api/load-branch",
+        ];
+        // Mirrors parish-mcp's ParishHttpBackend::command_to_path.
+        let translate = |cmd: &str| {
+            let stem = cmd.strip_prefix("get_").unwrap_or(cmd);
+            let kebab: String = stem
+                .chars()
+                .map(|c| if c == '_' { '-' } else { c.to_ascii_lowercase() })
+                .collect();
+            format!("/api/{kebab}")
+        };
+        for cmd in [
+            "get_world_snapshot",
+            "get_map",
+            "get_npcs_here",
+            "get_save_state",
+            "get_setup_snapshot",
+            "submit_input",
+            "new_game",
+            "save_game",
+            "load_branch",
+        ] {
+            let path = translate(cmd);
+            assert!(
+                EXPECTED.contains(&path.as_str()),
+                "parish-mcp would route {cmd} to {path} but the bridge router does not expose it",
+            );
+        }
+    }
+}

--- a/parish/crates/parish-tauri/src/mcp_bridge.rs
+++ b/parish/crates/parish-tauri/src/mcp_bridge.rs
@@ -85,6 +85,12 @@ fn build_router(bridge: BridgeState) -> Router {
         .route("/api/new-game", post(new_game))
         .route("/api/save-game", post(save_game))
         .route("/api/load-branch", post(load_branch))
+        // ── BYOK setup-flow stubs (#933) ─────────────────────────────────────
+        // Backend returns `{"stub": true, ...}` until the setup-UI branch
+        // lands; the route paths stay the same so MCP tool callers don't
+        // change when the real implementation arrives.
+        .route("/api/setup-status", get(setup_status_stub))
+        .route("/api/submit-byok", post(submit_byok_stub))
         .with_state(bridge)
 }
 
@@ -242,6 +248,39 @@ async fn load_branch(
     Ok(StatusCode::OK)
 }
 
+// ── BYOK setup-flow stubs ────────────────────────────────────────────────────
+//
+// The full implementation lives on a sibling branch. These two handlers
+// return a structured `{"stub": true, ...}` response so an MCP client can
+// distinguish "endpoint exists but unimplemented" from "transport error /
+// 404". When the real handlers land they replace these bodies; the route
+// paths and the JSON envelope shape stay the same.
+
+const STUB_MESSAGE: &str =
+    "BYOK setup flow is stubbed. Implementation lands with the setup-UI branch.";
+
+#[allow(clippy::unused_async)]
+async fn setup_status_stub() -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "stub": true,
+        "implemented": false,
+        "message": STUB_MESSAGE,
+        // Shape the eventual real response will fill in:
+        "providers": [],
+        "complete": false,
+    }))
+}
+
+#[allow(clippy::unused_async)]
+async fn submit_byok_stub(Json(_body): Json<serde_json::Value>) -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "stub": true,
+        "implemented": false,
+        "accepted": false,
+        "message": STUB_MESSAGE,
+    }))
+}
+
 // ── error mapping ───────────────────────────────────────────────────────────
 
 /// Bridges domain `Result<_, String>` errors from the `do_*` helpers onto
@@ -281,6 +320,9 @@ mod tests {
             "/api/new-game",
             "/api/save-game",
             "/api/load-branch",
+            // BYOK setup-flow stubs (#933).
+            "/api/setup-status",
+            "/api/submit-byok",
         ];
         // Mirrors parish-mcp's ParishHttpBackend::command_to_path.
         let translate = |cmd: &str| {
@@ -307,6 +349,8 @@ mod tests {
             "new_game",
             "save_game",
             "load_branch",
+            "get_setup_status",
+            "submit_byok",
         ] {
             let path = translate(cmd);
             assert!(

--- a/parish/crates/parish-tauri/src/mcp_bridge.rs
+++ b/parish/crates/parish-tauri/src/mcp_bridge.rs
@@ -263,8 +263,6 @@ impl IntoResponse for AppError {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     /// Pin the route table so a refactor that drops or renames an endpoint
     /// gets caught before the parish-mcp client breaks.
     #[test]

--- a/parish/crates/parish-tauri/src/mcp_bridge.rs
+++ b/parish/crates/parish-tauri/src/mcp_bridge.rs
@@ -90,11 +90,14 @@ fn build_router(bridge: BridgeState) -> Router {
 
 // ── handlers ────────────────────────────────────────────────────────────────
 
-async fn health() -> &'static str {
+// Sync handlers: axum implements `Handler` for both sync and async functions.
+// `health` and `setup_snapshot` do no async work, so making them sync avoids
+// `clippy::unused_async`.
+fn health() -> &'static str {
     "ok"
 }
 
-async fn world_snapshot(State(b): State<BridgeState>) -> Result<Json<WorldSnapshot>, AppError> {
+async fn world_snapshot(State(b): State<BridgeState>) -> Json<WorldSnapshot> {
     let world = b.state.world.lock().await;
     let transport = b.state.transport.default_mode();
     let npc_manager = b.state.npc_manager.lock().await;
@@ -104,10 +107,10 @@ async fn world_snapshot(State(b): State<BridgeState>) -> Result<Json<WorldSnapsh
         Some(&npc_manager),
         &b.state.pronunciations,
     );
-    Ok(Json(snap))
+    Json(snap)
 }
 
-async fn map(State(b): State<BridgeState>) -> Result<Json<MapData>, AppError> {
+async fn map(State(b): State<BridgeState>) -> Json<MapData> {
     let world = b.state.world.lock().await;
     let config = b.state.config.lock().await;
     let transport = b.state.transport.default_mode();
@@ -121,7 +124,7 @@ async fn map(State(b): State<BridgeState>) -> Result<Json<MapData>, AppError> {
         .map(|d| (d.lat, d.lon))
         .unwrap_or((0.0, 0.0));
 
-    Ok(Json(MapData {
+    Json(MapData {
         locations: core_map
             .locations
             .into_iter()
@@ -144,7 +147,7 @@ async fn map(State(b): State<BridgeState>) -> Result<Json<MapData>, AppError> {
         edge_traversals: core_map.edge_traversals,
         transport_label: core_map.transport_label,
         transport_id: core_map.transport_id,
-    }))
+    })
 }
 
 async fn npcs_here(State(b): State<BridgeState>) -> Json<Vec<NpcInfo>> {
@@ -167,7 +170,7 @@ async fn save_state(State(b): State<BridgeState>) -> Json<SaveState> {
     })
 }
 
-async fn setup_snapshot(State(b): State<BridgeState>) -> Json<SetupStatusSnapshot> {
+fn setup_snapshot(State(b): State<BridgeState>) -> Json<SetupStatusSnapshot> {
     Json(
         b.state
             .setup_status

--- a/parish/crates/parish-tauri/src/mcp_bridge.rs
+++ b/parish/crates/parish-tauri/src/mcp_bridge.rs
@@ -28,12 +28,12 @@ use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
-use serde_json::Value;
 use tauri::{AppHandle, Emitter};
-use tokio::task::JoinHandle;
 
 use crate::events::{EVENT_TEXT_LOG, TextLogPayload};
-use crate::{AppState, MapData, MapLocation, NpcInfo, SaveState, SetupStatusSnapshot, WorldSnapshot};
+use crate::{
+    AppState, MapData, MapLocation, NpcInfo, SaveState, SetupStatusSnapshot, WorldSnapshot,
+};
 
 /// Shared extractor state carried by every Axum handler in the bridge.
 ///
@@ -45,12 +45,12 @@ struct BridgeState {
     app: AppHandle,
 }
 
-/// Spawns the MCP bridge listener on `127.0.0.1:port`.
+/// Spawns the MCP bridge listener on `127.0.0.1:port` as a fire-and-forget
+/// background task — matches the `spawn_*_tick` pattern in `setup.rs`.
 ///
-/// Returns the `JoinHandle` so the caller can await shutdown if needed.
-/// Bind failures are logged and the task exits — they should not crash the
+/// Bind failures are logged and the task exits; they should not crash the
 /// desktop app.
-pub(crate) fn spawn(state: Arc<AppState>, app: AppHandle, port: u16) -> JoinHandle<()> {
+pub(crate) fn spawn(state: Arc<AppState>, app: AppHandle, port: u16) {
     let bridge = BridgeState { state, app };
     tokio::spawn(async move {
         let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
@@ -66,7 +66,7 @@ pub(crate) fn spawn(state: Arc<AppState>, app: AppHandle, port: u16) -> JoinHand
         if let Err(e) = axum::serve(listener, router).await {
             tracing::error!(error = %e, "mcp_bridge: server task exited with error");
         }
-    })
+    });
 }
 
 /// Builds the Axum router. Extracted so unit tests can pin the route table
@@ -214,7 +214,7 @@ async fn new_game(State(b): State<BridgeState>) -> Result<StatusCode, AppError> 
     Ok(StatusCode::OK)
 }
 
-async fn save_game(State(b): State<BridgeState>) -> Result<Json<Value>, AppError> {
+async fn save_game(State(b): State<BridgeState>) -> Result<Json<serde_json::Value>, AppError> {
     let msg = crate::commands::do_save_game(&b.state)
         .await
         .map_err(AppError::from)?;
@@ -284,7 +284,13 @@ mod tests {
             let stem = cmd.strip_prefix("get_").unwrap_or(cmd);
             let kebab: String = stem
                 .chars()
-                .map(|c| if c == '_' { '-' } else { c.to_ascii_lowercase() })
+                .map(|c| {
+                    if c == '_' {
+                        '-'
+                    } else {
+                        c.to_ascii_lowercase()
+                    }
+                })
                 .collect();
             format!("/api/{kebab}")
         };

--- a/parish/crates/parish-tauri/src/mcp_bridge.rs
+++ b/parish/crates/parish-tauri/src/mcp_bridge.rs
@@ -90,10 +90,11 @@ fn build_router(bridge: BridgeState) -> Router {
 
 // ── handlers ────────────────────────────────────────────────────────────────
 
-// Sync handlers: axum implements `Handler` for both sync and async functions.
-// `health` and `setup_snapshot` do no async work, so making them sync avoids
-// `clippy::unused_async`.
-fn health() -> &'static str {
+// `health` and `setup_snapshot` do no async work but stay `async fn` for
+// uniformity with the rest of the handler set; the explicit allow keeps
+// `cargo clippy --workspace -- -D warnings` happy.
+#[allow(clippy::unused_async)]
+async fn health() -> &'static str {
     "ok"
 }
 
@@ -170,7 +171,8 @@ async fn save_state(State(b): State<BridgeState>) -> Json<SaveState> {
     })
 }
 
-fn setup_snapshot(State(b): State<BridgeState>) -> Json<SetupStatusSnapshot> {
+#[allow(clippy::unused_async)]
+async fn setup_snapshot(State(b): State<BridgeState>) -> Json<SetupStatusSnapshot> {
     Json(
         b.state
             .setup_status

--- a/parish/scripts/parish-mcp-backend.sh
+++ b/parish/scripts/parish-mcp-backend.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Start / stop / status helper for the backend that parish-mcp drives.
+#
+# parish-mcp itself is a stateless HTTP client; it needs *something* serving
+# the `/api/*` routes on `127.0.0.1:3030` for tool calls to succeed. The
+# easiest backend in a sandbox is `parish web`, the headless Axum server
+# (the desktop `parish-tauri --mcp-port 3030` is the alternative when a
+# display is available).
+#
+# Usage:
+#   bash parish/scripts/parish-mcp-backend.sh start   # spawn parish web in background
+#   bash parish/scripts/parish-mcp-backend.sh stop    # kill the spawned process
+#   bash parish/scripts/parish-mcp-backend.sh status  # report PID + health
+#   bash parish/scripts/parish-mcp-backend.sh logs    # tail the log file
+#
+# Defaults:
+#   PORT=3030    PARISH_MCP_BACKEND_PORT=4000 to override
+#   PID file:    parish/.parish-mcp-backend.pid
+#   Log file:    parish/.parish-mcp-backend.log
+
+set -euo pipefail
+
+REPO="$(git rev-parse --show-toplevel)"
+cd "$REPO/parish"
+
+PORT="${PARISH_MCP_BACKEND_PORT:-3030}"
+PID_FILE=".parish-mcp-backend.pid"
+LOG_FILE=".parish-mcp-backend.log"
+HEALTH_URL="http://127.0.0.1:${PORT}/api/health"
+
+cmd_start() {
+    if cmd_running; then
+        echo "parish-mcp backend already running (pid=$(cat "$PID_FILE"))"
+        return 0
+    fi
+
+    echo "Starting parish web --port $PORT in background..."
+    # nohup detaches so the server survives the script's exit.
+    # `cargo run --quiet` reuses the cached build if `parish` is already
+    # compiled (the SessionStart hook pre-builds it).
+    nohup cargo run --quiet -p parish --bin parish -- web --port "$PORT" \
+        >"$LOG_FILE" 2>&1 &
+    echo $! >"$PID_FILE"
+
+    # Wait up to 60s for the health endpoint to come up. parish web has
+    # provider bootstrap that may take a few seconds on first run.
+    for _ in $(seq 1 60); do
+        if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
+            echo "parish-mcp backend ready (pid=$(cat "$PID_FILE"), port=$PORT)"
+            return 0
+        fi
+        sleep 1
+    done
+
+    echo "parish-mcp backend failed to come up in 60s. Last 20 log lines:" >&2
+    tail -20 "$LOG_FILE" >&2 || true
+    return 1
+}
+
+cmd_stop() {
+    if [ ! -f "$PID_FILE" ]; then
+        echo "parish-mcp backend not running (no pid file)"
+        return 0
+    fi
+    local pid
+    pid="$(cat "$PID_FILE")"
+    if kill -0 "$pid" 2>/dev/null; then
+        # Send TERM to the cargo wrapper; cargo forwards to the child binary.
+        kill "$pid" 2>/dev/null || true
+        for _ in $(seq 1 10); do
+            kill -0 "$pid" 2>/dev/null || break
+            sleep 1
+        done
+        # If still alive, escalate to KILL so the port is freed.
+        kill -9 "$pid" 2>/dev/null || true
+        echo "parish-mcp backend stopped (pid=$pid)"
+    else
+        echo "parish-mcp backend pid $pid not running; cleaning up pid file"
+    fi
+    rm -f "$PID_FILE"
+}
+
+cmd_status() {
+    if cmd_running; then
+        local pid
+        pid="$(cat "$PID_FILE")"
+        echo "parish-mcp backend: running (pid=$pid, port=$PORT)"
+        if curl -fsS "$HEALTH_URL" >/dev/null 2>&1; then
+            echo "health: ok ($HEALTH_URL)"
+        else
+            echo "health: NOT responding at $HEALTH_URL"
+        fi
+    else
+        echo "parish-mcp backend: not running"
+    fi
+}
+
+cmd_logs() {
+    if [ -f "$LOG_FILE" ]; then
+        tail -50 "$LOG_FILE"
+    else
+        echo "no log file at $LOG_FILE"
+    fi
+}
+
+cmd_running() {
+    [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null
+}
+
+case "${1:-status}" in
+    start)  cmd_start ;;
+    stop)   cmd_stop ;;
+    status) cmd_status ;;
+    logs)   cmd_logs ;;
+    *)
+        echo "usage: $0 {start|stop|status|logs}" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Adds a new `parish-mcp` workspace crate — a [Model Context Protocol](https://modelcontextprotocol.io) server over stdio that lets an LLM client (Claude Code, Claude Desktop) read and mutate a running Parish/Rundale instance through tool calls. Designed so a future generic Tauri controller (WebDriver / `tauri-driver`) can plug in without changing the protocol layer.

## Design

Layered as **JSON-RPC framing → MCP handshake → curated tool registry → `TauriBackend` trait**:

- `src/jsonrpc.rs` — line-delimited JSON-RPC 2.0 over async streams, request dispatch, error mapping.
- `src/mcp.rs` — `initialize`, `tools/list`, `tools/call`, `ping`. Spec rev `2025-06-18`.
- `src/tools.rs` — curated tool descriptors with input schemas + an `(args) -> (command, args)` translator.
- `src/backend.rs` — `TauriBackend` trait with two impls:
  - `ParishHttpBackend` — talks to a running `parish-server` over `/api/*`. Because those routes are mode-parity with the Tauri IPC commands (enforced by `parish-core/tests/wiring_parity.rs`), driving the server is equivalent to driving the desktop app for the parity surface.
  - `GenericTauriBackend` — `Unimplemented` stub for the future WebDriver/`tauri-driver` path. Wired through the same trait so the day it lands, nothing else changes.

## Tools shipped

| Tool | Effect |
| --- | --- |
| `parish_world_snapshot` | Read clock, player location, weather, recent log. |
| `parish_map` | Read the location graph plus the player's position. |
| `parish_npcs_here` | List NPCs co-located with the player. |
| `parish_save_state` | Read save-file / branch metadata. |
| `parish_submit_input` | Send player input (movement, action, dialogue). |
| `parish_new_game` | Start a fresh game on a new branch. |
| `parish_save_game` | Save the current branch. |
| `parish_load_branch` | Load a branch by integer id. |
| `tauri_invoke` | Generic escape hatch — invoke any backend command by name. |

## Transport

stdio newline-delimited JSON-RPC — the standard MCP transport for Claude Code / Claude Desktop. Logs go to stderr so stdout stays clean. The `serve()` function is generic over `AsyncRead`/`AsyncWrite`, so a future HTTP/SSE transport reuses it.

Requests are processed serially: Parish IPC handlers are stateful (`submit_input` → `world_snapshot` must observe the mutation), and serial processing also avoids losing in-flight responses if the client closes stdin. JSON-RPC `id` correlation is preserved.

## Test plan

- [x] `cargo test -p parish-mcp` — 25 unit tests pass:
  - JSON-RPC framing (round-trip, notifications get no response, malformed JSON → parse error)
  - HTTP backend (GET vs POST heuristic, auth header forwarding, non-2xx surfaced as `Rejected`) — wiremock-backed
  - Tool argument validation + command translation
  - MCP `initialize` / `tools/list` / `tools/call` dispatch
  - `command_to_path` matches `wiring_parity::tauri_to_canonical`
  - Backend `Rejected` errors surface as `isError: true` in tool responses
- [x] `cargo test -p parish-core --test architecture_fitness` — 3/3 pass (no orphans, no backend-runtime drift)
- [x] `cargo clippy -p parish-mcp --all-targets -- -D warnings` — clean
- [x] End-to-end smoke test: piped `initialize` + `tools/list` + `tools/call` to the binary; got the negotiated `protocolVersion`, the 9 tool descriptors, and a clean `transport error` surfaced via `isError` when no parish-server was running.

## Wiring it into Claude Code / Desktop

```json
{
  "mcpServers": {
    "parish": {
      "command": "/path/to/Rundale/target/debug/parish-mcp",
      "args": ["--base-url", "http://127.0.0.1:3030"]
    }
  }
}
```

`PARISH_MCP_AUTH_EMAIL` (or `--auth-email`) forwards `Cf-Access-Authenticated-User-Email` for servers behind Cloudflare Access.

https://claude.ai/code/session_012vXfsRG9MFMitDDkzsxU3i

---
_Generated by [Claude Code](https://claude.ai/code/session_012vXfsRG9MFMitDDkzsxU3i)_