### PR TITLE
docs: expand 19th-century Irish map sources in world-geography.md

### DIFF
--- a/docs/design/world-geography.md
+++ b/docs/design/world-geography.md
@@ -31,10 +31,52 @@ The world is built on real Irish geography. All places are real. All people and 
 
 ### Historical Reference (World-Building)
 
-Not for direct data import — used for world-building context and atmosphere:
+Used for period accuracy, atmosphere, and verifying that generated location data matches the 1820s landscape. Not suitable as a primary import pipeline but valuable for cross-checking and for the tile/visual layer.
 
-- GeoHive historical OS maps (6-inch and 25-inch series): https://webapps.geohive.ie/mapviewer/index.html
-- Down Survey maps (17th century): http://downsurvey.tcd.ie/down-survey-maps.php
+#### Raw GIS data — free downloads
+
+**GSI Goldmine / geologicalmaps.net (best available)**
+- The Geological Survey of Ireland's 1-inch historical sheets drawn on the same OS base survey as the 6-inch maps, covering all of Ireland
+- Free TIFF downloads per sheet; CC Attribution 4.0 license; ~450,000-page archive
+- The geological overlay is secondary — the base layer shows roads, settlements, drainage, townlands, and parish names, making these genuine 19th-century topographic sources
+- Sheet index and download: https://www.geologicalmaps.net/irishhistmaps/mapindex.cfm
+- Full archive (reports + maps): https://secure.decc.gov.ie/goldmine/index.html
+
+**irelandmapped.ie — OS200 Project (launched June 2024)**
+- Open-access digital archive from University of Limerick + Queen's University Belfast, funded by the Irish Research Council / AHRC
+- Connects First Edition 6-inch maps (surveyed 1829–1842) with OS Memoirs, Letters, and Name Books
+- Shapefile download confirmed; ArcGIS and OpenLayers integration; IIIF image links
+- https://www.irelandmapped.ie
+
+**David Rumsey Map Collection**
+- Has 19th-century Ireland coverage including the Railway Commissioners' map
+- Built-in georeferencing tool; export any map as GeoTIFF directly from the website
+- Thinner Irish coverage than UK but free and accessible
+- https://www.davidrumsey.com (search "Ireland")
+
+**OpenHistoricalMap**
+- OSM-format vector data with date-tagged historical features; daily planet dump on Amazon S3
+- Overpass API available for spatial queries by bounding box + date range
+- Ireland 1800s coverage is sparse (volunteer-traced); worth querying before investing
+- https://wiki.openstreetmap.org/wiki/OpenHistoricalMap
+
+**British Library Mechanical Curator → Wikimedia Commons**
+- The BL digitized ~1 million images from 19th-century books; a georeferencing project has worked through the Ireland-relevant subset
+- Individual high-res scans available; coverage is map-by-map rather than systematic
+- Category: https://commons.wikimedia.org/wiki/Category:19th-century_maps_of_Ireland
+- Georeferenced subset: https://commons.wikimedia.org/wiki/Commons:British_Library/Mechanical_Curator_collection/georeferencing_done
+
+#### Reference / viewer only
+
+- GeoHive historical OS maps (6-inch and 25-inch series, viewer): https://webapps.geohive.ie/mapviewer/index.html
+- Irish Townland and Historical Map Viewer (OSi ArcGIS): https://osi.maps.arcgis.com/apps/webappviewer/index.html?id=bc56a1cf08844a2aa2609aa92e89497e
+- Down Survey maps (17th-century, TCD GIS project): http://downsurvey.tcd.ie/down-survey-maps.php
+- NLS 6-inch Ireland 1829–1969 (viewable free, JPEG purchase): https://maps.nls.uk/os/6inch-ireland/
+- UCD Digital Collections — ~1,370 OS town plans 1847–1896: https://digital.ucd.ie/view/ucdlib:40377
+
+#### Survey of the field
+
+- "Open Historical Maps of Ireland" (academic overview): https://www.academia.edu/43288155/Open_Historical_Maps_of_Ireland
 
 ## World Structure
 

--- a/docs/design/world-geography.md
+++ b/docs/design/world-geography.md
@@ -58,7 +58,7 @@ Used for period accuracy, atmosphere, and verifying that generated location data
 - OSM-format vector data with date-tagged historical features; daily planet dump on Amazon S3
 - Overpass API available for spatial queries by bounding box + date range
 - Ireland 1800s coverage is sparse (volunteer-traced); worth querying before investing
-- https://wiki.openstreetmap.org/wiki/OpenHistoricalMap
+- https://www.openhistoricalmap.org
 
 **British Library Mechanical Curator → Wikimedia Commons**
 - The BL digitized ~1 million images from 19th-century books; a georeferencing project has worked through the Ireland-relevant subset
@@ -70,7 +70,7 @@ Used for period accuracy, atmosphere, and verifying that generated location data
 
 - GeoHive historical OS maps (6-inch and 25-inch series, viewer): https://webapps.geohive.ie/mapviewer/index.html
 - Irish Townland and Historical Map Viewer (OSi ArcGIS): https://osi.maps.arcgis.com/apps/webappviewer/index.html?id=bc56a1cf08844a2aa2609aa92e89497e
-- Down Survey maps (17th-century, TCD GIS project): http://downsurvey.tcd.ie/down-survey-maps.php
+- Down Survey maps (17th-century, TCD GIS project): https://downsurvey.tcd.ie/down-survey-maps.php
 - NLS 6-inch Ireland 1829–1969 (viewable free, JPEG purchase): https://maps.nls.uk/os/6inch-ireland/
 - UCD Digital Collections — ~1,370 OS town plans 1847–1896: https://digital.ucd.ie/view/ucdlib:40377
 


### PR DESCRIPTION
## Summary

- Expands the Historical Reference section of `docs/design/world-geography.md` from a two-link stub into a structured guide to raw 19th-century Irish map data
- Distinguishes free-download GIS sources (actual raster/vector files) from viewer-only links
- Covers seven sources not previously documented: GSI Goldmine, irelandmapped.ie (OS200), David Rumsey, OpenHistoricalMap, British Library/Wikimedia, NLS, and UCD town plans

## Sources added

| Source | Format | Free? | Notes |
|--------|--------|-------|-------|
| GSI Goldmine / geologicalmaps.net | TIFF | Yes (CC4.0) | 1-inch sheets on OS base; full national coverage |
| irelandmapped.ie (OS200, 2024) | Shapefile + images | Yes | First Edition 6-inch + OS Memoirs/Name Books |
| David Rumsey | GeoTIFF (export) | Yes | Georeferencing tool built in |
| OpenHistoricalMap | OSM PBF / vector | Yes | Date-tagged features; Ireland coverage sparse |
| BL Mechanical Curator / Wikimedia | PNG/JPG | Yes | Patchy; some georeferenced |

## Test plan

- No code changed; pure documentation update
- Verify links resolve and section reads clearly

https://claude.ai/code/session_01A9pM4aSqju7VhyRY1uuJuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9pM4aSqju7VhyRY1uuJuh)_