### PR TITLE
refactor: themes as asset mods; ship Zork + Solarized as standalone mods

### DIFF
--- a/apps/ui/src/app.css
+++ b/apps/ui/src/app.css
@@ -18,6 +18,26 @@
 	/* Typography */
 	--font-body: 'IM Fell English', Georgia, serif;
 	--font-display: 'Cinzel', 'Trajan Pro', Georgia, serif;
+
+	/* Structural tokens — palettes may override via applyThemePalette() */
+	--bubble-player-justify: flex-end;
+	--bubble-npc-bg: var(--color-panel-bg);
+	--bubble-npc-fg: var(--color-fg);
+	--bubble-npc-border-left: 3px solid var(--color-accent);
+	--bubble-npc-radius: 0 0.85rem 0.85rem 0.15rem;
+	--bubble-player-bg: var(--color-accent);
+	--bubble-player-fg: var(--color-bg);
+	--bubble-player-radius: 0.85rem 0 0.15rem 0.85rem;
+	--bubble-font-style: italic;
+	--status-bg: var(--color-panel-bg);
+	--status-fg: var(--color-muted);
+	--status-accent-fg: var(--color-accent);
+	--status-muted-fg: var(--color-muted);
+	--status-border: var(--color-border);
+	--status-clock-bg: var(--color-input-bg);
+	--status-clock-fg: var(--color-fg);
+	--status-sep-fg: var(--color-border);
+	--status-border-bottom: 1px solid var(--color-border);
 }
 
 *,

--- a/apps/ui/src/components/ChatPanel.svelte
+++ b/apps/ui/src/components/ChatPanel.svelte
@@ -362,7 +362,7 @@
 	}
 
 	.bubble-row.player {
-		justify-content: flex-end;
+		justify-content: var(--bubble-player-justify);
 	}
 
 	/* Wrapper keeps label + bubble aligned together */
@@ -395,11 +395,11 @@
 
 	/* NPC message: dialogue leaf — left accent border, no rounded top-left */
 	.npc .bubble {
-		background: var(--color-panel-bg);
-		color: var(--color-fg);
-		border-radius: 0 0.85rem 0.85rem 0.15rem;
-		border-left: 3px solid var(--color-accent);
-		font-style: italic;
+		background: var(--bubble-npc-bg);
+		color: var(--bubble-npc-fg);
+		border-radius: var(--bubble-npc-radius);
+		border-left: var(--bubble-npc-border-left);
+		font-style: var(--bubble-font-style);
 		padding: 0.6rem 0.9rem 0.6rem 0.85rem;
 		font-size: 1.1rem;
 		line-height: 1.6;
@@ -409,10 +409,10 @@
 
 	/* Player message: italic, no rounded top-right */
 	.player .bubble {
-		background: var(--color-accent);
-		color: var(--color-bg);
-		border-radius: 0.85rem 0 0.15rem 0.85rem;
-		font-style: italic;
+		background: var(--bubble-player-bg);
+		color: var(--bubble-player-fg);
+		border-radius: var(--bubble-player-radius);
+		font-style: var(--bubble-font-style);
 		padding: 0.6rem 0.9rem;
 		font-size: 1.05rem;
 		line-height: 1.5;

--- a/apps/ui/src/components/StatusBar.svelte
+++ b/apps/ui/src/components/StatusBar.svelte
@@ -96,8 +96,8 @@
 
 <style>
 	.status-bar {
-		background: var(--color-panel-bg);
-		border-bottom: 1px solid var(--color-border);
+		background: var(--status-bg);
+		border-bottom: var(--status-border-bottom);
 		padding: 0.32rem 1rem;
 		font-family: var(--font-display);
 		font-size: 0.7rem;
@@ -105,7 +105,7 @@
 		display: flex;
 		align-items: center;
 		gap: 0.55rem;
-		color: var(--color-muted);
+		color: var(--status-fg);
 		white-space: nowrap;
 		overflow: hidden;
 	}
@@ -117,12 +117,12 @@
 	.clock {
 		display: inline-flex;
 		align-items: baseline;
-		background: var(--color-input-bg);
-		border: 1px solid var(--color-border);
+		background: var(--status-clock-bg);
+		border: 1px solid var(--status-border);
 		padding: 0.1rem 0.5rem;
 		letter-spacing: 0.1em;
 		font-size: 0.78rem;
-		color: var(--color-fg);
+		color: var(--status-clock-fg);
 	}
 
 	.digit {
@@ -138,7 +138,7 @@
 	}
 
 	.sep {
-		color: var(--color-border);
+		color: var(--status-sep-fg);
 		font-size: 0.7rem;
 		letter-spacing: 0;
 		opacity: 0.8;
@@ -149,7 +149,7 @@
 		font-style: italic;
 		font-size: 1.05rem;
 		font-weight: normal;
-		color: var(--color-accent);
+		color: var(--status-accent-fg);
 		letter-spacing: 0.02em;
 	}
 
@@ -157,27 +157,27 @@
 	.weather,
 	.season,
 	.day-of-week {
-		color: var(--color-muted);
+		color: var(--status-muted-fg);
 	}
 
 	.festival {
-		color: var(--color-accent);
+		color: var(--status-accent-fg);
 	}
 
 	.paused {
-		color: var(--color-muted);
+		color: var(--status-muted-fg);
 		font-style: italic;
 	}
 
 	.muted {
-		color: var(--color-muted);
+		color: var(--status-muted-fg);
 		font-style: italic;
 	}
 
 	.save-toggle {
 		background: none;
-		border: 1px solid var(--color-border);
-		color: var(--color-muted);
+		border: 1px solid var(--status-border);
+		color: var(--status-muted-fg);
 		font-size: 0.6rem;
 		padding: 0.1rem 0.45rem;
 		cursor: pointer;
@@ -188,20 +188,20 @@
 
 	.save-toggle:hover,
 	.save-toggle:focus-visible {
-		color: var(--color-fg);
-		border-color: var(--color-accent);
+		color: var(--status-fg);
+		border-color: var(--status-accent-fg);
 	}
 
 	.save-toggle.save-active {
-		color: var(--color-accent);
-		border-color: var(--color-accent);
+		color: var(--status-accent-fg);
+		border-color: var(--status-accent-fg);
 	}
 
 	.debug-toggle,
 	.designer-link {
 		background: none;
-		border: 1px solid var(--color-border);
-		color: var(--color-muted);
+		border: 1px solid var(--status-border);
+		color: var(--status-muted-fg);
 		font-size: 0.6rem;
 		padding: 0.1rem 0.45rem;
 		cursor: pointer;
@@ -217,13 +217,13 @@
 	.debug-toggle:focus-visible,
 	.designer-link:hover,
 	.designer-link:focus-visible {
-		color: var(--color-fg);
-		border-color: var(--color-accent);
+		color: var(--status-fg);
+		border-color: var(--status-accent-fg);
 	}
 
 	.debug-toggle.debug-active {
-		color: var(--color-accent);
-		border-color: var(--color-accent);
+		color: var(--status-accent-fg);
+		border-color: var(--status-accent-fg);
 	}
 
 	/* ── Mobile: compact status bar ── */

--- a/apps/ui/src/lib/ipc.ts
+++ b/apps/ui/src/lib/ipc.ts
@@ -269,6 +269,9 @@ export const onThemeUpdate = (cb: (payload: ThemePalette) => void) =>
 export interface ThemeSwitchPayload {
 	name: string;
 	mode: string;
+	/** Resolved palette from the backend's registry. `null` when the theme
+	 *  name/mode wasn't found — frontend should fall back to local resolution. */
+	palette: ThemePalette | null;
 }
 export const onThemeSwitch = (cb: (payload: ThemeSwitchPayload) => void) =>
 	onEvent<ThemeSwitchPayload>('theme-switch', cb);

--- a/apps/ui/src/lib/theme.test.ts
+++ b/apps/ui/src/lib/theme.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	applyThemePalette,
+	DEFAULT_THEME_PALETTE,
+	SOLARIZED_LIGHT,
+	ZORK_C64,
+	ZORK_DOS
+} from './theme';
+
+describe('applyThemePalette', () => {
+	beforeEach(() => {
+		document.documentElement.removeAttribute('style');
+	});
+
+	it('writes the seven base color slots for any palette', () => {
+		applyThemePalette(SOLARIZED_LIGHT);
+		const s = document.documentElement.style;
+		expect(s.getPropertyValue('--color-bg')).toBe(SOLARIZED_LIGHT.bg);
+		expect(s.getPropertyValue('--color-fg')).toBe(SOLARIZED_LIGHT.fg);
+		expect(s.getPropertyValue('--color-accent')).toBe(SOLARIZED_LIGHT.accent);
+	});
+
+	it('does not set structural overrides for a palette without them', () => {
+		applyThemePalette(SOLARIZED_LIGHT);
+		const s = document.documentElement.style;
+		expect(s.getPropertyValue('--bubble-player-justify')).toBe('');
+		expect(s.getPropertyValue('--status-bg')).toBe('');
+		expect(s.getPropertyValue('--bubble-npc-bg')).toBe('');
+	});
+
+	it('sets monospace font, left chat alignment, flat bubbles, and inverted status for Zork C64', () => {
+		applyThemePalette(ZORK_C64);
+		const s = document.documentElement.style;
+		expect(s.getPropertyValue('--font-body')).toContain('monospace');
+		expect(s.getPropertyValue('--font-display')).toContain('monospace');
+		expect(s.getPropertyValue('--bubble-player-justify')).toBe('flex-start');
+		expect(s.getPropertyValue('--bubble-npc-bg')).toBe('transparent');
+		expect(s.getPropertyValue('--bubble-player-bg')).toBe('transparent');
+		expect(s.getPropertyValue('--bubble-font-style')).toBe('normal');
+		// Inverted status: bg becomes palette.fg, fg becomes palette.bg
+		expect(s.getPropertyValue('--status-bg')).toBe(ZORK_C64.fg);
+		expect(s.getPropertyValue('--status-fg')).toBe(ZORK_C64.bg);
+		expect(s.getPropertyValue('--status-accent-fg')).toBe(ZORK_C64.bg);
+	});
+
+	it('uses black/grey for Zork DOS', () => {
+		applyThemePalette(ZORK_DOS);
+		const s = document.documentElement.style;
+		expect(s.getPropertyValue('--color-bg')).toBe('#000000');
+		expect(s.getPropertyValue('--color-fg')).toBe('#c0c0c0');
+		expect(s.getPropertyValue('--status-bg')).toBe('#c0c0c0');
+		expect(s.getPropertyValue('--status-fg')).toBe('#000000');
+	});
+
+	it('clears Zork overrides when switching back to a plain palette', () => {
+		applyThemePalette(ZORK_C64);
+		applyThemePalette(DEFAULT_THEME_PALETTE);
+		const s = document.documentElement.style;
+		expect(s.getPropertyValue('--bubble-player-justify')).toBe('');
+		expect(s.getPropertyValue('--bubble-npc-bg')).toBe('');
+		expect(s.getPropertyValue('--status-bg')).toBe('');
+		expect(s.getPropertyValue('--font-body')).toBe('');
+	});
+});

--- a/apps/ui/src/lib/theme.test.ts
+++ b/apps/ui/src/lib/theme.test.ts
@@ -1,11 +1,23 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import {
-	applyThemePalette,
-	DEFAULT_THEME_PALETTE,
-	SOLARIZED_LIGHT,
-	ZORK_C64,
-	ZORK_DOS
-} from './theme';
+import { applyThemePalette, DEFAULT_THEME_PALETTE } from './theme';
+import type { ThemePalette } from './types';
+
+const PARCHMENT: ThemePalette = DEFAULT_THEME_PALETTE;
+
+const ZORK_C64: ThemePalette = {
+	bg: '#1f1b96',
+	fg: '#a8a8ff',
+	accent: '#ffffff',
+	panel_bg: '#1f1b96',
+	input_bg: '#15116b',
+	border: '#7878ff',
+	muted: '#6c5eb5',
+	font_body: "'Courier New', monospace",
+	font_display: "'Courier New', monospace",
+	chat_align: 'left',
+	bubble_style: 'flat',
+	status_invert: true
+};
 
 describe('applyThemePalette', () => {
 	beforeEach(() => {
@@ -13,22 +25,22 @@ describe('applyThemePalette', () => {
 	});
 
 	it('writes the seven base color slots for any palette', () => {
-		applyThemePalette(SOLARIZED_LIGHT);
+		applyThemePalette(PARCHMENT);
 		const s = document.documentElement.style;
-		expect(s.getPropertyValue('--color-bg')).toBe(SOLARIZED_LIGHT.bg);
-		expect(s.getPropertyValue('--color-fg')).toBe(SOLARIZED_LIGHT.fg);
-		expect(s.getPropertyValue('--color-accent')).toBe(SOLARIZED_LIGHT.accent);
+		expect(s.getPropertyValue('--color-bg')).toBe(PARCHMENT.bg);
+		expect(s.getPropertyValue('--color-fg')).toBe(PARCHMENT.fg);
+		expect(s.getPropertyValue('--color-accent')).toBe(PARCHMENT.accent);
 	});
 
 	it('does not set structural overrides for a palette without them', () => {
-		applyThemePalette(SOLARIZED_LIGHT);
+		applyThemePalette(PARCHMENT);
 		const s = document.documentElement.style;
 		expect(s.getPropertyValue('--bubble-player-justify')).toBe('');
 		expect(s.getPropertyValue('--status-bg')).toBe('');
 		expect(s.getPropertyValue('--bubble-npc-bg')).toBe('');
 	});
 
-	it('sets monospace font, left chat alignment, flat bubbles, and inverted status for Zork C64', () => {
+	it('applies monospace font, left chat alignment, flat bubbles, and inverted status when set', () => {
 		applyThemePalette(ZORK_C64);
 		const s = document.documentElement.style;
 		expect(s.getPropertyValue('--font-body')).toContain('monospace');
@@ -43,18 +55,9 @@ describe('applyThemePalette', () => {
 		expect(s.getPropertyValue('--status-accent-fg')).toBe(ZORK_C64.bg);
 	});
 
-	it('uses black/grey for Zork DOS', () => {
-		applyThemePalette(ZORK_DOS);
-		const s = document.documentElement.style;
-		expect(s.getPropertyValue('--color-bg')).toBe('#000000');
-		expect(s.getPropertyValue('--color-fg')).toBe('#c0c0c0');
-		expect(s.getPropertyValue('--status-bg')).toBe('#c0c0c0');
-		expect(s.getPropertyValue('--status-fg')).toBe('#000000');
-	});
-
-	it('clears Zork overrides when switching back to a plain palette', () => {
+	it('clears all structural overrides when switching back to a plain palette', () => {
 		applyThemePalette(ZORK_C64);
-		applyThemePalette(DEFAULT_THEME_PALETTE);
+		applyThemePalette(PARCHMENT);
 		const s = document.documentElement.style;
 		expect(s.getPropertyValue('--bubble-player-justify')).toBe('');
 		expect(s.getPropertyValue('--bubble-npc-bg')).toBe('');

--- a/apps/ui/src/lib/theme.ts
+++ b/apps/ui/src/lib/theme.ts
@@ -1,5 +1,10 @@
 import type { ThemePalette } from './types';
 
+/**
+ * Fallback palette used before the backend's `/api/ui-config` response lands
+ * (or in tests). Real-life palettes are loaded from the active setting mod's
+ * `[theme.palette]` plus any `kind = "asset"` mods under `mods/`.
+ */
 export const DEFAULT_THEME_PALETTE: ThemePalette = {
 	bg: '#fafad8',
 	fg: '#31240f',
@@ -10,65 +15,35 @@ export const DEFAULT_THEME_PALETTE: ThemePalette = {
 	muted: '#76663b'
 };
 
-/** Solarized Light — Ethan Schoonover's palette mapped to Parish color slots. */
-export const SOLARIZED_LIGHT: ThemePalette = {
-	bg: '#fdf6e3', // base3
-	fg: '#586e75', // base00
-	accent: '#268bd2', // blue
-	panel_bg: '#eee8d5', // base2
-	input_bg: '#e6dfc5', // between base2 and base3
-	border: '#93a1a1', // base1
-	muted: '#93a1a1' // base1
-};
+/** Wire shape of one theme entry from the backend's registry snapshot. */
+export interface ThemeRegistryEntry {
+	name: string;
+	mode: string;
+	label: string;
+	palette: ThemePalette;
+}
 
-/** Solarized Dark — Ethan Schoonover's palette mapped to Parish color slots. */
-export const SOLARIZED_DARK: ThemePalette = {
-	bg: '#002b36', // base03
-	fg: '#839496', // base0
-	accent: '#268bd2', // blue
-	panel_bg: '#073642', // base02
-	input_bg: '#0d3f4f', // slightly lighter than base02
-	border: '#586e75', // base01
-	muted: '#586e75' // base01
-};
+/** Synthetic mode that resolves to another mode based on game time. */
+export interface ModeAlias {
+	name: string;
+	mode: string;
+	day_mode: string;
+	night_mode: string;
+}
 
-const ZORK_FONT = "'Courier New', Consolas, ui-monospace, monospace";
+/** Wire shape of the full theme registry. */
+export interface ThemeRegistrySnapshot {
+	themes: ThemeRegistryEntry[];
+	mode_aliases: ModeAlias[];
+	mode_defaults: Record<string, string>;
+}
 
-/** Zork on Commodore 64 — VIC-II light-blue on blue, monospace, inverted status bar. */
-export const ZORK_C64: ThemePalette = {
-	bg: '#1f1b96',
-	fg: '#a8a8ff',
-	accent: '#ffffff',
-	panel_bg: '#1f1b96',
-	input_bg: '#15116b',
-	border: '#7878ff',
-	muted: '#6c5eb5',
-	font_body: ZORK_FONT,
-	font_display: ZORK_FONT,
-	chat_align: 'left',
-	bubble_style: 'flat',
-	status_invert: true
-};
-
-/** Zork on IBM PC / DOS — light-grey on black, monospace, inverted status bar. */
-export const ZORK_DOS: ThemePalette = {
-	bg: '#000000',
-	fg: '#c0c0c0',
-	accent: '#ffff55',
-	panel_bg: '#000000',
-	input_bg: '#0a0a0a',
-	border: '#808080',
-	muted: '#808080',
-	font_body: ZORK_FONT,
-	font_display: ZORK_FONT,
-	chat_align: 'left',
-	bubble_style: 'flat',
-	status_invert: true
-};
-
+/** User's persisted theme selection. The set of valid `name`s is dynamic — it
+ *  depends on which asset mods are installed. We type it as `string` and let
+ *  the registry validate at apply time. */
 export interface ThemePreference {
-	name: 'default' | 'solarized' | 'zork';
-	mode: 'light' | 'dark' | 'auto' | 'c64' | 'dos' | '';
+	name: string;
+	mode: string;
 }
 
 export const DEFAULT_PREFERENCE: ThemePreference = { name: 'default', mode: '' };

--- a/apps/ui/src/lib/theme.ts
+++ b/apps/ui/src/lib/theme.ts
@@ -32,9 +32,43 @@ export const SOLARIZED_DARK: ThemePalette = {
 	muted: '#586e75' // base01
 };
 
+const ZORK_FONT = "'Courier New', Consolas, ui-monospace, monospace";
+
+/** Zork on Commodore 64 — VIC-II light-blue on blue, monospace, inverted status bar. */
+export const ZORK_C64: ThemePalette = {
+	bg: '#1f1b96',
+	fg: '#a8a8ff',
+	accent: '#ffffff',
+	panel_bg: '#1f1b96',
+	input_bg: '#15116b',
+	border: '#7878ff',
+	muted: '#6c5eb5',
+	font_body: ZORK_FONT,
+	font_display: ZORK_FONT,
+	chat_align: 'left',
+	bubble_style: 'flat',
+	status_invert: true
+};
+
+/** Zork on IBM PC / DOS — light-grey on black, monospace, inverted status bar. */
+export const ZORK_DOS: ThemePalette = {
+	bg: '#000000',
+	fg: '#c0c0c0',
+	accent: '#ffff55',
+	panel_bg: '#000000',
+	input_bg: '#0a0a0a',
+	border: '#808080',
+	muted: '#808080',
+	font_body: ZORK_FONT,
+	font_display: ZORK_FONT,
+	chat_align: 'left',
+	bubble_style: 'flat',
+	status_invert: true
+};
+
 export interface ThemePreference {
-	name: 'default' | 'solarized';
-	mode: 'light' | 'dark' | 'auto' | '';
+	name: 'default' | 'solarized' | 'zork';
+	mode: 'light' | 'dark' | 'auto' | 'c64' | 'dos' | '';
 }
 
 export const DEFAULT_PREFERENCE: ThemePreference = { name: 'default', mode: '' };
@@ -61,6 +95,11 @@ export function saveThemePreference(pref: ThemePreference): void {
 	}
 }
 
+function setOrClear(root: HTMLElement, name: string, value: string | null | undefined): void {
+	if (value) root.style.setProperty(name, value);
+	else root.style.removeProperty(name);
+}
+
 export function applyThemePalette(palette: ThemePalette): void {
 	if (typeof document === 'undefined') return;
 
@@ -72,4 +111,56 @@ export function applyThemePalette(palette: ThemePalette): void {
 	root.style.setProperty('--color-input-bg', palette.input_bg);
 	root.style.setProperty('--color-border', palette.border);
 	root.style.setProperty('--color-muted', palette.muted);
+
+	setOrClear(root, '--font-body', palette.font_body);
+	setOrClear(root, '--font-display', palette.font_display);
+
+	setOrClear(
+		root,
+		'--bubble-player-justify',
+		palette.chat_align === 'left' ? 'flex-start' : null
+	);
+
+	if (palette.bubble_style === 'flat') {
+		root.style.setProperty('--bubble-npc-bg', 'transparent');
+		root.style.setProperty('--bubble-npc-fg', palette.fg);
+		root.style.setProperty('--bubble-npc-border-left', 'none');
+		root.style.setProperty('--bubble-npc-radius', '0');
+		root.style.setProperty('--bubble-player-bg', 'transparent');
+		root.style.setProperty('--bubble-player-fg', palette.fg);
+		root.style.setProperty('--bubble-player-radius', '0');
+		root.style.setProperty('--bubble-font-style', 'normal');
+	} else {
+		root.style.removeProperty('--bubble-npc-bg');
+		root.style.removeProperty('--bubble-npc-fg');
+		root.style.removeProperty('--bubble-npc-border-left');
+		root.style.removeProperty('--bubble-npc-radius');
+		root.style.removeProperty('--bubble-player-bg');
+		root.style.removeProperty('--bubble-player-fg');
+		root.style.removeProperty('--bubble-player-radius');
+		root.style.removeProperty('--bubble-font-style');
+	}
+
+	if (palette.status_invert) {
+		// Status bar swaps fg/bg against the chat — all status text becomes palette.bg on palette.fg.
+		root.style.setProperty('--status-bg', palette.fg);
+		root.style.setProperty('--status-fg', palette.bg);
+		root.style.setProperty('--status-accent-fg', palette.bg);
+		root.style.setProperty('--status-muted-fg', palette.bg);
+		root.style.setProperty('--status-border', palette.bg);
+		root.style.setProperty('--status-sep-fg', palette.bg);
+		root.style.setProperty('--status-clock-bg', palette.fg);
+		root.style.setProperty('--status-clock-fg', palette.bg);
+		root.style.setProperty('--status-border-bottom', `2px solid ${palette.fg}`);
+	} else {
+		root.style.removeProperty('--status-bg');
+		root.style.removeProperty('--status-fg');
+		root.style.removeProperty('--status-accent-fg');
+		root.style.removeProperty('--status-muted-fg');
+		root.style.removeProperty('--status-border');
+		root.style.removeProperty('--status-sep-fg');
+		root.style.removeProperty('--status-clock-bg');
+		root.style.removeProperty('--status-clock-fg');
+		root.style.removeProperty('--status-border-bottom');
+	}
 }

--- a/apps/ui/src/lib/types.ts
+++ b/apps/ui/src/lib/types.ts
@@ -97,9 +97,34 @@ export type IrishWordHint = LanguageHint;
 export interface UiConfig {
 	hints_label: string;
 	default_accent: string;
+	default_palette: ThemePalette;
 	splash_text: string;
 	active_tile_source: string;
 	tile_sources: TileSource[];
+	themes: ThemeRegistrySnapshot;
+}
+
+/** Wire shape of a single theme entry from the backend's registry. */
+export interface ThemeRegistryEntry {
+	name: string;
+	mode: string;
+	label: string;
+	palette: ThemePalette;
+}
+
+/** Synthetic mode that resolves to another mode based on game time. */
+export interface ThemeModeAlias {
+	name: string;
+	mode: string;
+	day_mode: string;
+	night_mode: string;
+}
+
+/** Wire shape of the theme registry sent over `GET /api/ui-config`. */
+export interface ThemeRegistrySnapshot {
+	themes: ThemeRegistryEntry[];
+	mode_aliases: ThemeModeAlias[];
+	mode_defaults: Record<string, string>;
 }
 
 /** A single map tile source sent from the backend. Mirrors

--- a/apps/ui/src/lib/types.ts
+++ b/apps/ui/src/lib/types.ts
@@ -76,6 +76,13 @@ export interface ThemePalette {
 	input_bg: string;
 	border: string;
 	muted: string;
+	// Structural overrides — optional so existing palettes and the
+	// server-pushed time-of-day palette stay valid. When unset, CSS defaults apply.
+	font_body?: string;
+	font_display?: string;
+	chat_align?: 'standard' | 'left';
+	bubble_style?: 'card' | 'flat';
+	status_invert?: boolean;
 }
 
 export interface LanguageHint {

--- a/apps/ui/src/routes/+page.svelte
+++ b/apps/ui/src/routes/+page.svelte
@@ -289,6 +289,11 @@
 			const cfg = await getUiConfig();
 			uiConfig.set(cfg);
 			tiles.initFromUiConfig(cfg);
+			// Hydrate the theme palette store with the active mod's default
+			// palette + the registry of themes loaded from `kind = "asset"` mods.
+			// Re-resolves the saved preference (e.g. `/theme zork c64`) now that
+			// the registry is known.
+			palette.hydrateFromUiConfig(cfg.themes, cfg.default_palette);
 			if (cfg.splash_text) {
 				textLog.update((log) => [
 					{ source: 'system', content: cfg.splash_text },
@@ -548,10 +553,7 @@
 			}));
 
 			listeners.push(await onThemeSwitch((p) => {
-				palette.setPreference({
-					name: p.name as 'default' | 'solarized',
-					mode: p.mode as 'light' | 'dark' | 'auto' | ''
-				});
+				palette.setPreference({ name: p.name, mode: p.mode }, p.palette);
 			}));
 
 			listeners.push(await onTilesSwitch((p) => {

--- a/apps/ui/src/stores/game.ts
+++ b/apps/ui/src/stores/game.ts
@@ -48,9 +48,19 @@ export const nameHints = writable<LanguageHint[]>([]);
 export const uiConfig = writable<UiConfig>({
 	hints_label: 'Language Hints',
 	default_accent: '#b08531',
+	default_palette: {
+		bg: '#fafad8',
+		fg: '#31240f',
+		accent: '#b08531',
+		panel_bg: '#f5f5d3',
+		input_bg: '#f0f0ce',
+		border: '#cec293',
+		muted: '#76663b'
+	},
 	splash_text: '',
 	active_tile_source: '',
-	tile_sources: []
+	tile_sources: [],
+	themes: { themes: [], mode_aliases: [], mode_defaults: {} }
 });
 
 export const fullMapOpen = writable<boolean>(false);

--- a/apps/ui/src/stores/theme.ts
+++ b/apps/ui/src/stores/theme.ts
@@ -4,6 +4,8 @@ import {
 	DEFAULT_THEME_PALETTE,
 	SOLARIZED_LIGHT,
 	SOLARIZED_DARK,
+	ZORK_C64,
+	ZORK_DOS,
 	applyThemePalette,
 	type ThemePreference,
 	DEFAULT_PREFERENCE,
@@ -41,8 +43,14 @@ function createPaletteStore() {
 				// 'light' or unspecified — default to light
 				apply(SOLARIZED_LIGHT);
 			}
+		} else if (pref.name === 'zork') {
+			apply(pref.mode === 'dos' ? ZORK_DOS : ZORK_C64);
+		} else {
+			// 'default': clear any structural overrides left over from a previous theme
+			// by applying the parchment palette explicitly. The server may push a fresh
+			// time-of-day palette shortly afterwards via applyServerPalette.
+			apply(DEFAULT_THEME_PALETTE);
 		}
-		// 'default': no-op — server palette is applied via applyServerPalette
 	}
 
 	/**

--- a/apps/ui/src/stores/theme.ts
+++ b/apps/ui/src/stores/theme.ts
@@ -2,12 +2,9 @@ import { writable } from 'svelte/store';
 import type { ThemePalette } from '$lib/types';
 import {
 	DEFAULT_THEME_PALETTE,
-	SOLARIZED_LIGHT,
-	SOLARIZED_DARK,
-	ZORK_C64,
-	ZORK_DOS,
 	applyThemePalette,
 	type ThemePreference,
+	type ThemeRegistrySnapshot,
 	DEFAULT_PREFERENCE,
 	loadThemePreference,
 	saveThemePreference
@@ -22,35 +19,49 @@ function createPaletteStore() {
 	const { subscribe, set } = writable<ThemePalette>(DEFAULT_THEME_PALETTE);
 	let preference: ThemePreference = DEFAULT_PREFERENCE;
 	let lastGameHour: number | null = null;
+	// Registry hydrated from `GET /api/ui-config`. Empty until then.
+	let registry: ThemeRegistrySnapshot = { themes: [], mode_aliases: [], mode_defaults: {} };
+	let modPalette: ThemePalette = DEFAULT_THEME_PALETTE;
 
 	function apply(p: ThemePalette) {
 		set(p);
 		applyThemePalette(p);
 	}
 
-	function resolveAndApply(pref: ThemePreference) {
-		if (pref.name === 'solarized') {
-			if (pref.mode === 'auto') {
-				// Use the last known game hour if available; default to light
-				if (lastGameHour !== null) {
-					apply(isGameNight(lastGameHour) ? SOLARIZED_DARK : SOLARIZED_LIGHT);
-				} else {
-					apply(SOLARIZED_LIGHT);
-				}
-			} else if (pref.mode === 'dark') {
-				apply(SOLARIZED_DARK);
-			} else {
-				// 'light' or unspecified — default to light
-				apply(SOLARIZED_LIGHT);
-			}
-		} else if (pref.name === 'zork') {
-			apply(pref.mode === 'dos' ? ZORK_DOS : ZORK_C64);
-		} else {
-			// 'default': clear any structural overrides left over from a previous theme
-			// by applying the parchment palette explicitly. The server may push a fresh
-			// time-of-day palette shortly afterwards via applyServerPalette.
-			apply(DEFAULT_THEME_PALETTE);
+	/** Look up `(name, mode)` in the registry, resolving aliases via game hour. */
+	function resolvePalette(name: string, mode: string): ThemePalette | null {
+		if (name === 'default' || name === '') return modPalette;
+
+		// Synthetic mode? (e.g. solarized auto)
+		const alias = registry.mode_aliases.find((a) => a.name === name && a.mode === mode);
+		if (alias) {
+			const isNight = lastGameHour !== null ? isGameNight(lastGameHour) : false;
+			const resolvedMode = isNight ? alias.night_mode : alias.day_mode;
+			const entry = registry.themes.find((t) => t.name === name && t.mode === resolvedMode);
+			return entry?.palette ?? null;
 		}
+
+		// Direct hit
+		const entry = registry.themes.find((t) => t.name === name && t.mode === mode);
+		if (entry) return entry.palette;
+
+		// Name with no explicit mode → consult mode_defaults
+		if (mode === '') {
+			const defaultMode = registry.mode_defaults[name];
+			if (defaultMode) return resolvePalette(name, defaultMode);
+		}
+
+		return null;
+	}
+
+	function resolveAndApply(pref: ThemePreference) {
+		const palette = resolvePalette(pref.name, pref.mode);
+		if (palette) {
+			apply(palette);
+		}
+		// Unknown theme: leave current palette in place. The backend's
+		// `theme-switch` event will deliver a palette next time the user
+		// types `/theme <name>`.
 	}
 
 	/**
@@ -59,38 +70,74 @@ function createPaletteStore() {
 	 * doesn't overwrite the user's choice.
 	 */
 	function applyServerPalette(p: ThemePalette) {
-		if (preference.name === 'default') apply(p);
+		if (preference.name === 'default' || preference.name === '') apply(p);
 	}
 
 	/**
 	 * Called on every world-update with the current game hour (0–23).
-	 * When solarized auto is active, switches light/dark based on game time.
+	 * When a synthetic-alias mode is active (e.g. solarized auto), switches
+	 * the resolved palette as we cross day/night.
 	 */
 	function applyGameHour(hour: number) {
+		const previousHour = lastGameHour;
 		lastGameHour = hour;
-		if (preference.name === 'solarized' && preference.mode === 'auto') {
-			apply(isGameNight(hour) ? SOLARIZED_DARK : SOLARIZED_LIGHT);
+		const alias = registry.mode_aliases.find(
+			(a) => a.name === preference.name && a.mode === preference.mode
+		);
+		if (!alias) return;
+		const wasNight = previousHour !== null ? isGameNight(previousHour) : false;
+		const isNight = isGameNight(hour);
+		if (wasNight !== isNight) {
+			const resolved = isNight ? alias.night_mode : alias.day_mode;
+			const entry = registry.themes.find((t) => t.name === alias.name && t.mode === resolved);
+			if (entry) apply(entry.palette);
 		}
 	}
 
 	/**
 	 * Called when a `"theme-switch"` event arrives from the backend
-	 * (i.e. the player typed a `/theme` command).
+	 * (i.e. the player typed a `/theme` command). The event carries the
+	 * resolved palette directly so we don't have to look it up.
 	 */
-	function setPreference(pref: ThemePreference) {
+	function setPreference(pref: ThemePreference, palette?: ThemePalette | null) {
 		preference = pref;
 		saveThemePreference(pref);
-		resolveAndApply(pref);
+		if (palette) {
+			apply(palette);
+		} else {
+			resolveAndApply(pref);
+		}
+	}
+
+	/**
+	 * Hydrate the registry and the setting-mod's default palette from
+	 * `GET /api/ui-config`. Called once at startup.
+	 */
+	function hydrateFromUiConfig(snapshot: ThemeRegistrySnapshot, defaultPalette: ThemePalette) {
+		registry = snapshot;
+		modPalette = defaultPalette;
+		// Re-resolve the active preference now that the registry is loaded —
+		// fixes the case where the user had `/theme zork` saved but the
+		// hardcoded fallback applied at boot.
+		resolveAndApply(preference);
 	}
 
 	// ── Initialise from localStorage ─────────────────────────────────────────
-	// Restore saved preference immediately so Solarized users never see a flash
-	// of the default parchment palette before the server responds.
+	// Restore saved preference immediately so users never see a flash of the
+	// default palette before the registry hydrates. Resolution against the
+	// (still-empty) registry is a no-op for any non-default name; once
+	// hydrateFromUiConfig() runs, the real palette is applied.
 	const saved = loadThemePreference();
 	preference = saved;
 	resolveAndApply(saved);
 
-	return { subscribe, applyServerPalette, applyGameHour, setPreference };
+	return {
+		subscribe,
+		applyServerPalette,
+		applyGameHour,
+		setPreference,
+		hydrateFromUiConfig
+	};
 }
 
 export const palette = createPaletteStore();

--- a/apps/ui/src/stores/tiles.test.ts
+++ b/apps/ui/src/stores/tiles.test.ts
@@ -36,9 +36,19 @@ function cfg(active = 'osm', sources = [osm(), historic()]): UiConfig {
 	return {
 		hints_label: '',
 		default_accent: '',
+		default_palette: {
+			bg: '',
+			fg: '',
+			accent: '',
+			panel_bg: '',
+			input_bg: '',
+			border: '',
+			muted: ''
+		},
 		splash_text: '',
 		active_tile_source: active,
-		tile_sources: sources
+		tile_sources: sources,
+		themes: { themes: [], mode_aliases: [], mode_defaults: {} }
 	};
 }
 

--- a/crates/parish-core/src/game_mod.rs
+++ b/crates/parish-core/src/game_mod.rs
@@ -257,6 +257,11 @@ impl From<ThemePaletteConfig> for ThemePalette {
             input_bg: config.input_bg,
             border: config.border,
             muted: config.muted,
+            font_body: None,
+            font_display: None,
+            chat_align: None,
+            bubble_style: None,
+            status_invert: None,
         }
     }
 }

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -510,75 +510,87 @@ pub fn handle_command(
         Command::Debug(sub) => CommandResult::effect_only(CommandEffect::Debug(sub)),
         Command::Spinner(secs) => CommandResult::effect_only(CommandEffect::ShowSpinner(secs)),
         Command::NewGame => CommandResult::effect_only(CommandEffect::NewGame),
-        Command::Theme(arg) => match arg.as_deref().map(str::trim) {
-            None | Some("") => CommandResult::text(
-                "Available themes: default, solarized, zork\n\
-                 Usage: /theme <name> [mode]\n\
-                 Modes: solarized [light|dark|auto], zork [c64|dos]. Solarized auto follows the game's time of day.",
-            ),
-            Some("default") => CommandResult::with_effect(
-                "Reverting to the parish's natural colours.",
-                CommandEffect::ApplyTheme("default".to_string(), String::new()),
-            ),
-            Some(rest) => {
-                let mut parts = rest.splitn(2, ' ');
-                let name = parts.next().unwrap_or("").to_lowercase();
-                let mode = parts.next().map(str::trim).unwrap_or("").to_lowercase();
-                match name.as_str() {
-                    "solarized" => {
-                        let mode = if mode.is_empty() {
-                            "auto".to_string()
-                        } else {
-                            mode
-                        };
-                        let msg = match mode.as_str() {
-                            "light" => "Solarized light applied.",
-                            "dark" => "Solarized dark applied.",
-                            "auto" => "Solarized auto — follows the game's time of day.",
-                            other => {
-                                return CommandResult::text(format!(
-                                    "Unknown mode '{}'. Try: light, dark, auto",
-                                    other
-                                ));
-                            }
-                        };
-                        CommandResult::with_effect(
-                            msg,
-                            CommandEffect::ApplyTheme("solarized".to_string(), mode),
-                        )
-                    }
-                    "zork" => {
-                        let mode = if mode.is_empty() {
-                            "c64".to_string()
-                        } else {
-                            mode
-                        };
-                        let msg = match mode.as_str() {
-                            "c64" => {
-                                "Theme set to Zork (C64). It is pitch black. You are likely to be eaten by a grue."
-                            }
-                            "dos" => {
-                                "Theme set to Zork (DOS). West of House. You are standing in an open field."
-                            }
-                            other => {
-                                return CommandResult::text(format!(
-                                    "Unknown zork mode '{}'. Try: c64, dos",
-                                    other
-                                ));
-                            }
-                        };
-                        CommandResult::with_effect(
-                            msg,
-                            CommandEffect::ApplyTheme("zork".to_string(), mode),
-                        )
-                    }
-                    other => CommandResult::text(format!(
-                        "Unknown theme '{}'. Available: default, solarized, zork",
-                        other
-                    )),
-                }
+        Command::Theme(arg) => handle_theme_command(arg, config),
+    }
+}
+
+/// Handles the `/theme` command by consulting the registry on `GameConfig`
+/// (populated at startup from `kind = "asset"` mods under `mods/`).
+///
+/// `default` is special — it always reverts to the active setting mod's
+/// `[theme.palette]`. Every other theme name must be registered.
+fn handle_theme_command(arg: Option<String>, config: &GameConfig) -> CommandResult {
+    let registry = &config.theme_registry;
+
+    let raw = arg.as_deref().map(str::trim).unwrap_or("");
+    if raw.is_empty() {
+        let mut names: Vec<String> = std::iter::once("default".to_string())
+            .chain(registry.names())
+            .collect();
+        names.dedup();
+        return CommandResult::text(format!(
+            "Available themes: {}\nUsage: /theme <name> [mode]",
+            names.join(", ")
+        ));
+    }
+
+    if raw.eq_ignore_ascii_case("default") {
+        return CommandResult::with_effect(
+            "Reverting to the parish's natural colours.",
+            CommandEffect::ApplyTheme("default".to_string(), String::new()),
+        );
+    }
+
+    let mut parts = raw.splitn(2, char::is_whitespace);
+    let name = parts.next().unwrap_or("").to_lowercase();
+    let mode_arg = parts.next().map(str::trim).unwrap_or("").to_lowercase();
+
+    // Resolve the mode: explicit > registry default > "" (mode-less).
+    let mode = if mode_arg.is_empty() {
+        registry.default_mode_for(&name).unwrap_or("").to_string()
+    } else {
+        mode_arg
+    };
+
+    // Synthetic alias (e.g. solarized auto) — accepted; frontend resolves day/night.
+    if registry.alias(&name, &mode).is_some() {
+        return CommandResult::with_effect(
+            format!("Theme set to {name} {mode}."),
+            CommandEffect::ApplyTheme(name, mode),
+        );
+    }
+
+    // Direct registry hit.
+    if let Some(entry) = registry.get(&name, &mode) {
+        let msg = entry.message.clone().unwrap_or_else(|| {
+            if mode.is_empty() {
+                format!("Theme set to {name}.")
+            } else {
+                format!("Theme set to {name} {mode}.")
             }
-        },
+        });
+        return CommandResult::with_effect(
+            msg,
+            CommandEffect::ApplyTheme(entry.name.clone(), entry.mode.clone()),
+        );
+    }
+
+    // Diagnose: unknown name vs known name with bad mode.
+    let known_modes = registry.modes_for(&name);
+    if known_modes.is_empty() {
+        let mut available: Vec<String> = std::iter::once("default".to_string())
+            .chain(registry.names())
+            .collect();
+        available.dedup();
+        CommandResult::text(format!(
+            "Unknown theme '{name}'. Available: {}",
+            available.join(", ")
+        ))
+    } else {
+        CommandResult::text(format!(
+            "Unknown mode '{mode}' for theme '{name}'. Try: {}",
+            known_modes.join(", ")
+        ))
     }
 }
 
@@ -743,6 +755,84 @@ mod tests {
 
     fn default_state() -> (WorldState, NpcManager, GameConfig) {
         (WorldState::new(), NpcManager::new(), GameConfig::default())
+    }
+
+    /// Builds a `GameConfig` whose theme registry mirrors having the
+    /// `solarized-theme` and `zork-theme` asset mods installed. Used by the
+    /// `/theme` tests so they exercise the registry path without spinning up
+    /// a real `mods/` directory tree.
+    fn state_with_themes() -> (WorldState, NpcManager, GameConfig) {
+        use crate::ipc::ThemePalette;
+        use crate::themes::{ModeAlias, ModeDefault, ThemeEntry, ThemeManifest, ThemeRegistry};
+        let palette = |bg: &str| ThemePalette {
+            bg: bg.to_string(),
+            fg: "#000000".to_string(),
+            accent: "#000000".to_string(),
+            panel_bg: bg.to_string(),
+            input_bg: bg.to_string(),
+            border: "#000000".to_string(),
+            muted: "#000000".to_string(),
+            font_body: None,
+            font_display: None,
+            chat_align: None,
+            bubble_style: None,
+            status_invert: None,
+        };
+        let manifest = ThemeManifest {
+            themes: vec![
+                ThemeEntry {
+                    name: "solarized".to_string(),
+                    mode: "light".to_string(),
+                    label: "Solarized Light".to_string(),
+                    message: Some("Solarized light applied.".to_string()),
+                    palette: palette("#fdf6e3"),
+                },
+                ThemeEntry {
+                    name: "solarized".to_string(),
+                    mode: "dark".to_string(),
+                    label: "Solarized Dark".to_string(),
+                    message: Some("Solarized dark applied.".to_string()),
+                    palette: palette("#002b36"),
+                },
+                ThemeEntry {
+                    name: "zork".to_string(),
+                    mode: "c64".to_string(),
+                    label: "Zork (C64)".to_string(),
+                    message: Some("Zork C64 applied.".to_string()),
+                    palette: palette("#1f1b96"),
+                },
+                ThemeEntry {
+                    name: "zork".to_string(),
+                    mode: "dos".to_string(),
+                    label: "Zork (DOS)".to_string(),
+                    message: Some("Zork DOS applied.".to_string()),
+                    palette: palette("#000000"),
+                },
+            ],
+            mode_defaults: vec![
+                ModeDefault {
+                    name: "solarized".to_string(),
+                    default_mode: "auto".to_string(),
+                },
+                ModeDefault {
+                    name: "zork".to_string(),
+                    default_mode: "c64".to_string(),
+                },
+            ],
+            mode_aliases: vec![ModeAlias {
+                name: "solarized".to_string(),
+                mode: "auto".to_string(),
+                day_mode: "light".to_string(),
+                night_mode: "dark".to_string(),
+            }],
+        };
+        let mut reg = ThemeRegistry::default();
+        reg.extend_from(manifest);
+        let config = GameConfig {
+            theme_registry: reg,
+            ..GameConfig::default()
+        };
+        (WorldState::new(), NpcManager::new(), config)
     }
 
     #[test]
@@ -1344,11 +1434,22 @@ mod tests {
     // ── Theme ────────────────────────────────────────────────────────────────
 
     #[test]
-    fn theme_no_arg_lists_available() {
+    fn theme_no_arg_with_empty_registry_lists_only_default() {
         let (mut world, mut npc, mut config) = default_state();
         let result = handle_command(Command::Theme(None), &mut world, &mut npc, &mut config);
         assert!(result.response.contains("default"));
+        assert!(!result.response.contains("solarized"));
+        assert!(!result.response.contains("zork"));
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn theme_no_arg_with_populated_registry_lists_all_names() {
+        let (mut world, mut npc, mut config) = state_with_themes();
+        let result = handle_command(Command::Theme(None), &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("default"));
         assert!(result.response.contains("solarized"));
+        assert!(result.response.contains("zork"));
         assert!(result.effects.is_empty());
     }
 
@@ -1368,7 +1469,7 @@ mod tests {
     }
 
     #[test]
-    fn theme_solarized_defaults_to_auto() {
+    fn theme_unknown_name_with_empty_registry_returns_error() {
         let (mut world, mut npc, mut config) = default_state();
         let result = handle_command(
             Command::Theme(Some("solarized".to_string())),
@@ -1376,6 +1477,20 @@ mod tests {
             &mut npc,
             &mut config,
         );
+        assert!(result.response.contains("solarized"));
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn theme_resolves_via_registry_default_mode() {
+        let (mut world, mut npc, mut config) = state_with_themes();
+        let result = handle_command(
+            Command::Theme(Some("solarized".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        // solarized's default mode is `auto` (a synthetic alias).
         assert!(result.effects.iter().any(|e| matches!(
             e,
             CommandEffect::ApplyTheme(name, mode) if name == "solarized" && mode == "auto"
@@ -1383,8 +1498,8 @@ mod tests {
     }
 
     #[test]
-    fn theme_solarized_with_explicit_mode() {
-        let (mut world, mut npc, mut config) = default_state();
+    fn theme_explicit_mode_overrides_default() {
+        let (mut world, mut npc, mut config) = state_with_themes();
         let result = handle_command(
             Command::Theme(Some("solarized dark".to_string())),
             &mut world,
@@ -1398,34 +1513,8 @@ mod tests {
     }
 
     #[test]
-    fn theme_unknown_name_returns_error() {
-        let (mut world, mut npc, mut config) = default_state();
-        let result = handle_command(
-            Command::Theme(Some("neon".to_string())),
-            &mut world,
-            &mut npc,
-            &mut config,
-        );
-        assert!(result.response.contains("neon"));
-        assert!(result.effects.is_empty());
-    }
-
-    #[test]
-    fn theme_solarized_invalid_mode() {
-        let (mut world, mut npc, mut config) = default_state();
-        let result = handle_command(
-            Command::Theme(Some("solarized taupe".to_string())),
-            &mut world,
-            &mut npc,
-            &mut config,
-        );
-        assert!(result.response.contains("taupe"));
-        assert!(result.effects.is_empty());
-    }
-
-    #[test]
-    fn theme_zork_defaults_to_c64() {
-        let (mut world, mut npc, mut config) = default_state();
+    fn theme_zork_default_mode_is_c64() {
+        let (mut world, mut npc, mut config) = state_with_themes();
         let result = handle_command(
             Command::Theme(Some("zork".to_string())),
             &mut world,
@@ -1440,7 +1529,7 @@ mod tests {
 
     #[test]
     fn theme_zork_dos_explicit() {
-        let (mut world, mut npc, mut config) = default_state();
+        let (mut world, mut npc, mut config) = state_with_themes();
         let result = handle_command(
             Command::Theme(Some("zork dos".to_string())),
             &mut world,
@@ -1454,8 +1543,8 @@ mod tests {
     }
 
     #[test]
-    fn theme_zork_invalid_mode() {
-        let (mut world, mut npc, mut config) = default_state();
+    fn theme_unknown_mode_for_known_name_lists_modes() {
+        let (mut world, mut npc, mut config) = state_with_themes();
         let result = handle_command(
             Command::Theme(Some("zork amiga".to_string())),
             &mut world,
@@ -1463,14 +1552,24 @@ mod tests {
             &mut config,
         );
         assert!(result.response.contains("amiga"));
+        assert!(result.response.contains("c64"));
+        assert!(result.response.contains("dos"));
         assert!(result.effects.is_empty());
     }
 
     #[test]
-    fn theme_no_arg_lists_zork() {
-        let (mut world, mut npc, mut config) = default_state();
-        let result = handle_command(Command::Theme(None), &mut world, &mut npc, &mut config);
+    fn theme_unknown_name_lists_available() {
+        let (mut world, mut npc, mut config) = state_with_themes();
+        let result = handle_command(
+            Command::Theme(Some("neon".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("neon"));
+        assert!(result.response.contains("solarized"));
         assert!(result.response.contains("zork"));
+        assert!(result.effects.is_empty());
     }
 
     // ── NpcsHere with population ─────────────────────────────────────────────

--- a/crates/parish-core/src/ipc/commands.rs
+++ b/crates/parish-core/src/ipc/commands.rs
@@ -512,9 +512,9 @@ pub fn handle_command(
         Command::NewGame => CommandResult::effect_only(CommandEffect::NewGame),
         Command::Theme(arg) => match arg.as_deref().map(str::trim) {
             None | Some("") => CommandResult::text(
-                "Available themes: default, solarized\n\
-                 Usage: /theme <name> [light|dark|auto]\n\
-                 Solarized auto switches with real-world sunrise and sunset.",
+                "Available themes: default, solarized, zork\n\
+                 Usage: /theme <name> [mode]\n\
+                 Modes: solarized [light|dark|auto], zork [c64|dos]. Solarized auto follows the game's time of day.",
             ),
             Some("default") => CommandResult::with_effect(
                 "Reverting to the parish's natural colours.",
@@ -547,8 +547,33 @@ pub fn handle_command(
                             CommandEffect::ApplyTheme("solarized".to_string(), mode),
                         )
                     }
+                    "zork" => {
+                        let mode = if mode.is_empty() {
+                            "c64".to_string()
+                        } else {
+                            mode
+                        };
+                        let msg = match mode.as_str() {
+                            "c64" => {
+                                "Theme set to Zork (C64). It is pitch black. You are likely to be eaten by a grue."
+                            }
+                            "dos" => {
+                                "Theme set to Zork (DOS). West of House. You are standing in an open field."
+                            }
+                            other => {
+                                return CommandResult::text(format!(
+                                    "Unknown zork mode '{}'. Try: c64, dos",
+                                    other
+                                ));
+                            }
+                        };
+                        CommandResult::with_effect(
+                            msg,
+                            CommandEffect::ApplyTheme("zork".to_string(), mode),
+                        )
+                    }
                     other => CommandResult::text(format!(
-                        "Unknown theme '{}'. Available: default, solarized",
+                        "Unknown theme '{}'. Available: default, solarized, zork",
                         other
                     )),
                 }
@@ -1396,6 +1421,56 @@ mod tests {
         );
         assert!(result.response.contains("taupe"));
         assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn theme_zork_defaults_to_c64() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Theme(Some("zork".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.iter().any(|e| matches!(
+            e,
+            CommandEffect::ApplyTheme(name, mode) if name == "zork" && mode == "c64"
+        )));
+    }
+
+    #[test]
+    fn theme_zork_dos_explicit() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Theme(Some("zork dos".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.effects.iter().any(|e| matches!(
+            e,
+            CommandEffect::ApplyTheme(name, mode) if name == "zork" && mode == "dos"
+        )));
+    }
+
+    #[test]
+    fn theme_zork_invalid_mode() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(
+            Command::Theme(Some("zork amiga".to_string())),
+            &mut world,
+            &mut npc,
+            &mut config,
+        );
+        assert!(result.response.contains("amiga"));
+        assert!(result.effects.is_empty());
+    }
+
+    #[test]
+    fn theme_no_arg_lists_zork() {
+        let (mut world, mut npc, mut config) = default_state();
+        let result = handle_command(Command::Theme(None), &mut world, &mut npc, &mut config);
+        assert!(result.response.contains("zork"));
     }
 
     // ── NpcsHere with population ─────────────────────────────────────────────

--- a/crates/parish-core/src/ipc/config.rs
+++ b/crates/parish-core/src/ipc/config.rs
@@ -7,6 +7,7 @@
 
 use crate::config::{FeatureFlags, InferenceCategory, RateLimitConfig};
 use crate::inference::InferenceRateLimiter;
+use crate::themes::ThemeRegistry;
 
 /// Mutable runtime configuration for provider, model, and cloud settings.
 ///
@@ -71,6 +72,10 @@ pub struct GameConfig {
     /// immediate frontier. When `true`, all graph nodes are shown with
     /// unvisited locations still marked `visited: false`.
     pub reveal_unexplored_locations: bool,
+    /// Registry of UI themes loaded from `kind = "asset"` mods at startup.
+    /// Empty when no theme mods are installed — the `/theme` command then
+    /// only knows `default` (the active setting mod's palette).
+    pub theme_registry: ThemeRegistry,
 }
 
 impl GameConfig {
@@ -210,6 +215,7 @@ impl Default for GameConfig {
             active_tile_source: String::new(),
             tile_sources: Vec::new(),
             reveal_unexplored_locations: false,
+            theme_registry: ThemeRegistry::default(),
         }
     }
 }

--- a/crates/parish-core/src/ipc/types.rs
+++ b/crates/parish-core/src/ipc/types.rs
@@ -125,8 +125,9 @@ pub struct NpcInfo {
 
 // ── Theme palette ───────────────────────────────────────────────────────────
 
-/// CSS hex-string theme palette derived from [`RawPalette`].
-#[derive(Serialize, Deserialize, Clone, Debug)]
+/// CSS hex-string theme palette derived from [`RawPalette`] or loaded from
+/// an asset mod's `themes.toml`.
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct ThemePalette {
     /// Main background colour (`"#rrggbb"`).
     pub bg: String,
@@ -142,6 +143,21 @@ pub struct ThemePalette {
     pub border: String,
     /// Muted colour for secondary text.
     pub muted: String,
+    /// Optional CSS font-family for prose / chat text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub font_body: Option<String>,
+    /// Optional CSS font-family for display / header text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub font_display: Option<String>,
+    /// Chat layout: `"standard"` (player right, NPC left) or `"left"` (everything left).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_align: Option<String>,
+    /// Bubble visual style: `"card"` (default) or `"flat"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bubble_style: Option<String>,
+    /// When true, the status bar inverts fg/bg against the chat (Infocom look).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_invert: Option<bool>,
 }
 
 impl From<RawPalette> for ThemePalette {
@@ -155,6 +171,11 @@ impl From<RawPalette> for ThemePalette {
             input_bg: hex(raw.input_bg),
             border: hex(raw.border),
             muted: hex(raw.muted),
+            font_body: None,
+            font_display: None,
+            chat_align: None,
+            bubble_style: None,
+            status_invert: None,
         }
     }
 }

--- a/crates/parish-core/src/lib.rs
+++ b/crates/parish-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod inference_guard;
 pub mod ipc;
 pub mod loading;
 pub mod prompts;
+pub mod themes;
 
 /// How often autosave tasks should snapshot active sessions (seconds).
 /// Used by both the Axum web server and the Tauri desktop backend.

--- a/crates/parish-core/src/themes.rs
+++ b/crates/parish-core/src/themes.rs
@@ -1,0 +1,509 @@
+//! Asset-mod theme registry.
+//!
+//! Themes are loaded from `themes.toml` files inside [`ModKind::Asset`](crate::game_mod::ModKind)
+//! mods. Each entry is a `(name, mode)` pair with a [`ThemePalette`] — the engine
+//! ships zero hardcoded themes and consults this registry when handling `/theme`.
+//!
+//! ## Schema
+//!
+//! ```toml
+//! # mods/zork-theme/themes.toml
+//! [[themes]]
+//! name = "zork"
+//! mode = "c64"
+//! label = "Zork (C64)"
+//! message = "Theme set to Zork (C64)."
+//! palette = { bg = "#1f1b96", fg = "#a8a8ff", accent = "#ffffff",
+//!             panel_bg = "#1f1b96", input_bg = "#15116b",
+//!             border = "#7878ff", muted = "#6c5eb5",
+//!             font_body = "'Courier New', monospace",
+//!             chat_align = "left", bubble_style = "flat",
+//!             status_invert = true }
+//!
+//! # Optional: this name's default mode (used when /theme <name> has no mode arg)
+//! [[mode_defaults]]
+//! name = "zork"
+//! default_mode = "c64"
+//!
+//! # Optional: a "synthetic" mode that resolves to another mode based on game time
+//! [[mode_aliases]]
+//! name = "solarized"
+//! mode = "auto"
+//! day_mode = "light"
+//! night_mode = "dark"
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::game_mod::{DiscoveredMod, ModKind};
+use crate::ipc::ThemePalette;
+use parish_types::error::ParishError;
+
+/// A single theme entry — one `(name, mode)` pair from an asset mod.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ThemeEntry {
+    /// Theme name, e.g. `"solarized"`. Multiple entries may share a name (one per mode).
+    pub name: String,
+    /// Mode within the theme, e.g. `"light"` / `"dark"` / `"c64"`. Empty string for mode-less themes.
+    #[serde(default)]
+    pub mode: String,
+    /// Human-readable label for menus and confirmation messages.
+    #[serde(default)]
+    pub label: String,
+    /// Optional flavour text shown when the user applies this theme.
+    #[serde(default)]
+    pub message: Option<String>,
+    /// The palette to apply.
+    pub palette: ThemePalette,
+}
+
+/// Default mode for a theme name (used when `/theme <name>` is invoked with no mode).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModeDefault {
+    pub name: String,
+    pub default_mode: String,
+}
+
+/// Synthetic mode that resolves to another mode based on game time.
+///
+/// The frontend selects `day_mode` when the in-game hour is daytime and
+/// `night_mode` at night. Both must already exist as `[[themes]]` entries
+/// with the same `name`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ModeAlias {
+    pub name: String,
+    pub mode: String,
+    pub day_mode: String,
+    pub night_mode: String,
+}
+
+/// The on-disk shape of a `themes.toml` file.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ThemeManifest {
+    #[serde(default)]
+    pub themes: Vec<ThemeEntry>,
+    #[serde(default)]
+    pub mode_defaults: Vec<ModeDefault>,
+    #[serde(default)]
+    pub mode_aliases: Vec<ModeAlias>,
+}
+
+/// A summary of a theme registry entry, sent to the frontend so it can
+/// list/preview available themes without re-parsing the mod files.
+#[derive(Debug, Clone, Serialize)]
+pub struct ThemeListing {
+    pub name: String,
+    pub mode: String,
+    pub label: String,
+}
+
+/// Serializable wire shape of a [`ThemeRegistry`]. Sent to the frontend once
+/// at startup (via `UiConfigSnapshot`) so themes can be applied client-side
+/// without round-tripping through the backend.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct ThemeRegistrySnapshot {
+    pub themes: Vec<ThemeRegistryEntry>,
+    pub mode_aliases: Vec<ModeAlias>,
+    pub mode_defaults: BTreeMap<String, String>,
+}
+
+/// Wire shape of a single theme entry, including the full palette.
+#[derive(Debug, Clone, Serialize)]
+pub struct ThemeRegistryEntry {
+    pub name: String,
+    pub mode: String,
+    pub label: String,
+    pub palette: ThemePalette,
+}
+
+/// Merged registry of all asset-mod themes.
+#[derive(Debug, Clone, Default)]
+pub struct ThemeRegistry {
+    /// Keyed by `(name, mode)`. BTreeMap so listings are deterministic.
+    entries: BTreeMap<(String, String), ThemeEntry>,
+    /// Default mode per name (e.g. `solarized -> auto`).
+    defaults: BTreeMap<String, String>,
+    /// Synthetic modes (e.g. `solarized auto -> {day=light, night=dark}`).
+    aliases: BTreeMap<(String, String), ModeAlias>,
+}
+
+impl ThemeRegistry {
+    /// Returns the palette for a `(name, mode)` pair, if registered.
+    pub fn get(&self, name: &str, mode: &str) -> Option<&ThemeEntry> {
+        self.entries.get(&(name.to_string(), mode.to_string()))
+    }
+
+    /// Returns the default mode for a theme name, if any. Falls back to the
+    /// empty string if the name is registered but has no declared default.
+    pub fn default_mode_for(&self, name: &str) -> Option<&str> {
+        self.defaults.get(name).map(String::as_str)
+    }
+
+    /// Returns the alias declaration for a synthetic mode, if any.
+    pub fn alias(&self, name: &str, mode: &str) -> Option<&ModeAlias> {
+        self.aliases.get(&(name.to_string(), mode.to_string()))
+    }
+
+    /// All distinct theme names in the registry, sorted.
+    pub fn names(&self) -> Vec<String> {
+        let mut out: Vec<String> = self.entries.keys().map(|(n, _)| n.clone()).collect();
+        out.sort();
+        out.dedup();
+        out
+    }
+
+    /// Modes registered for a given name, including synthetic aliases. Sorted.
+    pub fn modes_for(&self, name: &str) -> Vec<String> {
+        let mut modes: Vec<String> = self
+            .entries
+            .keys()
+            .filter(|(n, _)| n == name)
+            .map(|(_, m)| m.clone())
+            .chain(
+                self.aliases
+                    .keys()
+                    .filter(|(n, _)| n == name)
+                    .map(|(_, m)| m.clone()),
+            )
+            .collect();
+        modes.sort();
+        modes.dedup();
+        modes
+    }
+
+    /// Returns a serializable listing of all themes (without palettes), for
+    /// shipping to the frontend at startup.
+    pub fn listings(&self) -> Vec<ThemeListing> {
+        let mut out: Vec<ThemeListing> = self
+            .entries
+            .values()
+            .map(|e| ThemeListing {
+                name: e.name.clone(),
+                mode: e.mode.clone(),
+                label: if e.label.is_empty() {
+                    if e.mode.is_empty() {
+                        e.name.clone()
+                    } else {
+                        format!("{} {}", e.name, e.mode)
+                    }
+                } else {
+                    e.label.clone()
+                },
+            })
+            .collect();
+        // Plus synthetic mode aliases so the frontend can offer e.g. `solarized auto`.
+        for (name, mode) in self.aliases.keys() {
+            out.push(ThemeListing {
+                name: name.clone(),
+                mode: mode.clone(),
+                label: format!("{name} {mode}"),
+            });
+        }
+        out
+    }
+
+    /// Returns the full serializable palette map, for the frontend to apply
+    /// any theme without round-tripping through the backend.
+    pub fn palettes(&self) -> Vec<(String, String, ThemePalette)> {
+        self.entries
+            .values()
+            .map(|e| (e.name.clone(), e.mode.clone(), e.palette.clone()))
+            .collect()
+    }
+
+    /// All declared mode aliases, for shipping to the frontend.
+    pub fn aliases_vec(&self) -> Vec<ModeAlias> {
+        self.aliases.values().cloned().collect()
+    }
+
+    /// All declared mode defaults, for shipping to the frontend.
+    pub fn defaults_map(&self) -> BTreeMap<String, String> {
+        self.defaults.clone()
+    }
+
+    /// Returns a wire-shape snapshot for serialization to the frontend.
+    pub fn snapshot(&self) -> ThemeRegistrySnapshot {
+        ThemeRegistrySnapshot {
+            themes: self
+                .entries
+                .values()
+                .map(|e| ThemeRegistryEntry {
+                    name: e.name.clone(),
+                    mode: e.mode.clone(),
+                    label: if e.label.is_empty() {
+                        if e.mode.is_empty() {
+                            e.name.clone()
+                        } else {
+                            format!("{} {}", e.name, e.mode)
+                        }
+                    } else {
+                        e.label.clone()
+                    },
+                    palette: e.palette.clone(),
+                })
+                .collect(),
+            mode_aliases: self.aliases.values().cloned().collect(),
+            mode_defaults: self.defaults.clone(),
+        }
+    }
+
+    /// Merges another manifest's entries into this registry. Later mods override
+    /// earlier ones on conflict — deterministic because callers feed mods in
+    /// lexicographic-id order from [`crate::game_mod::discover_mods`].
+    pub fn extend_from(&mut self, manifest: ThemeManifest) {
+        for entry in manifest.themes {
+            let key = (entry.name.clone(), entry.mode.clone());
+            self.entries.insert(key, entry);
+        }
+        for def in manifest.mode_defaults {
+            self.defaults.insert(def.name.clone(), def.default_mode);
+        }
+        for alias in manifest.mode_aliases {
+            let key = (alias.name.clone(), alias.mode.clone());
+            self.aliases.insert(key, alias);
+        }
+    }
+}
+
+/// Walks the auxiliary mods, parsing each `themes.toml` (if present) and
+/// merging into a single [`ThemeRegistry`].
+///
+/// Per-mod parse failures are logged via `tracing` and skipped — a broken
+/// asset mod must never prevent the game from starting.
+pub fn load_asset_themes(auxiliary: &[DiscoveredMod]) -> ThemeRegistry {
+    let mut registry = ThemeRegistry::default();
+    for m in auxiliary {
+        if m.kind != ModKind::Asset {
+            continue;
+        }
+        match load_themes_from_dir(&m.path) {
+            Ok(Some(manifest)) => registry.extend_from(manifest),
+            Ok(None) => {} // No themes.toml in this asset mod — fine.
+            Err(e) => tracing::warn!(
+                mod_id = %m.id,
+                error = %e,
+                "Failed to load themes from asset mod; skipping."
+            ),
+        }
+    }
+    registry
+}
+
+fn load_themes_from_dir(mod_dir: &Path) -> Result<Option<ThemeManifest>, ParishError> {
+    let path = mod_dir.join("themes.toml");
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| ParishError::Config(format!("read {}: {e}", path.display())))?;
+    let manifest: ThemeManifest = toml::from_str(&raw)
+        .map_err(|e| ParishError::Config(format!("parse {}: {e}", path.display())))?;
+    Ok(Some(manifest))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game_mod::ModKind;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_asset_mod(dir: &std::path::Path, id: &str, themes_toml: &str) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(
+            dir.join("mod.toml"),
+            format!(
+                "[mod]\nname = \"{id}\"\nid = \"{id}\"\nversion = \"0.0.0\"\ndescription = \"x\"\nkind = \"asset\"\n"
+            ),
+        )
+        .unwrap();
+        fs::write(dir.join("themes.toml"), themes_toml).unwrap();
+    }
+
+    fn discover_asset(dir: std::path::PathBuf, id: &str) -> DiscoveredMod {
+        DiscoveredMod {
+            path: dir,
+            kind: ModKind::Asset,
+            id: id.to_string(),
+        }
+    }
+
+    #[test]
+    fn empty_auxiliary_returns_empty_registry() {
+        let reg = load_asset_themes(&[]);
+        assert!(reg.entries.is_empty());
+        assert!(reg.names().is_empty());
+    }
+
+    #[test]
+    fn loads_themes_from_asset_mod() {
+        let tmp = TempDir::new().unwrap();
+        let zork_dir = tmp.path().join("zork-theme");
+        write_asset_mod(
+            &zork_dir,
+            "zork-theme",
+            r##"
+[[themes]]
+name = "zork"
+mode = "c64"
+label = "Zork (C64)"
+message = "Pitch black."
+palette = { bg = "#1f1b96", fg = "#a8a8ff", accent = "#ffffff", panel_bg = "#1f1b96", input_bg = "#15116b", border = "#7878ff", muted = "#6c5eb5", chat_align = "left", status_invert = true }
+
+[[themes]]
+name = "zork"
+mode = "dos"
+label = "Zork (DOS)"
+palette = { bg = "#000000", fg = "#c0c0c0", accent = "#ffff55", panel_bg = "#000000", input_bg = "#0a0a0a", border = "#808080", muted = "#808080", chat_align = "left", status_invert = true }
+
+[[mode_defaults]]
+name = "zork"
+default_mode = "c64"
+"##,
+        );
+        let reg = load_asset_themes(&[discover_asset(zork_dir, "zork-theme")]);
+        assert_eq!(reg.names(), vec!["zork"]);
+        assert_eq!(reg.modes_for("zork"), vec!["c64", "dos"]);
+        assert_eq!(reg.default_mode_for("zork"), Some("c64"));
+        let c64 = reg.get("zork", "c64").unwrap();
+        assert_eq!(c64.palette.bg, "#1f1b96");
+        assert_eq!(c64.palette.chat_align.as_deref(), Some("left"));
+        assert_eq!(c64.palette.status_invert, Some(true));
+    }
+
+    #[test]
+    fn ignores_setting_kind_mods() {
+        let tmp = TempDir::new().unwrap();
+        let setting_dir = tmp.path().join("rundale");
+        fs::create_dir_all(&setting_dir).unwrap();
+        fs::write(setting_dir.join("themes.toml"), "garbage").unwrap();
+        let discovered = DiscoveredMod {
+            path: setting_dir,
+            kind: ModKind::Setting,
+            id: "rundale".to_string(),
+        };
+        let reg = load_asset_themes(&[discovered]);
+        assert!(reg.entries.is_empty());
+    }
+
+    #[test]
+    fn skips_asset_mod_without_themes_file() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("noisy");
+        fs::create_dir_all(&dir).unwrap();
+        let reg = load_asset_themes(&[discover_asset(dir, "noisy")]);
+        assert!(reg.entries.is_empty());
+    }
+
+    #[test]
+    fn merges_multiple_asset_mods() {
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("a");
+        let b = tmp.path().join("b");
+        write_asset_mod(
+            &a,
+            "a",
+            r##"
+[[themes]]
+name = "a-theme"
+mode = ""
+palette = { bg = "#111111", fg = "#222222", accent = "#333333", panel_bg = "#444444", input_bg = "#555555", border = "#666666", muted = "#777777" }
+"##,
+        );
+        write_asset_mod(
+            &b,
+            "b",
+            r##"
+[[themes]]
+name = "b-theme"
+mode = ""
+palette = { bg = "#aaaaaa", fg = "#bbbbbb", accent = "#cccccc", panel_bg = "#dddddd", input_bg = "#eeeeee", border = "#ffffff", muted = "#888888" }
+"##,
+        );
+        let reg = load_asset_themes(&[discover_asset(a, "a"), discover_asset(b, "b")]);
+        let mut names = reg.names();
+        names.sort();
+        assert_eq!(names, vec!["a-theme", "b-theme"]);
+    }
+
+    #[test]
+    fn malformed_themes_toml_is_skipped_not_fatal() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("broken");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("themes.toml"), "this is not valid toml [[").unwrap();
+        let reg = load_asset_themes(&[discover_asset(dir, "broken")]);
+        assert!(reg.entries.is_empty());
+    }
+
+    #[test]
+    fn shipped_asset_mods_parse() {
+        // Smoke test: every asset mod in the repo's `mods/` directory must
+        // have a parseable `themes.toml` (or none). Catches schema drift.
+        let mods_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../mods");
+        if !mods_root.is_dir() {
+            return; // workspace check; no mods checked out
+        }
+        for entry in std::fs::read_dir(&mods_root).unwrap().flatten() {
+            let dir = entry.path();
+            if !dir.is_dir() || !dir.join("mod.toml").is_file() {
+                continue;
+            }
+            let manifest = std::fs::read_to_string(dir.join("mod.toml")).unwrap();
+            if !manifest.contains("kind = \"asset\"") {
+                continue;
+            }
+            // load_themes_from_dir must succeed for every asset mod
+            let result = load_themes_from_dir(&dir);
+            assert!(
+                result.is_ok(),
+                "Asset mod at {} has malformed themes.toml: {:?}",
+                dir.display(),
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn mode_aliases_loaded() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("solarized");
+        write_asset_mod(
+            &dir,
+            "solarized",
+            r##"
+[[themes]]
+name = "solarized"
+mode = "light"
+palette = { bg = "#fdf6e3", fg = "#586e75", accent = "#268bd2", panel_bg = "#eee8d5", input_bg = "#e6dfc5", border = "#93a1a1", muted = "#93a1a1" }
+
+[[themes]]
+name = "solarized"
+mode = "dark"
+palette = { bg = "#002b36", fg = "#839496", accent = "#268bd2", panel_bg = "#073642", input_bg = "#0d3f4f", border = "#586e75", muted = "#586e75" }
+
+[[mode_aliases]]
+name = "solarized"
+mode = "auto"
+day_mode = "light"
+night_mode = "dark"
+
+[[mode_defaults]]
+name = "solarized"
+default_mode = "auto"
+"##,
+        );
+        let reg = load_asset_themes(&[discover_asset(dir, "solarized")]);
+        let alias = reg.alias("solarized", "auto").unwrap();
+        assert_eq!(alias.day_mode, "light");
+        assert_eq!(alias.night_mode, "dark");
+        assert_eq!(reg.default_mode_for("solarized"), Some("auto"));
+        let modes = reg.modes_for("solarized");
+        assert!(modes.contains(&"auto".to_string()));
+        assert!(modes.contains(&"light".to_string()));
+        assert!(modes.contains(&"dark".to_string()));
+    }
+}

--- a/crates/parish-server/src/lib.rs
+++ b/crates/parish-server/src/lib.rs
@@ -246,6 +246,14 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         .map(|gm| gm.ui.theme.resolved_palette())
         .unwrap_or_else(parish_core::game_mod::default_theme_palette);
 
+    // Asset-mod themes: walk every `kind = "asset"` mod and merge its
+    // `themes.toml`. The `/theme` handler consults this registry.
+    let theme_registry = parish_core::game_mod::discover_mods()
+        .ok()
+        .map(|d| parish_core::themes::load_asset_themes(&d.auxiliary))
+        .unwrap_or_default();
+    config.theme_registry = theme_registry.clone();
+
     // Load engine config (parish.toml) for the tile-source registry. Missing
     // file or parse errors fall back to baked defaults
     // (OSM + Ireland Historic 6").
@@ -256,21 +264,26 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     config.active_tile_source = active_tile_source.clone();
     config.tile_sources = engine_config.map.id_label_pairs();
 
+    let theme_snapshot = theme_registry.snapshot();
     let ui_config = if let Some(ref gm) = game_mod {
         UiConfigSnapshot {
             hints_label: gm.ui.sidebar.hints_label.clone(),
             default_accent: theme_palette.accent.clone(),
+            default_palette: theme_palette.clone(),
             splash_text,
             active_tile_source: active_tile_source.clone(),
             tile_sources: tile_sources_snapshot.clone(),
+            themes: theme_snapshot,
         }
     } else {
         UiConfigSnapshot {
             hints_label: "Language Hints".to_string(),
             default_accent: theme_palette.accent.clone(),
+            default_palette: theme_palette.clone(),
             splash_text,
             active_tile_source,
             tile_sources: tile_sources_snapshot,
+            themes: theme_snapshot,
         }
     };
 
@@ -641,6 +654,8 @@ fn build_client_and_config() -> (parish_core::config::ProviderConfig, GameConfig
         active_tile_source: String::new(),
         tile_sources: Vec::new(),
         reveal_unexplored_locations: false,
+        // Theme registry populated after this returns, once mods are discovered.
+        theme_registry: parish_core::themes::ThemeRegistry::default(),
     };
 
     (provider_cfg, config)

--- a/crates/parish-server/src/routes.rs
+++ b/crates/parish-server/src/routes.rs
@@ -486,9 +486,24 @@ async fn handle_system_command(cmd: parish_core::input::Command, state: &Arc<App
                 });
             }
             CommandEffect::ApplyTheme(name, mode) => {
+                // Look up the palette so the frontend can apply it without
+                // any hardcoded knowledge of theme names. `default` always
+                // resolves to the active setting mod's palette.
+                let palette = if name == "default" {
+                    Some(state.theme_palette.clone())
+                } else {
+                    let cfg = state.config.lock().await;
+                    cfg.theme_registry
+                        .get(name.as_str(), mode.as_str())
+                        .map(|e| e.palette.clone())
+                };
                 state.event_bus.emit(
                     "theme-switch",
-                    &serde_json::json!({ "name": name, "mode": mode }),
+                    &serde_json::json!({
+                        "name": name,
+                        "mode": mode,
+                        "palette": palette,
+                    }),
                 );
             }
             CommandEffect::ApplyTiles(id) => {
@@ -2348,9 +2363,11 @@ pub(crate) mod tests {
         let ui_config = crate::state::UiConfigSnapshot {
             hints_label: "test".to_string(),
             default_accent: "#000".to_string(),
+            default_palette: parish_core::game_mod::default_theme_palette(),
             splash_text: String::new(),
             active_tile_source: String::new(),
             tile_sources: Vec::new(),
+            themes: parish_core::themes::ThemeRegistrySnapshot::default(),
         };
         let theme_palette = parish_core::game_mod::default_theme_palette();
         let saves_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../saves");
@@ -2380,6 +2397,7 @@ pub(crate) mod tests {
                 active_tile_source: String::new(),
                 tile_sources: Vec::new(),
                 reveal_unexplored_locations: false,
+                theme_registry: parish_core::themes::ThemeRegistry::default(),
             },
             None,
             transport,

--- a/crates/parish-server/src/state.rs
+++ b/crates/parish-server/src/state.rs
@@ -31,12 +31,18 @@ pub struct UiConfigSnapshot {
     pub hints_label: String,
     /// Default accent colour (CSS hex string).
     pub default_accent: String,
+    /// Default palette (from the active setting mod's `[theme.palette]`).
+    /// The frontend uses this for `/theme default` and the initial render.
+    pub default_palette: ThemePalette,
     /// Splash text displayed on game start (Zork-style).
     pub splash_text: String,
     /// Id of the currently-active tile source (matches a `tile_sources` key).
     pub active_tile_source: String,
     /// Registry of available map tile sources, alphabetical by id.
     pub tile_sources: Vec<parish_core::ipc::TileSourceSnapshot>,
+    /// All themes loaded from `kind = "asset"` mods. Frontend uses this to
+    /// resolve `/theme <name> [mode]` palettes locally.
+    pub themes: parish_core::themes::ThemeRegistrySnapshot,
 }
 
 /// Current save state for display in the StatusBar.

--- a/crates/parish-server/tests/isolation.rs
+++ b/crates/parish-server/tests/isolation.rs
@@ -198,9 +198,11 @@ async fn second_ws_upgrade_same_email_is_409() {
     let ui_config = UiConfigSnapshot {
         hints_label: "test".to_string(),
         default_accent: "#000".to_string(),
+        default_palette: parish_core::game_mod::default_theme_palette(),
         splash_text: String::new(),
         active_tile_source: String::new(),
         tile_sources: Vec::new(),
+        themes: parish_core::themes::ThemeRegistrySnapshot::default(),
     };
     let theme_palette = parish_core::game_mod::default_theme_palette();
     let saves_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../saves");
@@ -231,6 +233,7 @@ async fn second_ws_upgrade_same_email_is_409() {
             active_tile_source: String::new(),
             tile_sources: Vec::new(),
             reveal_unexplored_locations: false,
+            theme_registry: parish_core::themes::ThemeRegistry::default(),
         },
         None,
         TransportConfig::default(),
@@ -310,9 +313,11 @@ async fn debug_snapshot_no_deadlock_with_concurrent_readers() {
     let ui_config = UiConfigSnapshot {
         hints_label: "test".to_string(),
         default_accent: "#000".to_string(),
+        default_palette: parish_core::game_mod::default_theme_palette(),
         splash_text: String::new(),
         active_tile_source: String::new(),
         tile_sources: Vec::new(),
+        themes: parish_core::themes::ThemeRegistrySnapshot::default(),
     };
     let theme_palette = parish_core::game_mod::default_theme_palette();
     let saves_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../saves");
@@ -343,6 +348,7 @@ async fn debug_snapshot_no_deadlock_with_concurrent_readers() {
             active_tile_source: String::new(),
             tile_sources: Vec::new(),
             reveal_unexplored_locations: false,
+            theme_registry: parish_core::themes::ThemeRegistry::default(),
         },
         None,
         TransportConfig::default(),

--- a/crates/parish-tauri/src/commands.rs
+++ b/crates/parish-tauri/src/commands.rs
@@ -485,9 +485,24 @@ async fn handle_system_command(
                 });
             }
             CommandEffect::ApplyTheme(name, mode) => {
+                // Look up the palette so the frontend can apply it without
+                // hardcoded knowledge of theme names. `default` resolves to
+                // the active setting mod's palette.
+                let palette = if name == "default" {
+                    Some(state.theme_palette.clone())
+                } else {
+                    let cfg = state.config.lock().await;
+                    cfg.theme_registry
+                        .get(name, mode)
+                        .map(|e| e.palette.clone())
+                };
                 let _ = app.emit(
                     crate::events::EVENT_THEME_SWITCH,
-                    serde_json::json!({ "name": name, "mode": mode }),
+                    serde_json::json!({
+                        "name": name,
+                        "mode": mode,
+                        "palette": palette,
+                    }),
                 );
             }
             CommandEffect::ApplyTiles(id) => {

--- a/crates/parish-tauri/src/lib.rs
+++ b/crates/parish-tauri/src/lib.rs
@@ -139,12 +139,17 @@ pub struct UiConfigSnapshot {
     pub hints_label: String,
     /// Default accent colour (CSS hex string).
     pub default_accent: String,
+    /// Default palette (from the active setting mod's `[theme.palette]`).
+    /// Used by the frontend for `/theme default` and initial render.
+    pub default_palette: parish_core::ipc::ThemePalette,
     /// Splash text displayed on game start (Zork-style).
     pub splash_text: String,
     /// Id of the currently-active tile source (matches a `tile_sources` key).
     pub active_tile_source: String,
     /// Registry of available map tile sources, alphabetical by id.
     pub tile_sources: Vec<parish_core::ipc::TileSourceSnapshot>,
+    /// All themes loaded from `kind = "asset"` mods.
+    pub themes: parish_core::themes::ThemeRegistrySnapshot,
 }
 
 /// Runtime conversation/session state used for continuity and inactivity timers.
@@ -564,6 +569,14 @@ pub fn run() {
         .map(|gm| gm.ui.theme.resolved_palette())
         .unwrap_or_else(parish_core::game_mod::default_theme_palette);
 
+    // Asset-mod themes: walk every `kind = "asset"` mod and merge its
+    // `themes.toml`. The `/theme` handler consults this registry.
+    let theme_registry = parish_core::game_mod::discover_mods()
+        .ok()
+        .map(|d| parish_core::themes::load_asset_themes(&d.auxiliary))
+        .unwrap_or_default();
+    let theme_snapshot = theme_registry.snapshot();
+
     // engine_config already loaded above (before provider bootstrap) and
     // includes both map tile-source registry and inference timeouts. (#417)
     let tile_sources_snapshot =
@@ -575,17 +588,21 @@ pub fn run() {
         UiConfigSnapshot {
             hints_label: gm.ui.sidebar.hints_label.clone(),
             default_accent: theme_palette.accent.clone(),
+            default_palette: theme_palette.clone(),
             splash_text: splash_text.clone(),
             active_tile_source: active_tile_source.clone(),
             tile_sources: tile_sources_snapshot.clone(),
+            themes: theme_snapshot.clone(),
         }
     } else {
         UiConfigSnapshot {
             hints_label: "Language Hints".to_string(),
             default_accent: theme_palette.accent.clone(),
+            default_palette: theme_palette.clone(),
             splash_text,
             active_tile_source: active_tile_source.clone(),
             tile_sources: tile_sources_snapshot,
+            themes: theme_snapshot.clone(),
         }
     };
 
@@ -654,6 +671,7 @@ pub fn run() {
             active_tile_source,
             tile_sources: engine_config.map.id_label_pairs(),
             reveal_unexplored_locations: false,
+            theme_registry: theme_registry.clone(),
         }),
     });
 

--- a/mods/solarized-theme/mod.toml
+++ b/mods/solarized-theme/mod.toml
@@ -1,0 +1,8 @@
+# Solarized UI theme — an asset mod (palettes only, no gameplay content).
+[mod]
+name = "Solarized Theme"
+title = "Solarized Theme"
+id = "solarized-theme"
+version = "1.0.0"
+description = "Ethan Schoonover's Solarized palette in light, dark, and time-of-day-auto modes."
+kind = "asset"

--- a/mods/solarized-theme/themes.toml
+++ b/mods/solarized-theme/themes.toml
@@ -1,0 +1,28 @@
+# Solarized — Ethan Schoonover's palette mapped to Parish theme slots.
+#
+# `auto` mode is a synthetic alias: the frontend selects `light` during game
+# day and `dark` at night based on the in-world clock.
+
+[[themes]]
+name = "solarized"
+mode = "light"
+label = "Solarized Light"
+message = "Solarized light applied."
+palette = { bg = "#fdf6e3", fg = "#586e75", accent = "#268bd2", panel_bg = "#eee8d5", input_bg = "#e6dfc5", border = "#93a1a1", muted = "#93a1a1" }
+
+[[themes]]
+name = "solarized"
+mode = "dark"
+label = "Solarized Dark"
+message = "Solarized dark applied."
+palette = { bg = "#002b36", fg = "#839496", accent = "#268bd2", panel_bg = "#073642", input_bg = "#0d3f4f", border = "#586e75", muted = "#586e75" }
+
+[[mode_aliases]]
+name = "solarized"
+mode = "auto"
+day_mode = "light"
+night_mode = "dark"
+
+[[mode_defaults]]
+name = "solarized"
+default_mode = "auto"

--- a/mods/zork-theme/mod.toml
+++ b/mods/zork-theme/mod.toml
@@ -1,0 +1,8 @@
+# Zork retro UI theme — an asset mod (palettes only, no gameplay content).
+[mod]
+name = "Zork Retro Theme"
+title = "Zork Retro Theme"
+id = "zork-theme"
+version = "1.0.0"
+description = "Infocom Zork I look: blue-on-blue (C64) and white-on-black (DOS)."
+kind = "asset"

--- a/mods/zork-theme/themes.toml
+++ b/mods/zork-theme/themes.toml
@@ -1,0 +1,23 @@
+# Zork Retro Theme — two modes evoking Infocom Zork I on Commodore 64 and IBM PC.
+#
+# Both modes share three structural traits: fixed-width font, all chat lines
+# left-justified (no right-aligned player bubbles), and an inverted status bar
+# (light bg, dark fg) — matching the classic Infocom screen layout.
+
+[[themes]]
+name = "zork"
+mode = "c64"
+label = "Zork (C64)"
+message = "Theme set to Zork (C64). It is pitch black. You are likely to be eaten by a grue."
+palette = { bg = "#1f1b96", fg = "#a8a8ff", accent = "#ffffff", panel_bg = "#1f1b96", input_bg = "#15116b", border = "#7878ff", muted = "#6c5eb5", font_body = "'Courier New', Consolas, ui-monospace, monospace", font_display = "'Courier New', Consolas, ui-monospace, monospace", chat_align = "left", bubble_style = "flat", status_invert = true }
+
+[[themes]]
+name = "zork"
+mode = "dos"
+label = "Zork (DOS)"
+message = "Theme set to Zork (DOS). West of House. You are standing in an open field."
+palette = { bg = "#000000", fg = "#c0c0c0", accent = "#ffff55", panel_bg = "#000000", input_bg = "#0a0a0a", border = "#808080", muted = "#808080", font_body = "'Courier New', Consolas, ui-monospace, monospace", font_display = "'Courier New', Consolas, ui-monospace, monospace", chat_align = "left", bubble_style = "flat", status_invert = true }
+
+[[mode_defaults]]
+name = "zork"
+default_mode = "c64"


### PR DESCRIPTION
## Summary

Migrates UI themes out of the engine and into standalone asset mods. The engine ships zero hardcoded named themes — only the active setting mod's `[theme.palette]` (the `default`). Any future palette is just a new directory under `mods/`.

Two new mods land in this PR:

- **`mods/zork-theme/`** — adds `/theme zork c64` (Commodore 64 blue-on-blue) and `/theme zork dos` (IBM PC white-on-black) with monospace font, left-justified chat, and inverted status bar.
- **`mods/solarized-theme/`** — moves the previously hardcoded `/theme solarized light/dark/auto` into a mod. `auto` is now a declared `mode_alias` resolved client-side from the in-game hour.

## How it works

```
mods/<id>-theme/
├── mod.toml      # kind = "asset"
└── themes.toml   # [[themes]] + [[mode_defaults]] + [[mode_aliases]]
```

- **Discovery**: `parish_core::game_mod::discover_mods()` already classifies asset mods. New `parish_core::themes::load_asset_themes()` walks `DiscoveredMods.auxiliary`, parses each `themes.toml`, and merges into a `ThemeRegistry`.
- **`/theme` handler**: refactored from hardcoded `match name` arms into a registry lookup. Lists names from registry, resolves mode aliases, returns helpful errors that list available modes.
- **Wire**: `theme-switch` events now carry the resolved palette directly, so the frontend doesn't need any hardcoded theme knowledge. The full registry is also shipped via `GET /api/ui-config` for autocomplete and preference re-resolution at startup.
- **`ThemePalette` IPC type** grew five optional structural fields (`font_body`, `font_display`, `chat_align`, `bubble_style`, `status_invert`) so mod-defined themes can express font/layout/inversion without bespoke CSS branches. `ChatPanel` and `StatusBar` now read bubble/status colours and shapes from CSS custom properties that these fields populate.

## Replaces PR #1044

That earlier PR shipped Zork as a hardcoded engine theme (matching how `solarized` already lived). The redesign here treats the original Zork PR's structural `ThemePalette` extensions and the `ChatPanel`/`StatusBar` CSS variable refactor as reusable infrastructure, and uses them to support any number of future mod-defined themes.

## Test plan

- [x] `cargo test -p parish-core --lib` — **257 pass**, including 8 new `themes::` tests (loader, mod_aliases, malformed-toml tolerance, schema-parity smoke against shipped mods) and 9 refactored `/theme` handler tests covering empty vs populated registry, default-mode resolution, alias resolution, unknown-name and unknown-mode errors.
- [x] `cargo test -p parish-server` — **128 + 6 + 5 + 7 + 10 pass**, including `UiConfigSnapshot` field additions in fixtures.
- [x] `cargo clippy -p parish-core -p parish-server --lib --tests -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo test -p parish-core --test architecture_fitness` — passes.
- [x] `npx vitest run` — **204 pass**.
- [x] `pnpm build` — clean.
- [ ] Tauri build — not run in this sandbox (no `gdk-3.0`); CI will exercise it.
- [ ] Visual smoke in a browser — not run here. The diff path is well-tested but a reviewer should `just run` and try `/theme zork`, `/theme zork dos`, `/theme solarized`, `/theme solarized auto` end-to-end before merging.

## What this deliberately doesn't do

- No live-reload of themes on `themes.toml` edit. Out of scope; a follow-up can extend `parish_core::editor::live_reload`.
- No mod ordering / dependency resolution beyond lex order on directory id. Sufficient for two mods; we can revisit if conflicts appear.
- No engine-level `solarized auto` time-of-day re-emit — auto-mode is resolved client-side using the in-game hour, same as before, just data-driven now.

Closes the design thread from #1044.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EjVMBcEN5keEMSGhZ2sDCy)_