### PR TITLE
chore(claude): auto-build parish-mcp on session start

### DIFF
--- a/.claude/hooks/SessionStart--build-mcp.sh
+++ b/.claude/hooks/SessionStart--build-mcp.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SessionStart hook — ensure parish-mcp binary exists locally so the project
+# MCP server in .mcp.json can spawn at session start without a cold compile.
+#
+# Skipped on remote sandboxes (CLAUDE_CODE_REMOTE=true), where
+# SessionStart--install-system-deps.sh already handles the build alongside
+# apt-installed system deps.
+#
+# Fast path: if the binary is already built, exit immediately so the session
+# prompt comes up instantly. Cold path runs cargo in the background.
+
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+    exit 0
+fi
+
+REPO="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+MCP_BIN="$REPO/parish/target/debug/parish-mcp"
+
+if [ -x "$MCP_BIN" ]; then
+    exit 0
+fi
+
+if [ ! -d "$REPO/parish/crates/parish-mcp" ]; then
+    exit 0
+fi
+
+echo '{"async": true, "asyncTimeout": 600000}'
+
+echo "[session-start-hook] Building parish-mcp (binary missing at $MCP_BIN)..." >&2
+(cd "$REPO/parish" && cargo build -p parish-mcp --quiet) \
+    || echo "[session-start-hook] WARN: parish-mcp build failed" >&2
+echo "[session-start-hook] parish-mcp build complete." >&2

--- a/.claude/hooks/SessionStart--build-mcp.sh
+++ b/.claude/hooks/SessionStart--build-mcp.sh
@@ -16,7 +16,8 @@ if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
 fi
 
 REPO="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-MCP_BIN="$REPO/parish/target/debug/parish-mcp"
+TARGET_DIR="${CARGO_TARGET_DIR:-$REPO/parish/target}"
+MCP_BIN="$TARGET_DIR/debug/parish-mcp"
 
 if [ -x "$MCP_BIN" ]; then
     exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,6 +73,10 @@
           {
             "type": "command",
             "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/SessionStart--install-system-deps.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/SessionStart--build-mcp.sh'"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- New SessionStart hook (`SessionStart--build-mcp.sh`) builds `parish-mcp` in the background when the binary is missing, so the project-level MCP server in `.mcp.json` can spawn at session start without a cold compile.
- Skips on `CLAUDE_CODE_REMOTE=true` — `SessionStart--install-system-deps.sh` already builds the binary alongside apt-installed Tauri deps on remote sandboxes.
- Registered under existing `startup|resume|clear` matcher in `.claude/settings.json`.

## Test plan
- [x] Hook fast-paths to exit 0 when binary already built (`bash .claude/hooks/SessionStart--build-mcp.sh` → exit 0).
- [ ] On a fresh worktree without `parish/target/debug/parish-mcp`, session start triggers async build and `claude mcp list` reports `parish: ✓ Connected` once finished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)