### PR TITLE
fix(demo): break repetition loop + intent-parser narrative-look carve-out

### DIFF
--- a/parish/apps/ui/src/lib/demo-player.test.ts
+++ b/parish/apps/ui/src/lib/demo-player.test.ts
@@ -217,4 +217,59 @@ describe('runDemoTurn', () => {
 			'go to the mill',
 		]);
 	});
+
+	// Regression for codex review on #1048: in long demo runs with heavy
+	// NPC/system output, the last 5 `[player]` entries can sit OUTSIDE the
+	// 40-entry recent_log window. recent_actions must therefore be derived
+	// from the full textLog, not from the pre-truncated 40-entry slice, or
+	// the anti-repetition signal silently stops working.
+	it('derives recent_actions from full textLog even past the 40-entry recent_log window', async () => {
+		demoEnabled.set(true);
+		const log = [
+			{ id: 'p1', source: 'player', content: 'first player utterance' },
+			{ id: 'p2', source: 'player', content: 'second player utterance' },
+		];
+		// Pad with 50 NPC entries so the player entries fall outside any
+		// 40-entry tail window.
+		for (let i = 0; i < 50; i += 1) {
+			log.push({ id: `n${i}`, source: 'Padraig', content: `npc line ${i}` });
+		}
+		textLog.set(log);
+
+		await runDemoTurn();
+
+		const ctxArg = vi.mocked(getLlmPlayerAction).mock.calls[0][0];
+		expect(ctxArg.recent_actions).toEqual([
+			'first player utterance',
+			'second player utterance',
+		]);
+		// recent_log still honours the 40-entry cap.
+		expect(ctxArg.recent_log.length).toBe(40);
+	});
+
+	// Regression for codex review on #1048: scene-echo filtering must happen
+	// BEFORE the 40-entry truncation, or a stretch of scene-blurb spam at
+	// the tail can consume the recent_log window and leave very little
+	// usable history after the filter.
+	it('filters scene echoes BEFORE truncating recent_log to 40 entries', async () => {
+		demoEnabled.set(true);
+		const log = [
+			{ id: 'useful-1', source: 'Padraig', content: 'A useful old line.' },
+			{ id: 'useful-2', source: 'player', content: 'A useful player line.' },
+		];
+		// Add 60 system scene echoes that should ALL be filtered.
+		for (let i = 0; i < 60; i += 1) {
+			log.push({ id: `echo-${i}`, source: 'system', content: KILTEEVAN_SCENE });
+		}
+		textLog.set(log);
+
+		await runDemoTurn();
+
+		const ctxArg = vi.mocked(getLlmPlayerAction).mock.calls[0][0];
+		// Scene echoes all stripped; the two useful older entries survive.
+		expect(ctxArg.recent_log).toEqual([
+			'[Padraig] A useful old line.',
+			'[player] A useful player line.',
+		]);
+	});
 });

--- a/parish/apps/ui/src/lib/demo-player.test.ts
+++ b/parish/apps/ui/src/lib/demo-player.test.ts
@@ -7,9 +7,9 @@ import {
 	demoTurnCount,
 	demoConfig,
 } from '../stores/demo';
-import { streamingActive } from '../stores/game';
+import { streamingActive, textLog } from '../stores/game';
 import { runDemoTurn, stopDemo } from './demo-player';
-import { submitInput } from './ipc';
+import { getLlmPlayerAction, submitInput } from './ipc';
 import { createStreamManager } from './setup/stream-manager';
 
 const testConfig = {
@@ -19,15 +19,23 @@ const testConfig = {
 	max_turns: null,
 };
 
+const KILTEEVAN_SCENE =
+	'The small village of Kilteevan — a handful of whitewashed cottages clustered around a well.';
+
 vi.mock('../lib/ipc', () => ({
 	getDemoContext: vi.fn(async () => ({
-		world_description: 'A village',
+		location_name: 'Kilteevan',
+		location_description: KILTEEVAN_SCENE,
+		game_time: 'Wednesday, 14 May 1820, morning',
+		season: 'spring',
+		weather: 'clear sky',
+		npcs_here: [],
+		adjacent: [],
 		recent_log: [],
-		nearby_npcs: [],
-		recent_events: [],
+		recent_actions: [],
 		extra_prompt: null,
 	})),
-	getLlmPlayerAction: vi.fn(async () => '"look around"'),
+	getLlmPlayerAction: vi.fn(async () => '"Good morning"'),
 	submitInput: vi.fn(async () => {}),
 }));
 
@@ -37,7 +45,9 @@ beforeEach(() => {
 	demoStatus.set('idle');
 	demoTurnCount.set(0);
 	demoConfig.set(testConfig);
+	textLog.set([]);
 	vi.mocked(submitInput).mockClear();
+	vi.mocked(getLlmPlayerAction).mockClear();
 });
 
 describe('stopDemo', () => {
@@ -158,5 +168,53 @@ describe('runDemoTurn', () => {
 		// chain rather than resolving on the mid-chain loading=false.
 		expect(get(streamingActive)).toBe(false);
 		expect(sm.isChainInProgress()).toBe(false);
+	});
+
+	// Regression for #999: `[system]` text-log entries that echo the
+	// current location description must NOT appear in the `recent_log`
+	// passed to `getLlmPlayerAction`. The static `location_description`
+	// field already conveys the scene; duplicating it via recent_log
+	// floods the prompt and anchors the auto-player on repeating itself.
+	it('filters scene-description echoes out of recent_log', async () => {
+		demoEnabled.set(true);
+		textLog.set([
+			{ id: 'a', source: 'player', content: 'Good morning' },
+			// A `[system]` echo of the current scene description — must
+			// be filtered.
+			{ id: 'b', source: 'system', content: KILTEEVAN_SCENE },
+			{ id: 'c', source: 'system', content: 'The clock chimes nine.' },
+		]);
+
+		await runDemoTurn();
+
+		expect(getLlmPlayerAction).toHaveBeenCalledTimes(1);
+		const ctxArg = vi.mocked(getLlmPlayerAction).mock.calls[0][0];
+		expect(ctxArg.recent_log).toEqual([
+			'[player] Good morning',
+			'[system] The clock chimes nine.',
+		]);
+	});
+
+	// Regression for #999: `recent_actions` must be populated from the
+	// last `[player]` entries of the text log so the demo system prompt
+	// can show the LLM what it has already said and break repetition.
+	it('populates recent_actions from the last 5 player log entries', async () => {
+		demoEnabled.set(true);
+		textLog.set([
+			{ id: 'p1', source: 'player', content: 'Good morning' },
+			{ id: 's1', source: 'system', content: 'The clock chimes nine.' },
+			{ id: 'p2', source: 'player', content: 'Good morning' },
+			{ id: 'n1', source: 'Padraig', content: 'And to ye.' },
+			{ id: 'p3', source: 'player', content: 'go to the mill' },
+		]);
+
+		await runDemoTurn();
+
+		const ctxArg = vi.mocked(getLlmPlayerAction).mock.calls[0][0];
+		expect(ctxArg.recent_actions).toEqual([
+			'Good morning',
+			'Good morning',
+			'go to the mill',
+		]);
 	});
 });

--- a/parish/apps/ui/src/lib/demo-player.ts
+++ b/parish/apps/ui/src/lib/demo-player.ts
@@ -73,9 +73,32 @@ export async function runDemoTurn(): Promise<void> {
 	const ctx = await getDemoContext();
 
 	// Fill recent log from frontend text log store (last 40 lines).
-	ctx.recent_log = get(textLog)
-		.slice(-40)
+	//
+	// #999: drop `[system]` entries that echo the current location description.
+	// The static `location_description` field already conveys the scene to the
+	// LLM; without this filter, any future or LLM-triggered `look` flood
+	// dominates recent_log with copies of the same blurb and the auto-player
+	// gets anchored on repeating itself.
+	const sceneHead = ctx.location_description.slice(0, 60).trim();
+	const log = get(textLog).slice(-40);
+	ctx.recent_log = log
+		.filter(
+			(e) =>
+				!(
+					e.source === 'system' &&
+					sceneHead.length > 0 &&
+					e.content.startsWith(sceneHead)
+				)
+		)
 		.map((e) => `[${e.source}] ${e.content}`);
+
+	// #999: surface the auto-player's own recent actions as a separate field so
+	// the demo system prompt can call them out explicitly ("do not repeat your
+	// last action"). Take the last 5 `[player]` entries, oldest first.
+	ctx.recent_actions = log
+		.filter((e) => e.source === 'player')
+		.slice(-5)
+		.map((e) => e.content);
 
 	// Frontend store's extra_prompt always wins — null means "cleared by user".
 	ctx.extra_prompt = config.extra_prompt;

--- a/parish/apps/ui/src/lib/demo-player.ts
+++ b/parish/apps/ui/src/lib/demo-player.ts
@@ -72,30 +72,35 @@ export async function runDemoTurn(): Promise<void> {
 	demoStatus.set('thinking');
 	const ctx = await getDemoContext();
 
-	// Fill recent log from frontend text log store (last 40 lines).
+	// Fill recent log from frontend text log store.
 	//
 	// #999: drop `[system]` entries that echo the current location description.
 	// The static `location_description` field already conveys the scene to the
 	// LLM; without this filter, any future or LLM-triggered `look` flood
 	// dominates recent_log with copies of the same blurb and the auto-player
 	// gets anchored on repeating itself.
+	//
+	// Filter scene echoes from the FULL textLog BEFORE truncating to 40
+	// entries. If we truncated first, a stretch of `look` spam could fill the
+	// 40-entry window and leave very little usable history after the filter.
 	const sceneHead = ctx.location_description.slice(0, 60).trim();
-	const log = get(textLog).slice(-40);
-	ctx.recent_log = log
-		.filter(
-			(e) =>
-				!(
-					e.source === 'system' &&
-					sceneHead.length > 0 &&
-					e.content.startsWith(sceneHead)
-				)
-		)
-		.map((e) => `[${e.source}] ${e.content}`);
+	const fullLog = get(textLog);
+	const filtered = fullLog.filter(
+		(e) =>
+			!(
+				e.source === 'system' &&
+				sceneHead.length > 0 &&
+				e.content.startsWith(sceneHead)
+			)
+	);
+	ctx.recent_log = filtered.slice(-40).map((e) => `[${e.source}] ${e.content}`);
 
 	// #999: surface the auto-player's own recent actions as a separate field so
 	// the demo system prompt can call them out explicitly ("do not repeat your
-	// last action"). Take the last 5 `[player]` entries, oldest first.
-	ctx.recent_actions = log
+	// last action"). Take the last 5 `[player]` entries from the FULL log so
+	// the anti-repetition signal still works in long runs where the last 5
+	// player entries sit outside the 40-entry recent_log window.
+	ctx.recent_actions = fullLog
 		.filter((e) => e.source === 'player')
 		.slice(-5)
 		.map((e) => e.content);

--- a/parish/apps/ui/src/lib/types.ts
+++ b/parish/apps/ui/src/lib/types.ts
@@ -515,6 +515,7 @@ export interface DemoContextSnapshot {
 	npcs_here: DemoNpcInfo[];
 	adjacent: DemoAdjacentLocation[];
 	recent_log: string[];
+	recent_actions: string[];
 	extra_prompt: string | null;
 }
 

--- a/parish/crates/parish-core/src/ipc/demo.rs
+++ b/parish/crates/parish-core/src/ipc/demo.rs
@@ -67,6 +67,13 @@ pub struct DemoContextSnapshot {
     /// Recent text-log entries. The Tauri command leaves this empty; the
     /// frontend fills it from its `textLog` store before invoking the LLM.
     pub recent_log: Vec<String>,
+    /// The auto-player's own most recent actions (oldest first, last 5).
+    /// The Tauri command leaves this empty; the frontend fills it from the
+    /// `[player]` entries of its `textLog` store before invoking the LLM.
+    /// Surfaced in the rendered prompt as a `Your last actions:` block so the
+    /// model can detect and break out of repetition loops (#999).
+    #[serde(default)]
+    pub recent_actions: Vec<String>,
     /// Operator-supplied steering text from the demo CLI flags.
     pub extra_prompt: Option<String>,
 }
@@ -125,8 +132,33 @@ pub fn build_demo_context(
         npcs_here,
         adjacent,
         recent_log: Vec::new(),
+        recent_actions: Vec::new(),
         extra_prompt,
     }
+}
+
+/// Dedupes consecutive identical entries in `actions`, returning each unique
+/// run with its repeat count. Used by [`render_user_prompt`] to surface
+/// repetition signals to the LLM without flooding the prompt with copies.
+///
+/// Input is oldest-first; output preserves order. Empty/whitespace entries
+/// are dropped to avoid `(last 0 turns)` artefacts.
+fn collapse_consecutive_actions(actions: &[String]) -> Vec<(String, usize)> {
+    let mut out: Vec<(String, usize)> = Vec::new();
+    for action in actions {
+        let trimmed = action.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(last) = out.last_mut()
+            && last.0 == trimmed
+        {
+            last.1 += 1;
+            continue;
+        }
+        out.push((trimmed.to_string(), 1));
+    }
+    out
 }
 
 /// Renders the demo snapshot into the user-prompt body shown to the LLM.
@@ -169,6 +201,21 @@ pub fn render_user_prompt(ctx: &DemoContextSnapshot) -> String {
             })
             .collect();
         parts.push(format!("Adjacent locations:\n{}", lines.join("\n")));
+    }
+
+    let collapsed = collapse_consecutive_actions(&ctx.recent_actions);
+    if !collapsed.is_empty() {
+        let lines: Vec<String> = collapsed
+            .iter()
+            .map(|(text, count)| match count {
+                1 => format!("  - {}", text),
+                n => format!("  - {} (last {} turns)", text, n),
+            })
+            .collect();
+        parts.push(format!(
+            "Your last actions (do not repeat these):\n{}",
+            lines.join("\n")
+        ));
     }
 
     if !ctx.recent_log.is_empty() {
@@ -418,6 +465,94 @@ mod tests {
         assert!(
             ctx.adjacent.iter().all(|a| a.name != "Distant Hamlet"),
             "non-adjacent location leaked"
+        );
+    }
+
+    #[test]
+    fn build_demo_context_initialises_empty_recent_actions() {
+        let ctx = build_demo_context(
+            &world_snapshot(),
+            &[],
+            &map_data(vec![], vec![]),
+            "Wednesday".to_string(),
+            "spring".to_string(),
+            None,
+        );
+        assert!(
+            ctx.recent_actions.is_empty(),
+            "Tauri/server build path must leave recent_actions empty; frontend fills it"
+        );
+    }
+
+    #[test]
+    fn render_user_prompt_omits_block_when_no_recent_actions() {
+        let ctx = build_demo_context(
+            &world_snapshot(),
+            &[],
+            &map_data(vec![], vec![]),
+            "Wednesday".to_string(),
+            "spring".to_string(),
+            None,
+        );
+        let prompt = render_user_prompt(&ctx);
+        assert!(
+            !prompt.contains("Your last actions"),
+            "empty recent_actions must not render the header:\n{prompt}"
+        );
+    }
+
+    /// #999 regression guard: when the auto-player has repeated the same
+    /// greeting two turns in a row, the rendered prompt must show that
+    /// repetition with a turn-count suffix so the model can break the loop.
+    #[test]
+    fn render_user_prompt_collapses_consecutive_recent_actions_with_count() {
+        let mut ctx = build_demo_context(
+            &world_snapshot(),
+            &[],
+            &map_data(vec![], vec![]),
+            "Wednesday".to_string(),
+            "spring".to_string(),
+            None,
+        );
+        ctx.recent_actions = vec![
+            "Good morning".to_string(),
+            "Good morning".to_string(),
+            "go to the mill".to_string(),
+        ];
+        let prompt = render_user_prompt(&ctx);
+        assert!(
+            prompt.contains("Your last actions (do not repeat these):"),
+            "missing header:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("Good morning (last 2 turns)"),
+            "missing collapsed repeat:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("- go to the mill"),
+            "missing singleton action:\n{prompt}"
+        );
+    }
+
+    #[test]
+    fn collapse_consecutive_actions_handles_runs_and_singletons() {
+        let input = vec![
+            "a".to_string(),
+            "a".to_string(),
+            "a".to_string(),
+            "b".to_string(),
+            "a".to_string(),
+            "  ".to_string(), // whitespace dropped
+            "a".to_string(),
+        ];
+        let collapsed = collapse_consecutive_actions(&input);
+        assert_eq!(
+            collapsed,
+            vec![
+                ("a".to_string(), 3),
+                ("b".to_string(), 1),
+                ("a".to_string(), 2),
+            ]
         );
     }
 }

--- a/parish/crates/parish-input/src/intent_llm.rs
+++ b/parish/crates/parish-input/src/intent_llm.rs
@@ -33,11 +33,19 @@ IMPORTANT: \"move\" is ONLY for when the player expresses a present desire to \
 navigate somewhere (imperative or future intent). Narrative, past-tense, or \
 reflective statements that merely mention a place name are \"talk\", not \"move\".\n\
 \n\
+IMPORTANT: \"look\" is ONLY for a bare imperative observation command — \
+\"look\", \"look around\", \"examine the room\", \"where am I\". A sentence \
+that merely contains the word \"look\" inside conversational speech (e.g. \
+\"Might I look about the village a while?\", \"I'll have a look at the \
+cattle later\", \"It looks fine to me\") is \"talk\", not \"look\".\n\
+\n\
 Examples:\n\
 Input: \"go to the pub\" → {\"intent\": \"move\", \"target\": \"the pub\", \"dialogue\": null}\n\
 Input: \"talk to Mary\" → {\"intent\": \"talk\", \"target\": \"Mary\", \"dialogue\": null}\n\
 Input: \"tell Padraig I saw his cow\" → {\"intent\": \"talk\", \"target\": \"Padraig\", \"dialogue\": \"I saw his cow\"}\n\
 Input: \"look around\" → {\"intent\": \"look\", \"target\": null, \"dialogue\": null}\n\
+Input: \"Might I look about the village a while?\" → {\"intent\": \"talk\", \"target\": null, \"dialogue\": \"Might I look about the village a while?\"}\n\
+Input: \"I'll have a look at the cattle later\" → {\"intent\": \"talk\", \"target\": null, \"dialogue\": \"I'll have a look at the cattle later\"}\n\
 Input: \"pick up the stone\" → {\"intent\": \"interact\", \"target\": \"the stone\", \"dialogue\": null}\n\
 Input: \"I came from the coast\" → {\"intent\": \"talk\", \"target\": null, \"dialogue\": \"I came from the coast\"}\n\
 Input: \"I was at the shore yesterday\" → {\"intent\": \"talk\", \"target\": null, \"dialogue\": \"I was at the shore yesterday\"}\n\
@@ -97,5 +105,32 @@ mod tests {
         assert!(resp.intent.is_none());
         assert!(resp.target.is_none());
         assert!(resp.dialogue.is_none());
+    }
+
+    /// Regression: the demo auto-player's own exemplar ("Might I look about
+    /// the village a while?") was being classified as `look` because the
+    /// intent system prompt did not distinguish narrative use of the word
+    /// "look" from the imperative observation command. That caused
+    /// `handle_look` to fire every turn, spamming the location description.
+    /// Closes #999.
+    #[test]
+    fn intent_system_prompt_distinguishes_narrative_look() {
+        assert!(
+            INTENT_SYSTEM_PROMPT.contains("\"look\" is ONLY for a bare imperative"),
+            "intent system prompt lost the narrative-look carve-out"
+        );
+        assert!(
+            INTENT_SYSTEM_PROMPT.contains("Might I look about the village a while?"),
+            "intent system prompt lost the narrative-look exemplar"
+        );
+        assert!(
+            INTENT_SYSTEM_PROMPT.contains("I'll have a look at the cattle later"),
+            "intent system prompt lost the second narrative-look exemplar"
+        );
+        // Regression guards for the imperative form.
+        assert!(
+            INTENT_SYSTEM_PROMPT.contains("\"look around\" → {\"intent\": \"look\""),
+            "intent system prompt lost the imperative-look exemplar"
+        );
     }
 }

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -2442,12 +2442,16 @@ Respond with a JSON object containing a single field \"action\" — the text the
 would type into the game. Do NOT use meta-commands like \"talk to X\"; write the actual \
 words or command directly.\n\
 \n\
+Do NOT repeat yourself: if your last action appears in the \"Your last actions\" or \
+\"Recent events\" block of the user prompt, pick a different action — try a different \
+greeting, ask a different question, or travel somewhere new. The location description \
+is already shown to you in the prompt; you do not need to issue a bare \"look\" command.\n\
+\n\
 Examples:\n\
-  {{\"action\": \"Good mornin'. Might I look about the village a while?\"}}\n\
+  {{\"action\": \"Good mornin' to ye. A fair day for the road.\"}}\n\
   {{\"action\": \"I've come from up the road. What news do ye have hereabouts?\"}}\n\
   {{\"action\": \"Might I ask about the harvest, then?\"}}\n\
   {{\"action\": \"go to the mill\"}}\n\
-  {{\"action\": \"look\"}}\n\
 \n\
 Your entire response must be a single JSON object — nothing before or after it.",
         extra = extra_section,

--- a/parish/testing/fixtures/play_999-demo-look-loop.txt
+++ b/parish/testing/fixtures/play_999-demo-look-loop.txt
@@ -1,0 +1,25 @@
+# Placeholder fixture for task 999-demo-look-loop.
+#
+# The CLI script harness does not exercise the demo auto-player code path
+# (`get_llm_player_action` lives in parish-tauri and requires the Tauri GUI +
+# an LLM client). Additionally, the LLM-backed `parse_intent` runs only when
+# an LLM client is configured, so the intent-classification regression for
+# narrative "look" is not reachable from a clientless CLI run.
+#
+# Verification for this task is therefore split:
+#
+#   1. Unit/integration tests for the four code seams:
+#        cargo test -p parish-input intent_llm
+#        cargo test -p parish-core ipc::demo
+#        (cd parish/apps/ui && npm test -- demo-player)
+#
+#   2. A live demo transcript proving the loop is gone and the scene blurb
+#      no longer re-emits between every player line:
+#        just demo 2 8 2>&1 | tee docs/proofs/999-demo-look-loop/transcript.txt
+#
+# This file exists so the task-start skill's directory layout is honoured and
+# so anyone grepping `parish/testing/fixtures/` for the task id finds this
+# note pointing at the real verification path.
+#
+# See docs/proofs/999-demo-look-loop/acceptance-criteria.md for the full
+# criteria and live-proof expectations.

--- a/parish/testing/fixtures/play_999-demo-look-loop.txt
+++ b/parish/testing/fixtures/play_999-demo-look-loop.txt
@@ -15,11 +15,16 @@
 #
 #   2. A live demo transcript proving the loop is gone and the scene blurb
 #      no longer re-emits between every player line:
-#        just demo 2 8 2>&1 | tee docs/proofs/999-demo-look-loop/transcript.txt
+#        just demo 2 8 2>&1 | tee .proofs/999-demo-look-loop/transcript.txt
 #
 # This file exists so the task-start skill's directory layout is honoured and
 # so anyone grepping `parish/testing/fixtures/` for the task id finds this
 # note pointing at the real verification path.
 #
-# See docs/proofs/999-demo-look-loop/acceptance-criteria.md for the full
-# criteria and live-proof expectations.
+# Proof bundles live under `.proofs/<task-id>/` (gitignored) and attach to PRs
+# via `just attach-proof <task-id> <pr-num>`. Long-lived benchmark archives at
+# `docs/proofs/local-perf/` and `docs/proofs/rundale-bench/` are exempt from
+# this convention.
+#
+# See .proofs/999-demo-look-loop/acceptance-criteria.md for the full criteria
+# and live-proof expectations.


### PR DESCRIPTION
## Summary

Additive fix on top of #1017 (UI scene-dedup) and #1018 (command-form rejector) that closes two remaining gaps in the demo auto-player:

- **Intent parser:** narrative use of `"look"` inside a sentence (e.g. `"Might I look about the village a while?"`) was being classified by the LLM intent parser as `IntentKind::Look`, firing `handle_look` and emitting a scene-text-log event. New carve-out in `INTENT_SYSTEM_PROMPT` plus two exemplars route narrative-look phrasing to `talk` while preserving imperative `"look"` / `"look around"`.
- **Anti-repetition signal:** the demo prompt now carries the auto-player's last 5 actions as a `Your last actions (do not repeat these):` block with deduped `(last N turns)` count suffixes, plus a system-prompt clause that explicitly tells the LLM to vary its approach when the block contains its prior output.

## Changes

| File | Change |
|---|---|
| `parish/crates/parish-input/src/intent_llm.rs` | `INTENT_SYSTEM_PROMPT` carve-out + 2 exemplars + regression test |
| `parish/crates/parish-tauri/src/commands.rs` | Drop `{"action": "look"}` exemplar; add anti-repetition clause |
| `parish/crates/parish-core/src/ipc/demo.rs` | New `recent_actions` field on `DemoContextSnapshot`; render `Your last actions:` block with consecutive-dedup count suffixes; 4 new tests |
| `parish/apps/ui/src/lib/demo-player.ts` | Populate `recent_actions` from last 5 `[player]` text-log entries; filter scene-blurb echoes from `recent_log` |
| `parish/apps/ui/src/lib/types.ts` | Mirror `recent_actions` on TS `DemoContextSnapshot` |
| `parish/apps/ui/src/lib/demo-player.test.ts` | 2 new vitest cases |
| `parish/testing/fixtures/play_999-demo-look-loop.txt` | Placeholder fixture pointing at live `just demo` verification path |

## Test plan

- [x] `cargo test -p parish-input intent_llm` → 3 passed (incl. new `intent_system_prompt_distinguishes_narrative_look` static guard)
- [x] `cargo test -p parish-core ipc::demo::tests` → 10 passed (4 new tests for `recent_actions` rendering + `collapse_consecutive_actions`)
- [x] `cargo test -p parish-core` → 402 passed (no regressions)
- [x] `cargo test -p parish-tauri` → 81 passed (no regressions; includes #1018's 11 rejector tests)
- [x] `npx vitest run` (UI) → 419 passed (incl. 2 new demo-player tests)
- [x] `cargo fmt --all -- --check` → clean
- [x] `npm run check` (svelte-check + tsc) → 0 errors
- [x] `just agent-check` → passed
- [x] Live `just demo 2 8` post-rebase: 8 turns, 0 command-form leaks (was 41 pre-rebase), 0 scene re-emissions, 8 byte-distinct utterances

## Live proof

Bundle at `.proofs/999-demo-look-loop/` (gitignored per repo convention; attach via `just attach-proof 999-demo-look-loop <pr#>` when ready).

## Known residual

Turn 7→8 in the post-rebase transcript are near-duplicates (only `"Aye, "` prefix differs). Passes byte-identical criterion; heuristic anti-repetition cannot force the LLM to diverge. The bug class moves from "rigidly identical 12× in a row" (pre-fix) to "occasionally near-identical with minor variations" — documented in `evidence.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)