### PR TITLE
chore: add reset-onboarding script and just recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -96,6 +96,10 @@ screenshots:
 
 # ─── Utilities ───────────────────────────────────────────────────────────────
 
+# Reset first-run onboarding (BYOK wizard). Pass extra args: --config, --keys, --all, --dry-run.
+reset-onboarding *ARGS:
+    bash parish/scripts/reset-onboarding.sh {{ARGS}}
+
 # Run the main game walkthrough test script
 game-test:
     cd parish && just game-test

--- a/parish/scripts/reset-onboarding.sh
+++ b/parish/scripts/reset-onboarding.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Reset Parish/Rundale first-run onboarding.
+#
+# Default: removes only the `.onboarded` sentinel so the BYOK wizard fires on
+# next launch but the saved provider/model and stored API key remain.
+#
+# Flags:
+#   --config   Also remove parish.toml (forgets provider/model/base_url choice).
+#   --keys     Also delete OS keychain entries for every known provider.
+#   --all      Implies --config --keys.
+#   --dry-run  Print actions without performing them.
+#   -h | --help
+set -euo pipefail
+
+remove_config=0
+remove_keys=0
+dry_run=0
+
+usage() {
+  sed -n '2,12p' "$0"
+  exit "${1:-0}"
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --config)  remove_config=1 ;;
+    --keys)    remove_keys=1 ;;
+    --all)     remove_config=1; remove_keys=1 ;;
+    --dry-run) dry_run=1 ;;
+    -h|--help) usage 0 ;;
+    *) echo "unknown flag: $arg" >&2; usage 1 ;;
+  esac
+done
+
+# Resolve user-config dir (matches parish-core::user_paths resolution order).
+if [[ -n "${PARISH_USER_CONFIG_DIR:-}" ]]; then
+  config_dir="$PARISH_USER_CONFIG_DIR"
+else
+  case "$(uname -s)" in
+    Darwin) config_dir="$HOME/Library/Application Support/Parish" ;;
+    Linux)  config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/parish" ;;
+    MINGW*|MSYS*|CYGWIN*) config_dir="${APPDATA:-$HOME/AppData/Roaming}/Parish" ;;
+    *) echo "unsupported platform: $(uname -s)" >&2; exit 2 ;;
+  esac
+fi
+
+run() {
+  if (( dry_run )); then
+    echo "DRY: $*"
+  else
+    echo "+ $*"
+    "$@"
+  fi
+}
+
+remove_path() {
+  local p="$1"
+  if [[ -e "$p" ]]; then
+    run rm -f "$p"
+  else
+    echo "skip (missing): $p"
+  fi
+}
+
+remove_path "$config_dir/.onboarded"
+
+if (( remove_config )); then
+  remove_path "$config_dir/parish.toml"
+fi
+
+if (( remove_keys )); then
+  # Service + accounts must match parish-tauri/src/keychain.rs and
+  # parish-config/src/provider.rs::Provider::id().
+  service="com.parish.rundale"
+  providers=(
+    ollama lmstudio openrouter vllmmlx openai google groq xai
+    mistral deepseek together nvidia-nim anthropic custom simulator
+  )
+  case "$(uname -s)" in
+    Darwin)
+      for p in "${providers[@]}"; do
+        account="provider:$p"
+        if security find-generic-password -s "$service" -a "$account" >/dev/null 2>&1; then
+          run security delete-generic-password -s "$service" -a "$account" >/dev/null
+        fi
+      done
+      ;;
+    Linux)
+      if command -v secret-tool >/dev/null 2>&1; then
+        for p in "${providers[@]}"; do
+          run secret-tool clear service "$service" account "provider:$p" || true
+        done
+      else
+        echo "warn: secret-tool not installed; clear keys via your wallet UI." >&2
+      fi
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      for p in "${providers[@]}"; do
+        target="$service/provider:$p"
+        run cmdkey /delete:"$target" >/dev/null 2>&1 || true
+      done
+      ;;
+  esac
+fi
+
+echo "done. relaunch Parish to re-enter onboarding."

--- a/parish/scripts/reset-onboarding.sh
+++ b/parish/scripts/reset-onboarding.sh
@@ -121,7 +121,11 @@ if (( remove_keys )); then
       # https://docs.rs/keyring/3/keyring/#linux
       if command -v secret-tool >/dev/null 2>&1; then
         for p in "${providers[@]}"; do
-          run secret-tool clear service "$service" username "provider:$p" || true
+          # Probe first so a missing key doesn't surface as a backend error
+          # (secret-tool exits 1 for "no match" and other failures alike).
+          if secret-tool search service "$service" username "provider:$p" >/dev/null 2>&1; then
+            run secret-tool clear service "$service" username "provider:$p"
+          fi
         done
       else
         echo "warn: secret-tool not installed; clear keys via your wallet UI." >&2
@@ -132,7 +136,9 @@ if (( remove_keys )); then
       # where user = `provider:<id>`. See keyring-3.x src/windows.rs.
       for p in "${providers[@]}"; do
         target="provider:$p.$service"
-        run cmdkey "/delete:$target" || true
+        if cmdkey "/list:$target" 2>/dev/null | grep -q "$target"; then
+          run cmdkey "/delete:$target"
+        fi
       done
       ;;
   esac

--- a/parish/scripts/reset-onboarding.sh
+++ b/parish/scripts/reset-onboarding.sh
@@ -12,14 +12,28 @@
 #   -h | --help
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROVIDERS_DIR="$SCRIPT_DIR/../crates/parish-config/providers"
+
+usage() {
+  cat <<'EOF'
+Reset Parish/Rundale first-run onboarding.
+
+Default: removes only the .onboarded sentinel so the BYOK wizard fires on
+next launch but the saved provider/model and stored API key remain.
+
+Flags:
+  --config   Also remove parish.toml (forgets provider/model/base_url choice).
+  --keys     Also delete OS keychain entries for every known provider.
+  --all      Implies --config --keys.
+  --dry-run  Print actions without performing them.
+  -h | --help
+EOF
+}
+
 remove_config=0
 remove_keys=0
 dry_run=0
-
-usage() {
-  sed -n '2,12p' "$0"
-  exit "${1:-0}"
-}
 
 for arg in "$@"; do
   case "$arg" in
@@ -27,8 +41,8 @@ for arg in "$@"; do
     --keys)    remove_keys=1 ;;
     --all)     remove_config=1; remove_keys=1 ;;
     --dry-run) dry_run=1 ;;
-    -h|--help) usage 0 ;;
-    *) echo "unknown flag: $arg" >&2; usage 1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown flag: $arg" >&2; usage >&2; exit 1 ;;
   esac
 done
 
@@ -62,6 +76,23 @@ remove_path() {
   fi
 }
 
+# Read provider IDs from parish-config/providers/*.toml so the list stays in
+# sync with the data-driven provider registry (#968).
+load_provider_ids() {
+  if [[ ! -d "$PROVIDERS_DIR" ]]; then
+    echo "warn: provider registry not found at $PROVIDERS_DIR; using built-in fallback list." >&2
+    printf '%s\n' \
+      ollama lmstudio openrouter vllmmlx openai google groq xai mistral \
+      deepseek together nvidia-nim anthropic custom simulator
+    return
+  fi
+  local f
+  for f in "$PROVIDERS_DIR"/*.toml; do
+    [[ -e "$f" ]] || continue
+    awk -F'"' '/^id = "/ { print $2; exit }' "$f"
+  done
+}
+
 remove_path "$config_dir/.onboarded"
 
 if (( remove_config )); then
@@ -69,35 +100,39 @@ if (( remove_config )); then
 fi
 
 if (( remove_keys )); then
-  # Service + accounts must match parish-tauri/src/keychain.rs and
-  # parish-config/src/provider.rs::Provider::id().
+  # Service must match parish-tauri/src/keychain.rs (`SERVICE` constant).
   service="com.parish.rundale"
-  providers=(
-    ollama lmstudio openrouter vllmmlx openai google groq xai
-    mistral deepseek together nvidia-nim anthropic custom simulator
-  )
+  providers=()
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && providers+=("$line")
+  done < <(load_provider_ids)
   case "$(uname -s)" in
     Darwin)
       for p in "${providers[@]}"; do
         account="provider:$p"
         if security find-generic-password -s "$service" -a "$account" >/dev/null 2>&1; then
-          run security delete-generic-password -s "$service" -a "$account" >/dev/null
+          run security delete-generic-password -s "$service" -a "$account"
         fi
       done
       ;;
     Linux)
+      # keyring v3 secret-service backend stores BYOK keys under attributes
+      # `service` + `username` (not `account`). See keyring-3.x docs:
+      # https://docs.rs/keyring/3/keyring/#linux
       if command -v secret-tool >/dev/null 2>&1; then
         for p in "${providers[@]}"; do
-          run secret-tool clear service "$service" account "provider:$p" || true
+          run secret-tool clear service "$service" username "provider:$p" || true
         done
       else
         echo "warn: secret-tool not installed; clear keys via your wallet UI." >&2
       fi
       ;;
     MINGW*|MSYS*|CYGWIN*)
+      # keyring v3 windows-native backend names credentials `<user>.<service>`,
+      # where user = `provider:<id>`. See keyring-3.x src/windows.rs.
       for p in "${providers[@]}"; do
-        target="$service/provider:$p"
-        run cmdkey /delete:"$target" >/dev/null 2>&1 || true
+        target="provider:$p.$service"
+        run cmdkey "/delete:$target" || true
       done
       ;;
   esac


### PR DESCRIPTION
## Summary

- New `parish/scripts/reset-onboarding.sh` clears the first-run BYOK wizard state. Default removes only the `.onboarded` sentinel; optional flags `--config` (also wipe `parish.toml`) and `--keys` (also clear OS keychain entries for every `Provider::id()`), `--all` for both. `--dry-run` previews actions.
- Resolves the user-config dir in the same order as `parish-core::user_paths` (`PARISH_USER_CONFIG_DIR` env override, then macOS / Linux / Windows defaults).
- Keychain wipe uses `security` on macOS, `secret-tool` on Linux, `cmdkey` on Windows, all targeting service `com.parish.rundale`.
- New `just reset-onboarding [args]` recipe proxies to the script.

## Test plan

- [x] `bash parish/scripts/reset-onboarding.sh --help`
- [x] `bash parish/scripts/reset-onboarding.sh --all --dry-run`
- [x] `just --list` shows the new `reset-onboarding` recipe
- [ ] Manual: run `just reset-onboarding --all` then relaunch Parish and confirm BYOK wizard fires

Pure tooling change (touches `parish/scripts/**` + `justfile`), exempt from the proof-evidence gate per CLAUDE.md rule #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)