### PR TITLE
[codex] Restore Rundale as default base mod

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -13,6 +13,7 @@ bottom; don't lengthen items past 2-3 lines.
 - **`PARISH_USER_DATA_DIR` env var IS the full path.** No app-name suffix is appended. `/tmp/x` → all apps use `/tmp/x`, not `/tmp/x/Rundale`. Resolution is in `parish-persistence/src/paths.rs::resolve_user_data_dir`.
 - **`parish-flags.json` is not loaded by `GameTestHarness`.** Runtime `/flag enable/disable` doesn't persist across script runs in the harness. For test-time flag behaviour, set `app.flags` directly.
 - **`DayType` has three variants** (`Weekday`, `Sunday`, `MarketDay`). No `Holiday`. See `parish-types/src/time.rs`.
+- **`mods/mod-list.toml` selects the default setting mod when both Rundale and testbed exist.** Keep the checked-in value at `active_setting = "rundale"` unless a test explicitly switches it.
 
 ## Character logs (`parish-core/src/character_log.rs`)
 

--- a/mods/mod-list.toml
+++ b/mods/mod-list.toml
@@ -1,1 +1,1 @@
-active_setting = "testbed"
+active_setting = "rundale"

--- a/parish/crates/parish-core/src/game_mod.rs
+++ b/parish/crates/parish-core/src/game_mod.rs
@@ -1775,6 +1775,18 @@ tier2_system = "prompts/tier2_system.txt"
     }
 
     #[test]
+    fn checked_in_mod_list_selects_rundale_by_default() {
+        let mods = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../mods");
+        if mods.exists() {
+            let discovered = discover_mods_in(&mods).expect("repo mod discovery succeeds");
+            assert!(
+                discovered.setting.ends_with("rundale"),
+                "checked-in mods/mod-list.toml should select Rundale by default"
+            );
+        }
+    }
+
+    #[test]
     fn discover_mods_errors_when_active_setting_missing() {
         let tmp = TempDir::new().unwrap();
         let mods = tmp.path().join("mods");

--- a/parish/testing/fixtures/play_default-base-mod-rundale.txt
+++ b/parish/testing/fixtures/play_default-base-mod-rundale.txt
@@ -1,0 +1,9 @@
+# Verification fixture for default-base-mod-rundale.
+#
+# With the checked-in mods/mod-list.toml, a fresh CLI script run should load
+# Rundale as the active setting mod. The transcript should show Kilteevan
+# Village and Rundale prose, not the testbed Origin/grid world.
+
+/status
+look
+/npcs

--- a/parish/testing/fixtures/play_issue-1011.txt
+++ b/parish/testing/fixtures/play_issue-1011.txt
@@ -3,15 +3,14 @@
 # Exercises: log subscribers rebind their directory when the active
 # branch changes (load_branch / fork_branch).
 #
-# Uses the testbed mod (Origin / Station grid), which is the default
-# active setting in mods/mod-list.toml. PlayerMoved events fire on
-# every successful /go because the path is short and unambiguous.
+# Uses the default Rundale mod. PlayerMoved events fire on every
+# successful /go because these paths are short and unambiguous.
 
 # 1. Baseline on branch 1 — fire PlayerMoved events so journal entries
 #    land under logs/branch-1/.
 /status
-go to North Station
-go to Origin
+go to The Crossroads
+go to Kilteevan Village
 
 # 2. Fork to a new branch. `/fork demo-branch` mutates
 #    app.active_branch_id without firing an immediate log event.
@@ -21,8 +20,8 @@ go to Origin
 
 # 3. Move so a PlayerMoved event fires AFTER the fork. The drain pump
 #    must rebind the log manager to the new branch dir before writing.
-go to East Station
-go to Origin
+go to The Forge
+go to Kilteevan Village
 
 # 4. List branches so the transcript shows the active id explicitly.
 /branches
@@ -30,5 +29,5 @@ go to Origin
 # 5. Switch back to main and fire one more event; subsequent writes
 #    must land under logs/branch-1/ again.
 /load main
-go to South Station
+go to The Holy Well
 /branches

--- a/parish/testing/fixtures/play_mod-selector-ui.txt
+++ b/parish/testing/fixtures/play_mod-selector-ui.txt
@@ -1,6 +1,6 @@
 # play_mod-selector-ui.txt
 #
-# Verifies the active mod at CLI startup (testbed → Origin) so the proof
+# Verifies the active mod at CLI startup (rundale → Kilteevan) so the proof
 # transcript confirms which mod is selected before any UI interaction.
 # API and UI criteria are verified separately via curl + browser screenshot.
 /status


### PR DESCRIPTION
## Summary

- Restore the checked-in mod selector to `active_setting = "rundale"`.
- Add a regression test that verifies the repository `mods/mod-list.toml` resolves to Rundale by default.
- Update fixtures that assumed testbed was the default, and add a focused default-mod proof fixture.
- Record the mod-list selector gotcha in `LEARNINGS.md`.

## Root Cause

The engine correctly honors `mods/mod-list.toml` when multiple setting mods coexist. A previous PR left that file selecting `testbed`, so normal startup loaded the testbed world instead of Rundale.

## Validation

- `cargo fmt --manifest-path parish/Cargo.toml --all -- --check`
- `cargo test --manifest-path parish/Cargo.toml -p parish-core discover_mods`
- `cargo run --manifest-path parish/Cargo.toml -p parish -- --script parish/testing/fixtures/play_default-base-mod-rundale.txt`
- `cargo run --manifest-path parish/Cargo.toml -p parish -- --script parish/testing/fixtures/play_issue-1011.txt`
- `just agent-check`
- `git diff --check`

## Proof

Local proof bundle: `.proofs/default-base-mod-rundale/`

Live transcript confirms default startup now reports `Location: Kilteevan Village` and `look` shows Rundale-specific Kilteevan prose.