### PR TITLE
fix(just): always sync ui deps in run/demo recipes

### DIFF
--- a/parish/justfile
+++ b/parish/justfile
@@ -95,12 +95,12 @@ clean:
 
 # ─── Run ─────────────────────────────────────────────────────────────────────
 
-# Run the game (Tauri desktop GUI) — installs frontend deps if missing.
+# Run the game (Tauri desktop GUI) — syncs frontend deps with package-lock.json first.
 # Auto-detects a free dev port so multiple instances can run simultaneously.
 run:
     #!/usr/bin/env bash
     eval "$(fnm env)"
-    test -d apps/ui/node_modules || (echo "Installing frontend dependencies..." && cd apps/ui && npm install)
+    (cd apps/ui && npm install --prefer-offline --no-audit --no-fund --silent)
     PORT=5173
     while ss -tln 2>/dev/null | grep -q ":$PORT " || lsof -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1; do
         PORT=$((PORT + 1))
@@ -121,7 +121,7 @@ run:
 demo PAUSE="2" MAX_TURNS="":
     #!/usr/bin/env bash
     eval "$(fnm env)"
-    test -d apps/ui/node_modules || (echo "Installing frontend dependencies..." && cd apps/ui && npm install)
+    (cd apps/ui && npm install --prefer-offline --no-audit --no-fund --silent)
     PORT=5173
     while ss -tln 2>/dev/null | grep -q ":$PORT " || lsof -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1; do
         PORT=$((PORT + 1))

--- a/parish/justfile
+++ b/parish/justfile
@@ -99,8 +99,9 @@ clean:
 # Auto-detects a free dev port so multiple instances can run simultaneously.
 run:
     #!/usr/bin/env bash
+    set -euo pipefail
     eval "$(fnm env)"
-    (cd apps/ui && npm install --prefer-offline --no-audit --no-fund --silent)
+    (cd apps/ui && npm install --prefer-offline --no-audit --no-fund --loglevel error)
     PORT=5173
     while ss -tln 2>/dev/null | grep -q ":$PORT " || lsof -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1; do
         PORT=$((PORT + 1))
@@ -120,8 +121,9 @@ run:
 # Uses mods/rundale/demo-prompt.txt as the extra prompt.
 demo PAUSE="2" MAX_TURNS="":
     #!/usr/bin/env bash
+    set -euo pipefail
     eval "$(fnm env)"
-    (cd apps/ui && npm install --prefer-offline --no-audit --no-fund --silent)
+    (cd apps/ui && npm install --prefer-offline --no-audit --no-fund --loglevel error)
     PORT=5173
     while ss -tln 2>/dev/null | grep -q ":$PORT " || lsof -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1; do
         PORT=$((PORT + 1))


### PR DESCRIPTION
## Summary
- `just run` crashed with `Failed to resolve import "html-to-image"` after pulling main, because the existing `test -d apps/ui/node_modules` guard only checks directory existence — a stale `node_modules/` from a prior install masked the new dep.
- Replaced the guard with `npm install --prefer-offline --no-audit --no-fund --silent`. Idempotent (~2s no-op when lockfile already matches node_modules), so it runs every time without measurable overhead.
- Same fix applied to the `demo` recipe (duplicate guard).

## Test plan
- [x] `just --list` still parses
- [x] Timed no-op `npm install --prefer-offline --no-audit --no-fund --silent`: 2.3s
- [ ] Run `just run` from a clean clone and confirm Vite starts without the import error

🤖 Generated with [Claude Code](https://claude.com/claude-code)