### PR TITLE
feat: add Zork retro UI theme (C64 + DOS modes)

### DIFF
--- a/apps/ui/src/app.css
+++ b/apps/ui/src/app.css
@@ -18,6 +18,26 @@
 	/* Typography */
 	--font-body: 'IM Fell English', Georgia, serif;
 	--font-display: 'Cinzel', 'Trajan Pro', Georgia, serif;
+
+	/* Structural tokens — palettes may override via applyThemePalette() */
+	--bubble-player-justify: flex-end;
+	--bubble-npc-bg: var(--color-panel-bg);
+	--bubble-npc-fg: var(--color-fg);
+	--bubble-npc-border-left: 3px solid var(--color-accent);
+	--bubble-npc-radius: 0 0.85rem 0.85rem 0.15rem;
+	--bubble-player-bg: var(--color-accent);
+	--bubble-player-fg: var(--color-bg);
+	--bubble-player-radius: 0.85rem 0 0.15rem 0.85rem;
+	--bubble-font-style: italic;
+	--status-bg: var(--color-panel-bg);
+	--status-fg: var(--color-muted);
+	--status-accent-fg: var(--color-accent);
+	--status-muted-fg: var(--color-muted);
+	--status-border: var(--color-border);
+	--status-clock-bg: var(--color-input-bg);
+	--status-clock-fg: var(--color-fg);
+	--status-sep-fg: var(--color-border);
+	--status-border-bottom: 1px solid var(--color-border);
 }
 
 *,

--- a/apps/ui/src/components/ChatPanel.svelte
+++ b/apps/ui/src/components/ChatPanel.svelte
@@ -362,7 +362,7 @@
 	}
 
 	.bubble-row.player {
-		justify-content: flex-end;
+		justify-content: var(--bubble-player-justify);
 	}
 
 	/* Wrapper keeps label + bubble aligned together */
@@ -395,11 +395,11 @@
 
 	/* NPC message: dialogue leaf — left accent border, no rounded top-left */
 	.npc .bubble {
-		background: var(--color-panel-bg);
-		color: var(--color-fg);
-		border-radius: 0 0.85rem 0.85rem 0.15rem;
-		border-left: 3px solid var(--color-accent);
-		font-style: italic;
+		background: var(--bubble-npc-bg);
+		color: var(--bubble-npc-fg);
+		border-radius: var(--bubble-npc-radius);
+		border-left: var(--bubble-npc-border-left);
+		font-style: var(--bubble-font-style);
 		padding: 0.6rem 0.9rem 0.6rem 0.85rem;
 		font-size: 1.1rem;
 		line-height: 1.6;
@@ -409,10 +409,10 @@
 
 	/* Player message: italic, no rounded top-right */
 	.player .bubble {
-		background: var(--color-accent);
-		color: var(--color-bg);
-		border-radius: 0.85rem 0 0.15rem 0.85rem;
-		font-style: italic;
+		background: var(--bubble-player-bg);
+		color: var(--bubble-player-fg);
+		border-radius: var(--bubble-player-radius);
+		font-style: var(--bubble-font-style);
 		padding: 0.6rem 0.9rem;
 		font-size: 1.05rem;
 		line-height: 1.5;

--- a/apps/ui/src/components/StatusBar.svelte
+++ b/apps/ui/src/components/StatusBar.svelte
@@ -96,8 +96,8 @@
 
 <style>
 	.status-bar {
-		background: var(--color-panel-bg);
-		border-bottom: 1px solid var(--color-border);
+		background: var(--status-bg);
+		border-bottom: var(--status-border-bottom);
 		padding: 0.32rem 1rem;
 		font-family: var(--font-display);
 		font-size: 0.7rem;
@@ -105,7 +105,7 @@
 		display: flex;
 		align-items: center;
 		gap: 0.55rem;
-		color: var(--color-muted);
+		color: var(--status-fg);
 		white-space: nowrap;
 		overflow: hidden;
 	}
@@ -117,12 +117,12 @@
 	.clock {
 		display: inline-flex;
 		align-items: baseline;
-		background: var(--color-input-bg);
-		border: 1px solid var(--color-border);
+		background: var(--status-clock-bg);
+		border: 1px solid var(--status-border);
 		padding: 0.1rem 0.5rem;
 		letter-spacing: 0.1em;
 		font-size: 0.78rem;
-		color: var(--color-fg);
+		color: var(--status-clock-fg);
 	}
 
 	.digit {
@@ -138,7 +138,7 @@
 	}
 
 	.sep {
-		color: var(--color-border);
+		color: var(--status-sep-fg);
 		font-size: 0.7rem;
 		letter-spacing: 0;
 		opacity: 0.8;
@@ -149,7 +149,7 @@
 		font-style: italic;
 		font-size: 1.05rem;
 		font-weight: normal;
-		color: var(--color-accent);
+		color: var(--status-accent-fg);
 		letter-spacing: 0.02em;
 	}
 
@@ -157,27 +157,27 @@
 	.weather,
 	.season,
 	.day-of-week {
-		color: var(--color-muted);
+		color: var(--status-muted-fg);
 	}
 
 	.festival {
-		color: var(--color-accent);
+		color: var(--status-accent-fg);
 	}
 
 	.paused {
-		color: var(--color-muted);
+		color: var(--status-muted-fg);
 		font-style: italic;
 	}
 
 	.muted {
-		color: var(--color-muted);
+		color: var(--status-muted-fg);
 		font-style: italic;
 	}
 
 	.save-toggle {
 		background: none;
-		border: 1px solid var(--color-border);
-		color: var(--color-muted);
+		border: 1px solid var(--status-border);
+		color: var(--status-muted-fg);
 		font-size: 0.6rem;
 		padding: 0.1rem 0.45rem;
 		cursor: pointer;
@@ -188,20 +188,20 @@
 
 	.save-toggle:hover,
 	.save-toggle:focus-visible {
-		color: var(--color-fg);
-		border-color: var(--color-accent);
+		color: var(--status-fg);
+		border-color: var(--status-accent-fg);
 	}
 
 	.save-toggle.save-active {
-		color: var(--color-accent);
-		border-color: var(--color-accent);
+		color: var(--status-accent-fg);
+		border-color: var(--status-accent-fg);
 	}
 
 	.debug-toggle,
 	.designer-link {
 		background: none;
-		border: 1px solid var(--color-border);
-		color: var(--color-muted);
+		border: 1px solid var(--status-border);
+		color: var(--status-muted-fg);
 		font-size: 0.6rem;
 		padding: 0.1rem 0.45rem;
 		cursor: pointer;
@@ -217,13 +217,13 @@
 	.debug-toggle:focus-visible,
 	.designer-link:hover,
 	.designer-link:focus-visible {
-		color: var(--color-fg);
-		border-color: var(--color-accent);
+		color: var(--status-fg);
+		border-color: var(--status-accent-fg);
 	}
 
 	.debug-toggle.debug-active {
-		color: var(--color-accent);
-		border-color: var(--color-accent);
+		color: var(--status-accent-fg);
+		border-color: var(--status-accent-fg);
 	}
 
 	/* ── Mobile: compact status bar ── */

--- a/apps/ui/src/lib/theme.test.ts
+++ b/apps/ui/src/lib/theme.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	applyThemePalette,
+	DEFAULT_THEME_PALETTE,
+	SOLARIZED_LIGHT,
+	ZORK_C64,
+	ZORK_DOS
+} from './theme';
+
+describe('applyThemePalette', () => {
+	beforeEach(() => {
+		document.documentElement.removeAttribute('style');
+	});
+
+	it('writes the seven base color slots for any palette', () => {
+		applyThemePalette(SOLARIZED_LIGHT);
+		const s = document.documentElement.style;
+		expect(s.getPropertyValue('--color-bg')).toBe(SOLARIZED_LIGHT.bg);
+		expect(s.getPropertyValue('--color-fg')).toBe(SOLARIZED_LIGHT.fg);
+		expect(s.getPropertyValue('--color-accent')).toBe(SOLARIZED_LIGHT.accent);
+	});
+
+	it('does not set structural overrides for a palette without them', () => {
+		applyThemePalette(SOLARIZED_LIGHT);
+		const s = document.documentElement.style;
+		expect(s.getPropertyValue('--bubble-player-justify')).toBe('');
+		expect(s.getPropertyValue('--status-bg')).toBe('');
+		expect(s.getPropertyValue('--bubble-npc-bg')).toBe('');
+	});
+
+	it('sets monospace font, left chat alignment, flat bubbles, and inverted status for Zork C64', () => {
+		applyThemePalette(ZORK_C64);
+		const s = document.documentElement.style;
+		expect(s.getPropertyValue('--font-body')).toContain('monospace');
+		expect(s.getPropertyValue('--font-display')).toContain('monospace');
+		expect(s.getPropertyValue('--bubble-player-justify')).toBe('flex-start');
+		expect(s.getPropertyValue('--bubble-npc-bg')).toBe('transparent');
+		expect(s.getPropertyValue('--bubble-player-bg')).toBe('transparent');
+		expect(s.getPropertyValue('--bubble-font-style')).toBe('normal');
+		// Inverted status: bg becomes palette.fg, fg becomes palette.bg
+		expect(s.getPropertyValue('--status-bg')).toBe(ZORK_C64.fg);
+		expect(s.getPropertyValue('--status-fg')).toBe(ZORK_C64.bg);
+		expect(s.getPropertyValue('--status-accent-fg')).toBe(ZORK_C64.bg);
+	});
+
+	it('uses black/grey for Zork DOS', () => {
+		applyThemePalette(ZORK_DOS);
+		const s = document.documentElement.style;
+		expect(s.getPropertyValue('--color-bg')).toBe('#000000');
+		expect(s.getPropertyValue('--color-fg')).toBe('#c0c0c0');
+		expect(s.getPropertyValue('--status-bg')).toBe('#c0c0c0');
+		expect(s.getPropertyValue('--status-fg')).toBe('#000000');
+	});
+
+	it('clears Zork overrides when switching back to a plain palette', () => {
+		applyThemePalette(ZORK_C64);
+		applyThemePalette(DEFAULT_THEME_PALETTE);
+		const s = document.documentElement.style;
+		expect(s.getPropertyValue('--bubble-player-justify')).toBe('');
+		expect(s.getPropertyValue('--bubble-npc-bg')).toBe('');
+		expect(s.getPropertyValue('--status-bg')).toBe('');
+		expect(s.getPropertyValue('--font-body')).toBe('');
+	});
+});

--- a/apps/ui/src/lib/theme.ts
+++ b/apps/ui/src/lib/theme.ts
@@ -32,9 +32,43 @@ export const SOLARIZED_DARK: ThemePalette = {
 	muted: '#586e75' // base01
 };
 
+const ZORK_FONT = "'Courier New', Consolas, ui-monospace, monospace";
+
+/** Zork on Commodore 64 — VIC-II light-blue on blue, monospace, inverted status bar. */
+export const ZORK_C64: ThemePalette = {
+	bg: '#1f1b96',
+	fg: '#a8a8ff',
+	accent: '#ffffff',
+	panel_bg: '#1f1b96',
+	input_bg: '#15116b',
+	border: '#7878ff',
+	muted: '#6c5eb5',
+	font_body: ZORK_FONT,
+	font_display: ZORK_FONT,
+	chat_align: 'left',
+	bubble_style: 'flat',
+	status_invert: true
+};
+
+/** Zork on IBM PC / DOS — light-grey on black, monospace, inverted status bar. */
+export const ZORK_DOS: ThemePalette = {
+	bg: '#000000',
+	fg: '#c0c0c0',
+	accent: '#ffff55',
+	panel_bg: '#000000',
+	input_bg: '#0a0a0a',
+	border: '#808080',
+	muted: '#808080',
+	font_body: ZORK_FONT,
+	font_display: ZORK_FONT,
+	chat_align: 'left',
+	bubble_style: 'flat',
+	status_invert: true
+};
+
 export interface ThemePreference {
-	name: 'default' | 'solarized';
-	mode: 'light' | 'dark' | 'auto' | '';
+	name: 'default' | 'solarized' | 'zork';
+	mode: 'light' | 'dark' | 'auto' | 'c64' | 'dos' | '';
 }
 
 export const DEFAULT_PREFERENCE: ThemePreference = { name: 'default', mode: '' };
@@ -61,6 +95,11 @@ export function saveThemePreference(pref: ThemePreference): void {
 	}
 }
 
+function setOrClear(root: HTMLElement, name: string, value: string | null | undefined): void {
+	if (value) root.style.setProperty(name, value);
+	else root.style.removeProperty(name);
+}
+
 export function applyThemePalette(palette: ThemePalette): void {
 	if (typeof document === 'undefined') return;
 
@@ -72,4 +111,56 @@ export function applyThemePalette(palette: ThemePalette): void {
 	root.style.setProperty('--color-input-bg', palette.input_bg);
 	root.style.setProperty('--color-border', palette.border);
 	root.style.setProperty('--color-muted', palette.muted);
+
+	setOrClear(root, '--font-body', palette.font_body);
+	setOrClear(root, '--font-display', palette.font_display);
+
+	setOrClear(
+		root,
+		'--bubble-player-justify',
+		palette.chat_align === 'left' ? 'flex-start' : null
+	);
+
+	if (palette.bubble_style === 'flat') {
+		root.style.setProperty('--bubble-npc-bg', 'transparent');
+		root.style.setProperty('--bubble-npc-fg', palette.fg);
+		root.style.setProperty('--bubble-npc-border-left', 'none');
+		root.style.setProperty('--bubble-npc-radius', '0');
+		root.style.setProperty('--bubble-player-bg', 'transparent');
+		root.style.setProperty('--bubble-player-fg', palette.fg);
+		root.style.setProperty('--bubble-player-radius', '0');
+		root.style.setProperty('--bubble-font-style', 'normal');
+	} else {
+		root.style.removeProperty('--bubble-npc-bg');
+		root.style.removeProperty('--bubble-npc-fg');
+		root.style.removeProperty('--bubble-npc-border-left');
+		root.style.removeProperty('--bubble-npc-radius');
+		root.style.removeProperty('--bubble-player-bg');
+		root.style.removeProperty('--bubble-player-fg');
+		root.style.removeProperty('--bubble-player-radius');
+		root.style.removeProperty('--bubble-font-style');
+	}
+
+	if (palette.status_invert) {
+		// Status bar swaps fg/bg against the chat — all status text becomes palette.bg on palette.fg.
+		root.style.setProperty('--status-bg', palette.fg);
+		root.style.setProperty('--status-fg', palette.bg);
+		root.style.setProperty('--status-accent-fg', palette.bg);
+		root.style.setProperty('--status-muted-fg', palette.bg);
+		root.style.setProperty('--status-border', palette.bg);
+		root.style.setProperty('--status-sep-fg', palette.bg);
+		root.style.setProperty('--status-clock-bg', palette.fg);
+		root.style.setProperty('--status-clock-fg', palette.bg);
+		root.style.setProperty('--status-border-bottom', `2px solid ${palette.fg}`);
+	} else {
+		root.style.removeProperty('--status-bg');
+		root.style.removeProperty('--status-fg');
+		root.style.removeProperty('--status-accent-fg');
+		root.style.removeProperty('--status-muted-fg');
+		root.style.removeProperty('--status-border');
+		root.style.removeProperty('--status-sep-fg');
+		root.style.removeProperty('--status-clock-bg');
+		root.style.removeProperty('--status-clock-fg');
+		root.style.removeProperty('--status-border-bottom');
+	}
 }

--- a/apps/ui/src/lib/types.ts
+++ b/apps/ui/src/lib/types.ts
@@ -76,6 +76,13 @@ export interface ThemePalette {
 	input_bg: string;
 	border: string;
 	muted: string;
+	// Structural overrides — optional so existing palettes and the
+	// server-pushed time-of-day palette stay valid. When unset, CSS defaults apply.
+	font_body?: string;
+	font_display?: string;
+	chat_align?: 'standard' | 'left';
+	bubble_style?: 'card' | 'flat';
+	status_invert?: boolean;
 }
 
 export interface LanguageHint {

--- a/apps/ui/src/stores/theme.ts
+++ b/apps/ui/src/stores/theme.ts
@@ -4,6 +4,8 @@ import {
 	DEFAULT_THEME_PALETTE,
 	SOLARIZED_LIGHT,
 	SOLARIZED_DARK,
+	ZORK_C64,
+	ZORK_DOS,
 	applyThemePalette,
 	type ThemePreference,
 	DEFAULT_PREFERENCE,
@@ -41,8 +43,14 @@ function createPaletteStore() {
 				// 'light' or unspecified — default to light
 				apply(SOLARIZED_LIGHT);
 			}
+		} else if (pref.name === 'zork') {
+			apply(pref.mode === 'dos' ? ZORK_DOS : ZORK_C64);
+		} else {
+			// 'default': clear any structural overrides left over from a previous theme
+			// by applying the parchment palette explicitly. The server may push a fresh
+			// time-of-day palette shortly afterwards via applyServerPalette.
+			apply(DEFAULT_THEME_PALETTE);
 		}
-		// 'default': no-op — server palette is applied via applyServerPalette
 	}
 
 	/**

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -512,9 +512,9 @@ pub fn handle_command(
         Command::NewGame => CommandResult::effect_only(CommandEffect::NewGame),
         Command::Theme(arg) => match arg.as_deref().map(str::trim) {
             None | Some("") => CommandResult::text(
-                "Available themes: default, solarized\n\
-                 Usage: /theme <name> [light|dark|auto]\n\
-                 Solarized auto switches with real-world sunrise and sunset.",
+                "Available themes: default, solarized, zork\n\
+                 Usage: /theme <name> [mode]\n\
+                 Modes: solarized [light|dark|auto], zork [c64|dos]. Solarized auto follows the game's time of day.",
             ),
             Some("default") => CommandResult::with_effect(
                 "Reverting to the parish's natural colours.",
@@ -547,8 +547,33 @@ pub fn handle_command(
                             CommandEffect::ApplyTheme("solarized".to_string(), mode),
                         )
                     }
+                    "zork" => {
+                        let mode = if mode.is_empty() {
+                            "c64".to_string()
+                        } else {
+                            mode
+                        };
+                        let msg = match mode.as_str() {
+                            "c64" => {
+                                "Theme set to Zork (C64). It is pitch black. You are likely to be eaten by a grue."
+                            }
+                            "dos" => {
+                                "Theme set to Zork (DOS). West of House. You are standing in an open field."
+                            }
+                            other => {
+                                return CommandResult::text(format!(
+                                    "Unknown zork mode '{}'. Try: c64, dos",
+                                    other
+                                ));
+                            }
+                        };
+                        CommandResult::with_effect(
+                            msg,
+                            CommandEffect::ApplyTheme("zork".to_string(), mode),
+                        )
+                    }
                     other => CommandResult::text(format!(
-                        "Unknown theme '{}'. Available: default, solarized",
+                        "Unknown theme '{}'. Available: default, solarized, zork",
                         other
                     )),
                 }
@@ -1396,6 +1421,56 @@ mod tests {
         );
         assert!(result.response.contains("taupe"));
         assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn theme_zork_defaults_to_c64() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Theme(Some("zork".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.iter().any(|e| matches!(
+            e,
+            CommandEffect::ApplyTheme(name, mode) if name == "zork" && mode == "c64"
+        )));
+    }
+
+    #[test]
+    fn theme_zork_dos_explicit() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Theme(Some("zork dos".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.iter().any(|e| matches!(
+            e,
+            CommandEffect::ApplyTheme(name, mode) if name == "zork" && mode == "dos"
+        )));
+    }
+
+    #[test]
+    fn theme_zork_invalid_mode() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Theme(Some("zork amiga".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("amiga"));
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn theme_no_arg_lists_zork() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Theme(None), &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("zork"));
     }
 
     // ── NpcsHere with population ─────────────────────────────────────────────


### PR DESCRIPTION
Closing in favour of a redesign: Zork (and Solarized) will be migrated to standalone asset mods under `mods/`, so the engine ships with zero hardcoded themes and any future palette is just a new mod directory. Same branch will be reused for the follow-up PR. The structural ThemePalette extensions (font_body, chat_align, bubble_style, status_invert) and the ChatPanel/StatusBar CSS variable refactor from this PR will be carried into the new one — they're the right shape for mod-defined themes too.