### PR TITLE
feat(eval): generalise local-eval scripts to drive cloud providers

### DIFF
--- a/.agents/skills/eval-dialogue/SKILL.md
+++ b/.agents/skills/eval-dialogue/SKILL.md
@@ -38,9 +38,13 @@ gpt-5.5@https://api.openai.com/v1#env:PARISH_OPENAI_API_KEY
 
 4. **Spawn local vllm-mlx processes** on consecutive ports starting at `:8000` for each *local* target. Use `--enable-prefix-cache --continuous-batching`. Save the pid for cleanup. Wait for `/v1/models` to respond before continuing (Monitor with an `until curl ... ; do sleep 2; done` loop). Skip this step entirely if every target is cloud.
 
-5. **Generate dialogue samples** for each target by calling:
+5. **Generate dialogue samples** for each target. First make a per-run temp dir so concurrent `/eval-dialogue` invocations don't collide on `/tmp/cand_*.txt`:
    ```sh
-   python3 parish/scripts/local-eval/gen_dlg.py '<target-spec>' /tmp/cand_<letter>.txt
+   RUN_DIR=$(mktemp -d -t eval-dialogue-XXXXXX)
+   ```
+   Then for each candidate:
+   ```sh
+   python3 parish/scripts/local-eval/gen_dlg.py '<target-spec>' "$RUN_DIR/cand_<letter>.txt"
    ```
    `gen_dlg.py` uses the canonical 5 prompts and writes a transcript plus a `=== Cost: ... ===` footer. Record the cost line per candidate.
 

--- a/.agents/skills/eval-dialogue/SKILL.md
+++ b/.agents/skills/eval-dialogue/SKILL.md
@@ -1,51 +1,63 @@
 ---
 name: eval-dialogue
-description: Blind A/B/N quality evaluation across dialogue-sample transcripts from candidate local-inference models. Generates fresh samples for any requested model list, masks model identities, asks a subagent judge to score each reply on a 5-axis rubric (character, authenticity, language, responsiveness, craft), prints an aggregate scoring table, and archives the report under docs/proofs/local-perf/. Use when comparing dialogue quality between MLX models (Qwen2.5-1.5B / 7B / 14B, future Qwen3.x, gemma swaps, etc.).
+description: Blind A/B/N quality evaluation across dialogue-sample transcripts from candidate models (local MLX or cloud). Generates fresh samples for any requested target list, masks identities, asks a subagent judge to score each reply on a 5-axis rubric (character, authenticity, language, responsiveness, craft), prints an aggregate scoring table with per-candidate USD cost, and archives the report under docs/proofs/local-perf/. Use when comparing dialogue quality across MLX models (Qwen2.5-1.5B / 7B / 14B, future Qwen3.x) and / or cloud providers (Anthropic, OpenAI, Groq, OpenRouter, Together, xAI, Mistral, DeepSeek, NVIDIA NIM, Google's OpenAI-compat endpoint).
 disable-model-invocation: false
-argument-hint: <model-id> <model-id> [<model-id> ...]
+argument-hint: <target-spec> <target-spec> [<target-spec> ...]
 ---
 
-Blind-judge dialogue quality across two or more local-inference models on the same canonical prompt set. Used to decide whether a tier swap (e.g. 7B → 14B) is worth the extra latency.
+Blind-judge dialogue quality across two or more targets on the same canonical prompt set. Used to decide which model + provider combo to wire into `parish-config::presets::preset_models()` for each `InferenceCategory`.
+
+## Target spec
+
+Every target is a `model@base_url[#env:VAR]` string accepted by `eval_lib.parse_target`:
+
+```text
+# Local MLX (no auth)
+mlx-community/Qwen2.5-7B-Instruct-4bit@http://localhost:8000/v1
+
+# Cloud (API key in environment)
+claude-sonnet-4-6@https://api.anthropic.com/v1#env:PARISH_ANTHROPIC_API_KEY
+llama-3.3-70b-versatile@https://api.groq.com/openai/v1#env:PARISH_GROQ_API_KEY
+gpt-5.5@https://api.openai.com/v1#env:PARISH_OPENAI_API_KEY
+```
+
+`mlx-community/*` targets pointing at `http://localhost:*` are treated as local — the skill spawns a vllm-mlx server for each on consecutive ports. Anything else is treated as cloud — no spawn; calls hit the URL directly using the API key from `$VAR`.
 
 ## Inputs
 
-- `$ARGUMENTS` — space-separated Hugging Face model ids in `mlx-community/<name>` form, e.g.
-  ```
-  /eval-dialogue mlx-community/Qwen2.5-7B-Instruct-4bit mlx-community/Qwen2.5-14B-Instruct-4bit
-  ```
-- At least two ids. Three is the sweet spot for an A/B/C with one model abstaining as judge.
+- `$ARGUMENTS` — space-separated target specs.
+- At least two specs. Three is the sweet spot for an A/B/C.
 
 ## Steps
 
-1. **Pre-flight.** Check vllm-mlx is installed (`which vllm-mlx`). If not, tell the user to run `uv tool install vllm-mlx`.
+1. **Classify each target.** Targets whose `base_url` starts with `http://localhost` are *local*. Others are *cloud*. Cloud targets need their `$VAR` set; verify with `printenv $VAR` before continuing and abort if any required key is missing.
 
-2. **The judge is YOU (Claude Opus, in this conversation).** Do NOT spawn a separate judge vllm-mlx process. Run candidates through their own spawned servers, collect replies, then score in the same chat using the 5-axis rubric below. Opus is cross-family and stronger than any local MLX tier, eliminating same-family bias. State this in the report header.
+2. **Pre-flight local targets only.** If any target is local, check `which vllm-mlx`. If missing, tell the user to run `uv tool install vllm-mlx`. Skip this for pure-cloud runs.
 
-3. **Spawn one vllm-mlx process per candidate** on consecutive ports starting at `:8000`. Use `--enable-prefix-cache --continuous-batching`. Save the pid for each so you can clean up on exit. Wait for `/v1/models` to respond on each port before continuing (Monitor with an `until curl ... ; do sleep 2; done` loop).
+3. **The judge is YOU (Claude Opus, in this conversation).** Do not spawn a separate judge process. Opus is cross-family and stronger than any local MLX tier, eliminating same-family bias; for cloud-vs-cloud sweeps it is still the most independent judge available in-chat. State this in the report header along with the judge model id and the date.
 
-4. **Generate dialogue samples** for each candidate using the 5 canonical prompts from `parish/scripts/local-eval/gen_dlg.py`:
-   - "I have been having trouble sleeping. The dreams keep coming back."
-   - "What do you know about the old Cailleach who lives near the fairy fort?"
-   - "My mother is taken with a bad cough. Is there anything you can give her?"
-   - "They say a stranger arrived in the village. Have you heard?"
-   - "I lost a sheep last night. Could it be more than a wolf?"
+4. **Spawn local vllm-mlx processes** on consecutive ports starting at `:8000` for each *local* target. Use `--enable-prefix-cache --continuous-batching`. Save the pid for cleanup. Wait for `/v1/models` to respond before continuing (Monitor with an `until curl ... ; do sleep 2; done` loop). Skip this step entirely if every target is cloud.
 
-   Use the production system prompt from `parish-npc/src/lib.rs::language_directive` (en-IE + ga-IE + non-Latin guard) wrapped around the Brigid persona — see `parish/scripts/local-eval/flaw_scan.py` for the canonical shape.
+5. **Generate dialogue samples** for each target by calling:
+   ```sh
+   python3 parish/scripts/local-eval/gen_dlg.py '<target-spec>' /tmp/cand_<letter>.txt
+   ```
+   `gen_dlg.py` uses the canonical 5 prompts and writes a transcript plus a `=== Cost: ... ===` footer. Record the cost line per candidate.
 
-5. **Score the replies yourself (Opus).** After collecting all candidate replies, build a single transcript bundle in chat — one section per prompt, each candidate labelled `Model X`, `Model Y`, `Model Z`... (no model-name leakage). Apply the 5-axis rubric below to every candidate reply, producing JSON `{character,authenticity,language,responsiveness,craft,overall}` per candidate per prompt. Output 1-5 integers (one decimal for `overall`).
+6. **Score the replies yourself (Opus).** After collecting all transcripts, build a single bundle in chat — one section per prompt, each candidate labelled `Model X`, `Model Y`, `Model Z`... (no model-name leakage). Apply the 5-axis rubric below to every candidate reply, producing JSON `{character,authenticity,language,responsiveness,craft,overall}` per candidate per prompt. Output 1-5 integers (one decimal for `overall`).
 
-6. **Aggregate.** Compute the mean of each axis across all 5 prompts for each candidate. Build a markdown table sorted by **Overall** descending.
+7. **Aggregate.** Compute the mean of each axis across all 5 prompts for each candidate. Build a markdown table sorted by **Overall** descending, including a `Cost (USD)` column from the `gen_dlg.py` cost footer.
 
-7. **Write the report** to `docs/proofs/local-perf/quality_eval_<UTC-stamp>.md` containing:
+8. **Write the report** to `docs/proofs/local-perf/quality_eval_<UTC-stamp>.md` containing:
    - judge model + URL
-   - candidate mapping (Model X → real id)
-   - aggregate table
+   - candidate mapping (Model X → real target spec)
+   - aggregate table (Overall + per-axis + cost)
    - per-prompt detail: each candidate's reply + parsed JSON scores
-   - any prompts where the judge reply failed to parse (kept as a raw block so future tuning can see why)
+   - any prompts where score-parsing failed (kept raw)
 
-8. **Clean up.** Kill every spawned vllm-mlx pid before reporting. `pkill -f Qwen2.5` is a reasonable safety net but kill specific pids first so an unrelated server stays up.
+9. **Clean up.** Kill every spawned vllm-mlx pid. `pkill -f Qwen2.5` is a reasonable safety net but kill specific pids first so an unrelated server stays up. Cloud targets have nothing to clean up.
 
-9. **Print the summary table** to the chat — one line per candidate with the real model id and the Overall score.
+10. **Print the summary table** to chat — one line per candidate with the real target id, the Overall score, and the USD cost.
 
 ## Judge rubric (paste verbatim into the judge system prompt)
 
@@ -69,15 +81,16 @@ mean of the five sub-scores (1-5, one decimal). No prose, no markdown.
 ## Notes
 
 - The judge is itself an LLM and has its own biases — interpret deltas <0.3 as noise.
-- Memory cost: each candidate vllm-mlx process keeps the model resident. On a 32 GB Mac, judge + 2 candidates is comfortable; 3 candidates pushes memory.
-- This skill prefers local judging (no API key required) so the loop runs offline. Switch to a cloud judge by editing `JUDGE_URL` / `JUDGE_MODEL` env vars inside the spawned `urllib` call — leave the env var contract documented when you do.
-- Mirrors the May 2026 manual `dlg-qwen{7,15}.txt` blind compare. That run scored 4.6/5 (7B) vs 2.4/5 (1.5B) and informed the two-slot Apple Silicon loadout; this skill reproduces that workflow automatically.
-- Companion scripts live at `parish/scripts/local-eval/` for direct CLI use without invoking the skill.
+- For cross-family sweeps (MLX vs Claude vs GPT vs Llama), prefer three or four candidates so Opus has more relative signal than absolute.
+- Costs in the aggregate table come from each provider's `usage` block (where reported). Local targets always show $0.00. Static $/M-token rates live in `parish/scripts/local-eval/eval_lib.py::COSTS` — verify those before treating totals as gospel; providers change pricing without warning.
+- Memory cost (local only): each candidate vllm-mlx process keeps the model resident. On a 32 GB Mac, judge + 2 candidates is comfortable; 3 candidates pushes memory. Cloud candidates use no local RAM.
+- Mirrors the May 2026 manual `dlg-qwen{7,15}.txt` blind compare. That run scored 4.6/5 (7B) vs 2.4/5 (1.5B) and informed the two-slot Apple Silicon loadout; this skill reproduces that workflow automatically and now extends it to cloud providers so `preset_models()` can be picked from data instead of guesses.
+- Companion scripts live at `parish/scripts/local-eval/` — `gen_samples.py` (per-category sweep), `flaw_scan.py` (100-prompt non-Latin script audit), `gen_dlg.py` (5-prompt dialogue) all take the same `model@base_url[#env:VAR]` spec.
 
 ## Output contract
 
 After running, summarize in chat:
 1. Judge model + reason for picking it.
-2. Aggregate scoring table.
+2. Aggregate scoring table (Overall + cost).
 3. Path to the saved markdown report.
-4. Recommendation: which candidate is best, and whether the delta is large enough to justify a tier swap given the memory / latency cost difference.
+4. Recommendation: which candidate is best, and whether the delta is large enough to justify a preset swap given the cost / latency difference.

--- a/docs/proofs/local-perf/dialogue_flaw_scan_gpt_oss_120b_free.md
+++ b/docs/proofs/local-perf/dialogue_flaw_scan_gpt_oss_120b_free.md
@@ -1,0 +1,142 @@
+# Dialogue flaw scan — 25 prompts on `gpt-oss-120b:free`
+
+Target: `openai/gpt-oss-120b:free` at `https://openrouter.ai/api/v1`.
+
+Flagged 1/25 (4%) for non-Latin script leakage or empty/over-long output.
+
+Run cost: 25 calls, 8,243 in + 2,290 out tokens, ~$0.0000.
+
+## Flagged samples
+
+### #24 — error:'choices'
+**Prompt:** Were you born in this parish?
+
+**Output:**
+> 
+
+## All 25 prompts + responses
+
+### #1
+**Q:** I have been having trouble sleeping. The dreams keep coming back.
+
+**A:** Ah, lass, a cup o’ chamomile tea before bed and a few drops of lavender oil on the pillow’ll do ye. If the dreams still haunt ye, a poultice of nettle leaf and a little honey before sleep may calm the spirit. Take care, and let me know if it eases.
+
+### #2
+**Q:** What do you know about the old Cailleach who lives near the fairy fort?
+
+**A:** Ah, the Cailleach o’ the hill‑top near the sí dún—she’s the ancient hag of the stone, keeper of the winter’s cold and the wild herbs that grow ‘neath her shade. ’Tis said she’ll grant a blessing to those who bring her a sprig of rowan and a cup of fresh milk, but cross her and the wind will drive ye mad. Keep yer respect, and perhaps she’ll whisper the cure for a fever, otherwise best not tempt the old woman’s wrath.
+
+### #3
+**Q:** My mother is taken with a bad cough. Is there anything you can give her?
+
+**A:** Ah sure, a cuppa tea brewed with a handful of fresh thyme and a touch of honey will soothe her throat, and a poultice of boiled nettle leaves pressed warm against the chest can ease the cough; be sure she rests and drinks plenty of water from the well.
+
+### #4
+**Q:** They say a stranger arrived in the village. Have you heard?
+
+**A:** Aye, I’ve heard the talk. A gaunt fellow came in on a cart last night, muttering about “healing arts” and asking for the wild thyme near the lough. He seemed harmless enough, but keep a wary eye, lad.
+
+### #5
+**Q:** I lost a sheep last night. Could it be more than a wolf?
+
+**A:** Ah sure, a wolf could take a ewe, but oft it’s the hungry hounds or a stray dog that nips at the flock. Check the tracks in the heather and keep a shepherd’s crook handy—if the beast is a wolf, the prints’ll be deeper and set farther apart.
+
+### #6
+**Q:** Do you remember when my father broke his leg in the south field?
+
+**A:** Ah, sure I recall that day well – your da fell in the clodded field near the old oak, and we had to set his leg with a splint of ash and a bit of linseed oil ’til the bone knit proper.
+
+### #7
+**Q:** I saw lights moving on the hill last night. What were they?
+
+**A:** Ah, those flickerin’ lights are likely the will‑o‑the‑wisp, the síthe‑folk’s lanterns on the hill; they’re naught but warm gases from the peat, not a sign o’ danger. If ye feel uneasy, say a quick prayer to the Bóithrín and keep yer lantern lit.
+
+### #8
+**Q:** The well water tastes strange this week. Should I be worried?
+
+**A:** Ah sure, if the water’s taken on a sour or metallic taste it may be leeching from the stones or a recent rain has washed in some rotting leaf‑matter. Bring a clean jug to the well, let it stand a while and taste a small sip; if the flavour lingers or makes you feel queasy, fetch some fresh spring water till we can see if the well’s been disturbed. I’ll come by tomorrow and we’ll give it a proper look, agus feicfimid an fadhb.
+
+### #9
+**Q:** My wife is heavy with child. When should I fetch you?
+
+**A:** Ah, sure, when the belly’s round as a full moon and she's feeling the cramps or the tide’s turning, send for me straightaway, lad. No time like the first signs of labour, or if any trouble brews.
+
+### #10
+**Q:** Father Cathal preached against the old ways on Sunday. What do you think?
+
+**A:** Ah, Cathal’s tongue may be swift, but the folk ways have kept our bairns from many a fever; a good cuileann of comfrey and a wash of sow thistle can mend what prayer alone cannot. Faith and herb alike have their place, so long as we mind the balance.
+
+### #11
+**Q:** Have you any cure for a toothache that will not let me rest?
+
+**A:** Ah, a tooth that gnaws at ye night, ’tis a cruel beast. Brew a strong tea of clove and a pinch of salt, swish it warm ’round the sore, and then chew a bit of crushed rosemary leaf on the aching side; if ’tis still fierce, a poultice of mashed yarrow and a few drops of linseed oil will ease the pain till the morning. An crú na bhruaich, as we say, will keep the ache at bay.
+
+### #12
+**Q:** I cut my hand on a scythe and the wound runs hot. What should I do?
+
+**A:** Press a clean cloth o’er the cut and run a little cold water over it, then dab a poultice of fresh yarrow (linné) or comfrey leaf, binding it with a strip of linen; keep it dry and change the dressing daily, and if the heat lingers or pus appears, send for the parish doctor straight away.
+
+### #13
+**Q:** Is it true that you delivered the Maguire twins?
+
+**A:** Aye, I did bring the Maguire twins into the world—fine lads, both as healthy as a hare in spring.
+
+### #14
+**Q:** The crows have been gathering at the crossroads. Is it an omen?
+
+**A:** Ah, the crows at the crossroads are naught but a sign that the wind’s changed, not a doom. ’Tis a warning to mind the hearth and keep the doors shut tight till the storm passes. Take a sprig of rowan and hang it above the lintel – it’ll keep the ill‑omen at bay.
+
+### #15
+**Q:** I dreamt of my dead grandmother three nights running. What does it mean?
+
+**A:** Ah, a spirit returning in a chase often means she’s trying to warn ye of some danger or unfinished business, perhaps a fever or a wound that needs watchin’; pray to Saint Brigid and lay a sprig of rowan by her bedside, and keep a keen eye on the young ones’ health.
+
+### #16
+**Q:** How does one ward off the evil eye?
+
+**A:** Ah, the evil eye o’ a child can be a cruel thing; a sprig of rosemary pressed to the brow each morn and a few drops of blessed water from the well will turn it away, and never forget to say “Lá na gréine” when the sun rises, for the light itself chases the malann.
+
+### #17
+**Q:** The cow's milk has gone bloody. The farmer says it's pixies.
+
+**A:** Ah sure, a bloody milk means the udder’s sore or a worm’s got in the teats; fetch a wash of warm water and a poultice of comfrey, and call the farmer to have the beast examined afore any pixie tales take hold.
+
+### #18
+**Q:** Tell me about the herbs that grow on the bog.
+
+**A:** Ah, the bog yields bláth na bhFionna—heather, bog rosemary and the bitter-sweet carragheen, plus the humble bog myrtle for a good tea; all grow in the peat’s damp loam, and a pinch of the ash‑y fernleaf can ease a cough.
+
+### #19
+**Q:** My boy will not stop crying through the night.
+
+**A:** Ah, poor lad, a restless night can be a sign o’ a swollen belly or a cold wind in his chest. Try a poultice of comfrey and nettle leaves, warm it a wee bit and lay it ’neath his back, and give him a sip of warm milk sweetened with a touch of honey; if the crying still lingers, bring him inside for a gentle chest‑rub with a little lavender oil and watch him settle.
+
+### #20
+**Q:** What plants do you keep for fever?
+
+**A:** Ah, a fever‑ish child needs the tea of elderflower and a poultice of yarrow, and if the heat climbs, a dash of feverfew leaf boiled in water will bring the sweat down. I also keep a few sprigs of rosemary for the night’s rest.
+
+### #21
+**Q:** The blacksmith's wife is barren. Could you help her?
+
+**A:** Aye, dear, I’ll fetch her some elderflower tea and a poultice of comfrey, and we’ll pray to Máthair na bhFlaitheas for a blessed bairn. Take care she rests, avoids heavy lifting, and eats plenty of oat bannocks with butter.
+
+### #22
+**Q:** I am afraid of what the priest would say if he knew I came to you.
+
+**A:** Ah, fear not, child. The priest may mutter his sermons, but a mother’s love and a proper herb can mend more than any sermon can scold. Come, sit and tell me what ails ye, and we’ll set it right.
+
+### #23
+**Q:** How long have you been a midwife?
+
+**A:** Ah, I've been tending the bairns for near twenty years now, ever since I took over after my aunt died. The work's a hard road, but the folk here trust the old ways.
+
+### #24 ⚠ error:'choices'
+**Q:** Were you born in this parish?
+
+**A:** 
+
+### #25
+**Q:** Did your mother teach you the healing ways?
+
+**A:** Aye, my mam taught me the old ways – the nettle tea for fevers, the yarrow for wounds, and the clover‑leaf charms for restless babes. She’d whisper the old Irish prayers as we gathered the herbs, and I’ve kept them close ever since.

--- a/parish/scripts/local-eval/README.md
+++ b/parish/scripts/local-eval/README.md
@@ -1,15 +1,24 @@
-# Local inference evaluation scripts
+# Inference evaluation scripts (local + cloud)
 
-Lightweight Python scripts that drive a running vllm-mlx (or any
-OpenAI-compatible) server with Parish's production prompt fixtures.
-Used to spot-check dialogue quality and detect non-Latin script
-leakage when swapping the macOS local-runtime model tier.
+Lightweight Python scripts that drive any OpenAI-compatible chat-completion
+endpoint with Parish's production prompt fixtures. Used to spot-check
+dialogue quality, detect non-Latin script leakage, and produce the data
+that backs `parish-config::presets::preset_models()` — replacing guessed
+model picks with measured winners.
+
+All scripts share `eval_lib.py`, which defines the `Target` abstraction:
+
+```text
+model@base_url                          # local, no auth
+model@base_url#env:VAR                  # cloud, API key in $VAR
+```
 
 | Script | Purpose | Output |
 |---|---|---|
-| `gen_samples.py` | Renders **2 examples per inference category** (Intent, Reaction, Tier 2 Sim, Tier 3 Sim, Dialogue) using the production prompt builders mirrored from [`parish-inference/examples/inf_bench.rs`](../../crates/parish-inference/examples/inf_bench.rs). Hits the two-slot loadout (small slot on `:8001`, large on `:8000`). | `docs/proofs/local-perf/category_samples.md` |
-| `flaw_scan.py` | Runs **100 dialogue prompts** through the Dialogue slot and flags responses containing non-Latin scripts (Cyrillic, Han, Hiragana, Katakana, Hangul, Arabic, Hebrew, Greek, Devanagari), empty output, or > 800 char output. | `docs/proofs/local-perf/dialogue_flaw_scan*.md` |
-| `gen_dlg.py` | Streaming-SSE 5-prompt dialogue sampler (older, kept for ad-hoc blind A/B compares with a single command-line `<model> <out_path>` invocation). | path supplied on CLI |
+| `gen_samples.py` | Renders **2 examples per inference category** (Intent, Reaction, Tier 2 Sim, Tier 3 Sim, Dialogue) using the production prompt builders mirrored from [`parish-inference/examples/inf_bench.rs`](../../crates/parish-inference/examples/inf_bench.rs). Takes `--small` and `--large` target specs; defaults reproduce the two-slot vllm-mlx loadout. | `docs/proofs/local-perf/category_samples.md` |
+| `flaw_scan.py` | Runs **N dialogue prompts** through one target and flags responses containing non-Latin scripts (Cyrillic, Han, Hiragana, Katakana, Hangul, Arabic, Hebrew, Greek, Devanagari), empty output, or > 800 char output. `--prompts` / `--workers` configurable. | `docs/proofs/local-perf/dialogue_flaw_scan*.md` |
+| `gen_dlg.py` | 5-prompt canonical dialogue sampler — paired with `/eval-dialogue` for blind A/B/N. Takes a single target spec + output path. | path supplied on CLI |
+| `eval_lib.py` | Shared `Target`, `parse_target`, `call_chat`, `CostTracker`, and `COSTS` table. | — |
 
 For blind-judge quality scoring across two or more models, prefer the
 [`/eval-dialogue`](../../../.agents/skills/eval-dialogue/SKILL.md) Claude
@@ -18,37 +27,53 @@ and archives a scoring report under `docs/proofs/local-perf/` in one go.
 
 ## Prerequisites
 
-1. `uv tool install vllm-mlx` (Apple Silicon only).
-2. Pull the model(s) under test; first launch will fetch from
-   Hugging Face. Example for the current two-slot loadout:
+### Local (Apple Silicon)
+
+1. `uv tool install vllm-mlx`.
+2. Spawn the slots before running. Example two-slot loadout:
    ```sh
-   # large slot (Dialogue)
    vllm-mlx serve mlx-community/Qwen2.5-7B-Instruct-4bit \
        --port 8000 --enable-prefix-cache --continuous-batching &
-   # small slot (Intent / Reaction / Simulation)
    vllm-mlx serve mlx-community/Qwen2.5-1.5B-Instruct-4bit \
        --port 8001 --enable-prefix-cache --continuous-batching &
    ```
 
+### Cloud
+
+Set the relevant `PARISH_*_API_KEY` env var (matches Parish runtime
+conventions) and reference it in the target spec via `#env:VAR`:
+
+```sh
+export PARISH_ANTHROPIC_API_KEY=sk-ant-...
+export PARISH_GROQ_API_KEY=gsk-...
+export PARISH_OPENAI_API_KEY=sk-...
+```
+
 ## Running the scripts
 
 ```sh
-# Production-faithful 2-per-category samples
+# Local two-slot vllm-mlx — defaults
 python3 parish/scripts/local-eval/gen_samples.py
 
-# 100-prompt flaw scan (defaults to large slot on :8000)
-python3 parish/scripts/local-eval/flaw_scan.py
+# Cross-provider: Groq small slot, Claude large slot
+python3 parish/scripts/local-eval/gen_samples.py \
+    --small 'llama-3.1-8b-instant@https://api.groq.com/openai/v1#env:PARISH_GROQ_API_KEY' \
+    --large 'claude-sonnet-4-6@https://api.anthropic.com/v1#env:PARISH_ANTHROPIC_API_KEY'
 
-# 5-prompt dialogue sampler — useful for blind compares between models
+# Cloud flaw scan, lower concurrency to stay under rate limits
+python3 parish/scripts/local-eval/flaw_scan.py \
+    --target 'claude-sonnet-4-6@https://api.anthropic.com/v1#env:PARISH_ANTHROPIC_API_KEY' \
+    --prompts 25 --workers 2
+
+# Blind dialogue sample for one target (used by /eval-dialogue)
 python3 parish/scripts/local-eval/gen_dlg.py \
-    mlx-community/Qwen2.5-14B-Instruct-4bit \
+    'mlx-community/Qwen2.5-14B-Instruct-4bit@http://localhost:8000/v1' \
     /tmp/dlg-qwen14.txt
 ```
 
-Each script edits the model name + output path at the top of the file.
-When benchmarking a new tier (Qwen2.5-14B, future Qwen3.x, etc.), copy
-the script, change the constants, run, archive the output under
-`docs/proofs/local-perf/`.
+Every run prints a `cost: N calls, X in + Y out tokens, ~$Z.ZZZZ` footer
+sourced from each call's `usage` block. Static $/M-token rates live in
+`eval_lib.py::COSTS` — verify before treating totals as gospel.
 
 ## Why keep these alongside the proof bundle?
 

--- a/parish/scripts/local-eval/eval_lib.py
+++ b/parish/scripts/local-eval/eval_lib.py
@@ -129,7 +129,13 @@ def call_chat(
                 time.sleep(wait)
                 continue
             raise
-    text = data["choices"][0]["message"]["content"] or ""
+    try:
+        text = data["choices"][0]["message"]["content"] or ""
+    except (KeyError, IndexError, TypeError) as e:
+        raise ValueError(
+            f"unexpected chat-completion response shape ({type(e).__name__}: {e}). "
+            f"Full response: {data}"
+        ) from e
     usage = data.get("usage") or {}
     return text, {
         "prompt_tokens": int(usage.get("prompt_tokens", 0)),

--- a/parish/scripts/local-eval/eval_lib.py
+++ b/parish/scripts/local-eval/eval_lib.py
@@ -1,0 +1,203 @@
+"""Shared target abstraction for local + cloud OpenAI-compatible eval scripts.
+
+A `Target` names an OpenAI-compatible chat-completions endpoint: a base URL,
+a model id, and (optionally) an environment variable holding the API key.
+Local vllm-mlx slots and cloud providers (OpenAI, Groq, OpenRouter, Together,
+xAI, Mistral, DeepSeek, NVIDIA NIM, Google's OpenAI-compat endpoint, the
+Anthropic `/v1` OpenAI-compat shim, vLLM, Ollama, LM Studio) all fit.
+
+`parse_target` accepts a compact spec string:
+
+    model@base_url                      # local, no auth
+    model@base_url#env:VAR              # cloud, API key in $VAR
+
+Example::
+
+    parse_target("gpt-5.5@https://api.openai.com/v1#env:PARISH_OPENAI_API_KEY")
+
+`call_chat` returns `(text, usage)` where `usage` is a dict with
+`prompt_tokens` and `completion_tokens` keys (zeros if the server omits
+them). `estimate_cost` consults the static `COSTS` table; unknown models
+return 0.0 so the framework keeps working without prices.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class Target:
+    """OpenAI-compatible chat-completions endpoint."""
+
+    model: str
+    base_url: str
+    api_key_env: Optional[str] = None
+
+    def label(self) -> str:
+        """Short human label: bare model name without org prefix."""
+        return self.model.split("/")[-1]
+
+    def api_key(self) -> Optional[str]:
+        if not self.api_key_env:
+            return None
+        key = os.environ.get(self.api_key_env)
+        if not key:
+            raise RuntimeError(
+                f"target {self.model} requires API key in ${self.api_key_env} but env is empty"
+            )
+        return key
+
+
+def parse_target(spec: str) -> Target:
+    """Parse `model@base_url[#env:VAR]` into a `Target`."""
+    if "@" not in spec:
+        raise ValueError(f"target spec must contain '@base_url': {spec!r}")
+    model, rest = spec.split("@", 1)
+    api_key_env: Optional[str] = None
+    if "#" in rest:
+        base_url, suffix = rest.split("#", 1)
+        if not suffix.startswith("env:"):
+            raise ValueError(f"target suffix must start with 'env:': {suffix!r}")
+        api_key_env = suffix[len("env:"):]
+    else:
+        base_url = rest
+    return Target(model=model.strip(), base_url=base_url.strip(), api_key_env=api_key_env)
+
+
+def call_chat(
+    target: Target,
+    system: Optional[str],
+    user: str,
+    *,
+    schema: Optional[dict] = None,
+    max_tokens: Optional[int] = None,
+    temperature: float = 0.7,
+    timeout: float = 180.0,
+    max_retries: int = 4,
+) -> Tuple[str, dict]:
+    """POST a single chat-completion. Returns `(text, usage)`.
+
+    Retries on HTTP 429 / 503 using the `Retry-After` header (capped at 60 s)
+    or exponential backoff (1, 2, 4, 8 s). Free-tier OpenRouter upstream
+    rate-limits in particular benefit from this.
+    """
+    msgs: list[dict] = []
+    if system:
+        msgs.append({"role": "system", "content": system})
+    msgs.append({"role": "user", "content": user})
+    body: dict = {
+        "model": target.model,
+        "messages": msgs,
+        "stream": False,
+        "temperature": temperature,
+    }
+    if max_tokens is not None:
+        body["max_tokens"] = max_tokens
+    if schema is not None:
+        body["response_format"] = {"type": "json_schema", "json_schema": schema}
+    headers = {"Content-Type": "application/json"}
+    key = target.api_key()
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    url = f"{target.base_url.rstrip('/')}/chat/completions"
+
+    attempt = 0
+    while True:
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(body).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.load(resp)
+            break
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 503) and attempt < max_retries:
+                retry_after = e.headers.get("Retry-After")
+                wait = min(float(retry_after), 60.0) if retry_after else 2 ** attempt
+                attempt += 1
+                print(f"  [{e.code}] retry {attempt}/{max_retries} after {wait:.0f}s ({target.model})")
+                time.sleep(wait)
+                continue
+            raise
+    text = data["choices"][0]["message"]["content"] or ""
+    usage = data.get("usage") or {}
+    return text, {
+        "prompt_tokens": int(usage.get("prompt_tokens", 0)),
+        "completion_tokens": int(usage.get("completion_tokens", 0)),
+    }
+
+
+# USD per 1M tokens (input, output). Verify before relying on totals — these
+# are static reference values and providers change pricing without warning.
+# Keep entries keyed by exact `model` id used in API calls. Unknown ids
+# return 0.0 in `estimate_cost`.
+COSTS: dict[str, Tuple[float, float]] = {
+    # Anthropic (verify at console.anthropic.com)
+    "claude-opus-4-7": (15.00, 75.00),
+    "claude-sonnet-4-6": (3.00, 15.00),
+    "claude-haiku-4-5": (1.00, 5.00),
+    # OpenAI (verify at openai.com/api/pricing)
+    "gpt-5.5": (0.0, 0.0),
+    "gpt-5.4-mini": (0.0, 0.0),
+    "gpt-5.4-nano": (0.0, 0.0),
+    # Google
+    "gemini-2.5-pro": (0.0, 0.0),
+    "gemini-2.5-flash": (0.0, 0.0),
+    "gemini-2.5-flash-lite": (0.0, 0.0),
+    # Groq
+    "openai/gpt-oss-120b": (0.0, 0.0),
+    "llama-3.3-70b-versatile": (0.59, 0.79),
+    "llama-3.1-8b-instant": (0.05, 0.08),
+    # xAI
+    "grok-4.20-reasoning": (0.0, 0.0),
+    "grok-4.20-non-reasoning": (0.0, 0.0),
+    "grok-4.1-fast-non-reasoning": (0.0, 0.0),
+    # Local (free)
+    "mlx-community/Qwen2.5-1.5B-Instruct-4bit": (0.0, 0.0),
+    "mlx-community/Qwen2.5-7B-Instruct-4bit": (0.0, 0.0),
+    "mlx-community/Qwen2.5-14B-Instruct-4bit": (0.0, 0.0),
+}
+
+
+def estimate_cost(target: Target, usage: dict) -> float:
+    """USD cost for one call. Unknown models cost 0.0 (free or unverified)."""
+    rates = COSTS.get(target.model)
+    if not rates:
+        return 0.0
+    in_per_M, out_per_M = rates
+    pt = usage.get("prompt_tokens", 0)
+    ct = usage.get("completion_tokens", 0)
+    return pt / 1_000_000 * in_per_M + ct / 1_000_000 * out_per_M
+
+
+class CostTracker:
+    """Accumulates token + USD totals across a run."""
+
+    def __init__(self) -> None:
+        self.prompt_tokens = 0
+        self.completion_tokens = 0
+        self.usd = 0.0
+        self.calls = 0
+
+    def record(self, target: Target, usage: dict) -> None:
+        self.prompt_tokens += usage.get("prompt_tokens", 0)
+        self.completion_tokens += usage.get("completion_tokens", 0)
+        self.usd += estimate_cost(target, usage)
+        self.calls += 1
+
+    def summary(self) -> str:
+        return (
+            f"{self.calls} calls, "
+            f"{self.prompt_tokens:,} in + {self.completion_tokens:,} out tokens, "
+            f"~${self.usd:.4f}"
+        )

--- a/parish/scripts/local-eval/flaw_scan.py
+++ b/parish/scripts/local-eval/flaw_scan.py
@@ -1,13 +1,39 @@
 #!/usr/bin/env python3
-"""Run 100 dialogue prompts through Qwen2.5-7B; flag non-Latin script leakage."""
-import json
-import re
-import unicodedata
-import urllib.request
-from concurrent.futures import ThreadPoolExecutor, as_completed
+"""Run N dialogue prompts through one target; flag non-Latin script leakage.
 
-MODEL = "mlx-community/Qwen2.5-14B-Instruct-4bit"
-PORT = 8000
+Target is a `model@base_url[#env:VAR]` spec (see `eval_lib.parse_target`).
+Default reproduces the macOS vllm-mlx large-slot run.
+
+Examples::
+
+    # default vllm-mlx large slot (Qwen2.5-14B on :8000)
+    python3 flaw_scan.py
+
+    # cloud: Claude Sonnet 4.6 via Anthropic's OpenAI-compat endpoint
+    python3 flaw_scan.py \\
+        --target 'claude-sonnet-4-6@https://api.anthropic.com/v1#env:PARISH_ANTHROPIC_API_KEY' \\
+        --output docs/proofs/local-perf/dialogue_flaw_scan_sonnet.md \\
+        --prompts 25
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import unicodedata
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from eval_lib import CostTracker, Target, call_chat, parse_target  # noqa: E402
+
+DEFAULT_TARGET = "mlx-community/Qwen2.5-14B-Instruct-4bit@http://localhost:8000/v1"
+DEFAULT_OUTPUT = (
+    Path(__file__).resolve().parents[3]
+    / "docs"
+    / "proofs"
+    / "local-perf"
+    / "dialogue_flaw_scan.md"
+)
 
 SYSTEM = (
     "You are Brigid O'Brien, a 42-year-old midwife in rural Ireland, 1820. "
@@ -15,8 +41,8 @@ SYSTEM = (
     "You have known the player's family for years.\n\n"
     "LANGUAGE: Speak in en-IE (Hiberno-English). "
     "Use spelling, idioms, and conventions appropriate to en-IE. "
-    "Never use en-US spellings such as \"color\", \"realize\", \"favor\", "
-    "\"neighbor\", or \"-ize\" verb endings — use the en-IE form. "
+    'Never use en-US spellings such as "color", "realize", "favor", '
+    '"neighbor", or "-ize" verb endings — use the en-IE form. '
     "Where a native speaker would naturally code-switch, sprinkle words and "
     "short phrases from ga-IE (Irish Gaeilge) into your dialogue. "
     "Use ONLY en-IE and ga-IE. "
@@ -134,42 +160,18 @@ PROMPTS = [
     "My grandfather is dying. How long should I sit with him?",
     "What was the worst winter you ever lived through?",
 ]
-PROMPTS = PROMPTS[:100]
-assert len(PROMPTS) == 100, len(PROMPTS)
+assert len(PROMPTS) >= 100, len(PROMPTS)
 
 
-def call(prompt):
-    body = {
-        "model": MODEL,
-        "messages": [
-            {"role": "system", "content": SYSTEM},
-            {"role": "user", "content": prompt},
-        ],
-        "stream": False,
-        "temperature": 0.7,
-    }
-    req = urllib.request.Request(
-        f"http://localhost:{PORT}/v1/chat/completions",
-        data=json.dumps(body).encode("utf-8"),
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=120) as resp:
-        return json.load(resp)["choices"][0]["message"]["content"]
-
-
-# Map character → unicode script (e.g. "Latin", "Cyrillic", "Han", "Hiragana")
-def chars_by_script(text):
-    bad = {}  # script -> set of chars
+def chars_by_script(text: str) -> dict[str, set[str]]:
+    bad: dict[str, set[str]] = {}
     for c in text:
         if c.isspace() or not c.isprintable():
             continue
         try:
-            name = unicodedata.name(c)
+            unicodedata.name(c)
         except ValueError:
             continue
-        # First word of the name is usually the script for letters.
-        # Better: use unicodedata.category + range.
         cp = ord(c)
         script = None
         if 0x0400 <= cp <= 0x04FF or 0x0500 <= cp <= 0x052F:
@@ -195,12 +197,11 @@ def chars_by_script(text):
     return bad
 
 
-def flaws(text):
-    found = []
+def flaws(text: str) -> list[str]:
+    found: list[str] = []
     by_script = chars_by_script(text)
     for script, chars in by_script.items():
         found.append(f"{script}({''.join(sorted(chars))})")
-    # Additional flaw signals
     if not text.strip():
         found.append("empty")
     if len(text) > 800:
@@ -208,53 +209,76 @@ def flaws(text):
     return found
 
 
-def run_one(idx, prompt):
+def run_one(idx: int, prompt: str, target: Target) -> tuple[int, str, str, list[str], dict]:
     try:
-        out = call(prompt)
+        out, usage = call_chat(target, SYSTEM, prompt, max_tokens=200)
     except Exception as e:
-        return idx, prompt, "", [f"error:{e}"]
-    return idx, prompt, out, flaws(out)
+        return idx, prompt, "", [f"error:{e}"], {}
+    return idx, prompt, out, flaws(out), usage
 
 
-def main():
-    results = []
-    with ThreadPoolExecutor(max_workers=4) as pool:
-        futs = [pool.submit(run_one, i, p) for i, p in enumerate(PROMPTS, 1)]
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--target", default=DEFAULT_TARGET,
+                    help=f"Target spec (default: {DEFAULT_TARGET})")
+    ap.add_argument("--output", default=str(DEFAULT_OUTPUT),
+                    help=f"Markdown report path (default: {DEFAULT_OUTPUT})")
+    ap.add_argument("--prompts", type=int, default=100,
+                    help="Number of prompts to run (default: 100, max: %d)" % len(PROMPTS))
+    ap.add_argument("--workers", type=int, default=4,
+                    help="Concurrent requests (default: 4; lower for rate-limited cloud)")
+    args = ap.parse_args()
+
+    target = parse_target(args.target)
+    n_prompts = min(args.prompts, len(PROMPTS))
+    selected = PROMPTS[:n_prompts]
+
+    print(f"target: {target.model} @ {target.base_url}")
+    print(f"running {n_prompts} prompts with {args.workers} workers")
+
+    tracker = CostTracker()
+    results: list[tuple[int, str, str, list[str], dict]] = []
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futs = [pool.submit(run_one, i, p, target) for i, p in enumerate(selected, 1)]
         for fut in as_completed(futs):
-            idx, prompt, out, fs = fut.result()
-            results.append((idx, prompt, out, fs))
+            idx, prompt, out, fs, usage = fut.result()
+            tracker.record(target, usage)
+            results.append((idx, prompt, out, fs, usage))
             tag = " ".join(fs) if fs else "ok"
             print(f"[{idx:3d}] {tag}")
     results.sort()
     flawed = [r for r in results if r[3]]
     print()
-    print(f"=== {len(flawed)}/{len(results)} ({len(flawed) * 100 / len(results):.0f}%) flagged ===")
-    for idx, prompt, out, fs in flawed:
+    print(f"=== {len(flawed)}/{len(results)} ({len(flawed) * 100 / max(1, len(results)):.0f}%) flagged ===")
+    for idx, prompt, out, fs, _u in flawed:
         print(f"\n#{idx}  flaws: {fs}")
         print(f"  Q: {prompt}")
         print(f"  A: {out.strip()[:400]}")
-    out_path = "/Users/dmooney/Rundale/.claude/worktrees/piped-imagining-meerkat/docs/proofs/local-perf/dialogue_flaw_scan_14b.md"
+    print(f"\ncost: {tracker.summary()}")
+
     lines = [
-        "# Dialogue flaw scan — 100 prompts on Qwen2.5-7B-Instruct-4bit\n",
-        f"\nFlagged {len(flawed)}/{len(results)} ({len(flawed) * 100 / len(results):.0f}%) for non-Latin script leakage or empty/over-long output.\n",
+        f"# Dialogue flaw scan — {n_prompts} prompts on `{target.label()}`\n",
+        f"\nTarget: `{target.model}` at `{target.base_url}`.\n",
+        f"\nFlagged {len(flawed)}/{len(results)} ({len(flawed) * 100 / max(1, len(results)):.0f}%) for non-Latin script leakage or empty/over-long output.\n",
+        f"\nRun cost: {tracker.summary()}.\n",
         "\n## Flagged samples\n",
     ]
     if flawed:
-        for idx, prompt, out, fs in flawed:
+        for idx, prompt, out, fs, _u in flawed:
             lines.append(f"\n### #{idx} — {', '.join(fs)}\n")
             lines.append(f"**Prompt:** {prompt}\n")
             lines.append(f"\n**Output:**\n> {out.strip().replace(chr(10), chr(10) + '> ')}\n")
     else:
         lines.append("\n_None._\n")
-    lines.append("\n## All 100 prompts + responses\n")
-    for idx, prompt, out, fs in results:
+    lines.append(f"\n## All {n_prompts} prompts + responses\n")
+    for idx, prompt, out, fs, _u in results:
         tag = " ⚠ " + " ".join(fs) if fs else ""
         lines.append(f"\n### #{idx}{tag}\n")
         lines.append(f"**Q:** {prompt}\n")
         lines.append(f"\n**A:** {out.strip()}\n")
-    with open(out_path, "w") as f:
-        f.write("".join(lines))
-    print(f"\nwrote {out_path}")
+    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output).write_text("".join(lines))
+    print(f"\nwrote {args.output}")
 
 
 if __name__ == "__main__":

--- a/parish/scripts/local-eval/gen_dlg.py
+++ b/parish/scripts/local-eval/gen_dlg.py
@@ -14,6 +14,7 @@ Usage::
 """
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -37,11 +38,13 @@ PROMPTS = [
 
 
 def main() -> None:
-    if len(sys.argv) != 3:
-        print("usage: gen_dlg.py <target-spec> <output-path>", file=sys.stderr)
-        sys.exit(2)
-    target = parse_target(sys.argv[1])
-    out_path = Path(sys.argv[2])
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("target", help="Target spec: 'model@base_url[#env:VAR]'")
+    ap.add_argument("output", help="Output path for the transcript")
+    args = ap.parse_args()
+
+    target = parse_target(args.target)
+    out_path = Path(args.output)
 
     tracker = CostTracker()
     lines = [f"=== Target: {target.model} @ {target.base_url} ===\n"]

--- a/parish/scripts/local-eval/gen_dlg.py
+++ b/parish/scripts/local-eval/gen_dlg.py
@@ -1,15 +1,24 @@
 #!/usr/bin/env python3
-"""Generate dialogue samples from a vllm-mlx model on identical prompts.
+"""Generate the canonical 5-prompt dialogue sample for one target.
 
-Usage:
-  python3 gen_dlg.py <model> <output_path>
+Used by the `/eval-dialogue` skill to score candidate models blind-judge.
+Target is a `model@base_url[#env:VAR]` spec (see `eval_lib.parse_target`).
+
+Usage::
+
+    # local vllm-mlx
+    python3 gen_dlg.py 'mlx-community/Qwen2.5-7B-Instruct-4bit@http://localhost:8000/v1' /tmp/cand_a.txt
+
+    # cloud
+    python3 gen_dlg.py 'claude-sonnet-4-6@https://api.anthropic.com/v1#env:PARISH_ANTHROPIC_API_KEY' /tmp/cand_b.txt
 """
-import json
-import sys
-import urllib.request
+from __future__ import annotations
 
-MODEL = sys.argv[1]
-OUT = sys.argv[2]
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from eval_lib import CostTracker, call_chat, parse_target  # noqa: E402
 
 SYSTEM = (
     "You are Brigid O'Brien, a 42-year-old midwife in rural Ireland, 1820. "
@@ -27,45 +36,24 @@ PROMPTS = [
 ]
 
 
-def call(prompt: str) -> str:
-    body = {
-        "model": MODEL,
-        "messages": [
-            {"role": "system", "content": SYSTEM},
-            {"role": "user", "content": prompt},
-        ],
-        "stream": True,
-        "max_tokens": 120,
-        "temperature": 0.7,
-    }
-    req = urllib.request.Request(
-        "http://localhost:8000/v1/chat/completions",
-        data=json.dumps(body).encode("utf-8"),
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    chunks = []
-    with urllib.request.urlopen(req, timeout=60) as resp:
-        for line in resp:
-            line = line.decode("utf-8").strip()
-            if not line.startswith("data: "):
-                continue
-            data_part = line[len("data: "):]
-            if data_part == "[DONE]":
-                break
-            try:
-                obj = json.loads(data_part)
-                delta = obj["choices"][0].get("delta", {}).get("content")
-                if delta:
-                    chunks.append(delta)
-            except Exception:
-                pass
-    return "".join(chunks)
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("usage: gen_dlg.py <target-spec> <output-path>", file=sys.stderr)
+        sys.exit(2)
+    target = parse_target(sys.argv[1])
+    out_path = Path(sys.argv[2])
 
-
-with open(OUT, "w") as f:
-    f.write(f"=== Model: {MODEL} ===\n")
+    tracker = CostTracker()
+    lines = [f"=== Target: {target.model} @ {target.base_url} ===\n"]
     for p in PROMPTS:
-        text = call(p).strip()
-        f.write(f"\nPROMPT: {p}\nREPLY:  {text}\n")
-print(f"wrote {OUT}")
+        text, usage = call_chat(target, SYSTEM, p, max_tokens=200)
+        tracker.record(target, usage)
+        lines.append(f"\nPROMPT: {p}\nREPLY:  {text.strip()}\n")
+    lines.append(f"\n=== Cost: {tracker.summary()} ===\n")
+    out_path.write_text("".join(lines))
+    print(f"wrote {out_path}")
+    print(f"cost: {tracker.summary()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/parish/scripts/local-eval/gen_samples.py
+++ b/parish/scripts/local-eval/gen_samples.py
@@ -2,15 +2,42 @@
 """Generate 2 production-faithful samples per inference category.
 
 Mirrors the prompts from `parish/crates/parish-inference/examples/inf_bench.rs`.
-Hits the two-slot vllm-mlx loadout:
-  Intent / Reaction / Simulation → :8001 (Qwen2.5-1.5B-Instruct-4bit)
-  Dialogue                        → :8000 (Qwen2.5-7B-Instruct-4bit)
-"""
-import json
-import urllib.request
 
-SMALL = "mlx-community/Qwen2.5-1.5B-Instruct-4bit"
-LARGE = "mlx-community/Qwen2.5-7B-Instruct-4bit"
+Two targets — `small` and `large` — handle Intent/Reaction/Simulation and
+Dialogue respectively. Each target is a `model@base_url[#env:VAR]` spec
+(see `eval_lib.parse_target`). Defaults reproduce the original two-slot
+Apple Silicon vllm-mlx loadout.
+
+Examples::
+
+    # default vllm-mlx two-slot loadout
+    python3 gen_samples.py
+
+    # cross-provider: Groq small slot, Claude large slot
+    python3 gen_samples.py \\
+        --small 'llama-3.1-8b-instant@https://api.groq.com/openai/v1#env:PARISH_GROQ_API_KEY' \\
+        --large 'claude-sonnet-4-6@https://api.anthropic.com/v1#env:PARISH_ANTHROPIC_API_KEY' \\
+        --output docs/proofs/local-perf/category_samples_xprovider.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from eval_lib import CostTracker, Target, call_chat, parse_target  # noqa: E402
+
+DEFAULT_SMALL = "mlx-community/Qwen2.5-1.5B-Instruct-4bit@http://localhost:8001/v1"
+DEFAULT_LARGE = "mlx-community/Qwen2.5-7B-Instruct-4bit@http://localhost:8000/v1"
+DEFAULT_OUTPUT = (
+    Path(__file__).resolve().parents[3]
+    / "docs"
+    / "proofs"
+    / "local-perf"
+    / "category_samples.md"
+)
 
 INTENT_SYS = (
     "You are a text adventure input parser. Given the player's natural language input, "
@@ -193,86 +220,68 @@ DIALOGUE_SYS = (
 )
 
 
-def call(port, model, system, user, schema=None, max_tokens=None):
-    msgs = []
-    if system:
-        msgs.append({"role": "system", "content": system})
-    msgs.append({"role": "user", "content": user})
-    body = {"model": model, "messages": msgs, "stream": False, "temperature": 0.7}
-    if max_tokens:
-        body["max_tokens"] = max_tokens
-    if schema:
-        body["response_format"] = {"type": "json_schema", "json_schema": schema}
-    req = urllib.request.Request(
-        f"http://localhost:{port}/v1/chat/completions",
-        data=json.dumps(body).encode("utf-8"),
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    with urllib.request.urlopen(req, timeout=180) as resp:
-        data = json.load(resp)
-    return data["choices"][0]["message"]["content"]
-
-
-def pretty_json(text):
-    """Try to re-emit JSON as pretty-printed; fall back to raw on parse fail."""
+def pretty_json(text: str) -> str:
     try:
         return json.dumps(json.loads(text), indent=2)
     except Exception:
         return text
 
 
-cases = [
-    # Intent x 2
-    ("Intent", 1, "small", SMALL, INTENT_SYS,
-     "go to the pub", INTENT_SCHEMA, None),
-    ("Intent", 2, "small", SMALL, INTENT_SYS,
-     "tell Padraig I saw his cow wandering near the bog", INTENT_SCHEMA, None),
-
-    # Reaction x 2
-    ("Reaction", 1, "small", SMALL, REACTION_SYS,
-     "A newcomer has just arrived at Darcy's Pub. It is evening, Clear.\n"
-     "You have not met this person before. You are working here as the Publican. "
-     "Introduce yourself briefly.", None, 100),
-    ("Reaction", 2, "small", SMALL, REACTION_SYS,
-     "A newcomer has just arrived at Darcy's Pub. It is morning, Light Rain.\n"
-     "You have met this person before.", None, 100),
-
-    # Simulation x 2 (Tier 2 + Tier 3)
-    ("Simulation (Tier 2)", 1, "small", SMALL, None, TIER2_USER, TIER2_SCHEMA, 200),
-    ("Simulation (Tier 3 batch)", 2, "small", SMALL, None, TIER3_USER, TIER3_SCHEMA, 600),
-
-    # Dialogue x 2
-    ("Dialogue", 1, "large", LARGE, DIALOGUE_SYS,
-     "I've been having trouble sleeping. The dreams keep coming back.", None, None),
-    ("Dialogue", 2, "large", LARGE, DIALOGUE_SYS,
-     "What do you know about the old Cailleach who lives near the fairy fort?",
-     None, None),
-]
+def cases(small: Target, large: Target) -> list[tuple]:
+    """Returns (category, n, slot_label, target, system, user, schema, max_tokens)."""
+    return [
+        ("Intent", 1, "small", small, INTENT_SYS, "go to the pub", INTENT_SCHEMA, None),
+        ("Intent", 2, "small", small, INTENT_SYS,
+         "tell Padraig I saw his cow wandering near the bog", INTENT_SCHEMA, None),
+        ("Reaction", 1, "small", small, REACTION_SYS,
+         "A newcomer has just arrived at Darcy's Pub. It is evening, Clear.\n"
+         "You have not met this person before. You are working here as the Publican. "
+         "Introduce yourself briefly.", None, 100),
+        ("Reaction", 2, "small", small, REACTION_SYS,
+         "A newcomer has just arrived at Darcy's Pub. It is morning, Light Rain.\n"
+         "You have met this person before.", None, 100),
+        ("Simulation (Tier 2)", 1, "small", small, None, TIER2_USER, TIER2_SCHEMA, 200),
+        ("Simulation (Tier 3 batch)", 2, "small", small, None, TIER3_USER, TIER3_SCHEMA, 600),
+        ("Dialogue", 1, "large", large, DIALOGUE_SYS,
+         "I've been having trouble sleeping. The dreams keep coming back.", None, None),
+        ("Dialogue", 2, "large", large, DIALOGUE_SYS,
+         "What do you know about the old Cailleach who lives near the fairy fort?", None, None),
+    ]
 
 
-def main():
-    out_lines = ["# Inference category samples (May 2026)\n"]
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--small", default=DEFAULT_SMALL,
+                    help=f"Target for Intent/Reaction/Simulation (default: {DEFAULT_SMALL})")
+    ap.add_argument("--large", default=DEFAULT_LARGE,
+                    help=f"Target for Dialogue (default: {DEFAULT_LARGE})")
+    ap.add_argument("--output", default=str(DEFAULT_OUTPUT),
+                    help=f"Markdown report path (default: {DEFAULT_OUTPUT})")
+    args = ap.parse_args()
+
+    small = parse_target(args.small)
+    large = parse_target(args.large)
+
+    out_lines = ["# Inference category samples\n"]
     out_lines.append(
-        "Production-faithful prompts mirroring "
-        "`parish-inference/examples/inf_bench.rs`. Two-slot Apple Silicon "
-        "loadout: small slot = `mlx-community/Qwen2.5-1.5B-Instruct-4bit` "
-        "on :8001 (Intent, Reaction, Simulation); large slot = "
-        "`mlx-community/Qwen2.5-7B-Instruct-4bit` on :8000 (Dialogue). "
-        "Generated via `/tmp/gen_samples.py`.\n"
+        f"Targets — small: `{small.model}` at `{small.base_url}` "
+        f"(Intent/Reaction/Simulation); large: `{large.model}` at "
+        f"`{large.base_url}` (Dialogue).\n"
     )
+
+    tracker = CostTracker()
     last_cat = None
-    for cat, n, slot, model, sys_p, user, schema, mt in cases:
-        port = 8000 if slot == "large" else 8001
-        print(f"# {cat} #{n} on :{port} {model}")
+    for cat, n, slot_label, target, sys_p, user, schema, mt in cases(small, large):
+        print(f"# {cat} #{n} ({slot_label}) {target.model}")
         try:
-            output = call(port, model, sys_p, user, schema, mt)
+            output, usage = call_chat(target, sys_p, user, schema=schema, max_tokens=mt)
+            tracker.record(target, usage)
         except Exception as e:
             output = f"ERROR: {e}"
         if cat != last_cat:
             out_lines.append(f"\n## {cat}\n")
             last_cat = cat
-        out_lines.append(f"### Sample {n}  (slot: {slot}, model: `{model.split('/')[-1]}`)\n")
+        out_lines.append(f"### Sample {n}  (slot: {slot_label}, model: `{target.label()}`)\n")
         if sys_p:
             out_lines.append("**System prompt:**\n")
             out_lines.append("```\n" + sys_p.strip() + "\n```\n")
@@ -284,10 +293,12 @@ def main():
             out_lines.append("```json\n" + rendered + "\n```\n")
         else:
             out_lines.append("> " + rendered.replace("\n", "\n> ") + "\n")
-    out_path = "/Users/dmooney/Rundale/.claude/worktrees/piped-imagining-meerkat/docs/proofs/local-perf/category_samples.md"
-    with open(out_path, "w") as f:
-        f.write("\n".join(out_lines))
-    print(f"wrote {out_path}")
+
+    out_lines.append(f"\n---\n\n_Run cost: {tracker.summary()}._\n")
+    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output).write_text("\n".join(out_lines))
+    print(f"wrote {args.output}")
+    print(f"cost: {tracker.summary()}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Refactors `parish/scripts/local-eval/` behind a shared `Target` abstraction (`model@base_url[#env:VAR]`) so the same fixtures used to prove the macOS vllm-mlx loadout now drive any OpenAI-compatible cloud endpoint — Anthropic compat, OpenAI, Groq, OpenRouter, xAI, Mistral, DeepSeek, NVIDIA NIM, Google's OpenAI shim, Together, vLLM, Ollama, LM Studio.

The existing `parish-config::presets::preset_models()` cloud picks were chosen without evaluation. With the eval framework provider-agnostic, future preset swaps can be backed by measured quality + cost data instead of guesses.

## Changes

- `eval_lib.py` — `Target`, `parse_target`, `call_chat` with 429/503 retry-after handling, `CostTracker`, static `COSTS` table
- `gen_samples.py` — `--small`/`--large`/`--output` flags, defaults reproduce the two-slot vllm-mlx loadout
- `flaw_scan.py` — `--target`/`--prompts`/`--workers`/`--output`, per-run USD cost footer
- `gen_dlg.py` — single-target 5-prompt sampler, used by `/eval-dialogue` per candidate
- `/eval-dialogue` skill — accepts both local MLX and cloud specs; skips spawn for cloud; cost column in aggregate
- `dialogue_flaw_scan_gpt_oss_120b_free.md` — smoke-test proof (25 prompts, OpenRouter `openai/gpt-oss-120b:free`, 0 non-Latin leaks, $0.00)

## Test plan

- [x] `python3 -c "import eval_lib, gen_samples, flaw_scan, gen_dlg"` — imports clean
- [x] `parse_target` round-trips both local and cloud spec forms; cost lookup matches table; missing-key raises
- [x] `python3 gen_dlg.py 'openai/gpt-oss-120b:free@https://openrouter.ai/api/v1#env:OPENROUTER_API_KEY' /tmp/dlg.txt` — 5/5 replies, in-character output
- [x] `python3 flaw_scan.py --target ... --prompts 25 --workers 2` — 24/25 successful, 0 non-Latin leaks, 1 transient API blip surfaced as flag
- [x] `just agent-check` — clean (paths exempt: agent-instruction, check-tooling, doc-only)
- [ ] Sweep cloud candidates per `InferenceCategory` and replace `presets.rs` picks with measured winners (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)