### PR TITLE
docs(learnings): record agent + tooling gotchas from drain-backlog session

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -19,7 +19,8 @@ bottom; don't lengthen items past 2-3 lines.
 ## Character logs (`parish-core/src/character_log.rs`)
 
 - **Profile section is rewritten every session**, journal is append-only. HTML comment markers `<!-- PROFILE_START -->` / `<!-- PROFILE_END -->` bound the rewritable region.
-- **Dedup has three layers**: in-memory `bump_last_arrival` for in-session, disk-scan in `new()` for cross-session, and heading-level idempotence in `append_journal_entry` for replay safety.
+- **Dedup was removed in PR #1032 (89ab669d).** The bus now only publishes real physical movements (`schedule::tick_schedules`, `ticks::apply_tier3_updates`, `game_session::apply_movement`), so the writer is stateless beyond `log_dir`. Do not reintroduce `last_arrival` / `scan_existing_*` — they were obsoleted on purpose. (Issues #1013, #1014 closed because of this.)
+- **Subscriber must rebind on branch switch.** Server (`parish-server/src/session.rs`) + Tauri (`parish-tauri/src/setup.rs`) + CLI (`App::rebind_log_managers_if_branch_changed`) each compare `current_branch_id` per event and rebuild the manager on mismatch. Otherwise post-`/load`/`/fork` events land under the old branch's `logs/branch-<old>/`. Same applies to `LocationLogManager` (#1011 #1034).
 
 ## rundale-bench local MLX sweep
 
@@ -27,3 +28,12 @@ bottom; don't lengthen items past 2-3 lines.
 - **`local_runner.py`'s "ready" signal is `/v1/models` returning 200, not actual model load.** Big-Tiger-Gemma-27B passed the readiness probe ~10 s before weights finished mmapping, so the first POSTs got HTTP 404 and the sweep recorded `overall=0.00` despite the model being viable later. On re-run it produced only `<pad>` tokens anyway — Gemma 4-bit quant is broken for in-character prose (same failure mode as `gemma-4-e4b-it-4bit`).
 - **Qwen3 thinking-mode leaks unless `chat_template_kwargs={"enable_thinking": False}` is injected on mlx_lm.server requests.** `parish/scripts/local-eval/eval_lib.py::THINKING_MLX_PREFIXES` lists the affected repos. Without the flag, reasoning fills `max_tokens` and the assistant content is empty → near-zero rubric scores. Cloud reasoning models (kimi-k2.5/6, deepseek-r1, claude, openai-o*, glm-4.6/7, gemini-2.5+) are already handled centrally by `_is_reasoning_model` → `_default_reasoning_for` in `eval_lib.py::call_chat`.
 - **opencode.ai is fronted by Cloudflare which 403s the default Python-urllib UA** (firewall rule 1010). `call_chat` sets `User-Agent: rundale-bench/1.0 (+...)` so the request gets through.
+
+## Agent + tooling gotchas
+
+- **`gh pr view --json baseRepository` was removed.** `parish/scripts/attach-proof.sh:67` still uses it and fails with "Unknown JSON field: baseRepository". Workaround: parse `gh pr view --json url --jq .url` and `sed` out `<owner>/<repo>`. Fallback for posting the proof bundle: `bash parish/scripts/render-proof-comment.sh <task-id> | gh pr comment <pr> --body-file -`.
+- **`awk -v var=value` interprets backslash escapes in `value`.** `\n` becomes a real newline mid-string. To insert a multi-character literal containing `\n` (e.g. a `printf` format), write the trap to a temp file and use `getline < tf` inside `BEGIN`, not `-v`.
+- **`gh pr edit` cannot change a PR's head branch.** If a sub-agent pushes a redo to `branch-v2` instead of the original branch, the PR keeps tracking the old SHA. Recovery: `git push origin +refs/remotes/origin/branch-v2:refs/heads/original-branch` to force-rewrite the PR's branch, then delete `branch-v2`.
+- **Stop hooks under `set -euo pipefail` need `|| true` at the END of every command-substitution pipeline.** `grep` no-match exits 1 → pipefail propagates → silent exit. Visible only as "Stop hook error: Failed with non-blocking status code: No stderr output". All Stop hooks now have an ERR trap that surfaces future silent failures.
+- **`PARISH_USER_DATA_DIR` only honors the FULL path** (no app_name appended). Tests setting `PARISH_USER_DATA_DIR=$tmp` should expect `$tmp/logs/branch-N/`, not `$tmp/<app>/logs/branch-N/`. See line 13 above; restated here because the rebind test (`headless.rs::rebind_log_managers_follows_branch_switch`) tripped on it.
+- **CLI flag is `--game-mod <DIR>`, not `--mod`.** `parish --script ... --mod mods/rundale` errors with "unexpected argument". Use `--game-mod` (env: `PARISH_MOD`).


### PR DESCRIPTION
## Summary

Adds Agent + tooling gotchas to `LEARNINGS.md` (6 entries discovered while draining the bug backlog this session). Also refreshes the now-stale Character logs dedup line to reflect PR #1032's stateless rewrite and #1011/#1034's per-event branch rebind.

## Entries

- `gh pr view --json baseRepository` removed — breaks `parish/scripts/attach-proof.sh:67`. Workaround documented.
- `awk -v var=value` interprets backslash escapes — `\n` becomes a real newline mid-string. Use temp-file + `getline` to insert multi-character literals.
- `gh pr edit` cannot change a PR's head branch — recovery via force-rewrite.
- Stop hooks under `set -euo pipefail` need `|| true` at the END of every pipeline; mid-pipe grep no-match silently exits. All Stop hooks now have an ERR trap (PR #1058).
- `PARISH_USER_DATA_DIR` is the FULL path (no app_name suffix) — restated.
- CLI flag is `--game-mod`, not `--mod`.

## Test plan

- [x] LEARNINGS.md still parses as markdown
- Docs-only; no source/runtime paths touched (CLAUDE.md rule #10 exemption)