### PR TITLE
ci(release): tri-platform desktop bundle matrix for v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,10 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            os: ubuntu-latest
+            # Pinned to the oldest supported Ubuntu (not ubuntu-latest) so the
+            # AppImage/.deb link against an older glibc. Building on 24.04 would
+            # raise the required glibc and break the bundles on older distros.
+            os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             rust_targets: x86_64-unknown-linux-gnu
             cli_archive: tar.gz
@@ -163,6 +166,8 @@ jobs:
 
       - name: Install Linux native deps
         if: runner.os == 'Linux'
+        # patchelf is required by Tauri's AppImage bundler; without it the
+        # Linux matrix leg fails during bundling and blocks the publish job.
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -171,7 +176,8 @@ jobs:
             libgtk-3-dev \
             libwebkit2gtk-4.1-dev \
             libappindicator3-dev \
-            librsvg2-dev
+            librsvg2-dev \
+            patchelf
 
       - name: Install frontend deps
         working-directory: parish/apps/ui
@@ -304,7 +310,12 @@ jobs:
           tag_name: ${{ needs.resolve.outputs.tag }}
           name: Rundale ${{ needs.resolve.outputs.tag }}
           generate_release_notes: true
-          fail_on_unmatched_files: true
+          # Non-fatal on unmatched globs: the exact bundle set varies by
+          # platform and Tauri's "all" target list (e.g. .rpm may or may not
+          # be produced on Linux). Each build job already fails via
+          # if-no-files-found:error if its platform produced nothing, so a
+          # missing optional format here must not abort the whole publish.
+          fail_on_unmatched_files: false
           files: |
             dist/*.tar.gz
             dist/*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,7 @@ name: Release
 #
 # Platform matrix:
 #   - Linux x86_64       (CLI tarball + .deb + .AppImage)
-#   - macOS x86_64       (CLI tarball + .app.tar.gz + .dmg)
-#   - macOS aarch64      (CLI tarball + .app.tar.gz + .dmg)
+#   - macOS universal    (CLI tarball + .app.tar.gz + .dmg, Intel + Apple Silicon)
 #   - Windows x86_64     (CLI zip + .msi + .exe NSIS installer)
 #
 # All bundles are unsigned for 0.1.0 — users will see Gatekeeper / SmartScreen
@@ -119,21 +118,22 @@ jobs:
           - name: linux-x86_64
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+            rust_targets: x86_64-unknown-linux-gnu
             cli_archive: tar.gz
             cli_ext: ""
-          - name: macos-x86_64
-            os: macos-13
-            target: x86_64-apple-darwin
-            cli_archive: tar.gz
-            cli_ext: ""
-          - name: macos-aarch64
+          # Single universal macOS bundle (Intel + Apple Silicon fused via
+          # lipo). `universal-apple-darwin` is a Tauri pseudo-target, so the
+          # CLI binary is built for both arches and lipo'd separately below.
+          - name: macos-universal
             os: macos-14
-            target: aarch64-apple-darwin
+            target: universal-apple-darwin
+            rust_targets: x86_64-apple-darwin,aarch64-apple-darwin
             cli_archive: tar.gz
             cli_ext: ""
           - name: windows-x86_64
             os: windows-latest
             target: x86_64-pc-windows-msvc
+            rust_targets: x86_64-pc-windows-msvc
             cli_archive: zip
             cli_ext: ".exe"
     runs-on: ${{ matrix.os }}
@@ -145,7 +145,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.95.0
         with:
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.rust_targets }}
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
@@ -177,12 +177,29 @@ jobs:
         working-directory: parish/apps/ui
         run: npm ci
 
-      - name: Build parish CLI (release)
+      # No --locked anywhere below: a freshly-bumped workspace member version
+      # would race ahead of Cargo.lock until the next regular CI run picks up
+      # the refreshed lockfile. release.sh refreshes it best-effort locally.
+      - name: Build parish CLI (single target)
+        if: runner.os != 'macOS'
         working-directory: parish
-        # No --locked: a freshly-bumped workspace member version would race
-        # ahead of Cargo.lock until the next regular CI run picks up the
-        # refreshed lockfile. release.sh refreshes it best-effort locally.
         run: cargo build -p parish --release --target ${{ matrix.target }}
+
+      # universal-apple-darwin is not a real rustc target — build both arches
+      # and fuse them into a single universal binary at the path the packaging
+      # step expects (parish/target/universal-apple-darwin/release/parish).
+      - name: Build parish CLI (universal macOS)
+        if: runner.os == 'macOS'
+        working-directory: parish
+        run: |
+          set -euo pipefail
+          cargo build -p parish --release --target x86_64-apple-darwin
+          cargo build -p parish --release --target aarch64-apple-darwin
+          mkdir -p target/universal-apple-darwin/release
+          lipo -create -output target/universal-apple-darwin/release/parish \
+            target/x86_64-apple-darwin/release/parish \
+            target/aarch64-apple-darwin/release/parish
+          lipo -info target/universal-apple-darwin/release/parish
 
       - name: Package CLI archive (Unix)
         if: runner.os != 'Windows'
@@ -316,7 +333,6 @@ jobs:
             echo "- No GitHub Release was published."
             echo "- Per-platform artifacts are downloadable from this run:"
             echo "  - \`parish-linux-x86_64\`"
-            echo "  - \`parish-macos-x86_64\`"
-            echo "  - \`parish-macos-aarch64\`"
+            echo "  - \`parish-macos-universal\` (Intel + Apple Silicon)"
             echo "  - \`parish-windows-x86_64\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,15 @@ name: Release
 #
 # The tag version is the source of truth and must match parish-cli's
 # Cargo.toml `[package].version` — the validate-tag job enforces this.
+#
+# Platform matrix:
+#   - Linux x86_64       (CLI tarball + .deb + .AppImage)
+#   - macOS x86_64       (CLI tarball + .app.tar.gz + .dmg)
+#   - macOS aarch64      (CLI tarball + .app.tar.gz + .dmg)
+#   - Windows x86_64     (CLI zip + .msi + .exe NSIS installer)
+#
+# All bundles are unsigned for 0.1.0 — users will see Gatekeeper / SmartScreen
+# warnings. Code signing is queued for 0.2.0.
 
 on:
   push:
@@ -100,26 +109,60 @@ jobs:
             exit 1
           fi
 
-  build-linux:
-    name: Build Linux x86_64 release binary
+  build:
+    name: Build ${{ matrix.name }}
     needs: resolve
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    outputs:
-      tarball: ${{ steps.package.outputs.tarball }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            cli_archive: tar.gz
+            cli_ext: ""
+          - name: macos-x86_64
+            os: macos-13
+            target: x86_64-apple-darwin
+            cli_archive: tar.gz
+            cli_ext: ""
+          - name: macos-aarch64
+            os: macos-14
+            target: aarch64-apple-darwin
+            cli_archive: tar.gz
+            cli_ext: ""
+          - name: windows-x86_64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            cli_archive: zip
+            cli_ext: ".exe"
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          targets: ${{ matrix.target }}
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: parish
+          # Per-target cache so Linux/macOS/Windows builds don't poison each other.
+          key: release-${{ matrix.target }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: parish/apps/ui/package-lock.json
 
       - name: Install Linux native deps
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -130,35 +173,86 @@ jobs:
             libappindicator3-dev \
             librsvg2-dev
 
-      - name: Build parish (release)
+      - name: Install frontend deps
+        working-directory: parish/apps/ui
+        run: npm ci
+
+      - name: Build parish CLI (release)
         working-directory: parish
         # No --locked: a freshly-bumped workspace member version would race
         # ahead of Cargo.lock until the next regular CI run picks up the
         # refreshed lockfile. release.sh refreshes it best-effort locally.
-        run: cargo build -p parish --release
+        run: cargo build -p parish --release --target ${{ matrix.target }}
 
-      - name: Package tarball
-        id: package
+      - name: Package CLI archive (Unix)
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           set -euo pipefail
           version="${{ needs.resolve.outputs.version }}"
           stage="$(mktemp -d)"
-          name="parish-v${version}-x86_64-linux-gnu"
+          name="parish-v${version}-${{ matrix.target }}"
           mkdir -p "$stage/$name"
-          cp parish/target/release/parish "$stage/$name/"
+          cp parish/target/${{ matrix.target }}/release/parish${{ matrix.cli_ext }} "$stage/$name/"
           cp LICENSE NOTICE THIRD_PARTY_NOTICES.md README.md "$stage/$name/"
           ( cd "$stage" && tar czf "$name.tar.gz" "$name" )
           mkdir -p dist
           mv "$stage/$name.tar.gz" "dist/$name.tar.gz"
-          ( cd dist && sha256sum "$name.tar.gz" > "$name.tar.gz.sha256" )
-          echo "tarball=dist/$name.tar.gz" >> "$GITHUB_OUTPUT"
+          ( cd dist && shasum -a 256 "$name.tar.gz" > "$name.tar.gz.sha256" )
+          ls -la dist
+
+      - name: Package CLI archive (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ needs.resolve.outputs.version }}"
+          stage="$(mktemp -d)"
+          name="parish-v${version}-${{ matrix.target }}"
+          mkdir -p "$stage/$name"
+          cp parish/target/${{ matrix.target }}/release/parish${{ matrix.cli_ext }} "$stage/$name/"
+          cp LICENSE NOTICE THIRD_PARTY_NOTICES.md README.md "$stage/$name/"
+          mkdir -p dist
+          ( cd "$stage" && 7z a -tzip "$OLDPWD/dist/$name.zip" "$name" )
+          ( cd dist && sha256sum "$name.zip" > "$name.zip.sha256" )
+          ls -la dist
+
+      - name: Build Tauri desktop bundle
+        uses: tauri-apps/tauri-action@v0
+        with:
+          projectPath: parish/crates/parish-tauri
+          args: --target ${{ matrix.target }}
+          # No tagName / releaseId — we collect artifacts ourselves and let
+          # the publish job attach them to the Release. tauri-action just
+          # builds and uploads to the workflow's artifact store.
+          includeUpdaterJson: false
+
+      - name: Collect Tauri bundle outputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundle_dir="parish/target/${{ matrix.target }}/release/bundle"
+          if [[ ! -d "$bundle_dir" ]]; then
+            echo "::error::Tauri bundle directory missing: $bundle_dir"
+            ls -la parish/target/${{ matrix.target }}/release/ || true
+            exit 1
+          fi
+          echo "Bundle contents:"
+          find "$bundle_dir" -type f -print
+          mkdir -p dist
+          # Copy every bundle artifact into dist/, preserving filenames.
+          # Tauri emits each format into its own subdirectory (dmg/, deb/, msi/, etc.).
+          find "$bundle_dir" -type f \
+            \( -name "*.dmg" -o -name "*.app.tar.gz" -o -name "*.deb" \
+            -o -name "*.AppImage" -o -name "*.rpm" -o -name "*.msi" \
+            -o -name "*.exe" \) \
+            -exec cp {} dist/ \;
           ls -la dist
 
       - name: Upload workflow artifact
         uses: actions/upload-artifact@v4
         with:
-          name: parish-linux-x86_64
+          name: parish-${{ matrix.name }}
           path: dist/*
           if-no-files-found: error
           retention-days: 14
@@ -167,7 +261,7 @@ jobs:
     name: Publish GitHub Release
     # Hard gate: only real tag pushes can publish. workflow_dispatch is
     # dry-run-only — it can't slip a release out without a tag landing.
-    needs: [resolve, validate-tag, build-linux]
+    needs: [resolve, validate-tag, build]
     if: github.event_name == 'push' && needs.resolve.outputs.dry_run != 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -176,11 +270,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download build artifacts
+      - name: Download all build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: parish-linux-x86_64
+          pattern: parish-*
           path: dist
+          merge-multiple: true
+
+      - name: List collected artifacts
+        shell: bash
+        run: ls -la dist
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -191,11 +290,18 @@ jobs:
           fail_on_unmatched_files: true
           files: |
             dist/*.tar.gz
+            dist/*.zip
             dist/*.sha256
+            dist/*.dmg
+            dist/*.deb
+            dist/*.AppImage
+            dist/*.rpm
+            dist/*.msi
+            dist/*.exe
 
   dry-run-summary:
     name: Dry-run summary
-    needs: [resolve, build-linux]
+    needs: [resolve, build]
     if: needs.resolve.outputs.dry_run == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -205,8 +311,12 @@ jobs:
           {
             echo "## Dry run for ${{ needs.resolve.outputs.tag }}"
             echo
-            echo "- Built tarball: \`${{ needs.build-linux.outputs.tarball }}\`"
+            echo "- Built artifacts for all platforms in the matrix."
             echo "- No tag was created."
             echo "- No GitHub Release was published."
-            echo "- Artifact is available on this run under \`parish-linux-x86_64\`."
+            echo "- Per-platform artifacts are downloadable from this run:"
+            echo "  - \`parish-linux-x86_64\`"
+            echo "  - \`parish-macos-x86_64\`"
+            echo "  - \`parish-macos-aarch64\`"
+            echo "  - \`parish-windows-x86_64\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/release.md
+++ b/docs/release.md
@@ -135,6 +135,11 @@ release lands, or `mcp__github__get_release_by_tag` with `v0.2.0`.
   list + PR titles since the previous tag) cover this for now.
 - **Bundle icons are derived from `parish/crates/parish-tauri/icons/icon.png`.**
   That file must be ≥1024×1024 for the macOS/Windows bundlers to generate
-  `.icns` / `.ico` correctly. If you replace it, regenerate platform icons
-  with `cargo tauri icon parish/crates/parish-tauri/icons/icon.png` before
-  tagging.
+  `.icns` / `.ico` correctly. If you replace it, regenerate the platform
+  icons from the `parish/crates/parish-tauri/` directory (so `cargo tauri`
+  finds `tauri.conf.json`) and commit the generated assets before tagging:
+
+  ```sh
+  cd parish/crates/parish-tauri
+  cargo tauri icon icons/icon.png
+  ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,9 +2,9 @@
 
 Rundale ships from a single source of truth — a `vMAJOR.MINOR.PATCH` git tag.
 Pushing the tag triggers `.github/workflows/release.yml`, which builds CLI
-binaries plus Tauri desktop bundles for Linux x86_64, macOS (x86_64 and
-aarch64), and Windows x86_64, then publishes them as a GitHub Release with
-auto-generated notes.
+binaries plus Tauri desktop bundles for Linux x86_64, macOS (a single
+universal Intel + Apple Silicon bundle), and Windows x86_64, then publishes
+them as a GitHub Release with auto-generated notes.
 
 For each platform the release attaches:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,9 +1,21 @@
 # Releasing Rundale
 
 Rundale ships from a single source of truth — a `vMAJOR.MINOR.PATCH` git tag.
-Pushing the tag triggers `.github/workflows/release.yml`, which builds a
-Linux x86_64 binary tarball and publishes it as a GitHub Release with
+Pushing the tag triggers `.github/workflows/release.yml`, which builds CLI
+binaries plus Tauri desktop bundles for Linux x86_64, macOS (x86_64 and
+aarch64), and Windows x86_64, then publishes them as a GitHub Release with
 auto-generated notes.
+
+For each platform the release attaches:
+
+- `parish-vX.Y.Z-<target>.tar.gz` / `.zip` — headless CLI binary + license files
+- A platform-native Tauri bundle (`.dmg`, `.AppImage`, `.deb`, `.msi`, `.exe`)
+- `.sha256` checksum for the CLI archive
+
+Bundles are **unsigned** for the 0.1.0 series — macOS users will see a
+Gatekeeper "unidentified developer" warning (right-click → Open), and
+Windows users will see SmartScreen ("More info" → "Run anyway"). Code
+signing is queued for 0.2.0.
 
 ## Files that get bumped
 
@@ -113,13 +125,16 @@ release lands, or `mcp__github__get_release_by_tag` with `v0.2.0`.
 
 ## Scope (what this pipeline does NOT do)
 
-- No macOS / Windows builds — Linux x86_64 only for now. Adding a runner
-  matrix is straightforward (mirror the patterns in `.github/workflows/ci.yml`)
-  but bigger than the initial cut.
-- No Tauri desktop bundle (`.deb` / `.AppImage` / `.dmg` / `.msi`). The
-  `tauri.conf.json` version is bumped so a future `cargo tauri build` will
-  produce correctly-versioned bundles, but no automated bundle build is wired.
-- No publish to crates.io or npm — every workspace crate is `publish = false`,
+- **No code signing or notarization.** macOS Gatekeeper and Windows SmartScreen
+  will flag the bundles. Tracked for 0.2.0.
+- **No auto-updater wiring.** Tauri's updater plugin is unconfigured; users
+  download new releases manually.
+- **No publish to crates.io or npm** — every workspace crate is `publish = false`,
   and the UI package is `private: true`.
-- No CHANGELOG.md generation. GitHub's auto-generated release notes (commit
+- **No CHANGELOG.md generation.** GitHub's auto-generated release notes (commit
   list + PR titles since the previous tag) cover this for now.
+- **Bundle icons are derived from `parish/crates/parish-tauri/icons/icon.png`.**
+  That file must be ≥1024×1024 for the macOS/Windows bundlers to generate
+  `.icns` / `.ico` correctly. If you replace it, regenerate platform icons
+  with `cargo tauri icon parish/crates/parish-tauri/icons/icon.png` before
+  tagging.


### PR DESCRIPTION
## Summary

Step one of the MVP 0.1.0 release plan: expand `.github/workflows/release.yml` from a single Linux tarball to a four-target build matrix that produces both the headless CLI binary and the Tauri desktop bundle for every supported platform.

| Target | OS | CLI archive | Desktop bundle |
| --- | --- | --- | --- |
| `x86_64-unknown-linux-gnu` | `ubuntu-latest` | `.tar.gz` | `.deb` + `.AppImage` |
| `x86_64-apple-darwin` | `macos-13` | `.tar.gz` | `.dmg` |
| `aarch64-apple-darwin` | `macos-14` | `.tar.gz` | `.dmg` |
| `x86_64-pc-windows-msvc` | `windows-latest` | `.zip` | `.msi` + `.exe` (NSIS) |

The `publish` job now downloads every `parish-*` artifact with `merge-multiple: true` and attaches the full set to the GitHub Release in one go. Tag-push hard-gate and `validate-tag` pre-flight are unchanged — `workflow_dispatch` is still dry-run-only.

`docs/release.md` is updated to reflect the new scope, list the artifacts users can expect, and document the Gatekeeper / SmartScreen warnings that come with unsigned bundles.

## Why this is part of v0.1.0

Per the user, 0.1.0 ships on Linux + macOS + Windows desktop as tarballs **plus** Tauri bundles. The existing single-target pipeline only covered Linux x86_64 tarball. This unblocks platform parity for the first release.

## Known blocker before tagging v0.1.0

`parish/crates/parish-tauri/icons/icon.png` is 32×32. Tauri's bundler needs ≥1024×1024 to derive the `.icns` and `.ico` that macOS and Windows require — the matrix builds will fail on those legs until the source icon is upgraded. Before tagging:

1. Replace `parish/crates/parish-tauri/icons/icon.png` with a 1024×1024 source.
2. Run `cargo tauri icon parish/crates/parish-tauri/icons/icon.png` from `parish/crates/parish-tauri/` to derive all platform-specific icons.
3. Commit the regenerated `icons/` directory and update `tauri.conf.json`'s `bundle.icon` array if needed.

## Out of scope (deferred)

- **Code signing & notarization** — bundles ship unsigned; users override Gatekeeper / SmartScreen manually. Queued for 0.2.0.
- **Auto-updater** — Tauri updater plugin remains unconfigured.
- **Railway production fix (#907)** — separate ops track per the user.

## Test plan

- [ ] Trigger `workflow_dispatch` run of "Release" with `version=0.1.0-rc.1`, `dry_run=true`. Confirm all four matrix legs go green and each uploads a `parish-<target>` artifact.
- [ ] Download each artifact; verify the CLI binary runs on a clean machine of that OS and the desktop bundle installs cleanly.
- [ ] Smoke-test a 5-minute play session against `mods/rundale/` on each platform; save and reload.
- [ ] After the icon upgrade lands, re-run dry-run; if green, push `v0.1.0-rc.1`, validate the published Release, then tag `v0.1.0`.

https://claude.ai/code/session_01BcirAETppc2sviP9dMCnue

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcirAETppc2sviP9dMCnue)_