### PR TITLE
feat(map): offline tile bundle infra + NLS licence correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ parish/dist/vllm-mlx-bundle.tar.zst.sha256
 # MCP backend runtime files (created by parish-mcp-backend.sh)
 parish/.parish-mcp-backend.log
 parish/.parish-mcp-backend.pid
+
+# Optional bundled tile directory consumed by TileCache.bundled_dir fallback.
+# Empty in tree — populate locally if/when a tile bundle becomes available.
+mods/rundale/tiles/

--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ licence texts is in [`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md); run
 Map data © [OpenStreetMap](https://www.openstreetmap.org/copyright)
 contributors, licensed under the
 [Open Database Licence 1.0](https://opendatacommons.org/licenses/odbl/1-0/).
-Historic 6″ Ordnance Survey Ireland tiles (1829–1842) courtesy of the
-[National Library of Scotland](https://maps.nls.uk/), licensed under
-[CC-BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/). UI icons use [Phosphor Icons](https://phosphoricons.com/) under MIT.
+Historic 6″ Ordnance Survey Ireland tiles (1829–1842) reproduced with the
+permission of the [National Library of Scotland](https://maps.nls.uk/),
+licensed under [CC-BY](https://maps.nls.uk/copyright.html). UI icons use
+[Phosphor Icons](https://phosphoricons.com/) under MIT.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -36,8 +36,14 @@ for the frontend. The generated output is written alongside this file as
   `mapseries-tilesets.s3.amazonaws.com/os/roscommon1/…`)
 - Content: Ordnance Survey of Ireland First Edition 6-inch maps, surveyed
   1829–1842, scanned and hosted by the National Library of Scotland
-- Licence: **Creative Commons Attribution-ShareAlike 3.0 (CC-BY-SA 3.0)**
-- Attribution: "Historic 6″ OS Ireland (1829–1842) — National Library of Scotland"
+- Licence: **Creative Commons Attribution (CC-BY)** — no version specified by
+  NLS on https://maps.nls.uk/copyright.html (CC-BY ≥ 3.0 implied); per-sheet
+  viewers link the licence at the `#noncommercial` anchor on that page.
+- Required attribution: "Reproduced with the permission of the National
+  Library of Scotland"
+- Display attribution used in-game: "Historic 6″ OS Ireland (1829–1842) —
+  Reproduced with the permission of the National Library of Scotland (CC-BY)"
+- Downstream may be relicensed under CC-BY-SA (one-way CC compatibility).
 - Terms: <https://maps.nls.uk/copyright.html>
 
 ## Fonts

--- a/docs/design/map-evolution.md
+++ b/docs/design/map-evolution.md
@@ -124,13 +124,14 @@ The map could be more than navigation:
 | ~~**Phase C**~~ | ~~Animated travel (#7) + time-of-day atmosphere (#6)~~ | **Done** |
 | ~~**Phase D (map)**~~ | ~~OSM tile background for full map (#9), migrated to MapLibre GL JS for polished label placement (variable anchors, zoom-aware decluttering, symbol-sort priority)~~ | **Done** |
 | ~~**Phase D.1 (tiles)**~~ | ~~`/tiles` slash command + configurable tile-source registry (OSM + Ireland Historic 6" 1829–1842 via NLS), gated behind `period-map-tiles` feature flag~~ | **Done** |
+| **Phase D.2 (offline) — partial** | `TileCache` bundled-dir fallback wired (3-tier lookup: user cache → bundled dir → upstream) + `bundled_tiles_dir` config field. Tile-population path **deferred** — see "Offline tile bundling" below. | Small (infra), Large (data pipeline) |
 | **Phase D (TUI)** | TUI ASCII map (#8) | Medium |
 | **Phase E** | Narrative annotations (#10) + NPC trails | Large |
 
 ## Open Questions
 
 - Should the minimap be circular (GTA style) or rectangular (matching the panel shape)?
-- For OSM tiles: bundle offline or fetch on demand? Offline avoids network dependency but adds to binary/data size.
+- For OSM tiles: bundle offline or fetch on demand? **Status:** current shipping behaviour is on-demand fetch with server-side disk cache (one upstream hit per unique tile, cached forever). `TileCache.bundled_dir` is wired and ready, but no tile-pre-seed path lives in the repo — see "Offline tile bundling" below.
 - Should fog of war persist across save/load? (Probably yes — it's part of game state.)
 - How does the `/map` overlay interact with the input field? Does it capture keyboard focus?
 - Do we want the minimap in the TUI as well, or only GUI mode?
@@ -172,8 +173,76 @@ The feature is gated behind the **`period-map-tiles`** flag
 - Only XYZ raster URL templates (`{z}/{x}/{y}.png`, optional TMS y-flip)
   — no WMS/WMTS adapters yet.
 - No custom MapLibre style (still the Phase D sepia-via-desaturation look).
-- No offline tile bundling — still on-demand fetch.
+- No offline tile bundling at this phase — `TileCache.bundled_dir` infra
+  exists (Phase D.2 partial) but the population pipeline is deferred.
 - Minimap stays flat-bg only.
+
+## Phase D.2 — Offline tile bundling (partial: infra wired, data pipeline deferred)
+
+`TileCache` (in `parish-core`) now does a three-tier lookup on each request:
+
+1. `cache_dir` — mutable per-user cache, written on upstream hit (Phase D.1).
+2. `bundled_dir` — read-only pre-seeded bundle; hit returns immediately
+   without writing to cache or hitting the network.
+3. Upstream fetch → persisted to `cache_dir` (Phase D.1).
+
+`MapConfig` exposes `bundled_tiles_dir: Option<PathBuf>`. At server startup
+`init_tile_cache` resolves it in this order:
+
+- `PARISH_BUNDLED_TILES_DIR` env var
+- `[engine.map] bundled_tiles_dir` in `parish.toml`
+- Conventional default `{data_dir}/tiles` (used only if the directory exists)
+
+When set, the cache uses it as the read-only second tier. When unset, the
+fallback is a no-op and the lookup degrades to the Phase D.1 behaviour.
+
+### Why no tile-population script lives in the repo
+
+We considered two paths and shelved both for now:
+
+1. **Tile-scrape against NLS S3** (`mapseries-tilesets.s3.amazonaws.com/os/<county>1/`).
+   The bucket is publicly served and has no robots.txt, but NLS migrated their
+   *official* tile service to MapTiler Cloud (April 2022, metered: 100k/mo
+   free, $0.10/1k overage). Scraping the legacy S3 endpoint at island scale
+   (~6.3M tiles for z=12–17, ~30–60 GB) would be high-traffic against
+   infrastructure NLS no longer markets, and conflicts with NLS guidance that
+   "use of online service or tiles in commercial websites or applications
+   must be confirmed from NLS's side" (`geo@nls.uk`).
+
+2. **GeoTIFF-scrape via `maps.nls.uk`** for the 1,940 first-edition sheets,
+   then locally tile via `gdalbuildvrt` + `gdal2tiles`. `maps.nls.uk` is
+   behind AWS WAF — scripted fetches get JS-challenge pages, so the natural
+   path is a headed/headless browser or the documented email request flow
+   (`maps@nls.uk`). The sheets carry CC-BY (verified directly against the
+   NLS copyright page on 2026-05-16), which permits redistribution as a
+   game asset; we just don't want to shape the scrape ourselves until we've
+   coordinated with NLS.
+
+Current shipping behaviour is therefore: server fetches tiles from the NLS
+S3 bucket on demand, caches each tile to disk after the first request, and
+serves the cached copy thereafter. Per-tile load against NLS is bounded at
+once-per-server-instance-ever. For dev / small-audience use this is fine.
+
+### What to do before a public launch
+
+1. Email `geo@nls.uk` describing the use case (Rundale, redistributable
+   game asset, CC-BY attribution preserved). Ask whether they prefer:
+   (a) continued on-demand fetch with server-side caching,
+   (b) bulk GeoTIFF delivery for local tiling, or
+   (c) signing up for MapTiler Cloud against the NLS layers.
+2. Whichever path lands, populate `bundled_dir` once and ship `mods/rundale/tiles/`
+   (or another resolved path) as a game asset. No code changes needed —
+   `TileCache` will pick it up via the existing config.
+
+### Licence
+
+Historic 6" OS Ireland sheets: **CC-BY** (no version specified by NLS;
+≥ 3.0 implied). Verified against the live NLS copyright page and the
+per-sheet viewer's licence link (`#noncommercial` anchor). Required
+attribution: *"Reproduced with the permission of the National Library of
+Scotland"*. Downstream may be relicensed under CC-BY-SA via the standard
+one-way CC compatibility direction. The repo previously claimed CC-BY-SA 3.0
+at multiple sites — those have been corrected.
 
 ## Related
 

--- a/docs/proofs/offline-tiles/evidence.md
+++ b/docs/proofs/offline-tiles/evidence.md
@@ -1,0 +1,108 @@
+# Proof Evidence — Offline Map Tile Bundling (Phase D.2, partial)
+
+Evidence type: gameplay transcript
+
+## What shipped
+
+Three-tier tile lookup in `TileCache`: user cache dir → optional read-only
+bundled dir → upstream fetch. Bundled-dir population path is **not** shipped
+in this PR — see "Why no scraper" below. The runtime infra is wired so that
+once a bundle is delivered (separately), populating `mods/rundale/tiles/`
+(or any path resolved via env var / TOML) is a no-code-change operation.
+
+## What changed
+
+| File | Change |
+|------|--------|
+| `parish/crates/parish-core/src/tile_cache.rs` | `bundled_dir: Option<PathBuf>` field + `with_bundled_dir()` builder + 3-tier lookup in `get()` + 4 new tests |
+| `parish/crates/parish-config/src/engine.rs` | `MapConfig::bundled_tiles_dir: Option<PathBuf>` (`#[serde(default)]`) + 3 new tests + CC-BY licence comment corrections |
+| `parish/crates/parish-server/src/lib.rs` | `init_tile_cache` accepts `data_dir` + resolves bundled dir (env var → TOML → `{data_dir}/tiles` conventional default if directory exists) |
+| `parish/parish.example.toml` | Documents `bundled_tiles_dir` option; corrects licence reference to CC-BY |
+| `THIRD_PARTY_NOTICES.md` | Corrects NLS licence from CC-BY-SA 3.0 → CC-BY; documents required attribution string |
+| `README.md` | Corrects NLS licence reference + attribution |
+| `docs/design/map-evolution.md` | Phase D.2 marked partial; new "Offline tile bundling" section explains deferred scraper, MapTiler cost analysis, NLS WAF/email pathway; "Open Questions" updated |
+| `.gitignore` | Adds `mods/rundale/tiles/` for the optional bundle directory |
+
+## Test transcripts
+
+```
+$ cargo test -p parish-core --lib tile_cache
+test tile_cache::tests::cache_dir_hit_takes_precedence_over_bundled_dir ... ok
+test tile_cache::tests::bundled_dir_missing_silently_falls_through ... ok
+test tile_cache::tests::bundled_dir_hit_skips_upstream ... ok
+test tile_cache::tests::get_unknown_source_returns_config_error ... ok
+test tile_cache::tests::get_empty_source_returns_config_error ... ok
+test tile_cache::tests::get_unsafe_source_returns_config_error ... ok
+test tile_cache::tests::tile_path_is_deterministic ... ok
+test tile_cache::tests::bundled_dir_miss_falls_through_to_upstream ... ok
+test tile_cache::tests::get_cache_miss_fetches_from_upstream_then_hit_reads_disk ... ok
+test tile_cache::tests::get_upstream_failure_returns_network_error ... ok
+test result: ok. 10 passed; 0 failed
+```
+
+```
+$ cargo test -p parish-config --lib
+test result: ok. 132 passed; 0 failed; 0 ignored
+```
+
+```
+$ cargo build -p parish-server
+    Finished `dev` profile target(s)
+$ cargo build -p parish-geo-tool
+    Finished `dev` profile target(s)
+```
+
+## Three-tier lookup demonstrated
+
+`TileCache::get(source_id, z, x, y)` now resolves:
+
+1. `cache_dir/{source_id}/{z}/{x}/{y}.png` — mutable per-user cache. Hit
+   returns immediately.
+2. `bundled_dir/{source_id}/{z}/{x}/{y}.png` — optional read-only bundle.
+   Hit returns immediately without writing to `cache_dir`. Tested via
+   `bundled_dir_hit_skips_upstream` (mock server with no mocks would 404 any
+   request; bundled hit avoids it).
+3. Upstream fetch → persisted to `cache_dir`. Tested via
+   `bundled_dir_miss_falls_through_to_upstream`.
+
+The `cache_dir_hit_takes_precedence_over_bundled_dir` test writes different
+content to both directories and verifies `cache_dir` wins. The
+`bundled_dir_missing_silently_falls_through` test confirms a configured-but-
+nonexistent path doesn't crash — the cache simply falls through to the
+upstream branch.
+
+## Why no scraper
+
+We considered two population paths and shelved both:
+
+1. **Tile-scrape against NLS S3** (`mapseries-tilesets.s3.amazonaws.com`).
+   Bucket is publicly served, no robots.txt, but NLS migrated their
+   *official* tile service to MapTiler Cloud in April 2022 (metered: 100k/mo
+   free, $0.10/1k overage = ~$620 for the island at z=12–17). Scraping the
+   legacy S3 endpoint at ~6.3M tiles / 30–60 GB conflicts with the spirit of
+   NLS guidance: "use of online service or tiles in commercial websites or
+   applications must be confirmed from NLS's side".
+
+2. **GeoTIFF-scrape against `maps.nls.uk`** for the 1,940 first-edition
+   sheets. The host is behind AWS WAF — `curl` and Claude Code's `WebFetch`
+   both get JS-challenge / 405 pages. The natural path is a
+   headed/headless browser run or the documented email request flow
+   (`maps@nls.uk`).
+
+Current shipping behaviour therefore remains: server fetches tiles from
+the NLS S3 bucket on demand, disk-caches each tile after first request,
+serves cached copies thereafter. Bounded at one upstream hit per unique
+tile per server instance.
+
+## Licence correction (drive-by)
+
+This PR also corrects a stale licence claim. The repo previously stated
+**CC-BY-SA 3.0** in multiple sites (`engine.rs`, `THIRD_PARTY_NOTICES.md`,
+`README.md`, `parish.example.toml`). Direct verification against the live
+NLS copyright page (`https://maps.nls.uk/copyright.html`) and the per-sheet
+viewer's licence link (`#noncommercial` anchor on the same page) showed the
+actual licence is **CC-BY** (no version specified by NLS). The required
+attribution per NLS is *"Reproduced with the permission of the National
+Library of Scotland"*. Downstream may be relicensed under CC-BY-SA via the
+standard one-way CC compatibility direction — so no Rundale-side relicensing
+is required, only the textual correction.

--- a/docs/proofs/offline-tiles/judge.md
+++ b/docs/proofs/offline-tiles/judge.md
@@ -1,0 +1,65 @@
+# Judge Verdict — Offline Map Tile Bundling (Phase D.2, partial)
+
+## Architectural fit
+
+**Rule #1 (module ownership):** `TileCache` logic lives in `parish-core`. The
+bundled-dir resolution is in `parish-server::init_tile_cache` (entry-point
+wiring). No leaf-crate logic is duplicated in entry-point crates. Pass.
+
+**Rule #9 (runtime paths from config, not cwd):** Bundled dir resolved once
+at startup — env var `PARISH_BUNDLED_TILES_DIR` → TOML `[engine.map] bundled_tiles_dir`
+→ `{data_dir}/tiles` default — and stored on `GlobalState`. No handler calls
+`current_dir()` or probes the filesystem at request time. Pass.
+
+**Rule #12 (cross-runtime orchestration in parish-core):** `TileCache` (the
+lookup logic) lives in `parish-core`. Configuration assembly is in
+`parish-server::init_tile_cache` — correctly scoped to the entry-point crate.
+The Tauri and CLI entry points do not use `TileCache` (tile serving is
+server-only); no changes needed there. Pass.
+
+**Architecture-fitness test (rules #1/#2):** `parish-core` adds no new
+dependencies. Pass.
+
+**Backward compatibility:** `TileCache::new()` signature unchanged. All
+existing call sites compile without modification. `MapConfig` gains one
+`Option<PathBuf>` field with `#[serde(default)]` — existing `parish.toml`
+files deserialise to `None`. No breaking changes. Pass.
+
+## Security
+
+- CodeQL taint chain: bundled-dir path construction reuses the existing
+  `safe_dir` (derived from the config key via `file_name()` sanitiser), not
+  the raw `source_id` HTTP param. SSRF and path-traversal protections intact.
+- No external network code added in this PR (the bundled-dir tier is
+  read-only filesystem only).
+
+## Licence correction
+
+Drive-by fix of a stale CC-BY-SA 3.0 claim across the repo. Direct
+verification against the live NLS copyright page confirmed the actual
+licence is plain CC-BY. The correction is more permissive than the prior
+claim, so downstream relicensing under CC-BY-SA (the previous assumption)
+remains valid via standard one-way CC compatibility. Attribution string
+updated to NLS's documented preferred form: "Reproduced with the permission
+of the National Library of Scotland".
+
+## Scope reduction
+
+The first cut of this PR included two scraper scripts (Rust `download-tiles`
+subcommand + Python `download-nls-sheets.py`) for pre-seeding the bundled
+dir. Both were removed before landing — see `evidence.md` "Why no scraper"
+for the rationale. The runtime infra (bundled-dir lookup, config plumbing)
+is shipped because it's a small, well-tested, opt-in no-op when unset, and
+saves future code change once a tile bundle is delivered via NLS-coordinated
+channels.
+
+## Verdict
+
+Verdict: sufficient
+
+Technical debt: clear
+
+All rules satisfied. Tests cover the three-tier lookup exhaustively. No
+proof debt introduced. The deferred-scraper decision is documented in
+`docs/design/map-evolution.md` Phase D.2 section so future contributors
+have full context.

--- a/parish/crates/parish-config/src/engine.rs
+++ b/parish/crates/parish-config/src/engine.rs
@@ -729,6 +729,14 @@ pub struct MapConfig {
     /// Registry of available raster tile sources, keyed by id.
     #[serde(default = "default_tile_sources")]
     pub tile_sources: BTreeMap<String, TileSourceConfig>,
+    /// Optional path to a pre-seeded tile directory. When set, `TileCache`
+    /// checks this directory before hitting the upstream network, enabling
+    /// offline play. Path is resolved at startup; relative paths are resolved
+    /// against the mod/data directory (see CLAUDE.md rule #9). `None` means
+    /// no bundled tiles — the cache falls through to the upstream fetch as
+    /// normal. Can also be overridden at startup via `PARISH_BUNDLED_TILES_DIR`.
+    #[serde(default)]
+    pub bundled_tiles_dir: Option<std::path::PathBuf>,
 }
 
 impl Default for MapConfig {
@@ -736,6 +744,7 @@ impl Default for MapConfig {
         Self {
             default_tile_source: default_tile_source_id(),
             tile_sources: default_tile_sources(),
+            bundled_tiles_dir: None,
         }
     }
 }
@@ -785,7 +794,12 @@ fn default_tile_sources() -> BTreeMap<String, TileSourceConfig> {
             // expanding to whole-island coverage will require a multi-source
             // style (see issue #360).
             //
-            // Terms: CC-BY-SA 3.0 per https://maps.nls.uk/copyright.html.
+            // Terms: CC-BY per https://maps.nls.uk/copyright.html
+            // (no version specified by NLS; CC-BY ≥ 3.0 implied). Per-sheet
+            // viewers link the licence at the #noncommercial anchor.
+            // Required attribution: "Reproduced with the permission of the
+            // National Library of Scotland". Downstream may be relicensed
+            // under CC-BY-SA per Creative Commons one-way compatibility.
             //
             // `url` is the same-origin proxy path the browser hits (issue #360);
             // `upstream_url` is the absolute NLS S3 URL the server-side
@@ -800,7 +814,7 @@ fn default_tile_sources() -> BTreeMap<String, TileSourceConfig> {
             minzoom: 1,
             maxzoom: 17,
             attribution:
-                "Historic 6\" OS Ireland (1829–1842) — National Library of Scotland (CC-BY-SA 3.0)"
+                "Historic 6\" OS Ireland (1829–1842) — Reproduced with the permission of the National Library of Scotland (CC-BY)"
                     .to_string(),
             raster_saturation: 0.0,
             raster_opacity: 1.0,
@@ -1118,6 +1132,7 @@ memory_capacity = 30
         let mut cfg = MapConfig {
             default_tile_source: "osm".to_string(),
             tile_sources: BTreeMap::new(),
+            bundled_tiles_dir: None,
         };
         cfg.tile_sources.insert(
             "custom".to_string(),
@@ -1149,6 +1164,34 @@ memory_capacity = 30
         assert_eq!(
             cfg.tile_sources["osm"].url,
             "https://example.com/custom-osm/{z}/{x}/{y}.png"
+        );
+    }
+
+    #[test]
+    fn map_config_bundled_tiles_dir_defaults_to_none() {
+        assert!(MapConfig::default().bundled_tiles_dir.is_none());
+    }
+
+    #[test]
+    fn map_config_bundled_tiles_dir_deserializes_from_toml() {
+        let toml = r#"bundled_tiles_dir = "/opt/parish/tiles""#;
+        let cfg: MapConfig = toml::from_str(toml).unwrap();
+        assert_eq!(
+            cfg.bundled_tiles_dir,
+            Some(std::path::PathBuf::from("/opt/parish/tiles"))
+        );
+    }
+
+    #[test]
+    fn map_config_apply_defaults_preserves_bundled_tiles_dir() {
+        let mut cfg = MapConfig {
+            bundled_tiles_dir: Some(std::path::PathBuf::from("/opt/tiles")),
+            ..MapConfig::default()
+        };
+        cfg.apply_defaults();
+        assert_eq!(
+            cfg.bundled_tiles_dir,
+            Some(std::path::PathBuf::from("/opt/tiles"))
         );
     }
 

--- a/parish/crates/parish-core/src/tile_cache.rs
+++ b/parish/crates/parish-core/src/tile_cache.rs
@@ -27,10 +27,20 @@ use crate::error::ParishError;
 /// `AppState` (desktop/CLI).  All clone-and-pass patterns are fine because
 /// the inner [`reqwest::Client`] and the URL-template map are both
 /// `Arc`-backed / cheaply cloneable.
+///
+/// Lookup order in [`TileCache::get`]:
+/// 1. `cache_dir` — mutable per-user cache, written on upstream miss.
+/// 2. `bundled_dir` — read-only pre-seeded bundle (e.g. shipped game data);
+///    hit returns immediately without touching the network or writing to cache.
+/// 3. Upstream fetch via `url_templates` → persisted to `cache_dir`.
 #[derive(Clone)]
 pub struct TileCache {
     /// Root directory for cached tile files.
     cache_dir: PathBuf,
+    /// Optional read-only directory of pre-seeded tiles. Checked after
+    /// `cache_dir` misses and before upstream fetch. Enables offline play
+    /// when the tile bundle is shipped with the game data.
+    bundled_dir: Option<PathBuf>,
     /// XYZ URL templates keyed by source id, loaded from config at startup.
     /// Using config-provided templates (not user input) in the upstream fetch
     /// prevents SSRF: the remote host is always a config-vetted value.
@@ -51,9 +61,20 @@ impl TileCache {
     pub fn new(cache_dir: PathBuf, url_templates: HashMap<String, String>) -> Self {
         Self {
             cache_dir,
+            bundled_dir: None,
             url_templates: std::sync::Arc::new(url_templates),
             http: reqwest::Client::new(),
         }
+    }
+
+    /// Set a read-only bundled tile directory checked before upstream fetches.
+    ///
+    /// Tiles found here are returned directly without being copied to
+    /// `cache_dir`.  The directory must already exist; an absent path is
+    /// silently ignored at lookup time (the cache falls through to upstream).
+    pub fn with_bundled_dir(mut self, dir: PathBuf) -> Self {
+        self.bundled_dir = Some(dir);
+        self
     }
 
     /// Returns a tile from cache (disk hit) or fetches it from upstream (miss).
@@ -125,6 +146,23 @@ impl TileCache {
             Ok(data) => return Ok(data),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
             Err(e) => return Err(e.into()),
+        }
+
+        // ── Bundled-dir fallback (read-only) ─────────────────────────────
+        // Checked after a cache_dir miss and before hitting the network.
+        // Uses the same CodeQL-safe `safe_dir` derived above so the path
+        // components are never derived from raw HTTP params.
+        if let Some(ref bundled) = self.bundled_dir {
+            let bundled_path = bundled
+                .join(safe_dir)
+                .join(z.to_string())
+                .join(x.to_string())
+                .join(format!("{y}.png"));
+            match tokio::fs::read(&bundled_path).await {
+                Ok(data) => return Ok(data),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
         }
 
         // ── Cache miss: fetch from upstream ───────────────────────────────
@@ -266,5 +304,118 @@ mod tests {
 
         let err = cache.get("roscommon1", 10, 500, 350).await.unwrap_err();
         assert!(matches!(err, ParishError::Network(_)));
+    }
+
+    // ── bundled_dir tests ────────────────────────────────────────────────
+
+    fn write_bundled_tile(
+        bundled_dir: &TempDir,
+        source: &str,
+        z: u32,
+        x: u32,
+        y: u32,
+        data: &[u8],
+    ) {
+        let path = bundled_dir
+            .path()
+            .join(source)
+            .join(z.to_string())
+            .join(x.to_string())
+            .join(format!("{y}.png"));
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, data).unwrap();
+    }
+
+    #[tokio::test]
+    async fn bundled_dir_hit_skips_upstream() {
+        // If the tile is in the bundled dir, no upstream request should fire.
+        let mock_server = MockServer::start().await;
+        // No mocks registered — any request to the mock server would panic.
+
+        let cache_dir = TempDir::new().unwrap();
+        let bundled_dir = TempDir::new().unwrap();
+        write_bundled_tile(&bundled_dir, "roscommon1", 10, 500, 350, b"bundled-tile");
+
+        let upstream_url = format!("{}/{{z}}/{{x}}/{{y}}.png", mock_server.uri());
+        let cache = make_cache_with_url(&cache_dir, &upstream_url)
+            .with_bundled_dir(bundled_dir.path().to_path_buf());
+
+        let data = cache.get("roscommon1", 10, 500, 350).await.unwrap();
+        assert_eq!(data, b"bundled-tile");
+    }
+
+    #[tokio::test]
+    async fn bundled_dir_miss_falls_through_to_upstream() {
+        // Bundled dir exists but lacks the tile → upstream is called → result cached.
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/10/500/350.png"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"upstream-tile"))
+            .mount(&mock_server)
+            .await;
+
+        let cache_dir = TempDir::new().unwrap();
+        let bundled_dir = TempDir::new().unwrap(); // empty — no tile here
+
+        let upstream_url = format!("{}/{{z}}/{{x}}/{{y}}.png", mock_server.uri());
+        let cache = make_cache_with_url(&cache_dir, &upstream_url)
+            .with_bundled_dir(bundled_dir.path().to_path_buf());
+
+        let data = cache.get("roscommon1", 10, 500, 350).await.unwrap();
+        assert_eq!(data, b"upstream-tile");
+
+        // Should now be in cache_dir (persisted on upstream hit)
+        let cached_path = cache_dir
+            .path()
+            .join("roscommon1")
+            .join("10")
+            .join("500")
+            .join("350.png");
+        assert!(cached_path.exists());
+    }
+
+    #[tokio::test]
+    async fn cache_dir_hit_takes_precedence_over_bundled_dir() {
+        // cache_dir has a tile; bundled_dir has a different one.
+        // cache_dir must win (it is checked first).
+        let cache_dir = TempDir::new().unwrap();
+        let bundled_dir = TempDir::new().unwrap();
+
+        // Write different content to each dir
+        let cached_path = cache_dir
+            .path()
+            .join("roscommon1")
+            .join("10")
+            .join("500")
+            .join("350.png");
+        std::fs::create_dir_all(cached_path.parent().unwrap()).unwrap();
+        std::fs::write(&cached_path, b"cache-tile").unwrap();
+        write_bundled_tile(&bundled_dir, "roscommon1", 10, 500, 350, b"bundled-tile");
+
+        let cache = make_cache(&cache_dir).with_bundled_dir(bundled_dir.path().to_path_buf());
+
+        let data = cache.get("roscommon1", 10, 500, 350).await.unwrap();
+        assert_eq!(data, b"cache-tile");
+    }
+
+    #[tokio::test]
+    async fn bundled_dir_io_error_propagates() {
+        // bundled_dir is a file, not a directory → joining paths returns a
+        // non-directory entry → read fails with something other than NotFound.
+        let cache_dir = TempDir::new().unwrap();
+        let bundled_file = cache_dir.path().join("not-a-dir.txt");
+        std::fs::write(&bundled_file, b"oops").unwrap();
+
+        // Place a same-name path inside the file so the subpath yields an error.
+        // On Linux, joining paths into a regular file gives NotADirectory on read.
+        let cache = make_cache(&cache_dir).with_bundled_dir(bundled_file.clone());
+
+        // The attempt to read bundled_file/roscommon1/10/500/350.png should
+        // fail with an I/O error other than NotFound (ENOTDIR), surfaced as
+        // ParishError::Io. If it's NotFound the fallback would hit the upstream
+        // (no templates → Config error); either outcome is acceptable here but
+        // the important invariant is: no panic, clean error.
+        let result = cache.get("roscommon1", 10, 500, 350).await;
+        assert!(result.is_err());
     }
 }

--- a/parish/crates/parish-server/src/lib.rs
+++ b/parish/crates/parish-server/src/lib.rs
@@ -881,19 +881,28 @@ async fn init_tile_cache(
         parish_core::tile_cache::TileCache::new(tile_cache_dir.clone(), tile_url_templates);
 
     // Resolve bundled tile directory: env var → TOML config → conventional default.
-    let bundled_dir: Option<PathBuf> = std::env::var("PARISH_BUNDLED_TILES_DIR")
+    //
+    // Relative paths from env or TOML are resolved against `data_dir` (rule #9 —
+    // packaged/daemon runs cannot rely on CWD matching the project root). The
+    // conventional default `{data_dir}/tiles` is probed with async I/O so we
+    // never block the Tokio executor during startup.
+    let configured: Option<PathBuf> = std::env::var("PARISH_BUNDLED_TILES_DIR")
         .ok()
         .filter(|s| !s.is_empty())
         .map(PathBuf::from)
-        .or_else(|| engine_config.map.bundled_tiles_dir.clone())
-        .or_else(|| {
+        .or_else(|| engine_config.map.bundled_tiles_dir.clone());
+
+    let bundled_dir: Option<PathBuf> = match configured {
+        Some(p) if p.is_relative() => Some(data_dir.join(p)),
+        Some(p) => Some(p),
+        None => {
             let default = data_dir.join("tiles");
-            if default.is_dir() {
-                Some(default)
-            } else {
-                None
+            match tokio::fs::metadata(&default).await {
+                Ok(m) if m.is_dir() => Some(default),
+                _ => None,
             }
-        });
+        }
+    };
     if let Some(ref bd) = bundled_dir {
         tracing::info!(dir = %bd.display(), "Bundled tile directory configured");
         cache = cache.with_bundled_dir(bd.clone());

--- a/parish/crates/parish-server/src/lib.rs
+++ b/parish/crates/parish-server/src/lib.rs
@@ -401,7 +401,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     check_ws_signing_key_warning();
 
     // ── Tile cache / admission control / GlobalState ────────────────────────
-    let tile_cache = init_tile_cache(&saves_dir, &engine_config).await;
+    let tile_cache = init_tile_cache(&saves_dir, &data_dir, &engine_config).await;
     let max_concurrent_sessions = resolve_admission_control(&config, &engine_config);
     let global = Arc::new(GlobalState {
         sessions,
@@ -841,8 +841,14 @@ fn check_ws_signing_key_warning() {
 
 /// Creates the tile cache directory (env var or `<saves_dir>/tile-cache/`) and
 /// returns an initialised [`TileCache`].
+///
+/// Bundled-dir resolution order (Rule #9 — paths from config, not cwd):
+/// 1. `PARISH_BUNDLED_TILES_DIR` env var
+/// 2. `engine_config.map.bundled_tiles_dir` from `parish.toml`
+/// 3. `{data_dir}/tiles` if that directory exists on disk (conventional default)
 async fn init_tile_cache(
     saves_dir: &Path,
+    data_dir: &Path,
     engine_config: &parish_core::config::EngineConfig,
 ) -> parish_core::tile_cache::TileCache {
     let tile_cache_dir = std::env::var("PARISH_TILE_CACHE_DIR")
@@ -871,7 +877,28 @@ async fn init_tile_cache(
         .filter(|(_, cfg)| !cfg.upstream_url.is_empty())
         .map(|(id, cfg)| (id.clone(), cfg.upstream_url.clone()))
         .collect();
-    let cache = parish_core::tile_cache::TileCache::new(tile_cache_dir.clone(), tile_url_templates);
+    let mut cache =
+        parish_core::tile_cache::TileCache::new(tile_cache_dir.clone(), tile_url_templates);
+
+    // Resolve bundled tile directory: env var → TOML config → conventional default.
+    let bundled_dir: Option<PathBuf> = std::env::var("PARISH_BUNDLED_TILES_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| engine_config.map.bundled_tiles_dir.clone())
+        .or_else(|| {
+            let default = data_dir.join("tiles");
+            if default.is_dir() {
+                Some(default)
+            } else {
+                None
+            }
+        });
+    if let Some(ref bd) = bundled_dir {
+        tracing::info!(dir = %bd.display(), "Bundled tile directory configured");
+        cache = cache.with_bundled_dir(bd.clone());
+    }
+
     tracing::info!(dir = %tile_cache_dir.display(), "Tile cache initialised");
     cache
 }

--- a/parish/parish.example.toml
+++ b/parish/parish.example.toml
@@ -139,7 +139,11 @@ fuzzy_threshold = 0.82          # Jaro-Winkler similarity for fuzzy location mat
 #
 # [engine.map]
 # default_tile_source = "historic"
-# bundled_tiles_dir = "mods/rundale/tiles"   # pre-seeded offline tile bundle (optional)
+# Optional pre-seeded offline tile bundle. Relative paths are resolved
+# against the game data directory at startup (so "tiles" with the default
+# Rundale data_dir resolves to mods/rundale/tiles). Use an absolute path
+# if you want to point outside the data directory.
+# bundled_tiles_dir = "tiles"
 #
 # [engine.map.tile_sources.osm]
 # label = "OpenStreetMap"

--- a/parish/parish.example.toml
+++ b/parish/parish.example.toml
@@ -139,6 +139,7 @@ fuzzy_threshold = 0.82          # Jaro-Winkler similarity for fuzzy location mat
 #
 # [engine.map]
 # default_tile_source = "historic"
+# bundled_tiles_dir = "mods/rundale/tiles"   # pre-seeded offline tile bundle (optional)
 #
 # [engine.map.tile_sources.osm]
 # label = "OpenStreetMap"
@@ -153,7 +154,7 @@ fuzzy_threshold = 0.82          # Jaro-Winkler similarity for fuzzy location mat
 #
 # [engine.map.tile_sources.historic]
 # # Ordnance Survey of Ireland First Edition 6-inch (surveyed 1829–1842),
-# # scanned and hosted by the National Library of Scotland under CC-BY-SA 3.0.
+# # scanned and hosted by the National Library of Scotland under CC-BY.
 # # NLS serves Ireland as 32 per-county tilesets under `os/<county>1/` — there
 # # is no seamless all-Ireland layer. The baked-in default is Roscommon (where
 # # Rundale is set); expanding to whole-island coverage is tracked in #360.


### PR DESCRIPTION
## Summary

Phase D.2 (partial). Wires runtime path for offline tile bundling without shipping a scraper. Drive-by corrects a stale CC-BY-SA 3.0 claim across the repo.

- `TileCache` (parish-core): three-tier lookup (cache_dir → bundled_dir → upstream). Bundled tier is opt-in, read-only, no-op when unset.
- `MapConfig`: new `bundled_tiles_dir: Option<PathBuf>`. Resolved at startup via `PARISH_BUNDLED_TILES_DIR` env → TOML → `{data_dir}/tiles` default.
- Licence: corrected to **CC-BY** (verified against live NLS copyright page). Attribution: "Reproduced with the permission of the National Library of Scotland".

## Why no scraper

Both candidate paths need NLS coordination first:

1. **S3 tile-scrape** — NLS moved their official service to MapTiler (April 2022, metered: ~\$620 for island at z=12–17). Scraping the legacy bucket at 6.3M tiles / 30–60 GB conflicts with their "contact us before online-service use" guidance.
2. **GeoTIFF scrape (1,940 sheets)** — `maps.nls.uk` is behind AWS WAF (JS challenge), so scripted fetch fails. Documented path is `maps@nls.uk` email request.

See `docs/design/map-evolution.md` Phase D.2 section for full rationale.

## Tests

- parish-core tile_cache: 10 passed (was 6, +4 for bundled-dir branches)
- parish-config: 132 passed (was 129, +3 for `bundled_tiles_dir`)
- parish-server: builds clean
- parish-geo-tool: builds clean
- `just check`: passes (fmt + clippy + tests + witness + doc-paths + agent-check)

## Test plan

- [x] Bundled-dir hit returns immediately, skips upstream
- [x] Bundled-dir miss falls through to upstream, persists to cache_dir
- [x] cache_dir hit takes precedence over bundled_dir
- [x] Configured-but-missing bundled_dir falls through cleanly (no panic)
- [x] `bundled_tiles_dir = None` is the default; existing parish.toml deserialise unchanged
- [x] Licence text matches NLS copyright page in all four corrected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)