### PR TITLE
[codex] fix techdebt skill YAML frontmatter

### DIFF
--- a/.agents/skills/techdebt/SKILL.md
+++ b/.agents/skills/techdebt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: techdebt
-description: Continuous technical-debt sweeper: consume TODO.md tasks (or discover debt when empty), dispatch focused fix agents, keep the list current, and repeat until no actionable debt remains.
+description: "Continuous technical-debt sweeper: consume TODO.md tasks (or discover debt when empty), dispatch focused fix agents, keep the list current, and repeat until no actionable debt remains."
 disable-model-invocation: false
 argument-hint: [path]
 ---


### PR DESCRIPTION
## Summary

- Quote the `description` value in `.agents/skills/techdebt/SKILL.md` so its embedded colon is parsed as YAML text.

## Root Cause

The skill frontmatter used an unquoted scalar containing `: `, which YAML treats as a mapping separator and rejected with `mapping values are not allowed in this context`.

## Impact

The `techdebt` skill metadata can now be loaded by Codex without a YAML parse error.

## Validation

- Parsed the skill frontmatter with Ruby `YAML.safe_load` and confirmed the expected keys were loaded: `name`, `description`, `disable-model-invocation`, `argument-hint`.