### PR TITLE
fix(ci): run cargo audit from parish workspace dir

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -23,6 +23,10 @@ concurrency:
 permissions:
   contents: read
 
+defaults:
+  run:
+    working-directory: parish
+
 jobs:
   cargo-audit:
     name: cargo audit


### PR DESCRIPTION
## Summary
- Security audit workflow ran `cargo audit` from repo root, but the Cargo workspace lives at `parish/`. Job failed with `error: not found: Couldn't load Cargo.lock` (run [25755969347](https://github.com/dmooney/Rundale/actions/runs/25755969347)).
- Added `defaults.run.working-directory: parish` to `.github/workflows/audit.yml`, matching the convention already in `ci.yml` (line 21-23).

## Test plan
- [ ] Audit workflow reruns green on this branch (`workflow_dispatch` after merge, or push that touches `parish/Cargo.lock`).
- [ ] Subsequent scheduled daily run reports advisories instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)