### PR TITLE
fix(hooks): surface silent Stop-hook failures + fix learnings pipefail bug

### DIFF
--- a/.claude/hooks/Stop--claude-md-cadence.sh
+++ b/.claude/hooks/Stop--claude-md-cadence.sh
@@ -7,6 +7,7 @@
 # refresh on their schedule.
 
 set -euo pipefail
+trap 'rc=$?; printf "Stop hook %s failed (exit=%d) at line %d\n" "${BASH_SOURCE[0]##*/}" "$rc" "$LINENO" >&2' ERR
 
 THRESHOLD_DAYS=90
 NOW=$(date +%s)

--- a/.claude/hooks/Stop--coverage-reminder.sh
+++ b/.claude/hooks/Stop--coverage-reminder.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+trap 'rc=$?; printf "Stop hook %s failed (exit=%d) at line %d\n" "${BASH_SOURCE[0]##*/}" "$rc" "$LINENO" >&2' ERR
 exec >&2
 
 # Stop hook: remind about coverage when .rs files are changed

--- a/.claude/hooks/Stop--design-doc-reminder.sh
+++ b/.claude/hooks/Stop--design-doc-reminder.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+trap 'rc=$?; printf "Stop hook %s failed (exit=%d) at line %d\n" "${BASH_SOURCE[0]##*/}" "$rc" "$LINENO" >&2' ERR
 exec >&2
 
 # Stop hook: enforce that design docs are updated alongside any non-trivial

--- a/.claude/hooks/Stop--doc-staleness.sh
+++ b/.claude/hooks/Stop--doc-staleness.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+trap 'rc=$?; printf "Stop hook %s failed (exit=%d) at line %d\n" "${BASH_SOURCE[0]##*/}" "$rc" "$LINENO" >&2' ERR
 exec >&2
 
 # Stop hook: warn when code changed but docs were not updated

--- a/.claude/hooks/Stop--harness-reminder.sh
+++ b/.claude/hooks/Stop--harness-reminder.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+trap 'rc=$?; printf "Stop hook %s failed (exit=%d) at line %d\n" "${BASH_SOURCE[0]##*/}" "$rc" "$LINENO" >&2' ERR
 exec >&2
 
 # Stop hook: remind to run game harness when parish-core or world logic changed

--- a/.claude/hooks/Stop--learnings-reminder.sh
+++ b/.claude/hooks/Stop--learnings-reminder.sh
@@ -9,6 +9,7 @@
 # Claude to ask "did I learn anything worth saving here?" before
 # closing out.
 set -euo pipefail
+trap 'rc=$?; printf "Stop hook %s failed (exit=%d) at line %d\n" "${BASH_SOURCE[0]##*/}" "$rc" "$LINENO" >&2' ERR
 exec >&2
 
 cd "$(git rev-parse --show-toplevel 2>/dev/null || echo ".")"
@@ -23,8 +24,10 @@ UNSTAGED_RS=$(git diff --name-only 2>/dev/null | grep -E "$SRC_RE" || true)
 UNTRACKED_RS=$(git ls-files --others --exclude-standard 2>/dev/null | grep -E "$SRC_RE" || true)
 
 # Count touched source files (deduped).
+# `grep -v '^$'` exits 1 when every input line is blank (all three vars empty);
+# under `pipefail` that would silently fail the script. Swallow with `|| true`.
 TOUCHED=$(printf '%s\n%s\n%s\n' "$CHANGED_RS" "$UNSTAGED_RS" "$UNTRACKED_RS" \
-    | grep -v '^$' | sort -u | wc -l | tr -d ' ')
+    | { grep -v '^$' || true; } | sort -u | wc -l | tr -d ' ')
 
 # Fire only when the session did real work (>= 3 source files
 # touched). One-or-two-file fixes rarely yield generalisable

--- a/.claude/hooks/Stop--no-excuses.sh
+++ b/.claude/hooks/Stop--no-excuses.sh
@@ -12,6 +12,7 @@
 # genuine hard blocker that truly cannot be automated (rare).
 
 set -euo pipefail
+trap 'rc=$?; printf "Stop hook %s failed (exit=%d) at line %d\n" "${BASH_SOURCE[0]##*/}" "$rc" "$LINENO" >&2' ERR
 
 INPUT="$(cat)"
 

--- a/.claude/hooks/Stop--proof-required.sh
+++ b/.claude/hooks/Stop--proof-required.sh
@@ -27,6 +27,7 @@
 # (Claude Code Stop-hook spec). Diagnostic chatter goes to stderr.
 
 set -euo pipefail
+trap 'rc=$?; printf "Stop hook %s failed (exit=%d) at line %d\n" "${BASH_SOURCE[0]##*/}" "$rc" "$LINENO" >&2' ERR
 
 INPUT="$(cat)"
 

--- a/.claude/hooks/Stop--quality-gates.sh
+++ b/.claude/hooks/Stop--quality-gates.sh
@@ -13,6 +13,7 @@
 #     after one block-and-retry — matches Stop--proof-required.sh).
 
 set -euo pipefail
+trap 'rc=$?; printf "Stop hook %s failed (exit=%d) at line %d\n" "${BASH_SOURCE[0]##*/}" "$rc" "$LINENO" >&2' ERR
 
 INPUT="$(cat 2>/dev/null || true)"
 

--- a/.claude/hooks/Stop--screenshot-reminder.sh
+++ b/.claude/hooks/Stop--screenshot-reminder.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+trap 'rc=$?; printf "Stop hook %s failed (exit=%d) at line %d\n" "${BASH_SOURCE[0]##*/}" "$rc" "$LINENO" >&2' ERR
 exec >&2
 
 # Stop hook: remind to regenerate screenshots when UI or Tauri backend changed


### PR DESCRIPTION
## Summary

Fixed recurring 'Stop hook error: Failed with non-blocking status code: No stderr output' by:

1. **Fix #1: Pipefail bug in Stop--learnings-reminder.sh** — The `grep -v '^$'` mid-pipeline exits 1 when all three source-file regex variables are empty, causing the script to fail silently under `set -euo pipefail`. Wrapped grep in a subshell with `|| true` to swallow the failure gracefully.

2. **Fix #2: Add ERR trap to all 10 Stop hooks** — Inserted an ERR trap immediately after `set -euo pipefail` in each hook so any unhandled failure is visible on stderr with the format: `Stop hook <NAME> failed (exit=<CODE>) at line <LINE>`. This provides visibility for any future silent failures.

## Root Cause

Under `set -euo pipefail`, when a pipeline stage exits 1, the entire pipeline exits 1, even if the failure is handled downstream. The learnings-reminder hook's grep pattern matches nothing when no source files are present, exit 1 propagates through pipefail, and there's no `|| true` to catch it.

## Testing

- Smoke test: all 10 hooks exit 0 on empty `{}` event
- Verification: all hooks contain the ERR trap
- Live proof: See `.proofs/stop-hooks-silent-failure/` (acceptance criteria, evidence, judge verdict)

🤖 Generated with Claude Code