### PR TITLE
fix(logs): rebind log managers on active-branch switch (closes #1011 #1034)

### DIFF
--- a/parish/crates/parish-cli/src/app.rs
+++ b/parish/crates/parish-cli/src/app.rs
@@ -151,6 +151,15 @@ pub struct App {
     /// `character_log_rx`. Independent receiver so both writers see every
     /// event without contention.
     pub location_log_rx: Option<broadcast::Receiver<GameEvent>>,
+    /// App-name slug used to resolve the user-data dir for log writers.
+    /// Set at startup from the active mod; needed to rebuild log managers
+    /// when the active branch changes (#1011).
+    pub log_app_name: String,
+    /// Branch id the current `character_log` / `location_log` managers
+    /// were built against. When `active_branch_id` diverges (e.g. after
+    /// `/load <branch>` or `/fork <branch>`), the drain pumps rebuild
+    /// the managers so events land under the new branch's log dir.
+    pub log_managers_branch: Option<i64>,
 }
 
 impl App {
@@ -207,7 +216,60 @@ impl App {
             character_log_rx: None,
             location_log: None,
             location_log_rx: None,
+            log_app_name: String::new(),
+            log_managers_branch: None,
         }
+    }
+
+    /// Rebuilds `self.character_log` / `self.location_log` when the active
+    /// branch has changed since the managers were last constructed (#1011,
+    /// #1034). Without this the writers keep appending to the original
+    /// branch's log directory after `/load <branch>` or `/fork <branch>`.
+    ///
+    /// Called at the tail of each REPL drain (headless and script harness),
+    /// so the next event in the new branch lands under `logs/branch-<new>/`.
+    pub fn rebind_log_managers_if_branch_changed(&mut self) {
+        let current = self.active_branch_id;
+        if self.log_managers_branch == Some(current) {
+            return;
+        }
+        if self.log_app_name.is_empty() {
+            return;
+        }
+        let app_name = self.log_app_name.clone();
+        if self.character_log.is_some() {
+            let enabled = !self
+                .flags
+                .is_disabled(parish_core::character_log::FEATURE_FLAG);
+            let manager =
+                parish_core::character_log::CharacterLogManager::new(&app_name, current, enabled);
+            if manager.enabled()
+                && let Err(e) = manager.write_all_profiles(&self.world, &self.npc_manager)
+            {
+                tracing::warn!(
+                    error = %e,
+                    "character-log profile write failed after branch switch"
+                );
+            }
+            self.character_log = Some(Arc::new(manager));
+        }
+        if self.location_log.is_some() {
+            let enabled = !self
+                .flags
+                .is_disabled(parish_core::location_log::FEATURE_FLAG);
+            let manager =
+                parish_core::location_log::LocationLogManager::new(&app_name, current, enabled);
+            if manager.enabled()
+                && let Err(e) = manager.write_all_profiles(&self.world, &self.npc_manager)
+            {
+                tracing::warn!(
+                    error = %e,
+                    "location-log profile write failed after branch switch"
+                );
+            }
+            self.location_log = Some(Arc::new(manager));
+        }
+        self.log_managers_branch = Some(current);
     }
 
     /// Returns the language settings derived from the active game mod.

--- a/parish/crates/parish-cli/src/headless.rs
+++ b/parish/crates/parish-cli/src/headless.rs
@@ -352,6 +352,7 @@ pub async fn run_headless(
     // Character logs — gated by `character-logs` flag (default on).
     // Subscribe BEFORE writing profiles so the rx doesn't miss any
     // events that fire during/just after profile generation.
+    app.log_app_name = app_name.clone();
     {
         let enabled = !app
             .flags
@@ -388,6 +389,7 @@ pub async fn run_headless(
         }
         app.location_log = Some(std::sync::Arc::new(manager));
     }
+    app.log_managers_branch = Some(app.active_branch_id);
 
     // Show initial location
     print_location_arrival(&app);
@@ -457,6 +459,7 @@ static HEADLESS_IDLE_COUNTER: std::sync::atomic::AtomicUsize =
 /// background task, but a synchronous drain catches everything since the
 /// REPL is the only producer between drains.
 fn drain_character_log_events(app: &mut App) {
+    app.rebind_log_managers_if_branch_changed();
     let (Some(manager), Some(rx)) = (app.character_log.as_ref(), app.character_log_rx.as_mut())
     else {
         return;
@@ -481,6 +484,7 @@ fn drain_character_log_events(app: &mut App) {
 /// Same shape as [`drain_character_log_events`] but for the per-location
 /// markdown log writer. Both run at the tail of each REPL iteration.
 fn drain_location_log_events(app: &mut App) {
+    app.rebind_log_managers_if_branch_changed();
     let (Some(manager), Some(rx)) = (app.location_log.as_ref(), app.location_log_rx.as_mut())
     else {
         return;
@@ -2240,5 +2244,63 @@ mod tests {
             !error_would_be_triggered,
             "interactive mode must not hard-error on a locked save file during /load save-switch"
         );
+    }
+
+    /// #1011 / #1034: after the active branch changes, `drain_*` must rebuild
+    /// the log managers so subsequent events land under the new branch's dir.
+    #[test]
+    fn rebind_log_managers_follows_branch_switch() {
+        use parish_core::character_log::CharacterLogManager;
+        use parish_core::location_log::LocationLogManager;
+        use tempfile::tempdir;
+
+        let tmp = tempdir().expect("tempdir");
+        // Both managers resolve their log dirs from PARISH_USER_DATA_DIR.
+        // SAFETY: env-var mutation in a test — single-threaded by test
+        // construction (no parallel test touches log_app_name "rebind-test").
+        // safety: env-mutation in test
+        unsafe {
+            std::env::set_var("PARISH_USER_DATA_DIR", tmp.path());
+        }
+
+        let mut app = App::new();
+        app.log_app_name = "rebind-test".to_string();
+        app.active_branch_id = 1;
+        app.character_log = Some(std::sync::Arc::new(CharacterLogManager::new(
+            "rebind-test",
+            1,
+            true,
+        )));
+        app.location_log = Some(std::sync::Arc::new(LocationLogManager::new(
+            "rebind-test",
+            1,
+            true,
+        )));
+        app.log_managers_branch = Some(1);
+
+        // Simulate /fork or /load mutating the active branch.
+        app.active_branch_id = 2;
+        app.rebind_log_managers_if_branch_changed();
+
+        assert_eq!(
+            app.log_managers_branch,
+            Some(2),
+            "rebind should record the new branch id"
+        );
+        // Both managers should now write under logs/branch-2/.
+        // `PARISH_USER_DATA_DIR` overrides the entire user-data root (the
+        // app_name is ignored when the env var is set — see
+        // resolve_user_data_dir in parish-persistence::paths).
+        let branch2 = tmp.path().join("logs").join("branch-2");
+        assert!(
+            branch2.exists(),
+            "expected logs/branch-2/ to exist after rebind, but missing at {}",
+            branch2.display()
+        );
+
+        // safety: env-cleanup in test
+        unsafe {
+            std::env::remove_var("PARISH_USER_DATA_DIR");
+        }
     }
 }

--- a/parish/crates/parish-cli/src/testing.rs
+++ b/parish/crates/parish-cli/src/testing.rs
@@ -204,14 +204,15 @@ impl GameTestHarness {
         // dump to the shared user-data dir. `new_with_character_logs`
         // (used by `run_script_mode`) sets `enable_character_logs=true`
         // so `parish --script ...` still produces log files.
+        let log_app_name = parish_core::game_mod::app_name_from_mod(&app.game_mod);
+        app.log_app_name = log_app_name.clone();
         {
             let flag_on = !app
                 .flags
                 .is_disabled(parish_core::character_log::FEATURE_FLAG);
             let enabled = enable_character_logs && flag_on;
-            let app_name = parish_core::game_mod::app_name_from_mod(&app.game_mod);
             let manager = parish_core::character_log::CharacterLogManager::new(
-                &app_name,
+                &log_app_name,
                 app.active_branch_id,
                 enabled,
             );
@@ -230,9 +231,8 @@ impl GameTestHarness {
                 .flags
                 .is_disabled(parish_core::location_log::FEATURE_FLAG);
             let enabled = enable_character_logs && flag_on;
-            let app_name = parish_core::game_mod::app_name_from_mod(&app.game_mod);
             let manager = parish_core::location_log::LocationLogManager::new(
-                &app_name,
+                &log_app_name,
                 app.active_branch_id,
                 enabled,
             );
@@ -244,6 +244,7 @@ impl GameTestHarness {
             }
             app.location_log = Some(Arc::new(manager));
         }
+        app.log_managers_branch = Some(app.active_branch_id);
 
         Self {
             app,
@@ -388,6 +389,9 @@ impl GameTestHarness {
         // Drain any GameEvents queued on the character-log receiver since
         // the previous execute() and append them to the right log files.
         // Mirrors the synchronous drain pattern in the REPL loop.
+        // Rebind on branch switch (#1011, #1034) — must run BEFORE the
+        // clones below capture `self.app.character_log` for the drain.
+        self.app.rebind_log_managers_if_branch_changed();
         if let (Some(manager), Some(rx)) = (
             self.app.character_log.clone(),
             self.app.character_log_rx.as_mut(),

--- a/parish/crates/parish-server/src/session.rs
+++ b/parish/crates/parish-server/src/session.rs
@@ -964,8 +964,8 @@ fn spawn_session_ticks(
                 return;
             }
             let app_name = parish_core::game_mod::app_name_from_mod(&s.game_mod);
-            let branch_id = s.current_branch_id.lock().await.unwrap_or(1);
-            let manager = CharacterLogManager::new(&app_name, branch_id, true);
+            let mut current_branch = s.current_branch_id.lock().await.unwrap_or(1);
+            let mut manager = CharacterLogManager::new(&app_name, current_branch, true);
             let mut rx = {
                 let world = s.world.lock().await;
                 world.event_bus.subscribe()
@@ -982,6 +982,20 @@ fn spawn_session_ticks(
                     _ = token.cancelled() => break,
                     result = rx.recv() => match result {
                         Ok(event) => {
+                            // Rebind manager when the active branch has changed
+                            // (e.g. load_branch / create_branch). Without this the
+                            // writer keeps appending to the original branch's
+                            // log directory after a branch switch (#1011).
+                            let bid = s.current_branch_id.lock().await.unwrap_or(1);
+                            if bid != current_branch {
+                                current_branch = bid;
+                                manager = CharacterLogManager::new(&app_name, bid, true);
+                                let world = s.world.lock().await;
+                                let npc_mgr = s.npc_manager.lock().await;
+                                if let Err(e) = manager.write_all_profiles(&world, &npc_mgr) {
+                                    tracing::warn!(error = %e, "character-log profile write failed after branch switch");
+                                }
+                            }
                             let world = s.world.lock().await;
                             let npc_mgr = s.npc_manager.lock().await;
                             if let Err(e) = manager.process_event(&event, &world, &npc_mgr) {
@@ -1014,8 +1028,8 @@ fn spawn_session_ticks(
                 return;
             }
             let app_name = parish_core::game_mod::app_name_from_mod(&s.game_mod);
-            let branch_id = s.current_branch_id.lock().await.unwrap_or(1);
-            let manager = LocationLogManager::new(&app_name, branch_id, true);
+            let mut current_branch = s.current_branch_id.lock().await.unwrap_or(1);
+            let mut manager = LocationLogManager::new(&app_name, current_branch, true);
             let mut rx = {
                 let world = s.world.lock().await;
                 world.event_bus.subscribe()
@@ -1032,6 +1046,19 @@ fn spawn_session_ticks(
                     _ = token.cancelled() => break,
                     result = rx.recv() => match result {
                         Ok(event) => {
+                            // Rebind manager when the active branch has changed
+                            // (e.g. load_branch / create_branch). Mirrors the
+                            // character-log subscriber fix from #1011 (#1034).
+                            let bid = s.current_branch_id.lock().await.unwrap_or(1);
+                            if bid != current_branch {
+                                current_branch = bid;
+                                manager = LocationLogManager::new(&app_name, bid, true);
+                                let world = s.world.lock().await;
+                                let npc_mgr = s.npc_manager.lock().await;
+                                if let Err(e) = manager.write_all_profiles(&world, &npc_mgr) {
+                                    tracing::warn!(error = %e, "location-log profile write failed after branch switch");
+                                }
+                            }
                             let world = s.world.lock().await;
                             let npc_mgr = s.npc_manager.lock().await;
                             if let Err(e) = manager.process_event(&event, &world, &npc_mgr) {

--- a/parish/crates/parish-tauri/src/setup.rs
+++ b/parish/crates/parish-tauri/src/setup.rs
@@ -531,8 +531,8 @@ pub(crate) async fn spawn_character_log_subscriber(state: &Arc<AppState>, app_na
     if !enabled {
         return;
     }
-    let branch_id = state.current_branch_id.lock().await.unwrap_or(1);
-    let manager = Arc::new(CharacterLogManager::new(&app_name, branch_id, true));
+    let initial_branch = state.current_branch_id.lock().await.unwrap_or(1);
+    let manager = CharacterLogManager::new(&app_name, initial_branch, true);
 
     // Subscribe BEFORE writing profiles so the rx doesn't miss any events
     // fired between the profile write and the subscriber task starting.
@@ -552,17 +552,32 @@ pub(crate) async fn spawn_character_log_subscriber(state: &Arc<AppState>, app_na
 
     let state_sub = Arc::clone(state);
     let token = state.shutdown_token.clone();
-    let manager_sub = Arc::clone(&manager);
     tokio::spawn(async move {
         let mut rx = rx;
+        let mut current_branch = initial_branch;
+        let mut manager = manager;
         loop {
             tokio::select! {
                 _ = token.cancelled() => break,
                 result = rx.recv() => match result {
                     Ok(event) => {
+                        // Rebind manager when the active branch has changed
+                        // (e.g. load_branch / create_branch). Without this the
+                        // writer keeps appending to the original branch's
+                        // log directory after a branch switch (#1011).
+                        let bid = state_sub.current_branch_id.lock().await.unwrap_or(1);
+                        if bid != current_branch {
+                            current_branch = bid;
+                            manager = CharacterLogManager::new(&app_name, bid, true);
+                            let world = state_sub.world.lock().await;
+                            let npc_mgr = state_sub.npc_manager.lock().await;
+                            if let Err(e) = manager.write_all_profiles(&world, &npc_mgr) {
+                                tracing::warn!(error = %e, "character-log profile write failed after branch switch");
+                            }
+                        }
                         let world = state_sub.world.lock().await;
                         let npc_mgr = state_sub.npc_manager.lock().await;
-                        if let Err(e) = manager_sub.process_event(&event, &world, &npc_mgr) {
+                        if let Err(e) = manager.process_event(&event, &world, &npc_mgr) {
                             tracing::warn!(error = %e, "character-log write failed");
                         }
                     }
@@ -587,8 +602,8 @@ pub(crate) async fn spawn_location_log_subscriber(state: &Arc<AppState>, app_nam
     if !enabled {
         return;
     }
-    let branch_id = state.current_branch_id.lock().await.unwrap_or(1);
-    let manager = Arc::new(LocationLogManager::new(&app_name, branch_id, true));
+    let initial_branch = state.current_branch_id.lock().await.unwrap_or(1);
+    let manager = LocationLogManager::new(&app_name, initial_branch, true);
 
     let rx = {
         let world = state.world.lock().await;
@@ -605,17 +620,31 @@ pub(crate) async fn spawn_location_log_subscriber(state: &Arc<AppState>, app_nam
 
     let state_sub = Arc::clone(state);
     let token = state.shutdown_token.clone();
-    let manager_sub = Arc::clone(&manager);
     tokio::spawn(async move {
         let mut rx = rx;
+        let mut current_branch = initial_branch;
+        let mut manager = manager;
         loop {
             tokio::select! {
                 _ = token.cancelled() => break,
                 result = rx.recv() => match result {
                     Ok(event) => {
+                        // Rebind manager when the active branch has changed
+                        // (e.g. load_branch / create_branch). Mirrors the
+                        // character-log subscriber fix from #1011 (#1034).
+                        let bid = state_sub.current_branch_id.lock().await.unwrap_or(1);
+                        if bid != current_branch {
+                            current_branch = bid;
+                            manager = LocationLogManager::new(&app_name, bid, true);
+                            let world = state_sub.world.lock().await;
+                            let npc_mgr = state_sub.npc_manager.lock().await;
+                            if let Err(e) = manager.write_all_profiles(&world, &npc_mgr) {
+                                tracing::warn!(error = %e, "location-log profile write failed after branch switch");
+                            }
+                        }
                         let world = state_sub.world.lock().await;
                         let npc_mgr = state_sub.npc_manager.lock().await;
-                        if let Err(e) = manager_sub.process_event(&event, &world, &npc_mgr) {
+                        if let Err(e) = manager.process_event(&event, &world, &npc_mgr) {
                             tracing::warn!(error = %e, "location-log write failed");
                         }
                     }

--- a/parish/testing/fixtures/play_issue-1011.txt
+++ b/parish/testing/fixtures/play_issue-1011.txt
@@ -1,0 +1,34 @@
+# issue-1011 + #1034 play-test
+# =================================
+# Exercises: log subscribers rebind their directory when the active
+# branch changes (load_branch / fork_branch).
+#
+# Uses the testbed mod (Origin / Station grid), which is the default
+# active setting in mods/mod-list.toml. PlayerMoved events fire on
+# every successful /go because the path is short and unambiguous.
+
+# 1. Baseline on branch 1 — fire PlayerMoved events so journal entries
+#    land under logs/branch-1/.
+/status
+go to North Station
+go to Origin
+
+# 2. Fork to a new branch. `/fork demo-branch` mutates
+#    app.active_branch_id without firing an immediate log event.
+#    The fix's rebind-on-drain detects the mismatch on the next event.
+/fork demo-branch
+/status
+
+# 3. Move so a PlayerMoved event fires AFTER the fork. The drain pump
+#    must rebind the log manager to the new branch dir before writing.
+go to East Station
+go to Origin
+
+# 4. List branches so the transcript shows the active id explicitly.
+/branches
+
+# 5. Switch back to main and fire one more event; subsequent writes
+#    must land under logs/branch-1/ again.
+/load main
+go to South Station
+/branches


### PR DESCRIPTION
## Summary

Server (`parish-server/src/session.rs`), Tauri (`parish-tauri/src/setup.rs`), and CLI (`parish-cli`) all captured `current_branch_id` once at subscriber spawn. After `load_branch` / `fork_branch` mutated the active id, the character-log AND location-log writers kept appending to the original branch's `logs/branch-<old>/` directory, silently bleeding both branches' timelines into one path.

Closes #1011 (character-log subscriber) and #1034 (location-log subscriber; same pattern).

#1013 (PR #1020) — separate arrival/departure dedup state — was obsoleted by #1032 which removed dedup state from `CharacterLogManager` altogether (bus now publishes only real movement events). That PR + issue are closed; this PR no longer depends on it.

## Changes

- **CLI App** (`parish-cli/src/app.rs`): new `log_app_name` + `log_managers_branch` fields; new `App::rebind_log_managers_if_branch_changed()` method that rebuilds both log managers when `active_branch_id` has moved and rewrites profiles to the new dir.
- **CLI headless** (`parish-cli/src/headless.rs`): drain pumps call the new method before each drain iteration; new unit test `rebind_log_managers_follows_branch_switch`.
- **CLI testing harness** (`parish-cli/src/testing.rs`): same rebind call before the drain in `execute()`.
- **Server** (`parish-server/src/session.rs`): both subscriber tasks (character + location) own the manager mutably, check `current_branch_id` per recv, rebuild on mismatch, rewrite profiles for the new branch dir.
- **Tauri** (`parish-tauri/src/setup.rs`): same per-event rebind pattern. The `Arc<Manager>` wrapping was dropped — no other code held the Arc.
- **Fixture**: `parish/testing/fixtures/play_issue-1011.txt` exercises /fork + /load + cross-branch moves under the testbed mod.

## Verification

- `cargo test --workspace`: **2876 passed**, 15 ignored (+1 new test)
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- Live --script transcript (`.proofs/issue-1011/`): two branches with disjoint journal sets after /fork + /load. `logs/branch-1/player.md` has the pre-fork moves + post-`/load main` move; `logs/branch-2/player.md` has only the post-fork moves. No cross-branch leakage.

🤖 Generated with Claude Code