### PR TITLE
feat(tauri): default to fullscreen with F11 toggle

### DIFF
--- a/parish/apps/ui/src/lib/ipc.ts
+++ b/parish/apps/ui/src/lib/ipc.ts
@@ -71,6 +71,9 @@ export const getDebugSnapshot = () => command<DebugSnapshot>('get_debug_snapshot
 
 export const getUiConfig = () => command<UiConfig>('get_ui_config');
 
+/** Toggles the desktop window's fullscreen state. Tauri-only (F11). */
+export const toggleFullscreen = () => command<boolean>('toggle_fullscreen');
+
 // ── Mod selection ────────────────────────────────────────────────────────────
 
 export const getMods = (): Promise<ModEntry[]> => {

--- a/parish/apps/ui/src/routes/+page.svelte
+++ b/parish/apps/ui/src/routes/+page.svelte
@@ -116,7 +116,7 @@
 			// let the native F11 fullscreen behaviour stand.
 			if (isTauri()) {
 				e.preventDefault();
-				void toggleFullscreen();
+				toggleFullscreen().catch((err) => console.warn('Fullscreen toggle failed:', err));
 			}
 		}
 		if (e.key === 'F12') {

--- a/parish/apps/ui/src/routes/+page.svelte
+++ b/parish/apps/ui/src/routes/+page.svelte
@@ -57,7 +57,9 @@
 		onTravelStart,
 		submitInput,
 		saveScreenshot,
-		disposeTransport
+		disposeTransport,
+		toggleFullscreen,
+		isTauri
 	} from '$lib/ipc';
 	import { captureScreen } from '$lib/screenshot';
 	import { createAutoPauseTracker } from '$lib/auto-pause';
@@ -89,8 +91,8 @@
 
 	const MOUSEMOVE_THROTTLE_MS = 1000;
 
-	// F2 = capture screenshot, F5 toggle for save picker, F11 toggle for demo panel,
-	// F12 toggle for debug panel, M toggle for map
+	// F2 = capture screenshot, F5 toggle for save picker, F10 toggle for demo panel,
+	// F11 toggle fullscreen (desktop), F12 toggle for debug panel, M toggle for map
 	function handleKeydown(e: KeyboardEvent) {
 		if (e.key === 'Escape' && get(demoEnabled)) {
 			e.preventDefault();
@@ -105,9 +107,17 @@
 			e.preventDefault();
 			savePickerVisible.update((v) => !v);
 		}
-		if (e.key === 'F11') {
+		if (e.key === 'F10') {
 			e.preventDefault();
 			demoVisible.update((v) => !v);
+		}
+		if (e.key === 'F11') {
+			// Desktop: toggle the Tauri window's fullscreen. In the browser,
+			// let the native F11 fullscreen behaviour stand.
+			if (isTauri()) {
+				e.preventDefault();
+				void toggleFullscreen();
+			}
 		}
 		if (e.key === 'F12') {
 			e.preventDefault();

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -233,6 +233,17 @@ pub async fn get_setup_snapshot(
         .clone())
 }
 
+/// Toggles the desktop window between fullscreen and windowed mode.
+///
+/// Bound to F11 in the frontend (desktop only — the web build lets the
+/// browser handle native F11). Returns the resulting fullscreen state.
+#[tauri::command]
+pub async fn toggle_fullscreen(window: tauri::WebviewWindow) -> Result<bool, String> {
+    let target = !window.is_fullscreen().map_err(|e| e.to_string())?;
+    window.set_fullscreen(target).map_err(|e| e.to_string())?;
+    Ok(target)
+}
+
 // ── BYOK onboarding commands ─────────────────────────────────────────────────
 
 fn byok_ctx<'a>(state: &'a Arc<AppState>) -> parish_core::ipc::byok::ByokContext<'a> {

--- a/parish/crates/parish-tauri/src/lib.rs
+++ b/parish/crates/parish-tauri/src/lib.rs
@@ -1353,6 +1353,7 @@ pub fn run() {
             commands::get_ui_config,
             commands::get_debug_snapshot,
             commands::get_setup_snapshot,
+            commands::toggle_fullscreen,
             commands::set_provider_config,
             commands::validate_provider_config,
             commands::get_provider_config,

--- a/parish/crates/parish-tauri/tauri.conf.json
+++ b/parish/crates/parish-tauri/tauri.conf.json
@@ -14,7 +14,8 @@
         "title": "Rundale — An Irish Living World",
         "width": 1280,
         "height": 800,
-        "resizable": true
+        "resizable": true,
+        "fullscreen": true
       }
     ],
     "security": {

--- a/parish/crates/parish-tauri/tests/command_registry.rs
+++ b/parish/crates/parish-tauri/tests/command_registry.rs
@@ -37,6 +37,11 @@ use parish_tauri_lib::commands::{
 // the MCP screenshot round-trip at runtime.
 #[allow(unused_imports)]
 use parish_tauri_lib::commands::{notify_screenshot_captured, notify_screenshot_error};
+// Desktop-window command (F11 fullscreen toggle). Not in EXPECTED_COMMANDS —
+// the web build has no HTTP equivalent (the browser handles native F11) — but
+// imported so a rename or deletion fails the build.
+#[allow(unused_imports)]
+use parish_tauri_lib::commands::toggle_fullscreen;
 #[allow(unused_imports)]
 use parish_tauri_lib::editor_commands::{
     editor_close, editor_get_snapshot, editor_list_branches, editor_list_mods, editor_list_saves,


### PR DESCRIPTION
## Summary

The desktop game now launches **fullscreen** like most games, and **F11** toggles fullscreen on/off.

- `tauri.conf.json`: the main window declares `"fullscreen": true`, so a fresh launch opens fullscreen instead of the old 1280×800 windowed default.
- New thin Tauri command `toggle_fullscreen(window)` flips `set_fullscreen` and returns the resulting state; wired into `generate_handler!` and exported from the frontend IPC layer.
- `+page.svelte` keydown: **F11** invokes `toggleFullscreen()` — but only under `isTauri()`, so the browser build keeps its native F11 fullscreen untouched.
- The dev **demo panel** toggle moves from F11 → **F10** to free the key. No demo functionality changes; no UI text or test advertised the old binding.

## Test plan

- [x] `cargo build -p parish-tauri` (clean)
- [x] `cargo test -p parish-tauri` — incl. `command_registry` symbol check (17/17 + registry green)
- [x] `cargo fmt --check` + `cargo clippy -p parish-tauri --tests` (clean)
- [x] `pnpm run check` — 0 errors in touched files (16 pre-existing `@types/geojson` errors untouched)
- [x] `npx vitest run` — 421/421 pass
- [x] `pnpm run build` — production bundle builds
- [x] Live engine sanity via `mcp__parish__*` (`parish_world_snapshot` + `parish_submit_input`)
- [ ] Desktop fullscreen launch + F11 toggle visually confirmed on a machine with a display (`just run`) — the raw binary can't render in this headless container (pre-existing unrelated startup panic)

Proof bundle attached as a PR comment.

https://claude.ai/code/session_01DPCx8Jrp5i9jeKx5kmvkxk

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPCx8Jrp5i9jeKx5kmvkxk)_