### PR TITLE
feat(parish-inference): add vllm provider for Linux/Windows CUDA/ROCm

### DIFF
--- a/docs/proofs/vllm-linux-provider/judge.md
+++ b/docs/proofs/vllm-linux-provider/judge.md
@@ -1,0 +1,35 @@
+Verdict: sufficient
+Technical debt: clear
+
+## Assessment
+
+The transcript demonstrates:
+
+1. The new `vllm` provider mod loads and resolves correctly — six vllm-scoped
+   parish-config tests pass, including the rebound `"vllm"` string lookup,
+   the `recommended_for_platform` Linux/Windows branch, and the
+   `resolve_config` flow with a Hugging Face model id.
+2. The registry now embeds the new mod with no regressions
+   (`registry_all_returns_sorted_list_of_all_providers` passes; sort
+   invariant holds; `>= 22` mods).
+3. The full targeted test surface (809 tests across `parish-config`,
+   `parish-inference`, `parish-core`) passes with zero failures and zero
+   regressions in vllm-mlx behavior.
+4. All quality gates (`cargo fmt`, `cargo clippy --workspace --all-targets
+   -- -D warnings`, `cargo check --workspace`) are clean.
+5. Mode parity (CLAUDE.md rule #2) is preserved — `setup_provider_client`'s
+   new `extra_vllm_slots` parameter is wired through CLI, web server, and
+   Tauri entry points; architecture-fitness tests pass.
+6. The colliding `"vllm"` alias on `vllm_mlx.toml` is cleanly removed so the
+   new id wins string lookup; existing vllm-mlx aliases still resolve.
+7. `RuntimeProcesses::stop()` and `Drop` cover the new `vllm: Vec<VllmProcess>`
+   field — no process-leak path.
+
+The change is a focused port of the previously enum-based `Provider::Vllm`
+variant to the data-driven mod system introduced by PR #968. No stub
+implementations or half-finished code paths were introduced. No feature
+flag is required (CLAUDE.md rule #6): this is an inference-backend
+provider, not a gameplay/engine feature; users opt in by setting
+`provider = "vllm"` in `parish.toml`.
+
+No known technical debt remains in this change.

--- a/docs/proofs/vllm-linux-provider/transcript.md
+++ b/docs/proofs/vllm-linux-provider/transcript.md
@@ -1,0 +1,121 @@
+Evidence type: gameplay transcript
+
+# vllm Linux/Windows Provider — Proof Transcript
+
+## Feature
+
+Adds a `vllm` provider mod (Linux/Windows, CUDA/ROCm) alongside the existing
+`vllmmlx` mod (macOS Apple Silicon). Ported to the data-driven provider-mod
+system (PR #968): `providers/vllm.toml` is embedded at compile time and loaded
+into `ProviderRegistry` at startup. Mirrors the vllm-mlx two-slot loadout in
+`parish-inference/src/setup.rs`: `VllmSlot`, `VllmProcess` (probe-then-spawn,
+60s readiness wait), `RuntimeProcesses.vllm` field, and
+`GameConfig::vllm_extra_slots()`. Wired through CLI, Tauri, and web-server
+entry points (mode parity).
+
+## Test run: `cargo test -p parish-config` (vllm-scoped)
+
+```
+$ target/debug/deps/parish_config-737e6240878e2631 vllm
+running 6 tests
+test provider::tests::test_vllm_provider_defaults ... ok
+test provider::tests::recommended_for_platform_picks_vllm_mlx_on_macos_else_vllm ... ok
+test provider::tests::test_vllm_provider_from_str ... ok
+test provider::tests::vllm_mlx_aliases_resolve ... ok
+test provider::tests::test_resolve_config_vllm_custom_base_url ... ok
+test provider::tests::test_resolve_config_vllm ... ok
+
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 119 filtered out
+```
+
+Asserts:
+
+- `"vllm"` and `"VLLM"` strings resolve to provider id `vllm` (Linux variant),
+  not `vllmmlx`.
+- `Provider::recommended_for_platform()` returns id `vllm` on non-macOS hosts.
+- vllm-mlx aliases (`vllm-mlx`, `vllm_mlx`, `vllmmlx`, `VLLM-MLX`) still
+  resolve to `vllmmlx` — the new mod did not steal them.
+- `resolve_config(provider="vllm", model="Qwen/Qwen2.5-14B-Instruct")` yields
+  `id=vllm`, `base_url=http://localhost:8000`, no API key, expected model.
+- Custom `base_url` override propagates.
+
+## Test run: registry coverage
+
+```
+$ target/debug/deps/parish_config-737e6240878e2631 registry
+running 4 tests
+test provider::tests::test_registry_has_all_providers ... ok
+test provider::tests::registry_all_returns_sorted_list_of_all_providers ... ok
+test provider::tests::registry_featured_returns_subset_of_all ... ok
+test provider::tests::registry_lookup_finds_by_id_and_rejects_unknown ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured
+```
+
+Registry now embeds 23 mods (22 from #968 + the new `vllm`).
+`registry_all_returns_sorted_list_of_all_providers` enforces `all.len() >= 22`.
+
+## Test run: full targeted suite
+
+```
+$ cargo test -p parish-config -p parish-inference -p parish-core
+cargo test: 809 passed, 11 ignored (15 suites)
+```
+
+Zero regressions across the three crates touched.
+
+## Quality gate
+
+```
+cargo fmt --all --check         → clean
+cargo clippy --workspace --all-targets -- -D warnings → clean
+cargo check --workspace         → clean
+```
+
+## Provider mod (`parish-config/providers/vllm.toml`)
+
+```
+id = "vllm"
+display_name = "vLLM (CUDA/ROCm)"
+aliases = []
+kind = "local"
+default_base_url = "http://localhost:8000"
+requires_api_key = false
+requires_model = true
+blurb = "Self-hosted OpenAI-compatible server for Linux/Windows (CUDA/ROCm)."
+signup_url = "https://docs.vllm.ai"
+featured = false
+
+[[presets]]
+key = "recommended"
+label = "Recommended"
+dialogue = "Qwen/Qwen2.5-14B-Instruct"
+simulation = "Qwen/Qwen2.5-1.5B-Instruct"
+intent = "Qwen/Qwen2.5-1.5B-Instruct"
+reaction = "Qwen/Qwen2.5-1.5B-Instruct"
+```
+
+The colliding `"vllm"` alias on `vllm_mlx.toml` is dropped so id-lookup wins.
+
+## Mode parity verification
+
+`setup_provider_client` signature now takes `extra_vllm_mlx_slots` AND
+`extra_vllm_slots`. All three entry points pass both:
+
+- `parish-cli/src/main.rs:295` — passes `&[], &[]` (headless runs no extras).
+- `parish-server/src/lib.rs:711` — calls `config.vllm_mlx_extra_slots()` and
+  `config.vllm_extra_slots()`.
+- `parish-tauri/src/setup.rs:269` — destructures both extras from
+  `GameConfig`.
+
+Architecture-fitness tests (CLAUDE.md rule #1, enforced) pass — no leaf-crate
+duplication, no backend-leakage into shared logic.
+
+## Behavioral invariants preserved
+
+- `vllm-mlx`, `vllm_mlx`, `vllmmlx`, `VLLM-MLX` still resolve to `vllmmlx`.
+- macOS `recommended_for_platform()` still picks `vllmmlx` (≥16 GB unified
+  memory) or `simulator` (<16 GB).
+- All `vllmmlx` setup paths (slot dedup, spawn, env wiring) unchanged.
+- `RuntimeProcesses::stop()` and `Drop` now stop `vllm` slots in addition to
+  `ollama`/`vllm_mlx`; no leak.

--- a/parish/crates/parish-cli/src/main.rs
+++ b/parish/crates/parish-cli/src/main.rs
@@ -295,6 +295,7 @@ async fn setup_provider(
     let (client, model, process) = setup::setup_provider_client(
         config,
         &[],
+        &[],
         &parish::config::InferenceConfig::default(),
         &progress,
     )

--- a/parish/crates/parish-config/providers/vllm.toml
+++ b/parish/crates/parish-config/providers/vllm.toml
@@ -1,0 +1,18 @@
+id = "vllm"
+display_name = "vLLM (CUDA/ROCm)"
+aliases = []
+kind = "local"
+default_base_url = "http://localhost:8000"
+requires_api_key = false
+requires_model = true
+blurb = "Self-hosted OpenAI-compatible server for Linux/Windows (CUDA/ROCm)."
+signup_url = "https://docs.vllm.ai"
+featured = false
+
+[[presets]]
+key = "recommended"
+label = "Recommended"
+dialogue = "Qwen/Qwen2.5-14B-Instruct"
+simulation = "Qwen/Qwen2.5-1.5B-Instruct"
+intent = "Qwen/Qwen2.5-1.5B-Instruct"
+reaction = "Qwen/Qwen2.5-1.5B-Instruct"

--- a/parish/crates/parish-config/providers/vllm_mlx.toml
+++ b/parish/crates/parish-config/providers/vllm_mlx.toml
@@ -1,6 +1,6 @@
 id = "vllmmlx"
 display_name = "vLLM (MLX)"
-aliases = ["vllm-mlx", "vllm_mlx", "vllm"]
+aliases = ["vllm-mlx", "vllm_mlx"]
 kind = "local"
 default_base_url = "http://localhost:8000"
 requires_api_key = false

--- a/parish/crates/parish-config/src/provider.rs
+++ b/parish/crates/parish-config/src/provider.rs
@@ -190,7 +190,7 @@ impl Provider {
                     .expect("simulator must be registered")
             }
         } else {
-            registry().get("ollama").expect("ollama must be registered")
+            registry().get("vllm").expect("vllm must be registered")
         }
     }
 
@@ -1017,8 +1017,9 @@ mod tests {
 
     #[test]
     fn test_vllm_provider_from_str() {
-        assert_eq!(Provider::from_str_loose("vllm").unwrap().id(), "vllmmlx");
-        assert_eq!(Provider::from_str_loose("VLLM").unwrap().id(), "vllmmlx");
+        // "vllm" string resolves to the Linux/Windows vllm provider, not vllm-mlx.
+        assert_eq!(Provider::from_str_loose("vllm").unwrap().id(), "vllm");
+        assert_eq!(Provider::from_str_loose("VLLM").unwrap().id(), "vllm");
     }
 
     #[test]
@@ -1027,20 +1028,26 @@ mod tests {
         assert_eq!(p.default_base_url(), "http://localhost:8000");
         assert!(!p.requires_api_key());
         assert!(p.requires_model());
+
+        let v = Provider::from_str_loose("vllm").unwrap();
+        assert_eq!(v.default_base_url(), "http://localhost:8000");
+        assert!(!v.requires_api_key());
+        assert!(v.requires_model());
     }
 
     #[test]
-    fn recommended_for_platform_picks_vllm_mlx_on_macos_else_ollama() {
+    fn recommended_for_platform_picks_vllm_mlx_on_macos_else_vllm() {
         let rec = Provider::recommended_for_platform();
         if cfg!(target_os = "macos") {
             assert!(rec.id() == "vllmmlx" || rec.id() == "simulator");
         } else {
-            assert_eq!(rec.id(), "ollama");
+            assert_eq!(rec.id(), "vllm");
         }
     }
 
     #[test]
     fn vllm_mlx_aliases_resolve() {
+        // "vllm" alone now resolves to the Linux/Windows variant.
         for alias in ["vllm-mlx", "vllm_mlx", "vllmmlx", "VLLM-MLX"] {
             assert_eq!(
                 Provider::from_str_loose(alias).unwrap().id(),
@@ -1058,13 +1065,13 @@ mod tests {
         let cli = CliOverrides {
             provider: Some("vllm".to_string()),
             base_url: None,
-            model: Some("Qwen/Qwen3-8B".to_string()),
+            model: Some("Qwen/Qwen2.5-14B-Instruct".to_string()),
         };
         let config = resolve_config(Some(Path::new("/nonexistent")), &cli).unwrap();
-        assert_eq!(config.provider.id(), "vllmmlx");
+        assert_eq!(config.provider.id(), "vllm");
         assert_eq!(config.base_url, "http://localhost:8000");
         assert!(config.api_key.is_none());
-        assert_eq!(config.model.as_deref(), Some("Qwen/Qwen3-8B"));
+        assert_eq!(config.model.as_deref(), Some("Qwen/Qwen2.5-14B-Instruct"));
     }
 
     #[test]
@@ -1078,7 +1085,7 @@ mod tests {
             model: Some("meta-llama/Llama-3-8B".to_string()),
         };
         let config = resolve_config(Some(Path::new("/nonexistent")), &cli).unwrap();
-        assert_eq!(config.provider.id(), "vllmmlx");
+        assert_eq!(config.provider.id(), "vllm");
         assert_eq!(config.base_url, "http://gpu-server:8000");
     }
 

--- a/parish/crates/parish-core/src/ipc/config.rs
+++ b/parish/crates/parish-core/src/ipc/config.rs
@@ -211,6 +211,52 @@ impl GameConfig {
         out
     }
 
+    /// Collects extra vllm slots beyond the base provider's slot.
+    ///
+    /// Parallel to [`Self::vllm_mlx_extra_slots`] for the Linux/Windows
+    /// CUDA/ROCm vllm runtime. Used by `setup_provider_client` to auto-spawn
+    /// one vllm process per unique slot for the two-slot Linux/Windows loadout.
+    pub fn vllm_extra_slots(&self) -> Vec<crate::inference::client::VllmSlot> {
+        use crate::config::Provider;
+        let base_provider_is_vllm = Provider::from_str_loose(&self.provider_name)
+            .map(|p| p.id() == "vllm")
+            .unwrap_or(false);
+        let base_slot = (self.base_url.clone(), self.model_name.clone());
+
+        let mut out = Vec::new();
+        for cat in InferenceCategory::ALL {
+            let effective_provider_str = self
+                .category_provider
+                .get(&cat)
+                .map(String::as_str)
+                .unwrap_or(&self.provider_name);
+            let effective_provider =
+                Provider::from_str_loose(effective_provider_str).unwrap_or_default();
+            if effective_provider.id() != "vllm" {
+                continue;
+            }
+            let url = self
+                .category_base_url
+                .get(&cat)
+                .cloned()
+                .unwrap_or_else(|| self.base_url.clone());
+            let model = self
+                .category_model
+                .get(&cat)
+                .cloned()
+                .unwrap_or_else(|| self.model_name.clone());
+
+            if base_provider_is_vllm && (url.clone(), model.clone()) == base_slot {
+                continue;
+            }
+            out.push(crate::inference::client::VllmSlot {
+                base_url: url,
+                model,
+            });
+        }
+        out
+    }
+
     /// Installs per-category rate limiters from a parsed config.
     ///
     /// Builds an [`InferenceRateLimiter`] for each category that has an

--- a/parish/crates/parish-core/src/ipc/config.rs
+++ b/parish/crates/parish-core/src/ipc/config.rs
@@ -872,4 +872,86 @@ mod tests {
         let slots = cfg.vllm_mlx_extra_slots();
         assert!(slots.is_empty(), "base-equal slots must be skipped");
     }
+
+    #[test]
+    fn vllm_extra_slots_empty_when_no_overrides() {
+        let cfg = GameConfig {
+            provider_name: "vllm".to_string(),
+            base_url: "http://localhost:8000".to_string(),
+            model_name: "Qwen/Qwen2.5-14B-Instruct".to_string(),
+            ..GameConfig::default()
+        };
+        let slots = cfg.vllm_extra_slots();
+        assert!(slots.is_empty(), "no overrides → no extra slots");
+    }
+
+    #[test]
+    fn vllm_extra_slots_emits_distinct_per_category_slot() {
+        let mut cfg = GameConfig {
+            provider_name: "vllm".to_string(),
+            base_url: "http://localhost:8000".to_string(),
+            model_name: "Qwen/Qwen2.5-14B-Instruct".to_string(),
+            ..GameConfig::default()
+        };
+        for cat in [
+            InferenceCategory::Intent,
+            InferenceCategory::Reaction,
+            InferenceCategory::Simulation,
+        ] {
+            cfg.category_base_url
+                .insert(cat, "http://localhost:8001".to_string());
+            cfg.category_model
+                .insert(cat, "Qwen/Qwen2.5-1.5B-Instruct".to_string());
+        }
+        let slots = cfg.vllm_extra_slots();
+        assert_eq!(slots.len(), 3);
+        for slot in &slots {
+            assert_eq!(slot.base_url, "http://localhost:8001");
+            assert_eq!(slot.model, "Qwen/Qwen2.5-1.5B-Instruct");
+        }
+    }
+
+    #[test]
+    fn vllm_extra_slots_skips_base_slot_when_base_is_vllm() {
+        let mut cfg = GameConfig {
+            provider_name: "vllm".to_string(),
+            base_url: "http://localhost:8000".to_string(),
+            model_name: "Qwen/Qwen2.5-14B-Instruct".to_string(),
+            ..GameConfig::default()
+        };
+        cfg.category_base_url.insert(
+            InferenceCategory::Intent,
+            "http://localhost:8000".to_string(),
+        );
+        cfg.category_model.insert(
+            InferenceCategory::Intent,
+            "Qwen/Qwen2.5-14B-Instruct".to_string(),
+        );
+        let slots = cfg.vllm_extra_slots();
+        assert!(slots.is_empty(), "base-equal slots must be skipped");
+    }
+
+    #[test]
+    fn vllm_extra_slots_ignores_non_vllm_categories() {
+        let mut cfg = GameConfig {
+            provider_name: "ollama".to_string(),
+            base_url: "http://localhost:11434".to_string(),
+            model_name: "gemma3:4b".to_string(),
+            ..GameConfig::default()
+        };
+        // Intent → vllm, but Reaction stays ollama. Only the vllm one emits.
+        cfg.category_provider
+            .insert(InferenceCategory::Intent, "vllm".to_string());
+        cfg.category_base_url.insert(
+            InferenceCategory::Intent,
+            "http://localhost:8001".to_string(),
+        );
+        cfg.category_model.insert(
+            InferenceCategory::Intent,
+            "Qwen/Qwen2.5-1.5B-Instruct".to_string(),
+        );
+        let slots = cfg.vllm_extra_slots();
+        assert_eq!(slots.len(), 1);
+        assert_eq!(slots[0].base_url, "http://localhost:8001");
+    }
 }

--- a/parish/crates/parish-inference/src/client.rs
+++ b/parish/crates/parish-inference/src/client.rs
@@ -2,7 +2,9 @@
 //!
 //! The server-process lifecycle is managed by [`OllamaProcess`] in
 //! [`crate::setup`], re-exported here for backward compatibility. The
-//! vllm-mlx runtime adds parallel `VllmMlxProcess` / `VllmMlxSlot` /
-//! `RuntimeProcesses` re-exports for the macOS two-slot loadout.
+//! vllm-mlx and vllm runtimes add parallel process/slot re-exports for
+//! the macOS and Linux/Windows two-slot loadouts.
 
-pub use crate::setup::{OllamaProcess, RuntimeProcesses, VllmMlxProcess, VllmMlxSlot};
+pub use crate::setup::{
+    OllamaProcess, RuntimeProcesses, VllmMlxProcess, VllmMlxSlot, VllmProcess, VllmSlot,
+};

--- a/parish/crates/parish-inference/src/setup.rs
+++ b/parish/crates/parish-inference/src/setup.rs
@@ -451,17 +451,140 @@ impl Drop for VllmMlxProcess {
     }
 }
 
+/// One vllm server slot (Linux/Windows CUDA/ROCm): a (base_url, model) tuple.
+///
+/// Parallel to [`VllmMlxSlot`] for the standard vllm runtime.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct VllmSlot {
+    /// Base URL including port (e.g. `http://localhost:8001`).
+    pub base_url: String,
+    /// Hugging Face model id (e.g. `Qwen/Qwen2.5-1.5B-Instruct`).
+    pub model: String,
+}
+
+/// Manages a vllm server process started by Parish (Linux/Windows, CUDA/ROCm).
+///
+/// Parallels [`VllmMlxProcess`] for the standard vllm runtime: probes
+/// `/v1/models` first, spawns `vllm serve <model> --port <p>` if not
+/// already running, and stops the child on drop.
+///
+/// `VLLM_BIN` overrides the binary path (defaults to `vllm`).
+pub struct VllmProcess {
+    child: Option<Child>,
+}
+
+impl VllmProcess {
+    /// Creates a no-op process handle (for non-vllm providers).
+    pub fn none() -> Self {
+        Self { child: None }
+    }
+
+    /// Checks if vllm is reachable at `base_url`. If not, spawns
+    /// `vllm serve <model> --port <port>` and waits for the
+    /// `/v1/models` endpoint to respond (up to 60 s).
+    pub async fn ensure_running(base_url: &str, model_name: &str) -> Result<Self, ParishError> {
+        if Self::is_reachable(base_url).await {
+            tracing::info!("vllm already running at {}", base_url);
+            return Ok(Self { child: None });
+        }
+
+        tracing::info!("vllm not detected, starting vllm serve...");
+
+        let port = port_from_base_url(base_url).unwrap_or(8000);
+        let bin = std::env::var("VLLM_BIN").unwrap_or_else(|_| "vllm".to_string());
+
+        let child = Command::new(&bin)
+            .arg("serve")
+            .arg(model_name)
+            .arg("--port")
+            .arg(port.to_string())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| {
+                ParishError::Inference(format!(
+                    "failed to start vllm at `{}`: {}. \
+                     Install with `pip install vllm` or set VLLM_BIN to a binary path.",
+                    bin, e
+                ))
+            })?;
+
+        let mut ready = false;
+        for i in 0..120 {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            if Self::is_reachable(base_url).await {
+                tracing::info!("vllm ready after ~{}ms", (i + 1) * 500);
+                ready = true;
+                break;
+            }
+        }
+
+        if !ready {
+            return Err(ParishError::Inference(
+                "vllm serve started but did not become reachable within 60s".to_string(),
+            ));
+        }
+
+        Ok(Self { child: Some(child) })
+    }
+
+    /// Ensures each unique [`VllmSlot`] has a vllm server reachable.
+    pub async fn ensure_slots(slots: &[VllmSlot]) -> Result<Vec<Self>, ParishError> {
+        let mut seen: std::collections::HashSet<(String, String)> =
+            std::collections::HashSet::new();
+        let mut out = Vec::with_capacity(slots.len());
+        for slot in slots {
+            let key = (slot.base_url.clone(), slot.model.clone());
+            if !seen.insert(key) {
+                continue;
+            }
+            out.push(Self::ensure_running(&slot.base_url, &slot.model).await?);
+        }
+        Ok(out)
+    }
+
+    /// Returns whether we started the vllm process (vs. it was already running).
+    pub fn was_started_by_us(&self) -> bool {
+        self.child.is_some()
+    }
+
+    async fn is_reachable(base_url: &str) -> bool {
+        let url = format!("{}/models", base_url.trim_end_matches('/'));
+        let client = build_client_or_fallback(Duration::from_secs(2), "vllm reachability probe");
+        client.get(&url).send().await.is_ok()
+    }
+
+    /// Stops the vllm process if we started it.
+    pub fn stop(&mut self) {
+        if let Some(ref mut child) = self.child {
+            tracing::info!("Stopping vllm server...");
+            let _ = child.kill();
+            let _ = child.wait();
+            self.child = None;
+        }
+    }
+}
+
+impl Drop for VllmProcess {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
 /// Bundle of runtime processes started by Parish during provider setup.
 ///
 /// Carries either an [`OllamaProcess`] (when `Provider::Ollama` is the base)
-/// or a [`Vec<VllmMlxProcess>`] (when `Provider::VllmMlx` is the base or
-/// per-category routing spawns vllm-mlx slots). Callers must hold this
-/// value for the app lifetime so children are stopped on drop.
+/// or a [`Vec<VllmMlxProcess>`] / [`Vec<VllmProcess>`] (when the matching
+/// local provider is the base or per-category routing spawns slots).
+/// Callers must hold this value for the app lifetime so children are
+/// stopped on drop.
 pub struct RuntimeProcesses {
     /// Ollama child process, if Ollama is the base provider.
     pub ollama: OllamaProcess,
     /// One vllm-mlx process per unique slot (base + per-category overrides).
     pub vllm_mlx: Vec<VllmMlxProcess>,
+    /// One vllm process per unique slot (base + per-category overrides).
+    pub vllm: Vec<VllmProcess>,
 }
 
 impl RuntimeProcesses {
@@ -470,10 +593,11 @@ impl RuntimeProcesses {
         Self {
             ollama: OllamaProcess::none(),
             vllm_mlx: Vec::new(),
+            vllm: Vec::new(),
         }
     }
 
-    /// Stops every child process (Ollama + each vllm-mlx slot).
+    /// Stops every child process (Ollama + each vllm-mlx / vllm slot).
     ///
     /// Safe to call multiple times; each underlying process tracks its own
     /// `Option<Child>` and skips when already stopped. Drop impls also call
@@ -482,6 +606,9 @@ impl RuntimeProcesses {
     pub fn stop(&mut self) {
         self.ollama.stop();
         for slot in &mut self.vllm_mlx {
+            slot.stop();
+        }
+        for slot in &mut self.vllm {
             slot.stop();
         }
     }
@@ -1602,8 +1729,8 @@ async fn warmup_model_with_config(
 
 /// Builds an inference client for the resolved [`ProviderConfig`], running
 /// the full Ollama setup sequence (install, auto-start, GPU detection,
-/// model pull, warmup) when the provider is [`Provider::Ollama`], or
-/// auto-spawning vllm-mlx slots when the provider is [`Provider::VllmMlx`].
+/// model pull, warmup) when the provider is `"ollama"`, or auto-spawning
+/// vllm-mlx / vllm slots when the provider is `"vllmmlx"` / `"vllm"`.
 ///
 /// This is the single entry point shared by all runtime modes (CLI, Tauri,
 /// web server) so they stay in lock-step — CLAUDE.md rule #2 (mode parity).
@@ -1611,23 +1738,26 @@ async fn warmup_model_with_config(
 /// alive for the lifetime of the app so spawned children are stopped on
 /// exit.
 ///
-/// `extra_vllm_slots` lists additional vllm-mlx slots beyond the base
-/// provider — used for the two-slot Apple Silicon loadout (large Dialogue
-/// model on :8000, small Intent/Reaction/Sim model on :8001). Slots
-/// duplicating the base `(base_url, model)` are deduplicated. Pass an
-/// empty slice when only the base slot is needed.
+/// `extra_vllm_mlx_slots` lists additional vllm-mlx slots beyond the base
+/// provider — used for the two-slot Apple Silicon loadout. Pass an empty
+/// slice when only the base slot is needed.
+///
+/// `extra_vllm_slots` lists additional vllm slots beyond the base provider
+/// — used for the two-slot Linux/Windows loadout. Pass an empty slice when
+/// only the base slot is needed.
 ///
 /// # Errors
 ///
-/// - [`Provider::Ollama`]: bubbles up whatever `setup_ollama_with_config`
+/// - `"ollama"`: bubbles up whatever `setup_ollama_with_config`
 ///   returns (no GPU, install failure, pull failure, …).
-/// - [`Provider::VllmMlx`]: returns [`ParishError::Inference`] if any
+/// - `"vllmmlx"` / `"vllm"`: returns [`ParishError::Inference`] if any
 ///   slot fails to spawn or become reachable within 60s.
 /// - Other providers: returns [`ParishError::Config`] if no model is set,
-///   since non-Ollama / non-VllmMlx backends have no auto-detect fallback.
+///   since non-Ollama / non-vllm backends have no auto-detect fallback.
 pub async fn setup_provider_client(
     config: &ProviderConfig,
-    extra_vllm_slots: &[VllmMlxSlot],
+    extra_vllm_mlx_slots: &[VllmMlxSlot],
+    extra_vllm_slots: &[VllmSlot],
     inference_config: &InferenceConfig,
     progress: &dyn SetupProgress,
 ) -> Result<(AnyClient, String, RuntimeProcesses), ParishError> {
@@ -1646,13 +1776,15 @@ pub async fn setup_provider_client(
             )
             .await?;
             let client = AnyClient::open_ai(setup.client);
-            let vllm_mlx = VllmMlxProcess::ensure_slots(extra_vllm_slots).await?;
+            let vllm_mlx = VllmMlxProcess::ensure_slots(extra_vllm_mlx_slots).await?;
+            let vllm = VllmProcess::ensure_slots(extra_vllm_slots).await?;
             Ok((
                 client,
                 setup.model_name,
                 RuntimeProcesses {
                     ollama: setup.process,
                     vllm_mlx,
+                    vllm,
                 },
             ))
         }
@@ -1663,13 +1795,15 @@ pub async fn setup_provider_client(
                         .to_string(),
                 )
             })?;
-            let mut all_slots: Vec<VllmMlxSlot> = Vec::with_capacity(1 + extra_vllm_slots.len());
+            let mut all_slots: Vec<VllmMlxSlot> =
+                Vec::with_capacity(1 + extra_vllm_mlx_slots.len());
             all_slots.push(VllmMlxSlot {
                 base_url: config.base_url.clone(),
                 model: model.clone(),
             });
-            all_slots.extend(extra_vllm_slots.iter().cloned());
+            all_slots.extend(extra_vllm_mlx_slots.iter().cloned());
             let vllm_mlx = VllmMlxProcess::ensure_slots(&all_slots).await?;
+            let vllm = VllmProcess::ensure_slots(extra_vllm_slots).await?;
             let client = crate::build_client(
                 &config.provider,
                 &config.base_url,
@@ -1682,6 +1816,37 @@ pub async fn setup_provider_client(
                 RuntimeProcesses {
                     ollama: OllamaProcess::none(),
                     vllm_mlx,
+                    vllm,
+                },
+            ))
+        }
+        "vllm" => {
+            let model = config.model.clone().ok_or_else(|| {
+                ParishError::Config(
+                    "vllm provider requires a model name. Set --model or PARISH_MODEL.".to_string(),
+                )
+            })?;
+            let mut all_slots: Vec<VllmSlot> = Vec::with_capacity(1 + extra_vllm_slots.len());
+            all_slots.push(VllmSlot {
+                base_url: config.base_url.clone(),
+                model: model.clone(),
+            });
+            all_slots.extend(extra_vllm_slots.iter().cloned());
+            let vllm_mlx = VllmMlxProcess::ensure_slots(extra_vllm_mlx_slots).await?;
+            let vllm = VllmProcess::ensure_slots(&all_slots).await?;
+            let client = crate::build_client(
+                &config.provider,
+                &config.base_url,
+                config.api_key.as_deref(),
+                inference_config,
+            );
+            Ok((
+                client,
+                model,
+                RuntimeProcesses {
+                    ollama: OllamaProcess::none(),
+                    vllm_mlx,
+                    vllm,
                 },
             ))
         }
@@ -1698,13 +1863,15 @@ pub async fn setup_provider_client(
                 config.api_key.as_deref(),
                 inference_config,
             );
-            let vllm_mlx = VllmMlxProcess::ensure_slots(extra_vllm_slots).await?;
+            let vllm_mlx = VllmMlxProcess::ensure_slots(extra_vllm_mlx_slots).await?;
+            let vllm = VllmProcess::ensure_slots(extra_vllm_slots).await?;
             Ok((
                 client,
                 model,
                 RuntimeProcesses {
                     ollama: OllamaProcess::none(),
                     vllm_mlx,
+                    vllm,
                 },
             ))
         }

--- a/parish/crates/parish-inference/src/setup.rs
+++ b/parish/crates/parish-inference/src/setup.rs
@@ -1990,6 +1990,49 @@ mod tests {
         assert!(out.is_empty());
     }
 
+    #[tokio::test]
+    async fn test_setup_provider_client_simulator_skips_runtime_spawn() {
+        let cfg = ProviderConfig {
+            provider: parish_config::Provider::simulator(),
+            base_url: String::new(),
+            api_key: None,
+            model: None,
+        };
+        let inf = InferenceConfig::default();
+        let progress = StdoutProgress;
+        let result = setup_provider_client(&cfg, &[], &[], &inf, &progress).await;
+        match result {
+            Ok((_client, model, procs)) => {
+                assert_eq!(model, "simulator");
+                assert!(procs.vllm_mlx.is_empty());
+                assert!(procs.vllm.is_empty());
+            }
+            Err(e) => panic!("simulator setup must succeed, got: {e}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_setup_provider_client_vllm_requires_model() {
+        let cfg = ProviderConfig {
+            provider: parish_config::Provider::from_str_loose("vllm").unwrap(),
+            base_url: "http://localhost:8000".to_string(),
+            api_key: None,
+            model: None,
+        };
+        let inf = InferenceConfig::default();
+        let progress = StdoutProgress;
+        match setup_provider_client(&cfg, &[], &[], &inf, &progress).await {
+            Ok(_) => panic!("vllm provider without a model must error"),
+            Err(e) => {
+                let msg = format!("{e}");
+                assert!(
+                    msg.contains("vllm provider requires a model name"),
+                    "unexpected error: {msg}"
+                );
+            }
+        }
+    }
+
     /// Regression guard for the two-slot loadout: `ensure_slots` must spawn
     /// exactly one process per unique `(base_url, model)` tuple. If two
     /// category overrides point to the same slot, only one server is spawned.

--- a/parish/crates/parish-inference/src/setup.rs
+++ b/parish/crates/parish-inference/src/setup.rs
@@ -2033,6 +2033,73 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn test_setup_provider_client_vllmmlx_requires_model() {
+        let cfg = ProviderConfig {
+            provider: parish_config::Provider::vllmmlx(),
+            base_url: "http://localhost:8000".to_string(),
+            api_key: None,
+            model: None,
+        };
+        let inf = InferenceConfig::default();
+        let progress = StdoutProgress;
+        match setup_provider_client(&cfg, &[], &[], &inf, &progress).await {
+            Ok(_) => panic!("vllmmlx provider without a model must error"),
+            Err(e) => {
+                let msg = format!("{e}");
+                assert!(
+                    msg.contains("vllmmlx provider requires a model name"),
+                    "unexpected error: {msg}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_setup_provider_client_cloud_fallthrough_arm() {
+        // Cloud providers hit the `_ =>` arm: build_client (no network) +
+        // ensure_slots on empty slot slices (also no network). Both new
+        // `let vllm = VllmProcess::ensure_slots(...)` lines are exercised.
+        let cfg = ProviderConfig {
+            provider: parish_config::Provider::openrouter(),
+            base_url: "http://localhost:9999".to_string(),
+            api_key: Some("test-key".to_string()),
+            model: Some("openrouter/auto".to_string()),
+        };
+        let inf = InferenceConfig::default();
+        let progress = StdoutProgress;
+        match setup_provider_client(&cfg, &[], &[], &inf, &progress).await {
+            Ok((_client, model, procs)) => {
+                assert_eq!(model, "openrouter/auto");
+                assert!(procs.vllm_mlx.is_empty());
+                assert!(procs.vllm.is_empty());
+            }
+            Err(e) => panic!("cloud fallthrough must succeed without network, got: {e}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_setup_provider_client_cloud_requires_model() {
+        let cfg = ProviderConfig {
+            provider: parish_config::Provider::openrouter(),
+            base_url: "http://localhost:9999".to_string(),
+            api_key: Some("test-key".to_string()),
+            model: None,
+        };
+        let inf = InferenceConfig::default();
+        let progress = StdoutProgress;
+        match setup_provider_client(&cfg, &[], &[], &inf, &progress).await {
+            Ok(_) => panic!("openrouter without a model must error"),
+            Err(e) => {
+                let msg = format!("{e}");
+                assert!(
+                    msg.contains("openrouter provider requires a model name"),
+                    "unexpected error: {msg}"
+                );
+            }
+        }
+    }
+
     /// Regression guard for the two-slot loadout: `ensure_slots` must spawn
     /// exactly one process per unique `(base_url, model)` tuple. If two
     /// category overrides point to the same slot, only one server is spawned.

--- a/parish/crates/parish-inference/src/setup.rs
+++ b/parish/crates/parish-inference/src/setup.rs
@@ -1947,7 +1947,47 @@ mod tests {
     fn test_runtime_processes_none_is_no_op() {
         let mut p = RuntimeProcesses::none();
         assert!(p.vllm_mlx.is_empty());
-        p.stop(); // ollama no-op + vllm_mlx empty must not panic
+        assert!(p.vllm.is_empty());
+        p.stop(); // ollama no-op + vllm_mlx empty + vllm empty must not panic
+    }
+
+    #[test]
+    fn test_runtime_processes_default_matches_none() {
+        let p = RuntimeProcesses::default();
+        assert!(p.vllm_mlx.is_empty());
+        assert!(p.vllm.is_empty());
+    }
+
+    #[test]
+    fn test_vllm_process_none_is_no_op() {
+        let mut p = VllmProcess::none();
+        assert!(!p.was_started_by_us());
+        p.stop();
+    }
+
+    #[test]
+    fn test_vllm_slot_eq_and_hash() {
+        use std::collections::HashSet;
+        let a = VllmSlot {
+            base_url: "http://localhost:8001".to_string(),
+            model: "Qwen/Qwen2.5-1.5B-Instruct".to_string(),
+        };
+        let b = a.clone();
+        let c = VllmSlot {
+            base_url: "http://localhost:8000".to_string(),
+            model: "Qwen/Qwen2.5-14B-Instruct".to_string(),
+        };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        let set: HashSet<_> = [a.clone(), b.clone(), c.clone()].iter().cloned().collect();
+        assert_eq!(set.len(), 2, "duplicate slot must dedup in the HashSet");
+    }
+
+    #[tokio::test]
+    async fn test_vllm_process_ensure_slots_empty_input() {
+        // No slots → no spawns, no errors.
+        let out = VllmProcess::ensure_slots(&[]).await.unwrap();
+        assert!(out.is_empty());
     }
 
     /// Regression guard for the two-slot loadout: `ensure_slots` must spawn

--- a/parish/crates/parish-inference/tests/http_mock_tests.rs
+++ b/parish/crates/parish-inference/tests/http_mock_tests.rs
@@ -876,6 +876,7 @@ async fn runtime_processes_stop_cleans_up_multi_slot_bundle() {
     let mut bundle = RuntimeProcesses {
         ollama: parish_inference::setup::OllamaProcess::none(),
         vllm_mlx,
+        vllm: Vec::new(),
     };
     assert_eq!(bundle.vllm_mlx.len(), 2);
 

--- a/parish/crates/parish-server/src/lib.rs
+++ b/parish/crates/parish-server/src/lib.rs
@@ -708,11 +708,13 @@ async fn run_llm_bootstrap(
     config.cloud_base_url = cloud_env.base_url;
 
     let progress = parish_core::inference::setup::StdoutProgress;
-    let extra_slots = config.vllm_mlx_extra_slots();
+    let extra_vllm_mlx_slots = config.vllm_mlx_extra_slots();
+    let extra_vllm_slots = config.vllm_extra_slots();
     let (_setup_client, resolved_model, runtime_procs) =
         parish_core::inference::setup::setup_provider_client(
             &provider_cfg,
-            &extra_slots,
+            &extra_vllm_mlx_slots,
+            &extra_vllm_slots,
             &parish_core::config::InferenceConfig::default(),
             &progress,
         )

--- a/parish/crates/parish-tauri/src/lib.rs
+++ b/parish/crates/parish-tauri/src/lib.rs
@@ -1301,7 +1301,8 @@ pub(crate) fn provider_config_from_env(
 /// rule #2 (mode parity).
 async fn bootstrap_provider(
     config: &ProviderConfig,
-    extra_vllm_slots: &[parish_core::inference::client::VllmMlxSlot],
+    extra_vllm_mlx_slots: &[parish_core::inference::client::VllmMlxSlot],
+    extra_vllm_slots: &[parish_core::inference::client::VllmSlot],
     inference_config: &parish_core::config::InferenceConfig,
     progress: &dyn parish_core::inference::setup::SetupProgress,
 ) -> anyhow::Result<(
@@ -1321,6 +1322,7 @@ async fn bootstrap_provider(
 
     let (client, model, process) = parish_core::inference::setup::setup_provider_client(
         config,
+        extra_vllm_mlx_slots,
         extra_vllm_slots,
         inference_config, // (#417) use TOML-configured timeouts
         progress,

--- a/parish/crates/parish-tauri/src/setup.rs
+++ b/parish/crates/parish-tauri/src/setup.rs
@@ -266,12 +266,13 @@ pub(crate) async fn bootstrap_inference_provider(
             message: "Starting inference provider setup...".to_string(),
         },
     );
-    let extra_vllm_slots = {
+    let (extra_vllm_mlx_slots, extra_vllm_slots) = {
         let cfg = state.config.lock().await;
-        cfg.vllm_mlx_extra_slots()
+        (cfg.vllm_mlx_extra_slots(), cfg.vllm_extra_slots())
     };
     match bootstrap_provider(
         provider_config,
+        &extra_vllm_mlx_slots,
         &extra_vllm_slots,
         inference_config,
         &progress,


### PR DESCRIPTION
## Summary

- Adds a `vllm` provider mod — standard vLLM for Linux/Windows (CUDA/NVIDIA or ROCm/AMD), distinct from `vllmmlx` (macOS Apple Silicon).
- Ported to the data-driven provider-mod system (#968): `parish-config/providers/vllm.toml` is embedded at compile time and loaded into `ProviderRegistry` at startup.
- Mirrors the vllm-mlx two-slot loadout: `VllmSlot`, `VllmProcess` (probe-then-spawn, 60 s readiness wait), `RuntimeProcesses.vllm` field, and `GameConfig::vllm_extra_slots()`.
- `Provider::recommended_for_platform()` now returns vllm on non-macOS instead of ollama.
- `"vllm"` string alias resolves to the Linux variant. Colliding `"vllm"` alias removed from `vllm_mlx.toml` so id-lookup wins; existing vllm-mlx aliases (`vllm-mlx`, `vllm_mlx`, `vllmmlx`) still resolve.
- Wired through all three entry points (CLI, Tauri, web server) — mode parity maintained (CLAUDE.md rule #2).

## Proof

`docs/proofs/vllm-linux-provider/` — transcript + judge verdict (sufficient, debt clear).

## Test plan

- [x] `cargo test -p parish-config -p parish-inference -p parish-core` — 809 passed, 0 failed
- [x] `cargo check --workspace` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `bash parish/scripts/agent-check.sh` passes