### PR TITLE
fix(config): port Linux vllm preset to ProviderPreset.base_urls schema

### DIFF
--- a/docs/proofs/issue-996/acceptance-criteria.md
+++ b/docs/proofs/issue-996/acceptance-criteria.md
@@ -1,0 +1,65 @@
+# Acceptance Criteria: issue-996
+
+## Task
+
+Port the canonical multi-slot loadout into the Linux/Windows `vllm` provider
+preset. PR #990 added `[presets.base_urls]` to `vllm_mlx.toml` (Apple Silicon)
+so each category routes to the slot where its preset model is actually loaded.
+The sister TOML — `parish/crates/parish-config/providers/vllm.toml` — was
+left behind, so `fill_missing_models_from_presets` auto-picks the preset
+model (e.g. `Qwen3-8B`) but inherits the user-level base URL (`:8000`, where
+only the 14B is loaded) → guaranteed 404 storm on Linux/Windows the moment a
+user pulls main.
+
+Fix: declare a three-slot loadout in `vllm.toml`, with each unique Qwen3 model
+size pinned to its own port — `:8000` (14B / dialogue), `:8001` (8B / shared
+by simulation + reaction), `:8002` (4B / intent). This is the layout the
+issue author named as primary; it also round-trips cleanly through
+`vllm_extra_slots` + `VllmProcess::ensure_slots`, because each unique model
+gets its own slot key.
+
+## Criteria
+
+- `vllm.toml`'s recommended preset declares a `[presets.base_urls]` block
+  pinning each category to its slot URL — observable via: `cat
+  parish/crates/parish-config/providers/vllm.toml`.
+- `Provider::from_str_loose("vllm")?.preset_base_url(cat)` returns the
+  expected URL for each of the four `InferenceCategory` variants (dialogue
+  `:8000`, simulation `:8001`, intent `:8002`, reaction `:8001`) — observable
+  via: a new `parish-core` unit test that calls `preset_base_url`.
+- `GameConfig { provider_name: "vllm", base_url: "http://localhost:8000", ..
+  }.fill_missing_models_from_presets()` populates `category_base_url` for all
+  four categories from the preset — observable via: a new `parish-core` unit
+  test that asserts the four entries match.
+- `vllm_extra_slots()` on that filled `GameConfig` emits three slots — sim
+  `Qwen3-8B@:8001`, intent `Qwen3-4B@:8002`, reaction `Qwen3-8B@:8001` — the
+  dialogue slot `Qwen3-14B@:8000` is the base and is correctly elided.
+  Downstream dedup (`VllmProcess::ensure_slots`) collapses the duplicate 8B
+  slot to two unique processes. Observable via: the same new unit test.
+- Engine still parses the modified TOML and boots a headless session
+  (regression guard for any TOML syntax slip) — observable via: the harness
+  smoke fixture below loads and emits a non-error `/status` payload.
+
+## Verification
+
+1. Cargo test (primary signal — exercises the schema round-trip):
+
+   ```sh
+   cargo test --manifest-path parish/Cargo.toml -p parish-core \
+     --lib ipc::config::tests::vllm_preset_supplies_per_category_base_url \
+     -- --nocapture
+   ```
+
+   Expected: test passes. Output should show the four URL/model assertions
+   succeed and `vllm_extra_slots` returning the 8B and 4B slots.
+
+2. Harness smoke (parse-error guard — confirms engine still loads):
+
+   ```sh
+   cargo run --manifest-path parish/Cargo.toml -p parish-cli -- \
+     --script parish/testing/fixtures/play_issue-996.txt
+   ```
+
+   Expected: `/status` JSON emitted, engine reaches end of script cleanly.
+
+Capture both into `docs/proofs/issue-996/transcript.txt`.

--- a/docs/proofs/issue-996/evidence.md
+++ b/docs/proofs/issue-996/evidence.md
@@ -1,0 +1,94 @@
+# Evidence: issue-996
+
+Evidence type: live gameplay transcript
+
+The "live" component is the harness smoke run at `transcript.txt:15-22`,
+which exercises the modified `vllm.toml` in a real engine boot. The unit
+test at `transcript.txt:1-12` exercises the schema round-trip through the
+production code paths (`Provider::preset_base_url`,
+`GameConfig::fill_missing_models_from_presets`, `GameConfig::vllm_extra_slots`).
+
+`parish-config` is not in the live-proof tier set (rule #10 path matrix), but
+the bundle ships both signals anyway for defense-in-depth.
+
+## Files changed
+
+- `parish/crates/parish-config/providers/vllm.toml` — added
+  `[presets.base_urls]` block pinning each category to its slot URL +
+  documentation of the three-slot layout.
+- `parish/crates/parish-core/src/ipc/config.rs` — added regression test
+  `vllm_preset_supplies_per_category_base_url` covering the schema +
+  fill-presets + extra-slots round-trip.
+- `parish/testing/fixtures/play_issue-996.txt` — harness smoke fixture
+  confirming the engine still parses the modified TOML.
+
+## Criterion-to-line mapping
+
+### Criterion 1 — `vllm.toml`'s recommended preset declares a `[presets.base_urls]` block
+
+The file now contains the block at lines 24-28 of `vllm.toml`:
+
+```toml
+[presets.base_urls]
+dialogue = "http://localhost:8000"
+simulation = "http://localhost:8001"
+intent = "http://localhost:8002"
+reaction = "http://localhost:8001"
+```
+
+### Criterion 2 — `Provider::preset_base_url` returns the expected URL per category
+
+`transcript.txt:10` shows the test passing:
+
+```
+test ipc::config::tests::vllm_preset_supplies_per_category_base_url ... ok
+```
+
+The test body asserts (`parish/crates/parish-core/src/ipc/config.rs`, new
+test in `tests` mod):
+
+- `vllm.preset_base_url(Dialogue) == Some("http://localhost:8000")`
+- `vllm.preset_base_url(Simulation) == Some("http://localhost:8001")`
+- `vllm.preset_base_url(Intent) == Some("http://localhost:8002")`
+- `vllm.preset_base_url(Reaction) == Some("http://localhost:8001")`
+
+### Criterion 3 — `fill_missing_models_from_presets` populates `category_base_url` for all four roles
+
+Same passing test asserts on a `GameConfig { provider_name: "vllm",
+base_url: "http://localhost:8000", .. }`:
+
+- `category_base_url[Dialogue]    == ":8000"`
+- `category_base_url[Simulation]  == ":8001"`
+- `category_base_url[Intent]      == ":8002"`
+- `category_base_url[Reaction]    == ":8001"`
+- `category_model[Dialogue]       == Qwen/Qwen3-14B`
+- `category_model[Simulation]     == Qwen/Qwen3-8B`
+- `category_model[Intent]         == Qwen/Qwen3-4B`
+- `category_model[Reaction]       == Qwen/Qwen3-8B`
+
+### Criterion 4 — `vllm_extra_slots` emits three slots, dialogue elided
+
+Same passing test asserts `slots.len() == 3` after setting `model_name =
+Qwen3-14B` (so the dialogue slot matches the base). It then asserts the
+returned URL/model pairs include `(:8001, 8B)`, `(:8002, 4B)`, and that
+two of the three slots are the shared `(:8001, 8B)` — i.e. simulation +
+reaction collapse onto the same backing process once
+`VllmProcess::ensure_slots` dedupes downstream.
+
+### Criterion 5 — Engine still parses the modified TOML and boots a headless session
+
+`transcript.txt:18-22` shows the harness fixture emitting clean JSON for
+`/status`, `look`, `/time`, `/npcs`, `/quit`. The session started, ran all
+five commands, and exited cleanly. No parse error, no panic. The TOML
+schema change is binary-compatible with the existing engine boot path.
+
+## Why not a live LLM-call demo
+
+The Linux/Windows `vllm` provider runs CUDA/ROCm hardware that this
+worktree (macOS) doesn't have. Reproducing the 404 storm in-process would
+require Linux + a real vllm server. The proof-of-correctness here is the
+schema round-trip — every code path the runtime would take from preset →
+`GameConfig` → `VllmSlot` list is exercised, and the same code is used by
+`vllm_mlx.toml` (already proven on Apple Silicon in PR #990). The TOML
+edit is a config port, not a logic change; the underlying machinery was
+landed and verified by #990.

--- a/docs/proofs/issue-996/judge.md
+++ b/docs/proofs/issue-996/judge.md
@@ -1,0 +1,27 @@
+# Judge: issue-996
+
+Verdict: sufficient
+Technical debt: clear
+Acceptance criteria: met
+
+## Per-criterion verification
+
+Criterion 1 (`vllm.toml` declares `[presets.base_urls]`): `vllm.toml:28-32` — `[presets.base_urls]` block present with `dialogue = "http://localhost:8000"`, `simulation = "http://localhost:8001"`, `intent = "http://localhost:8002"`, `reaction = "http://localhost:8001"`. Layout matches issue #996's proposal exactly (`:8000` 14B, `:8001` shared 8B, `:8002` 4B).
+
+Criterion 2 (`preset_base_url` returns expected URL per category): `transcript.txt:10` — `test ipc::config::tests::vllm_preset_supplies_per_category_base_url ... ok`. Test body at `config.rs:1042-1057` asserts all four URLs.
+
+Criterion 3 (`fill_missing_models_from_presets` populates `category_base_url` for all four categories): same passing test, `config.rs:1066-1100`. Asserts `changed == true` and all four `category_base_url` + `category_model` entries match the expected preset values (8000/14B, 8001/8B, 8002/4B, 8001/8B).
+
+Criterion 4 (`vllm_extra_slots` emits three slots, dialogue elided, 8B@:8001 appears twice): same passing test, `config.rs:1107-1127`. Sets `model_name = Qwen3-14B` so dialogue collapses to base, asserts `slots.len() == 3`, verifies presence of `(:8001, 8B)` and `(:8002, 4B)`, and counts exactly two `(:8001, 8B)` entries (sim + reaction).
+
+Criterion 5 (engine still parses modified TOML and boots a headless session): `transcript.txt:18-22` — clean JSON for `/status`, `look`, `/time`, `/npcs`, `/quit`. No TOML parse error, no panic, engine reached end of script.
+
+## Notes
+
+- TOML structure is correct. The `[presets.base_urls]` sub-table sits after the four scalar category keys (`dialogue/simulation/intent/reaction`) on the parent `[[presets]]` entry. Because the parent table's scalar fields are all set before the sub-table header, TOML parsing places `base_urls` as a child of the same preset rather than orphaning it — the harness smoke run confirms this empirically.
+- URL/model alignment matches the issue's intended layout: 14B on `:8000` (also the user-level `default_base_url`), 8B on `:8001` shared by sim + reaction, 4B on `:8002`. Each unique model size gets its own port, so `VllmProcess::ensure_slots`' dedup logic spawns exactly two extra processes beyond the base.
+- Mirrors the sister `vllm_mlx.toml` schema landed in PR #990. No drift between the two provider configs at the schema layer.
+- Test is not passing for the wrong reason: it directly inspects the populated maps and the `vllm_extra_slots` output, not just provider-load success. Dialogue is correctly elided by setting `model_name = Qwen3-14B` before calling `vllm_extra_slots`, otherwise the dialogue slot would also appear.
+- No scope creep: the change is purely the TOML port plus its regression test plus the smoke fixture. No unrelated edits.
+- Live-proof tier: `parish-config` is not in the matrix, so the harness smoke run is defense-in-depth rather than a hard requirement. Author correctly notes this in evidence.md.
+- Acceptance-criteria-first ordering: criteria file is present, all five criteria mapped to observable signals in transcript or files.

--- a/docs/proofs/issue-996/transcript.txt
+++ b/docs/proofs/issue-996/transcript.txt
@@ -1,0 +1,22 @@
+=== Verification 1: parish-core unit test ===
+Command: cargo test --manifest-path parish/Cargo.toml -p parish-core --lib ipc::config::tests::vllm_preset_supplies_per_category_base_url -- --nocapture
+
+    Blocking waiting for file lock on package cache
+    Blocking waiting for file lock on package cache
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.44s
+     Running unittests src/lib.rs (parish/target/debug/deps/parish_core-70e21ba2972904ad)
+
+running 1 test
+test ipc::config::tests::vllm_preset_supplies_per_category_base_url ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 366 filtered out; finished in 0.03s
+
+
+=== Verification 2: harness smoke fixture (engine boots with modified TOML) ===
+Command: cargo run -p parish -- --script parish/testing/fixtures/play_issue-996.txt
+
+{"command":"/status","result":"system_command","response":"Location: Kilteevan Village | Morning | Spring","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["Location: Kilteevan Village | Morning | Spring","An older woman with sharp eyes and herb-stained fingers heads off down the road.","An older man heads off down the road.","A lean, red-haired young man with hard eyes heads off down the road.","A young woman heads off down the road."]}
+{"command":"look","result":"looked","description":"The small village of Kilteevan — a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The clear sky hangs over the quiet street. It is morning.","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["The small village of Kilteevan — a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The clear sky hangs over the quiet street. It is morning.","You can go to: The Crossroads (13 min on foot), The Forge (1 min on foot), The Holy Well (1 min on foot), The Mill (1 min on foot), The Weaver's Cottage (2 min on foot), Knockcroghery Village (85 min on foot), St. Brigid's Church (9 min on foot), Murphy's Farm (21 min on foot), The Lime Kiln (1 min on foot), The Letter Office (11 min on foot)"]}
+{"command":"/time","result":"system_command","response":"08:00 Morning — Spring\nWeather: Clear\nSpeed: 36x\nFestival: none","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["08:00 Morning — Spring\nWeather: Clear\nSpeed: 36x\nFestival: none"]}
+{"command":"/npcs","result":"system_command","response":"NPCs here:\n  a small, sharp-eyed old woman wrapped in a shawl — Widow (sharp)","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["NPCs here:\n  a small, sharp-eyed old woman wrapped in a shawl — Widow (sharp)"]}
+{"command":"/quit","result":"quit","location":"Kilteevan Village","time":"Morning","season":"Spring"}

--- a/parish/crates/parish-config/providers/vllm.toml
+++ b/parish/crates/parish-config/providers/vllm.toml
@@ -12,7 +12,21 @@ featured = false
 [[presets]]
 key = "recommended"
 label = "Recommended"
+# Three-slot Linux/Windows CUDA/ROCm loadout:
+#   Slot 1 (:8000) — 14B for dialogue (narrative weight)
+#   Slot 2 (:8001) — 8B for simulation + reaction (mid-tier shared)
+#   Slot 3 (:8002) — 4B for intent (low-latency)
+# Each unique model size pinned to its own port. Downstream
+# VllmProcess::ensure_slots dedups duplicate (url, model) pairs so the
+# shared 8B slot only spawns one process. Mirrors vllm_mlx.toml's
+# two-slot Apple Silicon pattern (#990, #996).
 dialogue = "Qwen/Qwen3-14B"
 simulation = "Qwen/Qwen3-8B"
 intent = "Qwen/Qwen3-4B"
 reaction = "Qwen/Qwen3-8B"
+
+[presets.base_urls]
+dialogue = "http://localhost:8000"
+simulation = "http://localhost:8001"
+intent = "http://localhost:8002"
+reaction = "http://localhost:8001"

--- a/parish/crates/parish-core/src/ipc/config.rs
+++ b/parish/crates/parish-core/src/ipc/config.rs
@@ -1025,4 +1025,105 @@ mod tests {
         assert_eq!(slots.len(), 1);
         assert_eq!(slots[0].base_url, "http://localhost:8001");
     }
+
+    // Regression guard for #996. The Linux/Windows `vllm` provider preset
+    // must declare a `[presets.base_urls]` block so the multi-slot loadout
+    // round-trips through `fill_missing_models_from_presets` →
+    // `vllm_extra_slots` → `VllmProcess::ensure_slots`. Without this, the
+    // category model is auto-picked from the preset (e.g. Qwen3-8B) but the
+    // category base URL inherits the user-level base (:8000, where only the
+    // 14B is loaded) → 404 storm.
+    #[test]
+    fn vllm_preset_supplies_per_category_base_url() {
+        use parish_config::Provider;
+
+        // 1. Schema-level: the loaded provider exposes a base URL per category.
+        let vllm = Provider::from_str_loose("vllm").expect("vllm provider loaded");
+        assert_eq!(
+            vllm.preset_base_url(InferenceCategory::Dialogue),
+            Some("http://localhost:8000"),
+        );
+        assert_eq!(
+            vllm.preset_base_url(InferenceCategory::Simulation),
+            Some("http://localhost:8001"),
+        );
+        assert_eq!(
+            vllm.preset_base_url(InferenceCategory::Intent),
+            Some("http://localhost:8002"),
+        );
+        assert_eq!(
+            vllm.preset_base_url(InferenceCategory::Reaction),
+            Some("http://localhost:8001"),
+        );
+
+        // 2. Config-level: fill_missing_models_from_presets populates
+        //    category_base_url alongside category_model for all four roles.
+        let mut cfg = GameConfig {
+            provider_name: "vllm".to_string(),
+            base_url: "http://localhost:8000".to_string(),
+            ..GameConfig::default()
+        };
+        let changed = cfg.fill_missing_models_from_presets();
+        assert!(changed, "preset should fill all four categories");
+
+        assert_eq!(
+            cfg.category_base_url.get(&InferenceCategory::Dialogue),
+            Some(&"http://localhost:8000".to_string()),
+        );
+        assert_eq!(
+            cfg.category_base_url.get(&InferenceCategory::Simulation),
+            Some(&"http://localhost:8001".to_string()),
+        );
+        assert_eq!(
+            cfg.category_base_url.get(&InferenceCategory::Intent),
+            Some(&"http://localhost:8002".to_string()),
+        );
+        assert_eq!(
+            cfg.category_base_url.get(&InferenceCategory::Reaction),
+            Some(&"http://localhost:8001".to_string()),
+        );
+        assert_eq!(
+            cfg.category_model.get(&InferenceCategory::Dialogue),
+            Some(&"Qwen/Qwen3-14B".to_string()),
+        );
+        assert_eq!(
+            cfg.category_model.get(&InferenceCategory::Simulation),
+            Some(&"Qwen/Qwen3-8B".to_string()),
+        );
+        assert_eq!(
+            cfg.category_model.get(&InferenceCategory::Intent),
+            Some(&"Qwen/Qwen3-4B".to_string()),
+        );
+        assert_eq!(
+            cfg.category_model.get(&InferenceCategory::Reaction),
+            Some(&"Qwen/Qwen3-8B".to_string()),
+        );
+
+        // 3. Spawn-list level: dialogue (= base 14B@:8000) is elided as the
+        //    base slot; the remaining three categories emit one slot each.
+        //    Downstream VllmProcess::ensure_slots dedups the duplicate 8B
+        //    slot, but vllm_extra_slots itself does not.
+        // Set base model to the dialogue preset so the base slot matches.
+        cfg.model_name = "Qwen/Qwen3-14B".to_string();
+        let slots = cfg.vllm_extra_slots();
+        assert_eq!(slots.len(), 3, "sim + intent + reaction, dialogue elided");
+        let urls_models: Vec<(String, String)> = slots
+            .iter()
+            .map(|s| (s.base_url.clone(), s.model.clone()))
+            .collect();
+        assert!(urls_models.contains(&(
+            "http://localhost:8001".to_string(),
+            "Qwen/Qwen3-8B".to_string(),
+        )));
+        assert!(urls_models.contains(&(
+            "http://localhost:8002".to_string(),
+            "Qwen/Qwen3-4B".to_string(),
+        )));
+        // Two of the three should be the shared 8B@:8001 slot (sim + reaction).
+        let eight_b_count = urls_models
+            .iter()
+            .filter(|(u, m)| u == "http://localhost:8001" && m == "Qwen/Qwen3-8B")
+            .count();
+        assert_eq!(eight_b_count, 2, "sim + reaction share the 8B slot");
+    }
 }

--- a/parish/testing/fixtures/play_issue-996.txt
+++ b/parish/testing/fixtures/play_issue-996.txt
@@ -1,0 +1,11 @@
+# issue-996 — parse-error guard for vllm.toml schema change
+#
+# The actual schema round-trip is verified by a parish-core unit test
+# (see docs/proofs/issue-996/acceptance-criteria.md). This fixture just
+# confirms the modified TOML still loads cleanly and the engine boots.
+
+/status
+look
+/time
+/npcs
+/quit


### PR DESCRIPTION
Closes #996.

## Summary

- PR #990 added `[presets.base_urls]` to `vllm_mlx.toml` so each category on Apple Silicon routes to the slot where its preset model is actually loaded. The sister TOML for Linux/Windows CUDA/ROCm (`vllm.toml`) was left behind — `fill_missing_models_from_presets` auto-picks the preset model (e.g. `Qwen3-8B`) but inherits the user-level base URL (`:8000`, where only the 14B is loaded) → 404 storm equivalent to the pre-#990 macOS bug.
- Three-slot layout per the issue's primary suggestion: `:8000` 14B (dialogue) / `:8001` 8B shared (simulation + reaction) / `:8002` 4B (intent). Downstream `VllmProcess::ensure_slots` dedups the shared 8B slot, so only two extra processes spawn beyond the base.
- New `parish-core` regression test `vllm_preset_supplies_per_category_base_url` exercises `Provider::preset_base_url` → `fill_missing_models_from_presets` → `vllm_extra_slots` end-to-end and asserts URLs/models for all four categories plus dialogue-elision.

## Test plan

- [x] `cargo test -p parish-core --lib ipc::config::tests::vllm_preset_supplies_per_category_base_url` — passes
- [x] `cargo clippy -p parish-core --no-deps` — clean
- [x] `cargo fmt --check` — clean
- [x] Harness smoke (`cargo run -p parish -- --script parish/testing/fixtures/play_issue-996.txt`) — engine still parses modified TOML
- [x] `just agent-check` — proof bundle gate passes

Proof bundle: [docs/proofs/issue-996/](docs/proofs/issue-996/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)