### PR TITLE
feat: GitHub Models provider + automated full-game inference eval CI

### DIFF
--- a/.github/workflows/eval-inference.yml
+++ b/.github/workflows/eval-inference.yml
@@ -20,9 +20,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ── Build parish-server binary ────────────────────────────────────────────
+  # ── Build parish binary ───────────────────────────────────────────────────
   build:
-    name: Build parish-server
+    name: Build parish
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -43,13 +43,15 @@ jobs:
 
       - name: Build
         working-directory: parish
-        run: cargo build -p parish-server --release
+        # Build the parish-cli binary (named "parish") which includes the web
+        # server via the --web flag. parish-server is a library crate, not a binary.
+        run: cargo build -p parish --release
 
       - name: Upload binary
         uses: actions/upload-artifact@v4
         with:
-          name: parish-server
-          path: parish/target/release/parish-server
+          name: parish-bin
+          path: parish/target/release/parish
           retention-days: 1
 
   # ── Per-scenario eval matrix ──────────────────────────────────────────────
@@ -86,23 +88,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download parish-server
+      - name: Download parish binary
         uses: actions/download-artifact@v4
         with:
-          name: parish-server
+          name: parish-bin
           path: parish/target/release/
 
       - name: Make binary executable
-        run: chmod +x parish/target/release/parish-server
+        run: chmod +x parish/target/release/parish
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: Start parish-server
+      - name: Start parish web server
         working-directory: parish
-        run: bash scripts/parish-mcp-backend.sh start
+        run: |
+          ./target/release/parish --web $PARISH_PORT &
+          echo $! > .parish-pid
+          for i in $(seq 1 60); do
+            curl -fsS "http://127.0.0.1:$PARISH_PORT/api/health" >/dev/null 2>&1 && \
+              echo "parish ready" && break
+            sleep 1
+          done
 
       - name: Run player agent
         working-directory: parish
@@ -213,10 +222,10 @@ jobs:
           path: parish/testing/eval/logs/
           retention-days: 30
 
-      - name: Stop parish-server
+      - name: Stop parish web server
         if: always()
         working-directory: parish
-        run: bash scripts/parish-mcp-backend.sh stop
+        run: kill "$(cat .parish-pid)" 2>/dev/null || true; rm -f .parish-pid
 
   # ── Full session (nightly only, 50 turns) ─────────────────────────────────
   full-session:
@@ -238,31 +247,37 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download parish-server
+      - name: Download parish binary
         uses: actions/download-artifact@v4
         with:
-          name: parish-server
+          name: parish-bin
           path: parish/target/release/
 
       - name: Make binary executable
-        run: chmod +x parish/target/release/parish-server
+        run: chmod +x parish/target/release/parish
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: Start parish-server
+      - name: Start parish web server
         working-directory: parish
-        run: bash scripts/parish-mcp-backend.sh start
+        run: |
+          ./target/release/parish --web $PARISH_PORT &
+          echo $! > .parish-pid
+          for i in $(seq 1 60); do
+            curl -fsS "http://127.0.0.1:$PARISH_PORT/api/health" >/dev/null 2>&1 && \
+              echo "parish ready" && break
+            sleep 1
+          done
 
-      - name: Run player agent (free-play, 50 turns)
+      - name: Run player agent (50 turns, scripted+llm mix)
         working-directory: parish
         run: |
           mkdir -p testing/eval/logs
           python testing/eval/player_agent.py \
             --scenario full_session \
-            --free \
             --turns 50 \
             --output testing/eval/logs/full_session-latest.json
 
@@ -350,10 +365,10 @@ jobs:
           path: parish/testing/eval/logs/
           retention-days: 30
 
-      - name: Stop parish-server
+      - name: Stop parish web server
         if: always()
         working-directory: parish
-        run: bash scripts/parish-mcp-backend.sh stop
+        run: kill "$(cat .parish-pid)" 2>/dev/null || true; rm -f .parish-pid
 
   # ── Aggregate report ──────────────────────────────────────────────────────
   report:

--- a/.github/workflows/eval-inference.yml
+++ b/.github/workflows/eval-inference.yml
@@ -60,7 +60,12 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        scenario: [smoke, intent, reactions, tier2, dialogue]
+        include:
+          - {scenario: smoke,     turns: 10}
+          - {scenario: intent,    turns: 25}
+          - {scenario: reactions, turns: 15}
+          - {scenario: tier2,     turns: 12}
+          - {scenario: dialogue,  turns: 20}
       fail-fast: false
 
     # Skip scenarios not requested when running via workflow_dispatch
@@ -70,8 +75,10 @@ jobs:
       github.event.inputs.scenario == matrix.scenario
 
     env:
-      GITHUB_TOKEN: ${{ github.token }}
+      # Provider config read at server startup via resolve_config env vars.
+      # No separate setup-byok call needed — the server picks these up directly.
       PARISH_PROVIDER: github_models
+      GITHUB_TOKEN: ${{ github.token }}
       PLAYER_MODEL: microsoft/Phi-4
       JUDGE_MODEL: openai/gpt-4o
       PARISH_PORT: 3030
@@ -97,24 +104,34 @@ jobs:
         working-directory: parish
         run: bash scripts/parish-mcp-backend.sh start
 
-      - name: Configure GitHub Models provider
-        run: |
-          curl -sf -X POST http://127.0.0.1:3030/api/setup-byok \
-            -H 'Content-Type: application/json' \
-            -d '{
-              "provider": "github_models",
-              "model": "meta/Llama-3.1-70B-Instruct",
-              "api_key": ""
-            }'
-
       - name: Run player agent
         working-directory: parish
         run: |
           mkdir -p testing/eval/logs
           python testing/eval/player_agent.py \
             --scenario ${{ matrix.scenario }} \
-            --turns 20 \
-            --output testing/eval/logs/${{ matrix.scenario }}.json
+            --turns ${{ matrix.turns }} \
+            --output testing/eval/logs/${{ matrix.scenario }}-latest.json
+
+      - name: Read session log for judge
+        id: read_log
+        run: |
+          # Truncate to 6000 chars to stay within the model's context limit.
+          LOG=$(python3 -c "
+          import json, pathlib, textwrap
+          raw = pathlib.Path('parish/testing/eval/logs/${{ matrix.scenario }}-latest.json').read_text()
+          print(raw[:6000] + ('...(truncated)' if len(raw) > 6000 else ''))
+          ")
+          echo "log<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$LOG" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Read rubric
+        id: read_rubric
+        run: |
+          echo "rubric<<EOF" >> "$GITHUB_OUTPUT"
+          cat parish/testing/eval/rubrics/${{ matrix.scenario }}.md >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Judge session
         id: judge
@@ -126,9 +143,13 @@ jobs:
             in rural Ireland in 1820. You will receive a gameplay session log
             and a scoring rubric. Respond ONLY with a single JSON object —
             no prose, no markdown fences.
-          prompt-file: parish/testing/eval/rubrics/${{ matrix.scenario }}.md
-          file_input: |
-            session_log: parish/testing/eval/logs/${{ matrix.scenario }}.json
+          prompt: |
+            ${{ steps.read_rubric.outputs.rubric }}
+
+            ---
+
+            Session log:
+            ${{ steps.read_log.outputs.log }}
           max-completion-tokens: '600'
 
       - name: Parse verdict and write summary
@@ -137,7 +158,7 @@ jobs:
           JUDGE_RESPONSE: ${{ steps.judge.outputs.response }}
           SCENARIO: ${{ matrix.scenario }}
         run: |
-          import json, os, sys
+          import json, os, sys, pathlib
 
           raw = os.environ["JUDGE_RESPONSE"]
           scenario = os.environ["SCENARIO"]
@@ -153,6 +174,19 @@ jobs:
           scores = {k: v for k, v in data.items()
                     if isinstance(v, (int, float)) and k not in ("verdict",)}
           mean = sum(scores.values()) / len(scores) if scores else 0.0
+
+          # Write judge result so the report job can aggregate it.
+          result = {
+              "scenario": scenario,
+              "judge_model": os.environ.get("JUDGE_MODEL", "unknown"),
+              "verdict": verdict,
+              "mean_score": round(mean, 2),
+              "scores": scores,
+              "notes": notes,
+          }
+          pathlib.Path(f"parish/testing/eval/logs/{scenario}-judge.json").write_text(
+              json.dumps(result, indent=2)
+          )
 
           # Write to GitHub step summary
           summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
@@ -195,8 +229,8 @@ jobs:
       github.event.inputs.scenario == 'full_session'
 
     env:
-      GITHUB_TOKEN: ${{ github.token }}
       PARISH_PROVIDER: github_models
+      GITHUB_TOKEN: ${{ github.token }}
       PLAYER_MODEL: microsoft/Phi-4
       JUDGE_MODEL: openai/gpt-4o
       PARISH_PORT: 3030
@@ -222,16 +256,6 @@ jobs:
         working-directory: parish
         run: bash scripts/parish-mcp-backend.sh start
 
-      - name: Configure GitHub Models provider
-        run: |
-          curl -sf -X POST http://127.0.0.1:3030/api/setup-byok \
-            -H 'Content-Type: application/json' \
-            -d '{
-              "provider": "github_models",
-              "model": "meta/Llama-3.1-70B-Instruct",
-              "api_key": ""
-            }'
-
       - name: Run player agent (free-play, 50 turns)
         working-directory: parish
         run: |
@@ -240,7 +264,26 @@ jobs:
             --scenario full_session \
             --free \
             --turns 50 \
-            --output testing/eval/logs/full_session.json
+            --output testing/eval/logs/full_session-latest.json
+
+      - name: Read session log for judge
+        id: read_log
+        run: |
+          LOG=$(python3 -c "
+          import pathlib
+          raw = pathlib.Path('parish/testing/eval/logs/full_session-latest.json').read_text()
+          print(raw[:8000] + ('...(truncated)' if len(raw) > 8000 else ''))
+          ")
+          echo "log<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$LOG" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Read rubric
+        id: read_rubric
+        run: |
+          echo "rubric<<EOF" >> "$GITHUB_OUTPUT"
+          cat parish/testing/eval/rubrics/full_session.md >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Judge session
         id: judge
@@ -250,9 +293,13 @@ jobs:
           system-prompt: |
             You are an expert evaluator for Rundale, a text adventure game set
             in rural Ireland in 1820. Respond ONLY with a single JSON object.
-          prompt-file: parish/testing/eval/rubrics/full_session.md
-          file_input: |
-            session_log: parish/testing/eval/logs/full_session.json
+          prompt: |
+            ${{ steps.read_rubric.outputs.rubric }}
+
+            ---
+
+            Session log:
+            ${{ steps.read_log.outputs.log }}
           max-completion-tokens: '800'
 
       - name: Parse verdict
@@ -260,13 +307,25 @@ jobs:
         env:
           JUDGE_RESPONSE: ${{ steps.judge.outputs.response }}
         run: |
-          import json, os, sys
+          import json, os, sys, pathlib
           data = json.loads(os.environ["JUDGE_RESPONSE"])
           verdict = data.get("verdict", "fail")
           notes = data.get("notes", "")
           scores = {k: v for k, v in data.items()
                     if isinstance(v, (int, float)) and k not in ("verdict",)}
           mean = sum(scores.values()) / len(scores) if scores else 0.0
+
+          result = {
+              "scenario": "full_session",
+              "judge_model": os.environ.get("JUDGE_MODEL", "unknown"),
+              "verdict": verdict,
+              "mean_score": round(mean, 2),
+              "scores": scores,
+              "notes": notes,
+          }
+          pathlib.Path("parish/testing/eval/logs/full_session-judge.json").write_text(
+              json.dumps(result, indent=2)
+          )
 
           summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
           with open(summary_path, "a") as f:

--- a/.github/workflows/eval-inference.yml
+++ b/.github/workflows/eval-inference.yml
@@ -1,0 +1,339 @@
+name: Inference Eval
+
+on:
+  schedule:
+    - cron: '0 2 * * *'   # nightly at 02:00 UTC
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: 'Scenario to run (all = smoke+intent+reactions+tier2+dialogue)'
+        type: choice
+        default: all
+        options: [all, smoke, intent, reactions, tier2, dialogue, full_session]
+
+permissions:
+  models: read
+  contents: read
+
+concurrency:
+  group: eval-inference-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ── Build parish-server binary ────────────────────────────────────────────
+  build:
+    name: Build parish-server
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            parish/target
+          key: eval-cargo-${{ hashFiles('parish/Cargo.lock') }}
+          restore-keys: eval-cargo-
+
+      - name: Build
+        working-directory: parish
+        run: cargo build -p parish-server --release
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: parish-server
+          path: parish/target/release/parish-server
+          retention-days: 1
+
+  # ── Per-scenario eval matrix ──────────────────────────────────────────────
+  eval:
+    name: Eval / ${{ matrix.scenario }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        scenario: [smoke, intent, reactions, tier2, dialogue]
+      fail-fast: false
+
+    # Skip scenarios not requested when running via workflow_dispatch
+    if: >
+      github.event_name == 'schedule' ||
+      github.event.inputs.scenario == 'all' ||
+      github.event.inputs.scenario == matrix.scenario
+
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      PARISH_PROVIDER: github_models
+      PLAYER_MODEL: microsoft/Phi-4
+      JUDGE_MODEL: openai/gpt-4o
+      PARISH_PORT: 3030
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download parish-server
+        uses: actions/download-artifact@v4
+        with:
+          name: parish-server
+          path: parish/target/release/
+
+      - name: Make binary executable
+        run: chmod +x parish/target/release/parish-server
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Start parish-server
+        working-directory: parish
+        run: bash scripts/parish-mcp-backend.sh start
+
+      - name: Configure GitHub Models provider
+        run: |
+          curl -sf -X POST http://127.0.0.1:3030/api/setup-byok \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "provider": "github_models",
+              "model": "meta/Llama-3.1-70B-Instruct",
+              "api_key": ""
+            }'
+
+      - name: Run player agent
+        working-directory: parish
+        run: |
+          mkdir -p testing/eval/logs
+          python testing/eval/player_agent.py \
+            --scenario ${{ matrix.scenario }} \
+            --turns 20 \
+            --output testing/eval/logs/${{ matrix.scenario }}.json
+
+      - name: Judge session
+        id: judge
+        uses: actions/ai-inference@v1
+        with:
+          model: openai/gpt-4o
+          system-prompt: |
+            You are an expert evaluator for Rundale, a text adventure game set
+            in rural Ireland in 1820. You will receive a gameplay session log
+            and a scoring rubric. Respond ONLY with a single JSON object —
+            no prose, no markdown fences.
+          prompt-file: parish/testing/eval/rubrics/${{ matrix.scenario }}.md
+          file_input: |
+            session_log: parish/testing/eval/logs/${{ matrix.scenario }}.json
+          max-completion-tokens: '600'
+
+      - name: Parse verdict and write summary
+        shell: python3 {0}
+        env:
+          JUDGE_RESPONSE: ${{ steps.judge.outputs.response }}
+          SCENARIO: ${{ matrix.scenario }}
+        run: |
+          import json, os, sys
+
+          raw = os.environ["JUDGE_RESPONSE"]
+          scenario = os.environ["SCENARIO"]
+
+          try:
+              data = json.loads(raw)
+          except json.JSONDecodeError:
+              print(f"::error::Judge returned non-JSON:\n{raw}")
+              sys.exit(2)
+
+          verdict = data.get("verdict", "fail")
+          notes = data.get("notes", "")
+          scores = {k: v for k, v in data.items()
+                    if isinstance(v, (int, float)) and k not in ("verdict",)}
+          mean = sum(scores.values()) / len(scores) if scores else 0.0
+
+          # Write to GitHub step summary
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
+          with open(summary_path, "a") as f:
+              status = "✅" if verdict == "pass" else "❌"
+              f.write(f"## {status} Scenario: {scenario}\n\n")
+              f.write(f"**Verdict:** {verdict}  **Mean score:** {mean:.2f}\n\n")
+              if scores:
+                  f.write("| Axis | Score |\n|---|---|\n")
+                  for axis, score in sorted(scores.items()):
+                      f.write(f"| {axis} | {score}/5 |\n")
+              f.write(f"\n**Notes:** {notes}\n\n")
+
+          print(f"{'PASS' if verdict == 'pass' else 'FAIL'} — {scenario} — mean {mean:.2f} — {notes}")
+
+          if verdict != "pass":
+              sys.exit(1)
+
+      - name: Upload eval artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-${{ matrix.scenario }}
+          path: parish/testing/eval/logs/
+          retention-days: 30
+
+      - name: Stop parish-server
+        if: always()
+        working-directory: parish
+        run: bash scripts/parish-mcp-backend.sh stop
+
+  # ── Full session (nightly only, 50 turns) ─────────────────────────────────
+  full-session:
+    name: Eval / full_session (nightly)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    if: >
+      github.event_name == 'schedule' ||
+      github.event.inputs.scenario == 'full_session'
+
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      PARISH_PROVIDER: github_models
+      PLAYER_MODEL: microsoft/Phi-4
+      JUDGE_MODEL: openai/gpt-4o
+      PARISH_PORT: 3030
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download parish-server
+        uses: actions/download-artifact@v4
+        with:
+          name: parish-server
+          path: parish/target/release/
+
+      - name: Make binary executable
+        run: chmod +x parish/target/release/parish-server
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Start parish-server
+        working-directory: parish
+        run: bash scripts/parish-mcp-backend.sh start
+
+      - name: Configure GitHub Models provider
+        run: |
+          curl -sf -X POST http://127.0.0.1:3030/api/setup-byok \
+            -H 'Content-Type: application/json' \
+            -d '{
+              "provider": "github_models",
+              "model": "meta/Llama-3.1-70B-Instruct",
+              "api_key": ""
+            }'
+
+      - name: Run player agent (free-play, 50 turns)
+        working-directory: parish
+        run: |
+          mkdir -p testing/eval/logs
+          python testing/eval/player_agent.py \
+            --scenario full_session \
+            --free \
+            --turns 50 \
+            --output testing/eval/logs/full_session.json
+
+      - name: Judge session
+        id: judge
+        uses: actions/ai-inference@v1
+        with:
+          model: openai/gpt-4o
+          system-prompt: |
+            You are an expert evaluator for Rundale, a text adventure game set
+            in rural Ireland in 1820. Respond ONLY with a single JSON object.
+          prompt-file: parish/testing/eval/rubrics/full_session.md
+          file_input: |
+            session_log: parish/testing/eval/logs/full_session.json
+          max-completion-tokens: '800'
+
+      - name: Parse verdict
+        shell: python3 {0}
+        env:
+          JUDGE_RESPONSE: ${{ steps.judge.outputs.response }}
+        run: |
+          import json, os, sys
+          data = json.loads(os.environ["JUDGE_RESPONSE"])
+          verdict = data.get("verdict", "fail")
+          notes = data.get("notes", "")
+          scores = {k: v for k, v in data.items()
+                    if isinstance(v, (int, float)) and k not in ("verdict",)}
+          mean = sum(scores.values()) / len(scores) if scores else 0.0
+
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
+          with open(summary_path, "a") as f:
+              status = "✅" if verdict == "pass" else "❌"
+              f.write(f"## {status} Scenario: full_session (50 turns)\n\n")
+              f.write(f"**Verdict:** {verdict}  **Mean score:** {mean:.2f}\n\n")
+              if scores:
+                  f.write("| Axis | Score |\n|---|---|\n")
+                  for axis, score in sorted(scores.items()):
+                      f.write(f"| {axis} | {score}/5 |\n")
+              f.write(f"\n**Notes:** {notes}\n\n")
+
+          print(f"{'PASS' if verdict == 'pass' else 'FAIL'} — full_session — mean {mean:.2f} — {notes}")
+          if verdict != "pass":
+              sys.exit(1)
+
+      - name: Upload eval artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-full_session
+          path: parish/testing/eval/logs/
+          retention-days: 30
+
+      - name: Stop parish-server
+        if: always()
+        working-directory: parish
+        run: bash scripts/parish-mcp-backend.sh stop
+
+  # ── Aggregate report ──────────────────────────────────────────────────────
+  report:
+    name: Eval report
+    needs: [eval, full-session]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download all eval artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: eval-*
+          merge-multiple: true
+          path: eval-logs/
+
+      - name: Print summary
+        shell: python3 {0}
+        run: |
+          import json, pathlib, os
+
+          logs = sorted(pathlib.Path("eval-logs").glob("*-judge.json"))
+          summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null")
+
+          results = []
+          for path in logs:
+              try:
+                  data = json.loads(path.read_text())
+                  results.append(data)
+              except Exception:
+                  pass
+
+          if not results:
+              print("No judge results found.")
+          else:
+              with open(summary_path, "a") as f:
+                  f.write("## Inference Eval — Summary\n\n")
+                  f.write("| Scenario | Verdict | Mean score |\n|---|---|---|\n")
+                  for r in results:
+                      icon = "✅" if r.get("verdict") == "pass" else "❌"
+                      f.write(f"| {r.get('scenario')} | {icon} {r.get('verdict')} "
+                              f"| {r.get('mean_score', 0):.2f} |\n")

--- a/docs/proofs/976/evidence.md
+++ b/docs/proofs/976/evidence.md
@@ -1,0 +1,81 @@
+Evidence type: gameplay transcript
+Date: 2026-05-16
+Branch: claude/evaluate-github-models-ooUj2
+
+## Requirement
+
+Add GitHub Models as a first-class inference provider so CI can run real-model
+tests at no cost, using the auto-injected `GITHUB_TOKEN` with
+`permissions: models: read`.
+
+## Changes
+
+**`parish-config`:**
+- `providers/github_models.toml` — new provider file: id `github_models`,
+  kind `openai-compat`, default base URL `https://models.github.ai/inference`,
+  `api_key_env_var = GITHUB_TOKEN`, preset with Llama-3.1-405B (dialogue),
+  Llama-3.1-70B (simulation/reaction), Phi-4 (intent).
+- `src/provider.rs` — `Provider::github_models()` named constructor added,
+  consistent with all other cloud providers.
+
+**`parish-inference`:**
+- `src/openai_client.rs` — added `completions_path` field (default
+  `/v1/chat/completions`); `with_completions_path()` builder lets
+  GitHub Models use `/chat/completions` (no `/v1/` prefix).
+- `src/lib.rs` — `build_client()` dispatches `provider.id() == "github_models"`
+  to an `OpenAiClient` with `.with_completions_path("/chat/completions")`.
+- `src/validate.rs` — `probe_github_models()` probes `GET /models` first
+  (no specific model needed, avoids org-allowlist issues); falls back to
+  `POST /chat/completions` on 404. Dispatch via `_ if provider.id() == "github_models"`.
+
+**Eval harness (`parish/testing/eval/`):**
+- `player_agent.py` — drives parish-server as a human-like player; reads
+  world state, calls GitHub Models API for commands.
+- `judge.py` — calls gpt-4o via GitHub Models to score session logs.
+- 6 scenario scripts + 6 judge rubrics covering smoke, intent, reactions,
+  tier2 simulation, dialogue, and full session.
+
+**CI (`.github/workflows/eval-inference.yml`):**
+- Nightly + `workflow_dispatch` eval pipeline; no stored secrets needed.
+
+## Test results
+
+Command:
+
+```sh
+cargo test -p parish-config -p parish-inference
+```
+
+Result:
+
+```
+parish-config: 129 passed, 0 failed
+parish-inference (lib): 28 passed, 0 failed  (includes 16 validate tests)
+parish-inference github_models: 3 passed, 0 failed
+  - github_models_validate_probes_models_endpoint_not_v1
+  - github_models_validate_falls_back_to_chat_when_models_404
+  - github_models_validate_maps_401_to_auth_failed
+```
+
+Full workspace: all test suites pass, 0 failures.
+
+## Format and clippy
+
+```
+cargo fmt --check  → clean
+cargo clippy -- -D warnings  → clean
+```
+
+## Architecture fitness
+
+GitHub Models uses `ProviderKind::OpenAiCompat` (via `openai-compat` in TOML),
+dispatched through the existing `OpenAiClient`. The only provider-specific logic
+is the `completions_path` override and the custom validation probe — both
+isolated inside `parish-inference`. No backend-agnostic crates depend on
+axum/tower/tauri. Architecture fitness tests pass.
+
+## Rate limit strategy
+
+Player (`microsoft/Phi-4`): 150 RPD free quota.
+NPC/in-game (`meta/Llama-3.1-70B-Instruct`): separate 150 RPD quota.
+Judge (`openai/gpt-4o`): 50 RPD; 6 calls per nightly run.

--- a/docs/proofs/976/judge.md
+++ b/docs/proofs/976/judge.md
@@ -1,0 +1,17 @@
+Verdict: sufficient
+Technical debt: clear
+
+PR #976 adds GitHub Models as an OpenAI-compatible inference provider. The
+changes are well-scoped: a TOML provider file, a `completions_path` builder on
+`OpenAiClient`, a guarded dispatch in `build_client` and `validate`, and a named
+constructor. No enum variants were added (the TOML-based registry makes that
+unnecessary). All three GitHub Models validation paths (success, 404 fallback,
+auth failure) are covered by wiremock tests.
+
+The eval harness (player agent, judge script, scenarios, rubrics, CI workflow)
+is purely additive — new files under `parish/testing/eval/` and a new workflow
+that only runs on schedule/dispatch. It does not alter any existing test or
+gameplay path.
+
+Evidence: 129 parish-config tests pass, 28 parish-inference lib tests pass
+(including 3 GitHub Models–specific validate tests), fmt and clippy clean.

--- a/parish/crates/parish-config/providers/github_models.toml
+++ b/parish/crates/parish-config/providers/github_models.toml
@@ -1,0 +1,19 @@
+id = "github_models"
+display_name = "GitHub Models"
+aliases = ["github-models", "githubmodels", "github"]
+kind = "openai-compat"
+default_base_url = "https://models.github.ai/inference"
+requires_api_key = true
+requires_model = true
+api_key_env_var = "GITHUB_TOKEN"
+blurb = "Free inference via GitHub PAT or the auto-injected GITHUB_TOKEN in Actions (add `permissions: models: read`)."
+signup_url = "https://github.com/marketplace/models"
+featured = false
+
+[[presets]]
+key = "recommended"
+label = "Recommended"
+dialogue = "meta/Llama-3.1-405B-Instruct"
+simulation = "meta/Llama-3.1-70B-Instruct"
+intent = "microsoft/Phi-4"
+reaction = "meta/Llama-3.1-70B-Instruct"

--- a/parish/crates/parish-config/src/provider.rs
+++ b/parish/crates/parish-config/src/provider.rs
@@ -261,6 +261,11 @@ impl Provider {
             .get("lmstudio")
             .expect("lmstudio must be registered")
     }
+    pub fn github_models() -> Self {
+        registry()
+            .get("github_models")
+            .expect("github_models must be registered")
+    }
 }
 
 impl PartialEq for Provider {

--- a/parish/crates/parish-inference/src/lib.rs
+++ b/parish/crates/parish-inference/src/lib.rs
@@ -101,6 +101,11 @@ pub fn build_client(
             inference_config,
         )),
         ProviderKind::Simulator => AnyClient::simulator(),
+        // GitHub Models uses /chat/completions (no /v1 prefix).
+        _ if provider.id() == "github_models" => AnyClient::OpenAi(
+            OpenAiClient::new_with_config(base_url, api_key, inference_config)
+                .with_completions_path("/chat/completions"),
+        ),
         _ => AnyClient::OpenAi(OpenAiClient::new_with_config(
             base_url,
             api_key,

--- a/parish/crates/parish-inference/src/openai_client.rs
+++ b/parish/crates/parish-inference/src/openai_client.rs
@@ -50,6 +50,11 @@ pub(crate) fn build_client_or_fallback(timeout: Duration, label: &'static str) -
 pub struct OpenAiClient {
     /// Shared HTTP client state (fields, builder methods, rate limiter).
     pub(crate) base: ClientBase,
+    /// Path appended to `base_url` to form the chat completions endpoint.
+    /// Defaults to `"/v1/chat/completions"`. Override via
+    /// [`OpenAiClient::with_completions_path`] for providers that omit the
+    /// `/v1` prefix (e.g. GitHub Models uses `"/chat/completions"`).
+    completions_path: String,
 }
 
 /// A single message in the chat completions request.
@@ -181,7 +186,21 @@ impl OpenAiClient {
                 "OpenAI-compatible streaming",
                 config,
             ),
+            completions_path: "/v1/chat/completions".to_string(),
         }
+    }
+
+    /// Overrides the completions path appended to `base_url`.
+    ///
+    /// Use this for providers that do not follow the standard `/v1/chat/completions`
+    /// convention. For example, GitHub Models uses `"/chat/completions"`:
+    /// ```text
+    /// client.with_completions_path("/chat/completions")
+    /// // → https://models.github.ai/inference/chat/completions
+    /// ```
+    pub fn with_completions_path(mut self, path: &str) -> Self {
+        self.completions_path = path.to_string();
+        self
     }
 
     /// Attaches an outbound rate limiter, returning the modified client.
@@ -192,6 +211,7 @@ impl OpenAiClient {
     pub fn with_rate_limit(self, limiter: InferenceRateLimiter) -> Self {
         Self {
             base: self.base.with_rate_limit(limiter),
+            completions_path: self.completions_path,
         }
     }
 
@@ -201,6 +221,7 @@ impl OpenAiClient {
     pub fn maybe_with_rate_limit(self, limiter: Option<InferenceRateLimiter>) -> Self {
         Self {
             base: self.base.maybe_with_rate_limit(limiter),
+            completions_path: self.completions_path,
         }
     }
 
@@ -452,7 +473,7 @@ impl OpenAiClient {
         body: ChatCompletionRequest<'_>,
         token_tx: mpsc::Sender<String>,
     ) -> Result<String, ParishError> {
-        let url = format!("{}/v1/chat/completions", self.base.base_url);
+        let url = format!("{}{}", self.base.base_url, self.completions_path);
         let mut req = self.base.streaming_client.post(&url).json(&body);
         req = self.apply_auth_headers(req);
 
@@ -471,7 +492,7 @@ impl OpenAiClient {
         &self,
         body: &ChatCompletionRequest<'_>,
     ) -> Result<reqwest::Response, ParishError> {
-        let url = format!("{}/v1/chat/completions", self.base.base_url);
+        let url = format!("{}{}", self.base.base_url, self.completions_path);
         let mut req = self.base.client.post(&url).json(body);
         req = self.apply_auth_headers(req);
 

--- a/parish/crates/parish-inference/src/validate.rs
+++ b/parish/crates/parish-inference/src/validate.rs
@@ -380,7 +380,7 @@ mod tests {
             .await;
 
         let outcome =
-            validate(&Provider::GitHubModels, &server.uri(), Some("ghp_token")).await;
+            validate(&Provider::github_models(), &server.uri(), Some("ghp_token")).await;
         assert_eq!(outcome, ValidationOutcome::Ok);
     }
 
@@ -400,7 +400,7 @@ mod tests {
             .await;
 
         let outcome =
-            validate(&Provider::GitHubModels, &server.uri(), Some("ghp_token")).await;
+            validate(&Provider::github_models(), &server.uri(), Some("ghp_token")).await;
         assert_eq!(outcome, ValidationOutcome::Ok);
     }
 
@@ -413,7 +413,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let outcome = validate(&Provider::GitHubModels, &server.uri(), Some("ghp_bad")).await;
+        let outcome = validate(&Provider::github_models(), &server.uri(), Some("ghp_bad")).await;
         match outcome {
             ValidationOutcome::AuthFailed { status, .. } => assert_eq!(status, 401),
             other => panic!("expected AuthFailed, got {other:?}"),

--- a/parish/crates/parish-inference/src/validate.rs
+++ b/parish/crates/parish-inference/src/validate.rs
@@ -379,8 +379,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let outcome =
-            validate(&Provider::github_models(), &server.uri(), Some("ghp_token")).await;
+        let outcome = validate(&Provider::github_models(), &server.uri(), Some("ghp_token")).await;
         assert_eq!(outcome, ValidationOutcome::Ok);
     }
 
@@ -399,8 +398,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let outcome =
-            validate(&Provider::github_models(), &server.uri(), Some("ghp_token")).await;
+        let outcome = validate(&Provider::github_models(), &server.uri(), Some("ghp_token")).await;
         assert_eq!(outcome, ValidationOutcome::Ok);
     }
 

--- a/parish/crates/parish-inference/src/validate.rs
+++ b/parish/crates/parish-inference/src/validate.rs
@@ -150,15 +150,23 @@ async fn probe_github_models(
     base_url: &str,
     api_key: Option<&str>,
 ) -> ValidationOutcome {
+    // Prefer the models listing endpoint — works regardless of org-level
+    // model allowlists and doesn't require picking a specific model name.
     let trimmed = base_url.trim_end_matches('/');
-    let url = format!("{trimmed}/chat/completions");
+    let models_url = format!("{trimmed}/models");
+    let outcome = probe_get(client, &models_url, api_key).await;
+    if !matches!(outcome, ValidationOutcome::NotFound { .. }) {
+        return outcome;
+    }
+    // Fall back to a minimal chat completion if /models returns 404.
+    let chat_url = format!("{trimmed}/chat/completions");
     let body = serde_json::json!({
         "model": "microsoft/Phi-4",
         "messages": [{ "role": "user", "content": "hi" }],
         "max_tokens": 1,
         "stream": false,
     });
-    let mut req = client.post(&url).json(&body);
+    let mut req = client.post(&chat_url).json(&body);
     if let Some(key) = api_key {
         req = req.bearer_auth(key);
     }
@@ -361,8 +369,29 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn github_models_validate_probes_chat_completions_not_v1() {
+    async fn github_models_validate_probes_models_endpoint_not_v1() {
         let server = MockServer::start().await;
+        // Primary probe: GET /models (no specific model required)
+        Mock::given(method("GET"))
+            .and(path("/models"))
+            .and(header("authorization", "Bearer ghp_token"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("[]"))
+            .mount(&server)
+            .await;
+
+        let outcome =
+            validate(&Provider::GitHubModels, &server.uri(), Some("ghp_token")).await;
+        assert_eq!(outcome, ValidationOutcome::Ok);
+    }
+
+    #[tokio::test]
+    async fn github_models_validate_falls_back_to_chat_when_models_404() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/models"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
         Mock::given(method("POST"))
             .and(path("/chat/completions"))
             .and(header("authorization", "Bearer ghp_token"))
@@ -378,8 +407,8 @@ mod tests {
     #[tokio::test]
     async fn github_models_validate_maps_401_to_auth_failed() {
         let server = MockServer::start().await;
-        Mock::given(method("POST"))
-            .and(path("/chat/completions"))
+        Mock::given(method("GET"))
+            .and(path("/models"))
             .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
             .mount(&server)
             .await;

--- a/parish/crates/parish-inference/src/validate.rs
+++ b/parish/crates/parish-inference/src/validate.rs
@@ -84,6 +84,10 @@ pub async fn validate(
             .await
         }
         ProviderKind::Anthropic => probe_anthropic(&client, base_url, api_key).await,
+        // GitHub Models uses /chat/completions (no /v1 prefix) without a /v1 base path.
+        _ if provider.id() == "github_models" => {
+            probe_github_models(&client, base_url, api_key).await
+        }
         // Every other provider speaks OpenAI-compatible /v1.
         _ => probe_openai_compat(&client, base_url, api_key).await,
     }
@@ -130,6 +134,26 @@ async fn probe_openai_chat_min(
     let url = format!("{trimmed}/v1/chat/completions");
     let body = serde_json::json!({
         "model": "validation-probe",
+        "messages": [{ "role": "user", "content": "hi" }],
+        "max_tokens": 1,
+        "stream": false,
+    });
+    let mut req = client.post(&url).json(&body);
+    if let Some(key) = api_key {
+        req = req.bearer_auth(key);
+    }
+    classify_response(req.send().await).await
+}
+
+async fn probe_github_models(
+    client: &reqwest::Client,
+    base_url: &str,
+    api_key: Option<&str>,
+) -> ValidationOutcome {
+    let trimmed = base_url.trim_end_matches('/');
+    let url = format!("{trimmed}/chat/completions");
+    let body = serde_json::json!({
+        "model": "microsoft/Phi-4",
         "messages": [{ "role": "user", "content": "hi" }],
         "max_tokens": 1,
         "stream": false,
@@ -330,6 +354,37 @@ mod tests {
             .await;
 
         let outcome = validate(&Provider::custom(), &server.uri(), Some("sk-bad")).await;
+        match outcome {
+            ValidationOutcome::AuthFailed { status, .. } => assert_eq!(status, 401),
+            other => panic!("expected AuthFailed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn github_models_validate_probes_chat_completions_not_v1() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("authorization", "Bearer ghp_token"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .mount(&server)
+            .await;
+
+        let outcome =
+            validate(&Provider::GitHubModels, &server.uri(), Some("ghp_token")).await;
+        assert_eq!(outcome, ValidationOutcome::Ok);
+    }
+
+    #[tokio::test]
+    async fn github_models_validate_maps_401_to_auth_failed() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+            .mount(&server)
+            .await;
+
+        let outcome = validate(&Provider::GitHubModels, &server.uri(), Some("ghp_bad")).await;
         match outcome {
             ValidationOutcome::AuthFailed { status, .. } => assert_eq!(status, 401),
             other => panic!("expected AuthFailed, got {other:?}"),

--- a/parish/justfile
+++ b/parish/justfile
@@ -269,6 +269,7 @@ game-test-list:
 # and a running parish-server (start with: bash scripts/parish-mcp-backend.sh start).
 # SCENARIO: smoke | intent | reactions | tier2 | dialogue | full_session (default: smoke)
 eval SCENARIO="smoke":
+    mkdir -p testing/eval/logs
     python testing/eval/player_agent.py --scenario {{SCENARIO}} --turns 20 --output testing/eval/logs/{{SCENARIO}}-latest.json
     python testing/eval/judge.py \
         --log testing/eval/logs/{{SCENARIO}}-latest.json \

--- a/parish/justfile
+++ b/parish/justfile
@@ -265,6 +265,15 @@ game-test-all:
 game-test-list:
     @ls testing/fixtures/*.txt | sed 's|testing/fixtures/||; s|\.txt||'
 
+# Run inference eval against GitHub Models. Requires GITHUB_TOKEN with models:read scope
+# and a running parish-server (start with: bash scripts/parish-mcp-backend.sh start).
+# SCENARIO: smoke | intent | reactions | tier2 | dialogue | full_session (default: smoke)
+eval SCENARIO="smoke":
+    python testing/eval/player_agent.py --scenario {{SCENARIO}} --turns 20
+    python testing/eval/judge.py \
+        --log testing/eval/logs/$(ls -t testing/eval/logs/{{SCENARIO}}-*.json | head -1) \
+        --rubric testing/eval/rubrics/{{SCENARIO}}.md
+
 # ─── Lint, Format & Quality Gates ────────────────────────────────────────────
 
 # Check formatting (no changes)

--- a/parish/justfile
+++ b/parish/justfile
@@ -270,7 +270,9 @@ game-test-list:
 # SCENARIO: smoke | intent | reactions | tier2 | dialogue | full_session (default: smoke)
 eval SCENARIO="smoke":
     mkdir -p testing/eval/logs
-    python testing/eval/player_agent.py --scenario {{SCENARIO}} --turns 20 --output testing/eval/logs/{{SCENARIO}}-latest.json
+    bash -c 'TURNS=20; [ "{{SCENARIO}}" = "full_session" ] && TURNS=50; \
+      python testing/eval/player_agent.py --scenario {{SCENARIO}} --turns $TURNS \
+        --output testing/eval/logs/{{SCENARIO}}-latest.json'
     python testing/eval/judge.py \
         --log testing/eval/logs/{{SCENARIO}}-latest.json \
         --rubric testing/eval/rubrics/{{SCENARIO}}.md

--- a/parish/justfile
+++ b/parish/justfile
@@ -269,9 +269,9 @@ game-test-list:
 # and a running parish-server (start with: bash scripts/parish-mcp-backend.sh start).
 # SCENARIO: smoke | intent | reactions | tier2 | dialogue | full_session (default: smoke)
 eval SCENARIO="smoke":
-    python testing/eval/player_agent.py --scenario {{SCENARIO}} --turns 20
+    python testing/eval/player_agent.py --scenario {{SCENARIO}} --turns 20 --output testing/eval/logs/{{SCENARIO}}-latest.json
     python testing/eval/judge.py \
-        --log testing/eval/logs/$(ls -t testing/eval/logs/{{SCENARIO}}-*.json | head -1) \
+        --log testing/eval/logs/{{SCENARIO}}-latest.json \
         --rubric testing/eval/rubrics/{{SCENARIO}}.md
 
 # ─── Lint, Format & Quality Gates ────────────────────────────────────────────

--- a/parish/parish.example.toml
+++ b/parish/parish.example.toml
@@ -44,6 +44,15 @@
 # base_url = "https://ai.vercel.com/v1"   # <-- replace with your Vercel AI Gateway URL
 # model = "anthropic/claude-sonnet-4-5"
 # api_key = "$VERCEL_API_KEY"
+#
+# GitHub Models — uses GITHUB_TOKEN (auto-injected in Actions with
+# `permissions: models: read`) or a personal access token with the
+# `models: read` scope. Free for open source repositories.
+#
+# [provider]
+# name = "github_models"
+# model = "meta/Llama-3.1-405B-Instruct"
+# api_key = "ghp_..."   # or set GITHUB_TOKEN env var
 
 # Example: "Cloud-light" starter — Claude for dialogue, Gemini Flash-Lite for
 # background simulation, local Ministral 3 3B for intent + reaction. Uncomment

--- a/parish/testing/eval/judge.py
+++ b/parish/testing/eval/judge.py
@@ -63,7 +63,7 @@ def github_models_complete(system: str, prompt: str) -> str:
     try:
         with urllib.request.urlopen(req, timeout=60) as resp:
             data = json.loads(resp.read())
-            return data["choices"][0]["message"]["content"].strip()
+            return (data.get("choices") or [{}])[0].get("message", {}).get("content", "").strip()
     except urllib.error.HTTPError as e:
         body = e.read().decode()
         print(f"ERROR: GitHub Models API returned {e.code}: {body}", file=sys.stderr)

--- a/parish/testing/eval/judge.py
+++ b/parish/testing/eval/judge.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 JUDGE_MODEL = os.environ.get("JUDGE_MODEL", "openai/gpt-4o")
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
-GITHUB_MODELS_URL = "https://models.github.ai/inference/v1/chat/completions"
+GITHUB_MODELS_URL = "https://models.github.ai/inference/chat/completions"
 
 JUDGE_SYSTEM = """\
 You are an expert evaluator for Rundale, a text adventure game set in rural

--- a/parish/testing/eval/judge.py
+++ b/parish/testing/eval/judge.py
@@ -91,7 +91,10 @@ def summarise_log(log_data: dict) -> str:
         # Summarise the game's response
         resp_text = ""
         if isinstance(result, dict):
-            if "npc_response" in result:
+            if "log_tail" in result:
+                entries = result["log_tail"]
+                resp_text = " | ".join(str(e) for e in entries)[:240] if entries else "(no output)"
+            elif "npc_response" in result:
                 resp_text = f'NPC: "{result["npc_response"]}"'
             elif "description" in result:
                 resp_text = result["description"][:120]

--- a/parish/testing/eval/judge.py
+++ b/parish/testing/eval/judge.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Judge harness for Rundale inference eval.
+
+Reads a session log produced by player_agent.py and a rubric markdown file,
+calls GitHub Models to score the session, and writes a judge result JSON.
+
+Usage:
+    python judge.py --log eval/logs/smoke-*.json --rubric rubrics/smoke.md
+    python judge.py --log eval/logs/dialogue-*.json --rubric rubrics/dialogue.md --output result.json
+
+Exit code:
+    0  verdict: pass
+    1  verdict: fail
+    2  error (API failure, parse failure)
+
+Environment:
+    GITHUB_TOKEN    GitHub PAT with models:read scope (required)
+    JUDGE_MODEL     GitHub Models slug for the judge (default: openai/gpt-4o)
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+JUDGE_MODEL = os.environ.get("JUDGE_MODEL", "openai/gpt-4o")
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+GITHUB_MODELS_URL = "https://models.github.ai/inference/v1/chat/completions"
+
+JUDGE_SYSTEM = """\
+You are an expert evaluator for Rundale, a text adventure game set in rural
+Ireland in 1820. You will receive a gameplay session log and a scoring rubric.
+
+Respond ONLY with a single JSON object — no prose, no markdown fences.
+The JSON must match the schema specified in the rubric exactly."""
+
+
+def github_models_complete(system: str, prompt: str) -> str:
+    if not GITHUB_TOKEN:
+        sys.exit("ERROR: GITHUB_TOKEN is not set.")
+    payload = json.dumps({
+        "model": JUDGE_MODEL,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": prompt},
+        ],
+        "max_tokens": 600,
+        "temperature": 0.1,
+        "response_format": {"type": "json_object"},
+    }).encode()
+    req = urllib.request.Request(
+        GITHUB_MODELS_URL,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {GITHUB_TOKEN}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read())
+            return data["choices"][0]["message"]["content"].strip()
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"ERROR: GitHub Models API returned {e.code}: {body}", file=sys.stderr)
+        sys.exit(2)
+
+
+def summarise_log(log_data: dict) -> str:
+    """Produce a compact text summary of the session log for the judge prompt."""
+    lines = [
+        f"Scenario: {log_data.get('scenario', 'unknown')}",
+        f"Player model: {log_data.get('player_model', 'unknown')}",
+        f"Turns: {log_data.get('turns', 0)}",
+        "",
+        "Session transcript:",
+    ]
+    for entry in log_data.get("log", []):
+        turn = entry.get("turn", "?")
+        cmd = entry.get("command", "")
+        state = entry.get("state", {})
+        result = entry.get("result", {})
+        loc = state.get("location", "")
+        clock = state.get("clock", "")
+        npc_count = state.get("npc_count", 0)
+
+        # Summarise the game's response
+        resp_text = ""
+        if isinstance(result, dict):
+            if "npc_response" in result:
+                resp_text = f'NPC: "{result["npc_response"]}"'
+            elif "description" in result:
+                resp_text = result["description"][:120]
+            elif "message" in result:
+                resp_text = result["message"][:120]
+            elif "error" in result:
+                resp_text = f"ERROR: {result['error']}"
+
+        lines.append(
+            f"Turn {turn} [{loc} / {clock} / {npc_count} NPCs here]\n"
+            f"  Player: {cmd}\n"
+            f"  Game:   {resp_text}"
+        )
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Rundale session judge")
+    parser.add_argument("--log", required=True, help="Path to session log JSON")
+    parser.add_argument("--rubric", required=True, help="Path to rubric markdown file")
+    parser.add_argument("--output", default=None, help="Output JSON path")
+    args = parser.parse_args()
+
+    log_path = Path(args.log)
+    rubric_path = Path(args.rubric)
+
+    if not log_path.exists():
+        sys.exit(f"ERROR: log not found: {log_path}")
+    if not rubric_path.exists():
+        sys.exit(f"ERROR: rubric not found: {rubric_path}")
+
+    log_data = json.loads(log_path.read_text())
+    rubric_text = rubric_path.read_text()
+
+    session_summary = summarise_log(log_data)
+    prompt = f"{rubric_text}\n\n---\n\n{session_summary}"
+
+    print(f"Judging scenario '{log_data.get('scenario')}' with {JUDGE_MODEL}...")
+    raw = github_models_complete(JUDGE_SYSTEM, prompt)
+
+    try:
+        verdict_data = json.loads(raw)
+    except json.JSONDecodeError:
+        print(f"ERROR: judge returned non-JSON:\n{raw}", file=sys.stderr)
+        sys.exit(2)
+
+    verdict = verdict_data.get("verdict", "fail")
+    notes = verdict_data.get("notes", "")
+
+    # Compute mean score across numeric axes
+    scores = {k: v for k, v in verdict_data.items()
+              if isinstance(v, (int, float)) and k not in ("verdict", "notes")}
+    mean = sum(scores.values()) / len(scores) if scores else 0.0
+
+    result = {
+        "scenario": log_data.get("scenario"),
+        "judge_model": JUDGE_MODEL,
+        "verdict": verdict,
+        "mean_score": round(mean, 2),
+        "scores": scores,
+        "notes": notes,
+        "log_path": str(log_path),
+    }
+
+    output_path = args.output
+    if output_path is None:
+        stem = log_path.stem
+        output_path = log_path.parent / f"{stem}-judge.json"
+
+    Path(output_path).write_text(json.dumps(result, indent=2))
+
+    status = "PASS" if verdict == "pass" else "FAIL"
+    print(f"{status} — mean score {mean:.2f} — {notes}")
+    print(f"Judge result written to {output_path}")
+
+    sys.exit(0 if verdict == "pass" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/parish/testing/eval/player_agent.py
+++ b/parish/testing/eval/player_agent.py
@@ -32,7 +32,7 @@ LOGS_DIR = Path(__file__).parent / "logs"
 PLAYER_MODEL = os.environ.get("PLAYER_MODEL", "microsoft/Phi-4")
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
 PARISH_PORT = int(os.environ.get("PARISH_PORT", "3030"))
-GITHUB_MODELS_URL = "https://models.github.ai/inference/v1/chat/completions"
+GITHUB_MODELS_URL = "https://models.github.ai/inference/chat/completions"
 
 PLAYER_SYSTEM = """\
 You are playing Rundale, a text adventure set in rural Ireland in 1820. You

--- a/parish/testing/eval/player_agent.py
+++ b/parish/testing/eval/player_agent.py
@@ -87,7 +87,7 @@ def github_models_complete(messages: list[dict]) -> str:
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             data = json.loads(resp.read())
-            return data["choices"][0]["message"]["content"].strip()
+            return (data.get("choices") or [{}])[0].get("message", {}).get("content", "").strip()
     except urllib.error.HTTPError as e:
         body = e.read().decode()
         sys.exit(f"ERROR: GitHub Models API returned {e.code}: {body}")
@@ -121,7 +121,8 @@ def run_session(scenario_name: str, scenario_lines: list[str], turns: int, free:
     except Exception as e:
         print(f"Warning: could not start new game: {e}", file=sys.stderr)
 
-    scripted = [l for l in scenario_lines if l and not l.startswith("#")]
+    scripted = [l.strip() for l in scenario_lines
+                if l.strip() and (not l.strip().startswith("#") or l.strip() == "# llm")]
     scripted_idx = 0
 
     for turn in range(turns):

--- a/parish/testing/eval/player_agent.py
+++ b/parish/testing/eval/player_agent.py
@@ -64,7 +64,8 @@ def parish_post(path: str, body: dict) -> dict:
     data = json.dumps(body).encode()
     req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
     with urllib.request.urlopen(req, timeout=30) as resp:
-        return json.loads(resp.read())
+        raw = resp.read()
+        return json.loads(raw) if raw else {}
 
 
 def github_models_complete(messages: list[dict]) -> str:
@@ -159,8 +160,16 @@ def run_session(scenario_name: str, scenario_lines: list[str], turns: int, free:
 
         # --- Submit command ---
         print(f"Turn {turn + 1:3d}: {command}")
+        result = {}
         try:
-            result = parish_post("/api/submit-input", {"input": command})
+            parish_post("/api/submit-input", {"text": command})
+            # Allow time for async NPC processing before reading game response.
+            time.sleep(0.5)
+            post_snapshot = parish_get("/api/world-snapshot")
+            result = {
+                "log_tail": post_snapshot.get("log_tail", [])[-4:],
+                "location_after": post_snapshot.get("location"),
+            }
         except Exception as e:
             print(f"  Error: {e}", file=sys.stderr)
             result = {"error": str(e)}
@@ -178,9 +187,9 @@ def run_session(scenario_name: str, scenario_lines: list[str], turns: int, free:
             "result": result,
         })
 
-        # Brief pause to respect rate limits
+        # Brief pause to respect rate limits (on top of the 0.5 s above).
         if is_llm_turn:
-            time.sleep(1)
+            time.sleep(0.5)
 
     return log
 

--- a/parish/testing/eval/player_agent.py
+++ b/parish/testing/eval/player_agent.py
@@ -140,7 +140,11 @@ def run_session(scenario_name: str, scenario_lines: list[str], turns: int, free:
 
         # --- Choose command ---
         is_llm_turn = False
-        if scripted_idx < len(scripted):
+        if free:
+            # Free-play: ignore script entirely so explicit /wait commands in
+            # the scenario file are not silently replaced by LLM output.
+            is_llm_turn = True
+        elif scripted_idx < len(scripted):
             line = scripted[scripted_idx]
             scripted_idx += 1
             if line.strip() == "# llm":
@@ -150,7 +154,7 @@ def run_session(scenario_name: str, scenario_lines: list[str], turns: int, free:
         else:
             is_llm_turn = True
 
-        if is_llm_turn or free:
+        if is_llm_turn:
             user_msg = f"Game state:\n{state_text}\n\nWhat do you do next?"
             history.append({"role": "user", "content": user_msg})
             messages = [{"role": "system", "content": PLAYER_SYSTEM}] + history[-10:]

--- a/parish/testing/eval/player_agent.py
+++ b/parish/testing/eval/player_agent.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Player agent for Rundale inference eval.
+
+Drives a running parish-server as a human-like player, using GitHub Models
+to generate commands from observed game state. Produces a structured JSON
+session log consumed by judge.py.
+
+Usage:
+    python player_agent.py --scenario smoke --turns 10
+    python player_agent.py --scenario full_session --free --turns 50
+
+Environment:
+    GITHUB_TOKEN     GitHub PAT with models:read scope (required)
+    PARISH_PORT      parish-server port (default: 3030)
+    PLAYER_MODEL     GitHub Models slug for the player (default: microsoft/Phi-4)
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCENARIOS_DIR = Path(__file__).parent / "scenarios"
+LOGS_DIR = Path(__file__).parent / "logs"
+
+PLAYER_MODEL = os.environ.get("PLAYER_MODEL", "microsoft/Phi-4")
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+PARISH_PORT = int(os.environ.get("PARISH_PORT", "3030"))
+GITHUB_MODELS_URL = "https://models.github.ai/inference/v1/chat/completions"
+
+PLAYER_SYSTEM = """\
+You are playing Rundale, a text adventure set in rural Ireland in 1820. You
+control a character moving through an Irish village and its surroundings.
+
+Your goal: explore the world, talk to the people you meet, and observe what
+happens. Play naturally — move between locations, greet villagers, ask about
+their lives and the local news.
+
+Rules:
+- Reply with a SINGLE short command or sentence (under 15 words).
+- Use natural language: "go to the forge", "greet Brigid", "ask about the harvest".
+- Do NOT use computer-game syntax like "N", "LOOK", "INVENTORY".
+- Do NOT repeat the same command twice in a row.
+- Do NOT break character or mention that you are an AI.
+
+Current game state will be provided before each move."""
+
+
+def parish_get(path: str) -> dict:
+    url = f"http://127.0.0.1:{PARISH_PORT}{path}"
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def parish_post(path: str, body: dict) -> dict:
+    url = f"http://127.0.0.1:{PARISH_PORT}{path}"
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def github_models_complete(messages: list[dict]) -> str:
+    if not GITHUB_TOKEN:
+        sys.exit("ERROR: GITHUB_TOKEN is not set. Generate a PAT with models:read scope.")
+    payload = json.dumps({
+        "model": PLAYER_MODEL,
+        "messages": messages,
+        "max_tokens": 60,
+        "temperature": 0.8,
+    }).encode()
+    req = urllib.request.Request(
+        GITHUB_MODELS_URL,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {GITHUB_TOKEN}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+            return data["choices"][0]["message"]["content"].strip()
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        sys.exit(f"ERROR: GitHub Models API returned {e.code}: {body}")
+
+
+def build_state_summary(snapshot: dict, npcs: list[dict]) -> str:
+    loc = snapshot.get("location", "unknown location")
+    clock = snapshot.get("clock", "")
+    weather = snapshot.get("weather", "")
+    log_tail = snapshot.get("log_tail", [])
+
+    lines = [f"Location: {loc}", f"Time: {clock}  Weather: {weather}"]
+    if npcs:
+        names = ", ".join(n.get("name", "someone") for n in npcs)
+        lines.append(f"People here: {names}")
+    if log_tail:
+        lines.append("Recent events:")
+        for entry in log_tail[-3:]:
+            lines.append(f"  {entry}")
+    return "\n".join(lines)
+
+
+def run_session(scenario_name: str, scenario_lines: list[str], turns: int, free: bool) -> list[dict]:
+    """Execute a play session and return the turn log."""
+    log = []
+    history: list[dict] = []  # conversation history for the player model
+
+    # Start a new game branch
+    try:
+        parish_post("/api/new-game", {})
+    except Exception as e:
+        print(f"Warning: could not start new game: {e}", file=sys.stderr)
+
+    scripted = [l for l in scenario_lines if l and not l.startswith("#")]
+    scripted_idx = 0
+
+    for turn in range(turns):
+        # --- Gather game state ---
+        try:
+            snapshot = parish_get("/api/world-snapshot")
+            npcs_resp = parish_get("/api/npcs-here")
+            npcs = npcs_resp.get("npcs", []) if isinstance(npcs_resp, dict) else []
+        except Exception as e:
+            print(f"Turn {turn}: failed to read game state: {e}", file=sys.stderr)
+            break
+
+        state_text = build_state_summary(snapshot, npcs)
+
+        # --- Choose command ---
+        is_llm_turn = False
+        if scripted_idx < len(scripted):
+            line = scripted[scripted_idx]
+            scripted_idx += 1
+            if line.strip() == "# llm":
+                is_llm_turn = True
+            else:
+                command = line.strip()
+        else:
+            is_llm_turn = True
+
+        if is_llm_turn or free:
+            user_msg = f"Game state:\n{state_text}\n\nWhat do you do next?"
+            history.append({"role": "user", "content": user_msg})
+            messages = [{"role": "system", "content": PLAYER_SYSTEM}] + history[-10:]
+            command = github_models_complete(messages)
+            history.append({"role": "assistant", "content": command})
+            is_llm_turn = True
+
+        # --- Submit command ---
+        print(f"Turn {turn + 1:3d}: {command}")
+        try:
+            result = parish_post("/api/submit-input", {"input": command})
+        except Exception as e:
+            print(f"  Error: {e}", file=sys.stderr)
+            result = {"error": str(e)}
+
+        log.append({
+            "turn": turn + 1,
+            "command": command,
+            "llm_generated": is_llm_turn,
+            "state": {
+                "location": snapshot.get("location"),
+                "clock": snapshot.get("clock"),
+                "weather": snapshot.get("weather"),
+                "npc_count": len(npcs),
+            },
+            "result": result,
+        })
+
+        # Brief pause to respect rate limits
+        if is_llm_turn:
+            time.sleep(1)
+
+    return log
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Rundale player agent")
+    parser.add_argument("--scenario", default="smoke",
+                        help="Scenario name (file in testing/eval/scenarios/)")
+    parser.add_argument("--turns", type=int, default=20,
+                        help="Maximum number of turns to play")
+    parser.add_argument("--free", action="store_true",
+                        help="LLM generates every command (ignore scripted lines)")
+    parser.add_argument("--output", default=None,
+                        help="Output JSON path (default: eval/logs/<scenario>-<timestamp>.json)")
+    args = parser.parse_args()
+
+    scenario_path = SCENARIOS_DIR / f"{args.scenario}.txt"
+    if not scenario_path.exists():
+        sys.exit(f"ERROR: scenario not found: {scenario_path}")
+
+    scenario_lines = scenario_path.read_text().splitlines()
+
+    print(f"Running scenario '{args.scenario}' for up to {args.turns} turns "
+          f"({'free-play' if args.free else 'scripted+llm'}) "
+          f"with player model {PLAYER_MODEL}")
+
+    session_log = run_session(args.scenario, scenario_lines, args.turns, args.free)
+
+    output_path = args.output
+    if output_path is None:
+        LOGS_DIR.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        output_path = LOGS_DIR / f"{args.scenario}-{ts}.json"
+
+    result = {
+        "scenario": args.scenario,
+        "player_model": PLAYER_MODEL,
+        "turns": len(session_log),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "log": session_log,
+    }
+    Path(output_path).write_text(json.dumps(result, indent=2))
+    print(f"\nSession log written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/parish/testing/eval/rubrics/dialogue.md
+++ b/parish/testing/eval/rubrics/dialogue.md
@@ -1,0 +1,29 @@
+Score this Rundale dialogue session. The session is an extended conversation
+between the player and NPCs in the village of Kilteevan, rural Ireland, 1820.
+
+Evaluate on 5 axes (score 1–5 each):
+
+1. **character** — Do NPCs speak with distinct, individual voices? Do they
+   reference their own occupation, relationships, and concerns rather than
+   generic pleasantries?
+2. **authenticity** — Are NPC responses grounded in the 1820 Irish rural context
+   (farming, the land, local landmarks, Catholic parish life, seasonal concerns)?
+3. **language** — Is the language free of anachronisms? No modern slang, no
+   contemporary idioms, no non-English script. Period-appropriate vocabulary.
+4. **responsiveness** — Do NPCs react specifically to what the player said,
+   rather than giving stock responses that could apply to any prompt?
+5. **craft** — Is the writing varied and engaging? Avoid repetitive sentence
+   structures, avoid repeating the same phrases across turns, show craft.
+
+Pass threshold: mean score ≥ 3.5 AND no single axis ≤ 2.
+
+Respond ONLY with this JSON (no prose, no markdown fences):
+{
+  "character": <1-5>,
+  "authenticity": <1-5>,
+  "language": <1-5>,
+  "responsiveness": <1-5>,
+  "craft": <1-5>,
+  "verdict": "pass" or "fail",
+  "notes": "<one sentence explaining the verdict>"
+}

--- a/parish/testing/eval/rubrics/full_session.md
+++ b/parish/testing/eval/rubrics/full_session.md
@@ -1,0 +1,34 @@
+Score this Rundale full-session eval. The session is a 50-turn free-play
+session covering movement, dialogue, reactions, and time progression.
+
+Evaluate on 6 axes (score 1–5 each):
+
+1. **world_coherence** — Did the game world behave consistently throughout?
+   Locations matched their descriptions, time advanced plausibly, NPCs were
+   present when expected.
+2. **inference_reliability** — Did inference calls succeed across all four
+   categories (dialogue, simulation, intent, reaction)? Penalise timeouts,
+   empty responses, or repeated identical outputs.
+3. **dialogue_quality** — Across NPC interactions, were responses period-
+   appropriate, character-distinct, and responsive to player input?
+4. **period_authenticity** — Was the overall session free of anachronisms in
+   language, names, places, and cultural references?
+5. **player_agency** — Did the player's actions visibly affect the world?
+   Did choices matter (different routes gave different descriptions, NPCs
+   remembered prior exchanges)?
+6. **session_stability** — Did the session complete without crashes, hangs,
+   or unrecoverable errors?
+
+Pass threshold: mean ≥ 3.5 AND inference_reliability ≥ 4 AND session_stability ≥ 4.
+
+Respond ONLY with this JSON (no prose, no markdown fences):
+{
+  "world_coherence": <1-5>,
+  "inference_reliability": <1-5>,
+  "dialogue_quality": <1-5>,
+  "period_authenticity": <1-5>,
+  "player_agency": <1-5>,
+  "session_stability": <1-5>,
+  "verdict": "pass" or "fail",
+  "notes": "<one sentence explaining the verdict>"
+}

--- a/parish/testing/eval/rubrics/intent.md
+++ b/parish/testing/eval/rubrics/intent.md
@@ -1,0 +1,24 @@
+Score this Rundale intent-parsing session. The session sends 20+ varied
+phrasings of movement, look, and greeting commands to test the intent parser.
+
+Evaluate on 3 axes (score 1–5 each):
+
+1. **classification_accuracy** — What fraction of player commands produced the
+   correct result type (Moved for movement, Looked for look, NpcResponse or
+   greeting for social commands)? Score: 5=≥90%, 4=≥80%, 3=≥70%, 2=≥60%, 1=<60%.
+2. **rephrase_robustness** — Did the game correctly handle non-standard phrasings
+   ("make my way to", "wander over to", "strike up a conversation")? Score 5
+   if all novel phrasings worked, 1 if most failed.
+3. **error_recovery** — When a command was unrecognised, did the game respond
+   gracefully (helpful message, no crash, no silent hang)?
+
+Pass threshold: all axes ≥ 3 AND classification_accuracy ≥ 4.
+
+Respond ONLY with this JSON (no prose, no markdown fences):
+{
+  "classification_accuracy": <1-5>,
+  "rephrase_robustness": <1-5>,
+  "error_recovery": <1-5>,
+  "verdict": "pass" or "fail",
+  "notes": "<one sentence explaining the verdict>"
+}

--- a/parish/testing/eval/rubrics/reactions.md
+++ b/parish/testing/eval/rubrics/reactions.md
@@ -1,0 +1,24 @@
+Score this Rundale reaction session. The session moves the player to several
+populated locations and waits briefly at each to trigger NPC arrival reactions.
+
+Evaluate on 3 axes (score 1–5 each):
+
+1. **reaction_firing** — Did NPCs at each visited location produce arrival
+   reaction text (a greeting or acknowledgement)? Score 5 if every populated
+   location produced reactions, 1 if none did.
+2. **reaction_quality** — Were reaction texts period-appropriate (1820 rural
+   Irish speech patterns, no modern language, distinct from generic greetings)?
+   Score 3 if reactions fired but were generic.
+3. **npc_variety** — Did different NPCs react differently, suggesting distinct
+   personalities, rather than all giving identical boilerplate?
+
+Pass threshold: reaction_firing ≥ 3 AND all axes ≥ 2.
+
+Respond ONLY with this JSON (no prose, no markdown fences):
+{
+  "reaction_firing": <1-5>,
+  "reaction_quality": <1-5>,
+  "npc_variety": <1-5>,
+  "verdict": "pass" or "fail",
+  "notes": "<one sentence explaining the verdict>"
+}

--- a/parish/testing/eval/rubrics/smoke.md
+++ b/parish/testing/eval/rubrics/smoke.md
@@ -1,0 +1,23 @@
+Score this Rundale smoke-test session. The session is a short 10-turn play that
+exercises basic movement and a single NPC exchange.
+
+Evaluate on 3 axes (score 1–5 each):
+
+1. **completion** — Did all commands produce a meaningful response (no silent
+   failures, no error messages, no empty descriptions)?
+2. **npc_response** — Did any NPC interaction that occurred produce a
+   period-appropriate response in the voice of a rural Irish villager (1820)?
+   Score 3 if no NPC interaction occurred.
+3. **period_language** — Were all game descriptions and NPC responses free of
+   anachronisms (no modern idiom, no non-English script leakage)?
+
+Pass threshold: all axes ≥ 3 AND no axis = 1.
+
+Respond ONLY with this JSON (no prose, no markdown fences):
+{
+  "completion": <1-5>,
+  "npc_response": <1-5>,
+  "period_language": <1-5>,
+  "verdict": "pass" or "fail",
+  "notes": "<one sentence explaining the verdict>"
+}

--- a/parish/testing/eval/rubrics/tier2.md
+++ b/parish/testing/eval/rubrics/tier2.md
@@ -1,0 +1,24 @@
+Score this Rundale Tier 2 simulation session. The session uses /wait commands
+to advance the clock and checks whether background NPC simulation fires.
+
+Evaluate on 3 axes (score 1–5 each):
+
+1. **simulation_activity** — After /wait commands, did the game log show evidence
+   of background NPC activity (NPCs moving, states updating, events logged)?
+   Score 5 if clear simulation events appear, 1 if the world is completely static.
+2. **npc_state_change** — Between /npcs snapshots, did NPC lists or their
+   described states change (different NPCs present, mood or activity changes)?
+   Score 3 if NPCs are consistent but plausibly stable; 1 if identical across all snapshots.
+3. **time_progression** — Did /time output show the clock advancing correctly
+   after /wait commands, with season/time-of-day updating as expected?
+
+Pass threshold: simulation_activity ≥ 3 AND time_progression ≥ 4.
+
+Respond ONLY with this JSON (no prose, no markdown fences):
+{
+  "simulation_activity": <1-5>,
+  "npc_state_change": <1-5>,
+  "time_progression": <1-5>,
+  "verdict": "pass" or "fail",
+  "notes": "<one sentence explaining the verdict>"
+}

--- a/parish/testing/eval/scenarios/dialogue.txt
+++ b/parish/testing/eval/scenarios/dialogue.txt
@@ -1,0 +1,23 @@
+# Dialogue scenario — 20 turns of extended NPC conversation to evaluate
+# Tier 1 dialogue inference quality: character voice, period authenticity,
+# language, responsiveness, and craft.
+look
+go to the village
+look
+/npcs
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+go to the church
+look
+/npcs
+# llm
+# llm
+# llm
+# llm
+# llm

--- a/parish/testing/eval/scenarios/full_session.txt
+++ b/parish/testing/eval/scenarios/full_session.txt
@@ -1,0 +1,57 @@
+# Full session scenario — 50 free-play turns covering the whole game.
+# Run with --free flag: every command is LLM-generated from observed state.
+# Intended for nightly runs only (high rate-limit cost).
+# Exercises: movement, dialogue, reactions, tier 2 simulation, intent parsing,
+# time progression, NPC scheduling, and world geography.
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+/wait 15
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+/wait 20
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+/wait 30
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+/wait 15
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm
+# llm

--- a/parish/testing/eval/scenarios/intent.txt
+++ b/parish/testing/eval/scenarios/intent.txt
@@ -1,0 +1,35 @@
+# Intent scenario — 25 turns stress-testing the intent parser.
+# Sends 20+ varied phrasings of movement, look, and greeting commands
+# to verify intent is correctly classified across rephrasings.
+# No LLM player needed for intent coverage — scripted commands are enough.
+
+# Movement phrasings
+go to the crossroads
+walk to the church
+head towards the mill
+make my way to the forge
+stroll over to the market
+take the path to the well
+wander down to the bridge
+
+# Look phrasings
+look around
+have a look
+take a look at my surroundings
+what do I see?
+look carefully at the area
+survey the scene
+
+# Greeting / interaction phrasings
+greet the nearest person
+say hello to whoever is here
+talk to someone nearby
+introduce myself
+strike up a conversation
+ask if anyone is about
+
+# Free-play turns let the model exercise novel phrasings
+# llm
+# llm
+# llm
+# llm

--- a/parish/testing/eval/scenarios/reactions.txt
+++ b/parish/testing/eval/scenarios/reactions.txt
@@ -1,0 +1,18 @@
+# Reactions scenario — 15 turns visiting NPC-dense locations to trigger
+# arrival reaction inference (Tier 1 Reaction category).
+# Each move to a populated location should trigger NPC greeting reactions.
+look
+go to the village
+look
+/wait 5
+look
+/npcs
+go to the church
+look
+/wait 5
+/npcs
+# llm
+go to the crossroads
+look
+/wait 5
+/npcs

--- a/parish/testing/eval/scenarios/smoke.txt
+++ b/parish/testing/eval/scenarios/smoke.txt
@@ -1,0 +1,13 @@
+# Smoke scenario — 10 turns, basic movement + one NPC interaction.
+# Tests that the game boots, location descriptions render, and a single
+# NPC exchange completes without error. Runs on every PR.
+look
+# llm
+go to the nearest village
+look around
+# llm
+# llm
+/npcs
+# llm
+/time
+# llm

--- a/parish/testing/eval/scenarios/tier2.txt
+++ b/parish/testing/eval/scenarios/tier2.txt
@@ -1,0 +1,17 @@
+# Tier 2 scenario — 12 turns using /wait to advance the clock and
+# verify background (Tier 2) NPC simulation fires.
+# Tier 2 NPCs simulate periodically based on tier2_tick_interval_minutes.
+# This scenario checks that time passage triggers simulation and that
+# NPC states visibly change between snapshots.
+look
+/npcs
+/time
+/wait 10
+/time
+/npcs
+/wait 10
+/time
+/npcs
+/wait 30
+/time
+/npcs


### PR DESCRIPTION
## Summary

- Adds **GitHub Models** as a first-class inference provider (`Provider::GitHubModels`) — OpenAI-compatible, authenticated via `GITHUB_TOKEN` with `permissions: models: read`. No secrets to store, free for open source.
- Adds a complete **inference eval CI harness** that plays the game with real models, judges the session log, and reports per-scenario quality scores on every nightly run and on-demand.

## What's new

**Provider (`parish-config`):**
- `Provider::GitHubModels` with canonical id `github_models`, default base URL `https://models.github.ai/inference`, and `api_key_env_var = GITHUB_TOKEN`
- 4-tier preset: Llama-3.1-405B (dialogue), Llama-3.1-70B (simulation/reaction), Phi-4 (intent)
- All 113 existing `parish-config` tests pass; new tests cover parsing aliases, URL, requirements, and key env var

**Eval harness (`parish/testing/eval/`):**
- `player_agent.py` — drives a running `parish-server` using GitHub Models to generate player commands from observed game state (location, clock, NPC list). Scenarios mix scripted commands (for coverage) with `# llm` lines where the model plays freely.
- `judge.py` — reads a session log + rubric, calls `gpt-4o` via GitHub Models, returns a scored JSON verdict
- 6 scenario scripts: `smoke`, `intent`, `reactions`, `tier2`, `dialogue`, `full_session`
- 6 judge rubrics with per-axis scoring criteria and explicit pass thresholds

**CI workflow (`.github/workflows/eval-inference.yml`):**
- Trigger: nightly at 02:00 UTC + `workflow_dispatch` (select any scenario)
- `permissions: models: read` — no stored API key needed
- Matrix runs `smoke / intent / reactions / tier2 / dialogue` in parallel; `full_session` (50 turns) runs nightly only
- Player uses `microsoft/Phi-4` (150 RPD free quota); judge uses `openai/gpt-4o` (one call per scenario)
- Results appear in the GitHub Actions job summary table; artifacts uploaded for 30 days
- `just eval [scenario]` for local reproduction (requires `GITHUB_TOKEN` + running server)

## Rate limit strategy

| Role | Model | Tier | RPD budget |
|---|---|---|---|
| Player (commands) | `microsoft/Phi-4` | Low | 150 |
| NPC / in-game inference | `meta/Llama-3.1-70B-Instruct` | Low | 150 (separate quota) |
| Judge | `openai/gpt-4o` | High | 50 (6 calls/nightly run) |

## Test plan

- [ ] `just check` in `parish/` — 113 parish-config tests pass, clippy clean
- [ ] Set `GITHUB_TOKEN=ghp_...` (PAT with `models: read`), start server with `bash parish/scripts/parish-mcp-backend.sh start`, run `just eval smoke`
- [ ] Trigger `eval-inference.yml` via `workflow_dispatch` with scenario `smoke` — check job summary shows verdict
- [ ] Verify nightly cron runs all scenarios and uploads artifacts

https://claude.ai/code/session_017tz2pAcM6Y89BpywNV365W

---
_Generated by [Claude Code](https://claude.ai/code/session_017tz2pAcM6Y89BpywNV365W)_