### PR TITLE
ci(release): tag-driven GitHub release pipeline + bump tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,212 @@
+name: Release
+
+# Tag-driven release pipeline.
+#
+# Production trigger:
+#   git push origin vX.Y.Z   →  builds + publishes a GitHub Release.
+#
+# Human dry-run:
+#   workflow_dispatch with `dry_run: true` builds the artifacts but skips
+#   tagging, releasing, and uploading. The packaged tarball is still attached
+#   to the workflow run as a downloadable artifact for inspection.
+#
+# Claude execution path:
+#   parish/scripts/release.sh <version>      # bump + commit + tag locally
+#   git push origin <branch>                 # land the bump
+#   git push origin v<version>               # this workflow takes over
+#
+# The tag version is the source of truth and must match parish-cli's
+# Cargo.toml `[package].version` — the validate-tag job enforces this.
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semver version (without leading v), e.g. 0.2.0"
+        required: true
+        type: string
+      dry_run:
+        description: "Build artifacts but do not publish a Release"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write   # required to create the GitHub Release on tag push
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  resolve:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set.outputs.version }}
+      tag: ${{ steps.set.outputs.tag }}
+      dry_run: ${{ steps.set.outputs.dry_run }}
+    steps:
+      - name: Determine version + dry-run from event
+        id: set
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            tag="${GITHUB_REF##*/}"
+            version="${tag#v}"
+            dry_run="false"
+          else
+            version="${{ inputs.version }}"
+            tag="v${version}"
+            dry_run="${{ inputs.dry_run }}"
+          fi
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $version" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag"         >> "$GITHUB_OUTPUT"
+          echo "dry_run=$dry_run" >> "$GITHUB_OUTPUT"
+          echo "Resolved: tag=$tag dry_run=$dry_run"
+
+  validate-tag:
+    name: Validate tag matches Cargo.toml
+    needs: resolve
+    # Only enforced on real tag pushes. workflow_dispatch dry-runs are
+    # allowed to test the build pipeline before any version bump lands.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Compare tag version with parish-cli Cargo.toml
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected="${{ needs.resolve.outputs.version }}"
+          actual="$(awk '/^\[package\]/{p=1; next} p && /^version = "/{gsub(/^version = "|"$/, ""); print; exit}' parish/crates/parish-cli/Cargo.toml)"
+          echo "tag version:        $expected"
+          echo "Cargo.toml version: $actual"
+          if [[ "$expected" != "$actual" ]]; then
+            echo "::error::Tag $expected does not match parish-cli Cargo.toml ($actual). Run parish/scripts/release.sh $expected."
+            exit 1
+          fi
+
+  build-linux:
+    name: Build Linux x86_64 release binary
+    needs: resolve
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      tarball: ${{ steps.package.outputs.tarball }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@1.95.0
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: parish
+
+      - name: Install Linux native deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            pkg-config \
+            libssl-dev \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev
+
+      - name: Build parish (release)
+        working-directory: parish
+        # No --locked: a freshly-bumped workspace member version would race
+        # ahead of Cargo.lock until the next regular CI run picks up the
+        # refreshed lockfile. release.sh refreshes it best-effort locally.
+        run: cargo build -p parish --release
+
+      - name: Package tarball
+        id: package
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.resolve.outputs.version }}"
+          stage="$(mktemp -d)"
+          name="parish-v${version}-x86_64-linux-gnu"
+          mkdir -p "$stage/$name"
+          cp parish/target/release/parish "$stage/$name/"
+          cp LICENSE NOTICE THIRD_PARTY_NOTICES.md README.md "$stage/$name/"
+          ( cd "$stage" && tar czf "$name.tar.gz" "$name" )
+          mkdir -p dist
+          mv "$stage/$name.tar.gz" "dist/$name.tar.gz"
+          ( cd dist && sha256sum "$name.tar.gz" > "$name.tar.gz.sha256" )
+          echo "tarball=dist/$name.tar.gz" >> "$GITHUB_OUTPUT"
+          ls -la dist
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: parish-linux-x86_64
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    name: Publish GitHub Release
+    # Hard gate: only real tag pushes can publish. workflow_dispatch is
+    # dry-run-only — it can't slip a release out without a tag landing.
+    needs: [resolve, validate-tag, build-linux]
+    if: github.event_name == 'push' && needs.resolve.outputs.dry_run != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: parish-linux-x86_64
+          path: dist
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.resolve.outputs.tag }}
+          name: Rundale ${{ needs.resolve.outputs.tag }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            dist/*.tar.gz
+            dist/*.sha256
+
+  dry-run-summary:
+    name: Dry-run summary
+    needs: [resolve, build-linux]
+    if: needs.resolve.outputs.dry_run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print summary
+        shell: bash
+        run: |
+          {
+            echo "## Dry run for ${{ needs.resolve.outputs.tag }}"
+            echo
+            echo "- Built tarball: \`${{ needs.build-linux.outputs.tarball }}\`"
+            echo "- No tag was created."
+            echo "- No GitHub Release was published."
+            echo "- Artifact is available on this run under \`parish-linux-x86_64\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,125 @@
+# Releasing Rundale
+
+Rundale ships from a single source of truth — a `vMAJOR.MINOR.PATCH` git tag.
+Pushing the tag triggers `.github/workflows/release.yml`, which builds a
+Linux x86_64 binary tarball and publishes it as a GitHub Release with
+auto-generated notes.
+
+## Files that get bumped
+
+`parish/scripts/release.sh` rewrites three user-visible version fields:
+
+| File | Field |
+| --- | --- |
+| `parish/crates/parish-cli/Cargo.toml` | `[package].version` |
+| `parish/crates/parish-tauri/tauri.conf.json` | `.version` |
+| `parish/apps/ui/package.json` | `.version` |
+
+`Cargo.lock` is refreshed as a side effect. Internal leaf crates keep their
+`0.1.0` baseline — they are unpublished workspace members and don't carry an
+external contract.
+
+## Standard release (human or Claude)
+
+```sh
+# 1. From a clean working tree on the branch you want to release from:
+just release-dry-run 0.2.0     # prints diffs only — nothing is written
+
+# 2. If the diffs look right, apply for real:
+just release 0.2.0             # bumps the three files, commits, tags v0.2.0
+
+# 3. Land the bump and the tag separately:
+git push origin <branch>       # land the chore(release): v0.2.0 commit
+git push origin v0.2.0         # triggers .github/workflows/release.yml
+```
+
+The workflow runs `validate-tag` first and fails fast if `v0.2.0` and
+`parish-cli` Cargo.toml disagree, so a stray `git tag` without `release.sh`
+won't slip a half-bumped release into production.
+
+## Dry-running without an actual release showing up
+
+There are two complementary ways to dry-run, depending on whether you want to
+verify the **bump** or the **build/publish pipeline**:
+
+1. **Bump dry-run (local, no network):**
+
+   ```sh
+   just release-dry-run 0.2.0
+   ```
+
+   Prints the three diffs and exits. No files written, no commit, no tag.
+
+2. **Pipeline dry-run (CI builds, no Release published):**
+   Trigger `release.yml` manually via the GitHub Actions UI →
+   "Release" workflow → "Run workflow" → set `version=0.2.0`,
+   leave `dry_run=true` (default).
+
+   - `validate-tag` is skipped on `workflow_dispatch` (it only enforces
+     against real tag pushes), so dispatch-mode dry-runs work even if the
+     bump hasn't landed.
+   - The build job runs end-to-end and uploads
+     `parish-v0.2.0-x86_64-linux-gnu.tar.gz` as a workflow artifact.
+   - The `publish` job is hard-gated on `github.event_name == 'push'`, so
+     **`workflow_dispatch` can never publish a Release**, even with
+     `dry_run=false`. No tag is created either way.
+
+   The artifact is downloadable from the workflow run page for ~14 days.
+
+If you want to test the *real* tag-driven flow without polluting the public
+release list, push to a throwaway tag like `v0.0.0-rc.1` (a prerelease semver),
+delete it after, and delete the resulting Release manually. The workflow's
+tag pattern accepts prereleases (`v0.0.0-rc.1`, etc.).
+
+## How Claude executes a release
+
+Claude has the tools required to run this end-to-end:
+
+- `Bash` to run `just release <version>` and `git push origin v<version>`.
+- `mcp__github__list_releases` / `mcp__github__get_release_by_tag` to confirm
+  the workflow published the Release.
+- No `mcp__github__create_release` tool is needed — the workflow handles
+  creation. (Claude doesn't have a direct `workflow_dispatch` tool, so
+  pipeline dry-runs are a human action via the Actions UI.)
+
+A typical Claude session:
+
+```sh
+# Verify the bump first
+just release-dry-run 0.2.0
+
+# Apply, land, and trigger
+just release 0.2.0
+git push origin main
+git push origin v0.2.0
+```
+
+Then poll `mcp__github__list_releases` for `dmooney/rundale` until the
+release lands, or `mcp__github__get_release_by_tag` with `v0.2.0`.
+
+## Failure modes worth knowing
+
+- **Tag/Cargo.toml drift.** `validate-tag` fails. Fix: `git tag -d v0.2.0`,
+  push `:refs/tags/v0.2.0` to delete the remote tag, re-run `just release`.
+- **Working tree dirty.** `release.sh` refuses to run unless `--dry-run`.
+  Fix: commit or stash first.
+- **Tag already exists locally.** `release.sh` refuses to overwrite. Either
+  bump to the next version or `git tag -d v0.2.0` first.
+- **Cargo.lock update fails for `parish`.** `release.sh` warns but continues;
+  inspect and recommit if needed before pushing the tag.
+- **`softprops/action-gh-release` upload fails.** The build artifact is still
+  attached to the workflow run; download and upload manually via the GitHub
+  Releases UI.
+
+## Scope (what this pipeline does NOT do)
+
+- No macOS / Windows builds — Linux x86_64 only for now. Adding a runner
+  matrix is straightforward (mirror the patterns in `.github/workflows/ci.yml`)
+  but bigger than the initial cut.
+- No Tauri desktop bundle (`.deb` / `.AppImage` / `.dmg` / `.msi`). The
+  `tauri.conf.json` version is bumped so a future `cargo tauri build` will
+  produce correctly-versioned bundles, but no automated bundle build is wired.
+- No publish to crates.io or npm — every workspace crate is `publish = false`,
+  and the UI package is `private: true`.
+- No CHANGELOG.md generation. GitHub's auto-generated release notes (commit
+  list + PR titles since the previous tag) cover this for now.

--- a/justfile
+++ b/justfile
@@ -111,3 +111,13 @@ notices:
 # Audit dependencies for security vulnerabilities
 audit:
     cd parish && just audit
+
+# ─── Release ────────────────────────────────────────────────────────────────
+
+# Bump versions, commit, and tag a release locally. See docs/release.md.
+release VERSION:
+    cd parish && just release {{VERSION}}
+
+# Dry-run the release: show would-be diffs without writing or tagging.
+release-dry-run VERSION:
+    cd parish && just release-dry-run {{VERSION}}

--- a/parish/justfile
+++ b/parish/justfile
@@ -346,6 +346,17 @@ realign-coords:
 realign-coords-run *ARGS:
     cargo run -p parish-geo-tool --bin realign_rundale_coords -- {{ARGS}}
 
+# ─── Release ─────────────────────────────────────────────────────────────────
+
+# Bump versions, commit, and tag a release locally. Push the branch and the
+# new tag separately to trigger .github/workflows/release.yml. See docs/release.md.
+release VERSION:
+    bash scripts/release.sh {{VERSION}}
+
+# Show the would-be diff without writing files, committing, or tagging.
+release-dry-run VERSION:
+    bash scripts/release.sh {{VERSION}} --dry-run
+
 # ─── Dependencies ────────────────────────────────────────────────────────────
 
 # Check for outdated dependencies (requires cargo-outdated)

--- a/parish/scripts/release.sh
+++ b/parish/scripts/release.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Bump release version across the workspace, then create a tagged commit.
+#
+# Usage:
+#   parish/scripts/release.sh <version> [--dry-run] [--no-tag]
+#
+# <version>    — semver `MAJOR.MINOR.PATCH` (without the leading `v`)
+# --dry-run    — show the would-be diff and exit without writing anything
+# --no-tag     — write the version bumps and commit, but skip the `vX.Y.Z` tag
+#
+# Files touched:
+#   parish/crates/parish-cli/Cargo.toml         [package].version
+#   parish/crates/parish-tauri/tauri.conf.json  .version
+#   parish/apps/ui/package.json                 .version
+#   parish/Cargo.lock                           refreshed via `cargo update -p parish`
+#
+# The script is intentionally narrow: only the user-visible version sources
+# are bumped. Internal leaf crates stay on their unpublished `0.1.0` baseline.
+set -euo pipefail
+
+usage() {
+    cat <<'EOF' >&2
+Usage: parish/scripts/release.sh <version> [--dry-run] [--no-tag]
+EOF
+    exit 2
+}
+
+VERSION=""
+DRY_RUN=0
+NO_TAG=0
+
+while (( "$#" )); do
+    case "$1" in
+        --dry-run) DRY_RUN=1 ;;
+        --no-tag)  NO_TAG=1 ;;
+        -h|--help) usage ;;
+        -*)        echo "Unknown flag: $1" >&2; usage ;;
+        *)
+            if [[ -n "$VERSION" ]]; then
+                echo "Multiple version arguments: '$VERSION' and '$1'" >&2
+                usage
+            fi
+            VERSION="$1"
+            ;;
+    esac
+    shift
+done
+
+[[ -n "$VERSION" ]] || usage
+
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+    echo "Version must be MAJOR.MINOR.PATCH (with optional -prerelease): got '$VERSION'" >&2
+    exit 2
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+cd "$REPO_ROOT"
+
+CARGO_TOML="parish/crates/parish-cli/Cargo.toml"
+TAURI_JSON="parish/crates/parish-tauri/tauri.conf.json"
+UI_PKG="parish/apps/ui/package.json"
+
+for f in "$CARGO_TOML" "$TAURI_JSON" "$UI_PKG"; do
+    [[ -f "$f" ]] || { echo "Missing expected file: $f" >&2; exit 1; }
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required (sudo apt-get install jq)" >&2
+    exit 1
+fi
+
+if (( DRY_RUN == 0 )); then
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "Working tree is dirty — commit or stash before releasing." >&2
+        git status --short >&2
+        exit 1
+    fi
+    if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+        echo "Tag v$VERSION already exists locally." >&2
+        exit 1
+    fi
+fi
+
+# ─── Apply version bumps to a temporary tree ────────────────────────────────
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+cp "$CARGO_TOML"  "$WORK_DIR/Cargo.toml.new"
+cp "$TAURI_JSON"  "$WORK_DIR/tauri.conf.json.new"
+cp "$UI_PKG"      "$WORK_DIR/package.json.new"
+
+# parish-cli Cargo.toml: replace the `[package]` table's `version = "..."`.
+# We only touch the first `version =` line, which sits in `[package]` per the
+# convention used across the workspace.
+awk -v new="$VERSION" '
+    BEGIN { done = 0 }
+    /^version = "/ && !done { print "version = \"" new "\""; done = 1; next }
+    { print }
+' "$CARGO_TOML" > "$WORK_DIR/Cargo.toml.new"
+
+# tauri.conf.json: targeted line replacement to preserve unrelated formatting
+# (jq would normalize inline arrays like `"icon": ["icons/icon.png"]`).
+# Sanity-check first that the top-level `"version"` line exists and is unique.
+tauri_matches=$(grep -cE '^[[:space:]]*"version"[[:space:]]*:' "$TAURI_JSON" || true)
+if [[ "$tauri_matches" != "1" ]]; then
+    echo "Expected exactly one top-level \"version\" line in $TAURI_JSON, found $tauri_matches" >&2
+    exit 1
+fi
+sed -E "s|^([[:space:]]*\"version\"[[:space:]]*:[[:space:]]*\")[^\"]+(\".*)|\1${VERSION}\2|" \
+    "$TAURI_JSON" > "$WORK_DIR/tauri.conf.json.new"
+
+# package.json uses tabs; jq emits spaces. Convert leading 2-space indents
+# back to tabs so we match the existing file exactly.
+jq --indent 2 --arg v "$VERSION" '.version = $v' "$UI_PKG" \
+    | sed -E 's/^(  )+/&/; :a; s/^(\t*)  /\1\t/; t a' \
+    > "$WORK_DIR/package.json.new"
+
+show_diff() {
+    diff -u "$1" "$2" || true
+}
+
+echo "── Diff: $CARGO_TOML"
+show_diff "$CARGO_TOML" "$WORK_DIR/Cargo.toml.new"
+echo "── Diff: $TAURI_JSON"
+show_diff "$TAURI_JSON" "$WORK_DIR/tauri.conf.json.new"
+echo "── Diff: $UI_PKG"
+show_diff "$UI_PKG" "$WORK_DIR/package.json.new"
+
+if (( DRY_RUN == 1 )); then
+    echo
+    echo "Dry run — no files written, no commit, no tag."
+    exit 0
+fi
+
+# ─── Apply ──────────────────────────────────────────────────────────────────
+cp "$WORK_DIR/Cargo.toml.new"        "$CARGO_TOML"
+cp "$WORK_DIR/tauri.conf.json.new"   "$TAURI_JSON"
+cp "$WORK_DIR/package.json.new"      "$UI_PKG"
+
+# Best-effort refresh of Cargo.lock so the new workspace-member version is
+# recorded. `cargo check -p parish` is the only reliable way to update a
+# local-only crate's lockfile entry; if deps aren't available offline it
+# may fail, in which case CI's release build (no --locked) will refresh it.
+if command -v cargo >/dev/null 2>&1; then
+    ( cd parish && cargo check -p parish --offline -q 2>/dev/null ) \
+        || ( cd parish && cargo check -p parish -q 2>/dev/null ) \
+        || echo "warning: could not refresh Cargo.lock for parish $VERSION (continuing)" >&2
+fi
+
+git add "$CARGO_TOML" "$TAURI_JSON" "$UI_PKG" parish/Cargo.lock 2>/dev/null || true
+git commit -m "chore(release): v$VERSION" >/dev/null
+echo "Committed: chore(release): v$VERSION"
+
+if (( NO_TAG == 0 )); then
+    git tag -a "v$VERSION" -m "Rundale v$VERSION"
+    echo "Tagged:    v$VERSION"
+    echo
+    echo "Next steps:"
+    echo "  git push origin <branch>     # e.g. main"
+    echo "  git push origin v$VERSION    # triggers .github/workflows/release.yml"
+else
+    echo "Skipping tag (--no-tag)."
+fi


### PR DESCRIPTION
## Summary

Automates GitHub Releases. Push a `vX.Y.Z` tag → CI builds a Linux x86_64 `parish` tarball and publishes a Release with auto-generated notes.

- **`.github/workflows/release.yml`** — triggers on `v*.*.*` tag push or `workflow_dispatch`. Validates the tag matches `parish-cli` `Cargo.toml`, builds the release binary, packages `parish-vX.Y.Z-x86_64-linux-gnu.tar.gz` with `LICENSE`/`NOTICE`/`THIRD_PARTY_NOTICES.md`/`README.md` plus a `.sha256`, and uses `softprops/action-gh-release@v2` with `generate_release_notes: true`.
- **`parish/scripts/release.sh <version> [--dry-run] [--no-tag]`** — bumps `parish-cli` `Cargo.toml`, `tauri.conf.json`, and `ui/package.json` in lockstep, refreshes `Cargo.lock` best-effort, commits `chore(release): vX.Y.Z`, and creates the tag. Internal leaf crates stay on `0.1.0`.
- **`just release VERSION`** / **`just release-dry-run VERSION`** — thin wrappers.
- **`docs/release.md`** — runbook.

### How Claude executes a release

```sh
just release-dry-run 0.2.0   # confirm the diff
just release 0.2.0           # bump + commit + tag locally
git push origin main         # land the bump
git push origin v0.2.0       # triggers release.yml
```

Verification is via `mcp__github__get_release_by_tag` once the workflow completes. No `create_release` MCP tool is needed — the workflow handles publication.

### Two dry-run paths (no real Release shows up)

1. **Local bump dry-run:** `just release-dry-run 0.2.0` prints the three diffs and exits. Nothing is written, committed, or tagged.
2. **Pipeline dry-run:** Trigger `release.yml` from the Actions UI with `dry_run=true` (default). The build runs end-to-end and uploads the tarball as a workflow artifact, but the `publish` job is hard-gated on `github.event_name == 'push'`, so **`workflow_dispatch` can never produce a tag or a Release**, even with `dry_run=false`.

### Scope (intentional non-goals)

- Linux x86_64 only — no macOS/Windows/Tauri bundle yet.
- No crates.io / npm publish (every workspace crate is `publish = false`; UI is `private`).
- No CHANGELOG.md — relies on GitHub's auto-generated notes.

## Test plan

- [x] `parish/scripts/release.sh 0.2.0 --dry-run` produces clean one-line diffs across all three files.
- [x] Prerelease semver (`1.2.3-rc.4`) accepted.
- [x] `bash -n` and Python YAML parse both pass.
- [ ] After merge, run `release.yml` via Actions UI with `version=0.2.0`, `dry_run=true` to verify the build/package step end-to-end. The workflow run should produce a `parish-linux-x86_64` artifact and skip the `publish` job.
- [ ] After dry-run passes, do a real `vX.Y.Z` tag push and confirm the Release appears under https://github.com/dmooney/rundale/releases.

https://claude.ai/code/session_01TrDJUwJJTYHKmjJB2f8NHn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrDJUwJJTYHKmjJB2f8NHn)_