### PR TITLE
fix: route free-text NPC names without @mentions

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -13,6 +13,7 @@ bottom; don't lengthen items past 2-3 lines.
 - **`PARISH_USER_DATA_DIR` env var IS the full path.** No app-name suffix is appended. `/tmp/x` → all apps use `/tmp/x`, not `/tmp/x/Rundale`. Resolution is in `parish-persistence/src/paths.rs::resolve_user_data_dir`.
 - **`parish-flags.json` is not loaded by `GameTestHarness`.** Runtime `/flag enable/disable` doesn't persist across script runs in the harness. For test-time flag behaviour, set `app.flags` directly.
 - **`DayType` has three variants** (`Weekday`, `Sunday`, `MarketDay`). No `Holiday`. See `parish-types/src/time.rs`.
+- **`parish --script` uses the active mod from `mods/mod-list.toml`.** `GameTestHarness::new()` loads Rundale, but live script mode currently follows `active_setting`; use a Rundale-only `PARISH_MODS_DIR` for Rundale-specific proof runs when the active setting is `testbed`.
 
 ## Character logs (`parish-core/src/character_log.rs`)
 

--- a/parish/crates/parish-cli/src/testing.rs
+++ b/parish/crates/parish-cli/src/testing.rs
@@ -19,8 +19,8 @@
 use crate::app::App;
 use crate::inference::simulator::SimulatorClient;
 use crate::input::{self, Command, InputResult, IntentKind};
-use crate::npc::Npc;
 use crate::npc::manager::NpcManager;
+use crate::npc::{Npc, NpcId};
 use crate::world::description::{format_exits, render_description};
 use crate::world::time::{Season, TimeOfDay};
 use crate::world::{DEFAULT_START_LOCATION, LocationId};
@@ -1212,10 +1212,11 @@ impl GameTestHarness {
         }
     }
 
-    /// Checks all NPCs at the current location for canned responses,
-    /// not just the first one. This allows tests to target specific NPCs
-    /// regardless of iteration order. Also runs anachronism detection on
-    /// the player's input and includes any detected terms in the result.
+    /// Checks NPCs at the current location for canned responses. Free-text
+    /// names and `@mentions` use the shared routing resolver; generic
+    /// untargeted dialogue keeps the historical first-canned-response fallback.
+    /// Also runs anachronism detection on the player's input and includes any
+    /// detected terms in the result.
     ///
     /// When a canned response is consumed, the interaction is processed
     /// through the same memory pipeline as a real LLM response: the NPC's
@@ -1233,117 +1234,168 @@ impl GameTestHarness {
         let detected = crate::npc::anachronism::check_input(text);
         let anachronism_terms: Vec<String> = detected.iter().map(|a| a.term.clone()).collect();
 
-        // Check each NPC at this location for canned responses
-        for npc in &npcs_here {
-            let key = npc.name.to_lowercase();
-            if let Some(responses) = self.canned_responses.get_mut(&key)
-                && !responses.is_empty()
-            {
-                let dialogue = responses.remove(0);
-                let name = npc.name.clone();
-                let npc_id = npc.id;
-                self.app.world.log(format!("{}: {}", name, dialogue));
+        let mentions =
+            parish_core::ipc::extract_npc_mentions(text, &self.app.world, &self.app.npc_manager);
+        let target_ids = if mentions.names.is_empty() {
+            Vec::new()
+        } else {
+            parish_core::ipc::resolve_npc_targets(
+                &self.app.world,
+                &self.app.npc_manager,
+                &mentions.names,
+            )
+        };
 
-                // Build a synthetic NPC response and run it through the memory pipeline
-                let response = crate::npc::NpcStreamResponse {
-                    dialogue: dialogue.clone(),
-                    metadata: Some(crate::npc::NpcMetadata {
-                        action: "responds".to_string(),
-                        mood: npc.mood.clone(),
-                        internal_thought: None,
-                        language_hints: Vec::new(),
-                        mentioned_people: Vec::new(),
-                    }),
-                };
-                let game_time = self.app.world.clock.now();
-                let player_name_for_mem = if self.app.npc_manager.knows_player_name(npc_id) {
-                    self.app.world.player_name.clone()
-                } else {
-                    None
-                };
-                if let Some(npc_mut) = self.app.npc_manager.get_mut(npc_id) {
-                    let debug_events = crate::npc::ticks::apply_tier1_response_with_config(
-                        npc_mut,
-                        &response,
-                        text,
-                        game_time,
-                        &Default::default(),
-                        player_name_for_mem.as_deref(),
-                    );
-                    for event in debug_events {
-                        self.app.debug_event(event);
-                    }
-                }
+        if !mentions.names.is_empty() && target_ids.is_empty() {
+            return ActionResult::NpcNotAvailable;
+        }
 
-                // Record conversation exchange for scene awareness
-                let location = self.app.world.player_location;
-                self.app.world.conversation_log.add(
-                    crate::npc::conversation::ConversationExchange {
-                        timestamp: game_time,
-                        speaker_id: npc_id,
-                        speaker_name: name.clone(),
-                        player_input: text.to_string(),
-                        npc_dialogue: dialogue.clone(),
-                        location,
-                    },
-                );
+        let ordered_npcs: Vec<(NpcId, String, String)> = if target_ids.is_empty() {
+            npcs_here
+                .into_iter()
+                .map(|npc| (npc.id, npc.name.clone(), npc.mood.clone()))
+                .collect()
+        } else {
+            target_ids
+                .iter()
+                .filter_map(|id| self.app.npc_manager.get(*id))
+                .map(|npc| (npc.id, npc.name.clone(), npc.mood.clone()))
+                .collect()
+        };
 
-                // Record witness memories for bystander NPCs
-                let witness_events = crate::npc::ticks::record_witness_memories(
-                    self.app.npc_manager.npcs_mut(),
-                    npc_id,
-                    &name,
-                    text,
-                    &dialogue,
-                    game_time,
-                    location,
-                );
-                for event in witness_events {
-                    self.app.debug_event(event);
-                }
+        let allow_multiple = !target_ids.is_empty();
+        let mut first_response = None;
+        for (npc_id, name, mood) in ordered_npcs.iter().cloned() {
+            let Some(result) =
+                self.consume_canned_npc_response(npc_id, name, mood, text, &anachronism_terms)
+            else {
+                continue;
+            };
 
-                // Mirror the live game-loop behaviour: publish a full-text
-                // DialogueOccurred so the character-log subscriber records
-                // both **You:** and **NPC:** lines for canned-response runs.
-                //
-                // Strip the leading verb (`say `, `tell <name>`, etc.) so
-                // the player line in the journal reads as natural speech.
-                // The live LLM path passes a clean `prompt_input`; only the
-                // harness gets the raw command text.
-                let player_line = strip_dialogue_verb(text);
-                self.app.world.event_bus.publish(
-                    parish_core::world::events::GameEvent::DialogueOccurred {
-                        npc_id,
-                        summary: dialogue.clone(),
-                        player_said: Some(player_line),
-                        npc_said: Some(dialogue.clone()),
-                        timestamp: game_time,
-                    },
-                );
-
-                return ActionResult::NpcResponse {
-                    npc: name,
-                    dialogue,
-                    anachronisms: anachronism_terms,
-                };
+            if !allow_multiple {
+                return result;
             }
+            if first_response.is_none() {
+                first_response = Some(result);
+            }
+        }
+
+        if let Some(result) = first_response {
+            return result;
         }
 
         // No canned response — fall back to the simulator if configured.
         if let Some(ref sim) = self.simulator
-            && let Some(npc) = npcs_here.first()
+            && let Some((_, name, _)) = ordered_npcs.first()
         {
             let dialogue = sim.generate_sync(text, None);
-            let name = npc.name.clone();
             self.app.world.log(format!("{}: {}", name, dialogue));
             return ActionResult::NpcResponse {
-                npc: name,
+                npc: name.clone(),
                 dialogue,
                 anachronisms: anachronism_terms,
             };
         }
 
         ActionResult::NpcNotAvailable
+    }
+
+    fn consume_canned_npc_response(
+        &mut self,
+        npc_id: NpcId,
+        name: String,
+        mood: String,
+        text: &str,
+        anachronism_terms: &[String],
+    ) -> Option<ActionResult> {
+        let key = name.to_lowercase();
+        let responses = self.canned_responses.get_mut(&key)?;
+        if responses.is_empty() {
+            return None;
+        }
+
+        let dialogue = responses.remove(0);
+        self.app.world.log(format!("{}: {}", name, dialogue));
+
+        // Build a synthetic NPC response and run it through the memory pipeline
+        let response = crate::npc::NpcStreamResponse {
+            dialogue: dialogue.clone(),
+            metadata: Some(crate::npc::NpcMetadata {
+                action: "responds".to_string(),
+                mood,
+                internal_thought: None,
+                language_hints: Vec::new(),
+                mentioned_people: Vec::new(),
+            }),
+        };
+        let game_time = self.app.world.clock.now();
+        let player_name_for_mem = if self.app.npc_manager.knows_player_name(npc_id) {
+            self.app.world.player_name.clone()
+        } else {
+            None
+        };
+        if let Some(npc_mut) = self.app.npc_manager.get_mut(npc_id) {
+            let debug_events = crate::npc::ticks::apply_tier1_response_with_config(
+                npc_mut,
+                &response,
+                text,
+                game_time,
+                &Default::default(),
+                player_name_for_mem.as_deref(),
+            );
+            for event in debug_events {
+                self.app.debug_event(event);
+            }
+        }
+
+        // Record conversation exchange for scene awareness
+        let location = self.app.world.player_location;
+        self.app
+            .world
+            .conversation_log
+            .add(crate::npc::conversation::ConversationExchange {
+                timestamp: game_time,
+                speaker_id: npc_id,
+                speaker_name: name.clone(),
+                player_input: text.to_string(),
+                npc_dialogue: dialogue.clone(),
+                location,
+            });
+
+        // Record witness memories for bystander NPCs
+        let witness_events = crate::npc::ticks::record_witness_memories(
+            self.app.npc_manager.npcs_mut(),
+            npc_id,
+            &name,
+            text,
+            &dialogue,
+            game_time,
+            location,
+        );
+        for event in witness_events {
+            self.app.debug_event(event);
+        }
+
+        // Mirror the live game-loop behaviour: publish a full-text
+        // DialogueOccurred so the character-log subscriber records both
+        // **You:** and **NPC:** lines for canned-response runs.
+        let player_line = strip_dialogue_verb(text);
+        self.app
+            .world
+            .event_bus
+            .publish(parish_core::world::events::GameEvent::DialogueOccurred {
+                npc_id,
+                summary: dialogue.clone(),
+                player_said: Some(player_line),
+                npc_said: Some(dialogue.clone()),
+                timestamp: game_time,
+            });
+
+        Some(ActionResult::NpcResponse {
+            npc: name,
+            dialogue,
+            anachronisms: anachronism_terms.to_vec(),
+        })
     }
 
     /// Renders the current location description.
@@ -1670,6 +1722,53 @@ mod tests {
             assert_eq!(npc, "Padraig Darcy");
             assert_eq!(dialogue, "Ah, good morning to ye!");
         }
+    }
+
+    #[test]
+    fn test_canned_multi_npc_response_from_free_text_names() {
+        let mut h = GameTestHarness::new();
+        h.advance_time(120); // 10am — Padraig and Niamh are scheduled at the pub.
+        h.execute("go to crossroads");
+        h.execute("go to pub");
+
+        let npcs = h.npcs_here();
+        assert!(npcs.iter().any(|n| n == &"Padraig Darcy"), "{npcs:?}");
+        assert!(npcs.iter().any(|n| n == &"Niamh Darcy"), "{npcs:?}");
+
+        h.add_canned_response("Padraig Darcy", "A fair morning to ye from Padraig.");
+        h.add_canned_response("Niamh Darcy", "And a good day back to ye from Niamh.");
+
+        let result = h.execute("Good morning, Padraig and good day, Niamh.");
+        assert!(matches!(result, ActionResult::NpcResponse { .. }));
+
+        let loc = h.location_id();
+        let recent = h.app.world.conversation_log.recent_at(loc, 2);
+        let speakers: Vec<&str> = recent
+            .iter()
+            .map(|exchange| exchange.speaker_name.as_str())
+            .collect();
+        assert_eq!(speakers, vec!["Padraig Darcy", "Niamh Darcy"]);
+    }
+
+    #[test]
+    fn test_canned_free_text_names_ignore_absent_npcs() {
+        let mut h = GameTestHarness::new();
+        h.advance_time(120);
+        h.execute("go to crossroads");
+
+        h.add_canned_response("Padraig Darcy", "This should not fire.");
+        h.add_canned_response("Niamh Darcy", "Nor should this.");
+
+        let result = h.execute("I saw Padraig and Niamh by the road.");
+        assert!(!matches!(result, ActionResult::NpcResponse { .. }));
+        assert!(
+            h.text_log()
+                .iter()
+                .all(|line| !line.contains("This should not fire")
+                    && !line.contains("Nor should this")),
+            "{:?}",
+            h.text_log()
+        );
     }
 
     #[test]

--- a/parish/crates/parish-core/src/game_loop/input.rs
+++ b/parish/crates/parish-core/src/game_loop/input.rs
@@ -149,28 +149,6 @@ pub async fn handle_game_input(
         return;
     }
 
-    // `talk to <name>` / `speak to <name>` — bypass @mention parsing and
-    // route directly to the multi-target dispatch loop with this single
-    // addressee.  The chip-selection list still gets prepended below.
-    //
-    // Pass `raw` (the original input) rather than an empty string so that
-    // dialogue like "Hello Brigid, good morning!" is not discarded when the
-    // intent parser classifies it as Talk.  An empty `raw` still produces the
-    // "say something first" prompt, which is correct for bare "talk to X".
-    if is_talk && let Some(target) = talk_target {
-        let mut targets: Vec<String> = Vec::with_capacity(addressed_to.len() + 1);
-        for name in addressed_to {
-            if !targets.iter().any(|t| t == &name) {
-                targets.push(name);
-            }
-        }
-        if !targets.iter().any(|t| t == &target) {
-            targets.push(target);
-        }
-        handle_npc_conversation(ctx, raw, targets, spawn_loading).await;
-        return;
-    }
-
     // Resolve ordered NPC recipients from visible local names.
     let mentions = {
         let world = ctx.world.lock().await;
@@ -178,11 +156,12 @@ pub async fn handle_game_input(
         extract_npc_mentions(&raw, &world, &npc_manager)
     };
 
-    // Chip selections (real names from the frontend) come first, then any
-    // inline @mentions that aren't already in the chip set.  Deduping happens
-    // in `resolve_npc_targets` via `find_by_name`, which matches both real
-    // and display names.
-    let mut targets: Vec<String> = Vec::with_capacity(addressed_to.len() + mentions.names.len());
+    // Chip selections (real names from the frontend) come first, then names
+    // detected in the player's text, then the LLM's single talk target when it
+    // supplied one. Deduping happens in `resolve_npc_targets` via
+    // `find_by_name`, which matches both real and display names.
+    let mut targets: Vec<String> =
+        Vec::with_capacity(addressed_to.len() + mentions.names.len() + 1);
     for name in addressed_to {
         if !targets.iter().any(|t| t == &name) {
             targets.push(name);
@@ -192,6 +171,12 @@ pub async fn handle_game_input(
         if !targets.iter().any(|t| t == &name) {
             targets.push(name);
         }
+    }
+    if is_talk
+        && let Some(target) = talk_target
+        && !targets.iter().any(|t| t == &target)
+    {
+        targets.push(target);
     }
 
     handle_npc_conversation(ctx, mentions.remaining, targets, spawn_loading).await;

--- a/parish/crates/parish-core/src/ipc/handlers.rs
+++ b/parish/crates/parish-core/src/ipc/handlers.rs
@@ -325,7 +325,8 @@ pub struct ConversationLine {
 pub struct MentionedNpcs {
     /// Mentioned NPC display names, deduplicated while preserving order.
     pub names: Vec<String>,
-    /// Remaining player text with the mentions stripped out.
+    /// Remaining player text. Explicit `@mentions` are stripped; natural
+    /// free-text name mentions are retained as part of the utterance.
     pub remaining: String,
 }
 
@@ -340,21 +341,118 @@ fn mention_boundary(ch: Option<char>) -> bool {
     }
 }
 
+#[derive(Debug, Clone)]
+struct NpcMentionCandidate {
+    text: String,
+    target: String,
+}
+
+fn add_npc_mention_candidate(
+    candidates: &mut Vec<NpcMentionCandidate>,
+    seen: &mut HashSet<String>,
+    text: &str,
+    target: &str,
+) {
+    let text = text.trim();
+    if text.is_empty() {
+        return;
+    }
+
+    let key = text.to_lowercase();
+    if seen.insert(key) {
+        candidates.push(NpcMentionCandidate {
+            text: text.to_string(),
+            target: target.to_string(),
+        });
+    }
+}
+
+fn npc_mention_candidates(
+    world: &WorldState,
+    npc_manager: &NpcManager,
+) -> Vec<NpcMentionCandidate> {
+    let mut candidates = Vec::new();
+    let mut seen = HashSet::new();
+
+    for npc in npc_manager.npcs_at(world.player_location) {
+        add_npc_mention_candidate(&mut candidates, &mut seen, &npc.name, &npc.name);
+
+        if let Some(first_name) = npc.name.split_whitespace().next() {
+            add_npc_mention_candidate(&mut candidates, &mut seen, first_name, &npc.name);
+        }
+
+        let display = npc_manager.display_name(npc);
+        add_npc_mention_candidate(&mut candidates, &mut seen, display, display);
+    }
+
+    candidates
+}
+
+fn find_natural_npc_mentions(
+    raw: &str,
+    candidates: &[NpcMentionCandidate],
+) -> Vec<(usize, usize, String)> {
+    let raw_lower = raw.to_ascii_lowercase();
+    let mut spans: Vec<(usize, usize, String)> = Vec::new();
+
+    for candidate in candidates {
+        let needle = candidate.text.to_ascii_lowercase();
+        if needle.is_empty() {
+            continue;
+        }
+
+        let mut cursor = 0usize;
+        while cursor < raw_lower.len() {
+            let Some(rel_start) = raw_lower[cursor..].find(&needle) else {
+                break;
+            };
+            let start = cursor + rel_start;
+            let end = start + candidate.text.len();
+            let before = if start == 0 {
+                None
+            } else {
+                raw[..start].chars().next_back()
+            };
+            let after = raw[end..].chars().next();
+
+            if mention_boundary(before) && mention_boundary(after) {
+                spans.push((start, end, candidate.target.clone()));
+            }
+
+            cursor = end;
+        }
+    }
+
+    spans.sort_by(|(a_start, a_end, _), (b_start, b_end, _)| {
+        a_start
+            .cmp(b_start)
+            .then_with(|| (b_end - b_start).cmp(&(a_end - a_start)))
+    });
+
+    let mut filtered = Vec::new();
+    let mut last_end = 0usize;
+    for (start, end, target) in spans {
+        if start >= last_end {
+            filtered.push((start, end, target));
+            last_end = end;
+        }
+    }
+
+    filtered
+}
+
 /// Extracts all valid `@mentions` that match NPCs at the player's location.
 ///
-/// Matching is done against the NPCs currently present using their visible
-/// display names, so multi-word lowercase descriptions like "an older man
-/// behind the bar" remain parseable.
+/// Matching is done against the NPCs currently present. Explicit `@mentions`
+/// and natural free-text names match full names, first names, and visible
+/// display names, so `Padraig`, `Padraig Darcy`, and multi-word lowercase
+/// descriptions like `an older man behind the bar` remain parseable.
 pub fn extract_npc_mentions(
     raw: &str,
     world: &WorldState,
     npc_manager: &NpcManager,
 ) -> MentionedNpcs {
-    let candidates: Vec<String> = npc_manager
-        .npcs_at(world.player_location)
-        .into_iter()
-        .map(|npc| npc_manager.display_name(npc).to_string())
-        .collect();
+    let candidates = npc_mention_candidates(world, npc_manager);
 
     if candidates.is_empty() {
         return MentionedNpcs {
@@ -379,17 +477,17 @@ pub fn extract_npc_mentions(
 
         let rest = &raw[at + 1..];
         let mut matched: Option<(usize, String)> = None;
-        for name in &candidates {
-            if rest.len() < name.len() {
+        for candidate in &candidates {
+            if rest.len() < candidate.text.len() {
                 continue;
             }
-            let candidate = &rest[..name.len()];
-            if candidate.eq_ignore_ascii_case(name)
-                && mention_boundary(rest[name.len()..].chars().next())
+            let text = &rest[..candidate.text.len()];
+            if text.eq_ignore_ascii_case(&candidate.text)
+                && mention_boundary(rest[candidate.text.len()..].chars().next())
             {
                 match &matched {
-                    Some((len, _)) if *len >= name.len() => {}
-                    _ => matched = Some((name.len(), name.clone())),
+                    Some((len, _)) if *len >= candidate.text.len() => {}
+                    _ => matched = Some((candidate.text.len(), candidate.target.clone())),
                 }
             }
         }
@@ -403,6 +501,21 @@ pub fn extract_npc_mentions(
     }
 
     if spans.is_empty() {
+        let spans = find_natural_npc_mentions(raw, &candidates);
+        if !spans.is_empty() {
+            let mut names = Vec::new();
+            let mut dedupe = HashSet::new();
+            for (_, _, name) in spans {
+                if dedupe.insert(name.to_lowercase()) {
+                    names.push(name);
+                }
+            }
+            return MentionedNpcs {
+                names,
+                remaining: raw.trim().to_string(),
+            };
+        }
+
         return MentionedNpcs {
             names: vec![],
             remaining: raw.trim().to_string(),
@@ -997,6 +1110,73 @@ mod tests {
             vec!["an older man behind the bar".to_string()]
         );
         assert_eq!(extracted.remaining, "what have you heard?");
+    }
+
+    #[test]
+    fn extract_npc_mentions_detects_free_text_names_in_order() {
+        let world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+
+        let mut npc1 = Npc::new_test_npc();
+        npc1.id = NpcId(1);
+        npc1.name = "Padraig Darcy".to_string();
+        npc1.location = world.player_location;
+
+        let mut npc2 = Npc::new_test_npc();
+        npc2.id = NpcId(2);
+        npc2.name = "Niamh Darcy".to_string();
+        npc2.location = world.player_location;
+
+        npc_mgr.add_npc(npc1);
+        npc_mgr.add_npc(npc2);
+        npc_mgr.mark_introduced(NpcId(1));
+        npc_mgr.mark_introduced(NpcId(2));
+
+        let raw = "Good morning, Padraig and good day, Niamh Darcy.";
+        let extracted = extract_npc_mentions(raw, &world, &npc_mgr);
+
+        assert_eq!(
+            extracted.names,
+            vec!["Padraig Darcy".to_string(), "Niamh Darcy".to_string()]
+        );
+        assert_eq!(extracted.remaining, raw);
+    }
+
+    #[test]
+    fn extract_npc_mentions_free_text_only_matches_co_located_npcs() {
+        let world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+        let mut npc = Npc::new_test_npc();
+        npc.id = NpcId(1);
+        npc.name = "Padraig Darcy".to_string();
+        npc.location = LocationId(world.player_location.0 + 1);
+        npc_mgr.add_npc(npc);
+        npc_mgr.mark_introduced(NpcId(1));
+
+        let raw = "I saw Padraig Darcy yesterday.";
+        let extracted = extract_npc_mentions(raw, &world, &npc_mgr);
+
+        assert!(extracted.names.is_empty());
+        assert_eq!(extracted.remaining, raw);
+    }
+
+    #[test]
+    fn extract_npc_mentions_detects_free_text_display_description() {
+        let world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+        let mut npc = Npc::new_test_npc();
+        npc.location = world.player_location;
+        npc.brief_description = "an older man behind the bar".to_string();
+        npc_mgr.add_npc(npc);
+
+        let raw = "Could I ask an older man behind the bar about the harvest?";
+        let extracted = extract_npc_mentions(raw, &world, &npc_mgr);
+
+        assert_eq!(
+            extracted.names,
+            vec!["an older man behind the bar".to_string()]
+        );
+        assert_eq!(extracted.remaining, raw);
     }
 
     #[test]

--- a/parish/crates/parish-core/src/ipc/handlers.rs
+++ b/parish/crates/parish-core/src/ipc/handlers.rs
@@ -3,7 +3,7 @@
 //! These are consumed by both the Tauri desktop backend and the axum web
 //! server, keeping game-logic → IPC-type mapping in a single place.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use chrono::{Datelike, Timelike};
@@ -347,24 +347,40 @@ struct NpcMentionCandidate {
     target: String,
 }
 
-fn add_npc_mention_candidate(
-    candidates: &mut Vec<NpcMentionCandidate>,
-    seen: &mut HashSet<String>,
-    text: &str,
-    target: &str,
-) {
+fn add_npc_mention_candidate(candidates: &mut Vec<(String, String)>, text: &str, target: &str) {
     let text = text.trim();
     if text.is_empty() {
         return;
     }
 
-    let key = text.to_lowercase();
-    if seen.insert(key) {
-        candidates.push(NpcMentionCandidate {
-            text: text.to_string(),
-            target: target.to_string(),
-        });
+    candidates.push((text.to_string(), target.to_string()));
+}
+
+fn unambiguous_npc_mention_candidates(
+    candidates: Vec<(String, String)>,
+) -> Vec<NpcMentionCandidate> {
+    let mut targets_by_text: HashMap<String, HashSet<String>> = HashMap::new();
+    for (text, target) in &candidates {
+        targets_by_text
+            .entry(text.to_lowercase())
+            .or_default()
+            .insert(target.to_lowercase());
     }
+
+    let mut seen = HashSet::new();
+    let mut filtered = Vec::new();
+    for (text, target) in candidates {
+        let key = text.to_lowercase();
+        if targets_by_text
+            .get(&key)
+            .is_some_and(|targets| targets.len() == 1)
+            && seen.insert(key)
+        {
+            filtered.push(NpcMentionCandidate { text, target });
+        }
+    }
+
+    filtered
 }
 
 fn npc_mention_candidates(
@@ -372,20 +388,21 @@ fn npc_mention_candidates(
     npc_manager: &NpcManager,
 ) -> Vec<NpcMentionCandidate> {
     let mut candidates = Vec::new();
-    let mut seen = HashSet::new();
 
     for npc in npc_manager.npcs_at(world.player_location) {
-        add_npc_mention_candidate(&mut candidates, &mut seen, &npc.name, &npc.name);
-
-        if let Some(first_name) = npc.name.split_whitespace().next() {
-            add_npc_mention_candidate(&mut candidates, &mut seen, first_name, &npc.name);
-        }
-
         let display = npc_manager.display_name(npc);
-        add_npc_mention_candidate(&mut candidates, &mut seen, display, display);
+        add_npc_mention_candidate(&mut candidates, display, display);
+
+        if npc_manager.is_introduced(npc.id) {
+            add_npc_mention_candidate(&mut candidates, &npc.name, &npc.name);
+
+            if let Some(first_name) = npc.name.split_whitespace().next() {
+                add_npc_mention_candidate(&mut candidates, first_name, &npc.name);
+            }
+        }
     }
 
-    candidates
+    unambiguous_npc_mention_candidates(candidates)
 }
 
 fn find_natural_npc_mentions(
@@ -456,9 +473,10 @@ fn find_natural_npc_mentions(
 /// Extracts all valid `@mentions` that match NPCs at the player's location.
 ///
 /// Matching is done against the NPCs currently present. Explicit `@mentions`
-/// and natural free-text names match full names, first names, and visible
+/// and natural free-text names match introduced full/first names and visible
 /// display names, so `Padraig`, `Padraig Darcy`, and multi-word lowercase
-/// descriptions like `an older man behind the bar` remain parseable.
+/// descriptions like `an older man behind the bar` remain parseable. Ambiguous
+/// mention text is ignored rather than routed to an arbitrary co-located NPC.
 pub fn extract_npc_mentions(
     raw: &str,
     world: &WorldState,
@@ -1135,6 +1153,50 @@ mod tests {
             vec!["an older man behind the bar".to_string()]
         );
         assert_eq!(extracted.remaining, "what have you heard?");
+    }
+
+    #[test]
+    fn extract_npc_mentions_does_not_match_unintroduced_real_name() {
+        let world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+        let mut npc = Npc::new_test_npc();
+        npc.location = world.player_location;
+        npc.name = "Padraig O'Brien".to_string();
+        npc.brief_description = "an older man behind the bar".to_string();
+        npc_mgr.add_npc(npc);
+
+        let raw = "@Padraig O'Brien what have you heard?";
+        let extracted = extract_npc_mentions(raw, &world, &npc_mgr);
+
+        assert!(extracted.names.is_empty());
+        assert_eq!(extracted.remaining, raw);
+    }
+
+    #[test]
+    fn extract_npc_mentions_ignores_ambiguous_first_names() {
+        let world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+
+        let mut npc1 = Npc::new_test_npc();
+        npc1.id = NpcId(1);
+        npc1.name = "Mary Byrne".to_string();
+        npc1.location = world.player_location;
+
+        let mut npc2 = Npc::new_test_npc();
+        npc2.id = NpcId(2);
+        npc2.name = "Mary Kelly".to_string();
+        npc2.location = world.player_location;
+
+        npc_mgr.add_npc(npc1);
+        npc_mgr.add_npc(npc2);
+        npc_mgr.mark_introduced(NpcId(1));
+        npc_mgr.mark_introduced(NpcId(2));
+
+        let raw = "@Mary could I ask ye both something?";
+        let extracted = extract_npc_mentions(raw, &world, &npc_mgr);
+
+        assert!(extracted.names.is_empty());
+        assert_eq!(extracted.remaining, raw);
     }
 
     #[test]

--- a/parish/crates/parish-core/src/ipc/handlers.rs
+++ b/parish/crates/parish-core/src/ipc/handlers.rs
@@ -391,6 +391,7 @@ fn npc_mention_candidates(
 fn find_natural_npc_mentions(
     raw: &str,
     candidates: &[NpcMentionCandidate],
+    excluded_spans: &[(usize, usize, String)],
 ) -> Vec<(usize, usize, String)> {
     let raw_lower = raw.to_ascii_lowercase();
     let mut spans: Vec<(usize, usize, String)> = Vec::new();
@@ -408,6 +409,17 @@ fn find_natural_npc_mentions(
             };
             let start = cursor + rel_start;
             let end = start + candidate.text.len();
+            let overlaps_excluded =
+                excluded_spans
+                    .iter()
+                    .any(|(excluded_start, excluded_end, _)| {
+                        start < *excluded_end && end > *excluded_start
+                    });
+            if overlaps_excluded || raw.get(start..end).is_none() {
+                cursor = end;
+                continue;
+            }
+
             let before = if start == 0 {
                 None
             } else {
@@ -481,13 +493,18 @@ pub fn extract_npc_mentions(
             if rest.len() < candidate.text.len() {
                 continue;
             }
-            let text = &rest[..candidate.text.len()];
-            if text.eq_ignore_ascii_case(&candidate.text)
-                && mention_boundary(rest[candidate.text.len()..].chars().next())
+            let candidate_len = candidate.text.len();
+            let Some(text) = rest.get(..candidate_len) else {
+                continue;
+            };
+            let Some(after) = rest.get(candidate_len..) else {
+                continue;
+            };
+            if text.eq_ignore_ascii_case(&candidate.text) && mention_boundary(after.chars().next())
             {
                 match &matched {
-                    Some((len, _)) if *len >= candidate.text.len() => {}
-                    _ => matched = Some((candidate.text.len(), candidate.target.clone())),
+                    Some((len, _)) if *len >= candidate_len => {}
+                    _ => matched = Some((candidate_len, candidate.target.clone())),
                 }
             }
         }
@@ -500,36 +517,44 @@ pub fn extract_npc_mentions(
         }
     }
 
+    let natural_spans = find_natural_npc_mentions(raw, &candidates, &spans);
+
     if spans.is_empty() {
-        let spans = find_natural_npc_mentions(raw, &candidates);
-        if !spans.is_empty() {
-            let mut names = Vec::new();
-            let mut dedupe = HashSet::new();
-            for (_, _, name) in spans {
-                if dedupe.insert(name.to_lowercase()) {
-                    names.push(name);
-                }
-            }
+        if natural_spans.is_empty() {
             return MentionedNpcs {
-                names,
+                names: vec![],
                 remaining: raw.trim().to_string(),
             };
         }
 
+        let mut names = Vec::new();
+        let mut dedupe = HashSet::new();
+        for (_, _, name) in natural_spans {
+            if dedupe.insert(name.to_lowercase()) {
+                names.push(name);
+            }
+        }
         return MentionedNpcs {
-            names: vec![],
+            names,
             remaining: raw.trim().to_string(),
         };
     }
 
+    let mut name_spans = spans.clone();
+    name_spans.extend(natural_spans);
+    name_spans.sort_by_key(|(start, _, _)| *start);
+
     let mut names = Vec::new();
     let mut dedupe = HashSet::new();
-    let mut remaining = String::new();
-    let mut last = 0usize;
-    for (start, end, name) in spans {
+    for (_, _, name) in name_spans {
         if dedupe.insert(name.to_lowercase()) {
             names.push(name);
         }
+    }
+
+    let mut remaining = String::new();
+    let mut last = 0usize;
+    for (start, end, _) in spans {
         remaining.push_str(&raw[last..start]);
         remaining.push(' ');
         last = end;
@@ -1176,6 +1201,52 @@ mod tests {
             extracted.names,
             vec!["an older man behind the bar".to_string()]
         );
+        assert_eq!(extracted.remaining, raw);
+    }
+
+    #[test]
+    fn extract_npc_mentions_merges_at_mentions_with_free_text_names() {
+        let world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+
+        let mut npc1 = Npc::new_test_npc();
+        npc1.id = NpcId(1);
+        npc1.name = "Padraig Darcy".to_string();
+        npc1.location = world.player_location;
+
+        let mut npc2 = Npc::new_test_npc();
+        npc2.id = NpcId(2);
+        npc2.name = "Niamh Darcy".to_string();
+        npc2.location = world.player_location;
+
+        npc_mgr.add_npc(npc1);
+        npc_mgr.add_npc(npc2);
+        npc_mgr.mark_introduced(NpcId(1));
+        npc_mgr.mark_introduced(NpcId(2));
+
+        let extracted = extract_npc_mentions("@Padraig Darcy hello Niamh", &world, &npc_mgr);
+
+        assert_eq!(
+            extracted.names,
+            vec!["Padraig Darcy".to_string(), "Niamh Darcy".to_string()]
+        );
+        assert_eq!(extracted.remaining, "hello Niamh");
+    }
+
+    #[test]
+    fn extract_npc_mentions_ignores_non_boundary_multibyte_prefix() {
+        let world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+        let mut npc = Npc::new_test_npc();
+        npc.name = "A".to_string();
+        npc.location = world.player_location;
+        npc_mgr.add_npc(npc);
+        npc_mgr.mark_introduced(NpcId(1));
+
+        let raw = "Áine says hello";
+        let extracted = extract_npc_mentions(raw, &world, &npc_mgr);
+
+        assert!(extracted.names.is_empty());
         assert_eq!(extracted.remaining, raw);
     }
 

--- a/parish/crates/parish-npc/src/manager.rs
+++ b/parish/crates/parish-npc/src/manager.rs
@@ -295,33 +295,45 @@ impl NpcManager {
             .collect()
     }
 
-    /// Finds an NPC at a location by name (case-insensitive).
+    /// Finds an NPC at a location by visible name (case-insensitive).
     ///
-    /// Tries exact match first, then first-name prefix match.
+    /// Tries exact visible display-name match first, then introduced first-name
+    /// match. Ambiguous matches return `None` rather than guessing.
     pub fn find_by_name(&self, name: &str, location: LocationId) -> Option<&Npc> {
         let npcs = self.npcs_at(location);
-        let lower = name.to_lowercase();
-        let mut prefix_match: Option<&Npc> = None;
-        for &npc in &npcs {
-            let name_lower = npc.name.to_lowercase();
-            let display_lower = self.display_name(npc).to_lowercase();
-            if name_lower == lower || display_lower == lower {
-                return Some(npc);
-            }
-            if prefix_match.is_none()
-                && (name_lower
-                    .split_whitespace()
-                    .next()
-                    .is_some_and(|first| first == lower)
-                    || display_lower
+        let lower = name.trim().to_lowercase();
+        if lower.is_empty() {
+            return None;
+        }
+
+        let exact_matches: Vec<&Npc> = npcs
+            .iter()
+            .copied()
+            .filter(|npc| self.display_name(npc).to_lowercase() == lower)
+            .collect();
+        match exact_matches.as_slice() {
+            [npc] => return Some(npc),
+            [] => {}
+            _ => return None,
+        }
+
+        let first_name_matches: Vec<&Npc> = npcs
+            .iter()
+            .copied()
+            .filter(|npc| {
+                self.is_introduced(npc.id)
+                    && npc
+                        .name
+                        .to_lowercase()
                         .split_whitespace()
                         .next()
-                        .is_some_and(|first| first == lower))
-            {
-                prefix_match = Some(npc);
-            }
+                        .is_some_and(|first| first == lower)
+            })
+            .collect();
+        match first_name_matches.as_slice() {
+            [npc] => Some(npc),
+            _ => None,
         }
-        prefix_match
     }
 
     /// Finds an NPC at a location by occupation/role (case-insensitive).
@@ -840,6 +852,21 @@ mod tests {
     }
 
     #[test]
+    fn test_find_by_name_ambiguous_first_name_returns_none() {
+        let mut mgr = NpcManager::new();
+        let mut a = make_test_npc(1, 2);
+        a.name = "Mary Byrne".to_string();
+        let mut b = make_test_npc(2, 2);
+        b.name = "Mary Kelly".to_string();
+        mgr.add_npc(a);
+        mgr.add_npc(b);
+        mgr.mark_introduced(NpcId(1));
+        mgr.mark_introduced(NpcId(2));
+
+        assert!(mgr.find_by_name("Mary", LocationId(2)).is_none());
+    }
+
+    #[test]
     fn test_find_by_name_wrong_location() {
         let mut mgr = NpcManager::new();
         let mut npc = make_test_npc(1, 2);
@@ -996,6 +1023,18 @@ mod tests {
         let found = mgr.find_by_name("an older man behind the bar", LocationId(2));
         assert!(found.is_some());
         assert_eq!(found.unwrap().id, NpcId(1));
+    }
+
+    #[test]
+    fn test_find_by_name_unintroduced_rejects_hidden_real_name() {
+        let mut mgr = NpcManager::new();
+        let mut npc = make_test_npc(1, 2);
+        npc.name = "Padraig Darcy".to_string();
+        npc.brief_description = "an older man behind the bar".to_string();
+        mgr.add_npc(npc);
+
+        assert!(mgr.find_by_name("Padraig Darcy", LocationId(2)).is_none());
+        assert!(mgr.find_by_name("Padraig", LocationId(2)).is_none());
     }
 
     #[test]

--- a/parish/crates/parish-npc/src/manager.rs
+++ b/parish/crates/parish-npc/src/manager.rs
@@ -295,10 +295,13 @@ impl NpcManager {
             .collect()
     }
 
-    /// Finds an NPC at a location by visible name (case-insensitive).
+    /// Finds an NPC at a location by display or canonical name (case-insensitive).
     ///
-    /// Tries exact visible display-name match first, then introduced first-name
-    /// match. Ambiguous matches return `None` rather than guessing.
+    /// Tries exact display/canonical match first, then introduced first-name
+    /// match. Canonical exact matches are kept for explicit recipient lists
+    /// such as UI chip selections; free-text mention parsing is responsible
+    /// for not exposing hidden names before introduction. Ambiguous matches
+    /// return `None` rather than guessing.
     pub fn find_by_name(&self, name: &str, location: LocationId) -> Option<&Npc> {
         let npcs = self.npcs_at(location);
         let lower = name.trim().to_lowercase();
@@ -309,7 +312,9 @@ impl NpcManager {
         let exact_matches: Vec<&Npc> = npcs
             .iter()
             .copied()
-            .filter(|npc| self.display_name(npc).to_lowercase() == lower)
+            .filter(|npc| {
+                self.display_name(npc).to_lowercase() == lower || npc.name.to_lowercase() == lower
+            })
             .collect();
         match exact_matches.as_slice() {
             [npc] => return Some(npc),
@@ -1026,14 +1031,16 @@ mod tests {
     }
 
     #[test]
-    fn test_find_by_name_unintroduced_rejects_hidden_real_name() {
+    fn test_find_by_name_unintroduced_allows_exact_canonical_target() {
         let mut mgr = NpcManager::new();
         let mut npc = make_test_npc(1, 2);
         npc.name = "Padraig Darcy".to_string();
         npc.brief_description = "an older man behind the bar".to_string();
         mgr.add_npc(npc);
 
-        assert!(mgr.find_by_name("Padraig Darcy", LocationId(2)).is_none());
+        let found = mgr.find_by_name("Padraig Darcy", LocationId(2));
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().id, NpcId(1));
         assert!(mgr.find_by_name("Padraig", LocationId(2)).is_none());
     }
 

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -931,45 +931,19 @@ pub(crate) async fn handle_game_input(
         return;
     }
 
-    // `talk to <name>` / `speak to <name>` — bypass @mention parsing and
-    // route directly to the multi-target dispatch loop with this single
-    // addressee. The chip-selection list still gets prepended below.
-    //
-    // Pass `raw` (the original input) rather than an empty string so that
-    // dialogue like "Hello Brigid, good morning!" is not discarded when the
-    // intent parser classifies it as Talk. An empty `raw` still produces the
-    // "say something first" prompt, which is correct for bare "talk to X".
-    if is_talk && let Some(target) = talk_target {
-        // Pre-allocate at the validated upper bound. Using the constant
-        // directly (rather than `addressed_to.len() + 1`) keeps the
-        // allocation size independent of user-controlled values for
-        // CodeQL's `rust/uncontrolled-allocation-size` query (#933).
-        let mut targets: Vec<String> = Vec::with_capacity(MAX_ADDRESSED_TO + 1);
-        for name in addressed_to {
-            if !targets.iter().any(|t| t == &name) {
-                targets.push(name);
-            }
-        }
-        if !targets.iter().any(|t| t == &target) {
-            targets.push(target);
-        }
-        handle_npc_conversation(raw, targets, state, app).await;
-        return;
-    }
-
     let mentions = {
         let world = state.world.lock().await;
         let npc_manager = state.npc_manager.lock().await;
         parish_core::ipc::extract_npc_mentions(&raw, &world, &npc_manager)
     };
 
-    // Chip selections (real names from the frontend) come first, then any
-    // inline @mentions that aren't already in the chip set. Deduping happens
-    // in `resolve_npc_targets` via `find_by_name`, which matches both real
-    // and display names.
-    // See note above. Pre-allocate at the fixed upper bound so the
-    // allocation argument is a constant — independent of any user-controlled
-    // input — and CodeQL's data-flow analyzer can see that.
+    // Chip selections (real names from the frontend) come first, then names
+    // detected in the player's text, then the LLM's single talk target when it
+    // supplied one. Deduping happens in `resolve_npc_targets` via
+    // `find_by_name`, which matches both real and display names.
+    // Pre-allocate at the fixed upper bound so the allocation argument is a
+    // constant — independent of any user-controlled input — and CodeQL's
+    // data-flow analyzer can see that.
     let mut targets: Vec<String> = Vec::with_capacity(MAX_TARGETS);
     for name in addressed_to {
         if !targets.iter().any(|t| t == &name) {
@@ -980,6 +954,12 @@ pub(crate) async fn handle_game_input(
         if !targets.iter().any(|t| t == &name) {
             targets.push(name);
         }
+    }
+    if is_talk
+        && let Some(target) = talk_target
+        && !targets.iter().any(|t| t == &target)
+    {
+        targets.push(target);
     }
 
     handle_npc_conversation(mentions.remaining, targets, state, app).await;

--- a/parish/testing/fixtures/play_issue-1019.txt
+++ b/parish/testing/fixtures/play_issue-1019.txt
@@ -1,0 +1,36 @@
+# issue-1019 play-test
+# ====================
+# Exercises free-text multi-NPC dialogue routing without requiring @mention
+# prefixes, plus the existing @mention path and the co-location guard.
+#
+# Run with Rundale active. In worktrees where mods/mod-list.toml selects the
+# generic testbed mod, set PARISH_MODS_DIR to a temporary mods root containing
+# only mods/rundale.
+
+/status
+/wait 120
+go to The Crossroads
+go to Darcy's Pub
+/npcs
+
+# Natural-name routing: both co-located NPCs should answer this single line
+# in the order their names appear, without @ prefixes.
+/stub Padraig Darcy: A fair morning to ye from Padraig.
+/stub Niamh Darcy: And a good day back to ye from Niamh.
+say Good morning, Padraig and good day, Niamh.
+/wait 1
+
+# Existing @mention routing must keep working and preserve mention order.
+/stub Niamh Darcy: Niamh heard her name first this time.
+/stub Padraig Darcy: Padraig follows after Niamh.
+say @Niamh Darcy @Padraig Darcy what news has reached the bar?
+/wait 1
+
+# Co-location guard: once the player leaves the pub, plain references to
+# Padraig and Niamh should not route dialogue to those absent pub NPCs.
+go to The Crossroads
+/npcs
+/stub Padraig Darcy: This should not appear while Padraig is absent.
+/stub Niamh Darcy: This should not appear while Niamh is absent.
+say I saw Padraig and Niamh by the road.
+/status


### PR DESCRIPTION
## Summary

Fixes #1019.

- Detect co-located NPC names in natural dialogue without requiring `@` prefixes.
- Merge chip selections, natural mentions, `@mentions`, and the LLM's single talk target into one ordered target list.
- Extend the script harness and add `play_issue-1019.txt` to prove multi-NPC routing, existing `@mention` routing, and the co-location guard.

## Proof Evidence

- [x] Proof bundle prepared in `.proofs/issue-1019/` (gitignored — not committed).
- [x] Evidence is a live gameplay transcript; `Evidence type: live gameplay transcript` header set for runtime changes.
- [x] `.proofs/issue-1019/judge.md` records an independent sufficiency verdict and `Acceptance criteria: met`.
- [x] `just agent-check` passes locally.
- [x] Posted to this PR with `just attach-proof issue-1019` — look for the `parish-proof-bundle:issue-1019` comment below.

## Checks

- [x] `just check`
- [x] `just verify` when gameplay, runtime, or UI behavior changed

## Notes

Live proof was run with a temporary Rundale-only `PARISH_MODS_DIR` because this worktree's `mods/mod-list.toml` selects the generic testbed mod by default. That gotcha is recorded in `LEARNINGS.md`.