### PR TITLE
fix(demo): unblock Tauri demo boot + default to Rundale + populate travel detail

### DIFF
--- a/mods/mod-list.toml
+++ b/mods/mod-list.toml
@@ -1,2 +1,2 @@
-active_setting = "testbed"
+active_setting = "rundale"
 

--- a/parish/crates/parish-core/src/game_mod.rs
+++ b/parish/crates/parish-core/src/game_mod.rs
@@ -1841,13 +1841,13 @@ tier2_system = "prompts/tier2_system.txt"
     }
 
     #[test]
-    fn checked_in_mod_list_selects_testbed_by_default() {
+    fn checked_in_mod_list_selects_rundale_by_default() {
         let mods = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../mods");
         if mods.exists() {
             let discovered = discover_mods_in(&mods).expect("repo mod discovery succeeds");
             assert!(
-                discovered.base.ends_with("testbed"),
-                "checked-in mods/mod-list.toml should select testbed for blueprint testing"
+                discovered.base.ends_with("rundale"),
+                "checked-in mods/mod-list.toml should select rundale (the shipped base mod) by default"
             );
         }
     }

--- a/parish/crates/parish-core/src/ipc/handlers.rs
+++ b/parish/crates/parish-core/src/ipc/handlers.rs
@@ -224,18 +224,19 @@ pub fn build_travel_start(
         .and_then(|id| graph.get(*id))
         .map(|data| data.name.clone())
         .unwrap_or_default();
-    let to = path
-        .last()
+    let last = path.last();
+    let to = last
         .and_then(|id| graph.get(*id))
         .map(|data| data.name.clone())
         .unwrap_or_default();
+    let destination = last.map(|id| id.0.to_string()).unwrap_or_default();
 
     super::types::TravelStartPayload {
         from,
         to,
         waypoints,
         duration_minutes: minutes,
-        destination: path.last().map(|id| id.0.to_string()).unwrap_or_default(),
+        destination,
     }
 }
 

--- a/parish/crates/parish-core/src/ipc/handlers.rs
+++ b/parish/crates/parish-core/src/ipc/handlers.rs
@@ -219,7 +219,20 @@ pub fn build_travel_start(
         })
         .collect();
 
+    let from = path
+        .first()
+        .and_then(|id| graph.get(*id))
+        .map(|data| data.name.clone())
+        .unwrap_or_default();
+    let to = path
+        .last()
+        .and_then(|id| graph.get(*id))
+        .map(|data| data.name.clone())
+        .unwrap_or_default();
+
     super::types::TravelStartPayload {
+        from,
+        to,
         waypoints,
         duration_minutes: minutes,
         destination: path.last().map(|id| id.0.to_string()).unwrap_or_default(),

--- a/parish/crates/parish-core/src/ipc/types.rs
+++ b/parish/crates/parish-core/src/ipc/types.rs
@@ -259,8 +259,16 @@ pub struct TravelWaypoint {
 /// Payload for `travel-start` events, emitted when the player begins moving.
 ///
 /// The frontend uses this to animate a moving dot along the path on the map.
+/// The `from` / `to` location names are also consumed by the synchronous
+/// `/api/command` drain to populate the response's `travel` field.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TravelStartPayload {
+    /// Origin location name (player's location before the move).
+    #[serde(default)]
+    pub from: String,
+    /// Destination location name.
+    #[serde(default)]
+    pub to: String,
     /// Ordered waypoints from origin to destination (including both endpoints).
     pub waypoints: Vec<TravelWaypoint>,
     /// Total travel duration in game minutes.

--- a/parish/crates/parish-tauri/src/lib.rs
+++ b/parish/crates/parish-tauri/src/lib.rs
@@ -1279,20 +1279,31 @@ pub fn run() {
     }
 
     // Persistent on-disk inference + chat transcript logs (#xxx).
+    //
+    // Both `spawn` constructors internally call `tokio::spawn` to start their
+    // writer tasks. `pub fn run()` is sync and has no Tokio reactor in scope
+    // here, so we route the construction through `tauri::async_runtime::block_on`
+    // which enters the Tauri-managed tokio runtime that the writer tasks will
+    // actually live on. Without this wrap, both calls panic with
+    // "there is no reactor running, must be called from the context of a
+    // Tokio 1.x runtime" before the Tauri builder even starts.
     let log_to_disk = parish_core::inference::file_log::resolve_enabled(
         false, // Tauri does not (yet) expose a --no-inference-log flag; env wins
         engine_config.inference.log_to_disk,
     );
-    let inference_file_log = parish_core::inference::file_log::InferenceFileLog::spawn(
-        &saves_dir,
-        log_to_disk,
-        Some(&game_config.base_url),
-    );
-    let chat_transcript_log = parish_core::chat_transcript::ChatTranscriptLog::spawn_with_flag(
-        &saves_dir,
-        inference_file_log.session_id().to_string(),
-        inference_file_log.enabled_flag(),
-    );
+    let (inference_file_log, chat_transcript_log) = tauri::async_runtime::block_on(async {
+        let inference_file_log = parish_core::inference::file_log::InferenceFileLog::spawn(
+            &saves_dir,
+            log_to_disk,
+            Some(&game_config.base_url),
+        );
+        let chat_transcript_log = parish_core::chat_transcript::ChatTranscriptLog::spawn_with_flag(
+            &saves_dir,
+            inference_file_log.session_id().to_string(),
+            inference_file_log.enabled_flag(),
+        );
+        (inference_file_log, chat_transcript_log)
+    });
 
     let state = Arc::new(AppState {
         world: Mutex::new(world),

--- a/parish/testing/fixtures/play_demo-run-fixes.txt
+++ b/parish/testing/fixtures/play_demo-run-fixes.txt
@@ -1,0 +1,17 @@
+# Verification fixture for demo-run-fixes.
+#
+# Drives the synchronous /api/command path to expose the one engine-side
+# bug that survived triage:
+#
+#   C3 — travel.from / travel.to populated on kind=moved.
+#
+# C1 + C2 (Tauri tokio panic, default-mod selection) are validated
+# against `.demo-run.log` from a separate `just demo MAX_TURNS=3`
+# invocation, not from this CLI script.
+#
+# Three initially-suspected bugs (state-bundle rewind across non-moved
+# kinds, empty world.text_log, real_name leak) were ruled out — see
+# acceptance-criteria.md "Initially suspected, then ruled out".
+
+# Move to a new location. Travel detail must include from/to (C3).
+go to the holy well


### PR DESCRIPTION
## Summary

Three demo-run problems surfaced when driving `just demo`:

- **P0** — Tauri demo panicked at startup: `tokio::spawn` called outside reactor in `parish-inference/src/file_log.rs:187` because `parish-tauri`'s sync `pub fn run()` constructed `InferenceFileLog` + `ChatTranscriptLog` before the Tauri builder started a reactor. Wrapped both constructors in `tauri::async_runtime::block_on`.
- **P1** — `mods/mod-list.toml` shipped `active_setting = "testbed"`, so `just demo` (feeds the Rundale demo prompt) loaded the wrong world. Flipped default to `rundale`; updated the matching regression test.
- **P2** — `POST /api/command` returned `travel.from = ""` / `travel.to = ""` for `kind=moved`. `drain.rs` read string fields the payload never carried. Added `from` / `to` to `TravelStartPayload` and populated them in `build_travel_start`.

## Test plan

- [x] `cargo test -p parish-core --lib` — 436 passed
- [x] `cargo test -p parish-server --lib` — 197 passed
- [x] `cargo test -p parish-tauri --lib` — 81 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `just agent-check` — passes
- [x] Live: `cargo tauri dev -- -- --demo --demo-prompt mods/rundale/demo-prompt.txt --demo-pause 2 --demo-max-turns 3 --mcp-port 3030` boots cleanly, logs `Loaded game mod 'Rundale'`, detects vllm-mlx on :8000 + :8001, and runs three autonomous LLM-player turns with in-character Hiberno-English NPC replies from `Cormac Duffy` / `Brendan Duffy` at The Mill.
- [x] Fixture: `play_demo-run-fixes.txt` returns `travel={"from":"Kilteevan Village","to":"The Holy Well","duration_minutes":1}` for `go to the holy well`.

## Initially suspected, ruled out

Three additional bugs surfaced during the original evaluation but were proven non-engine (see `acceptance-criteria.md`):

- State-bundle rewind across non-moved kinds + empty `world.text_log` — both curl-driver session-cookie artifacts; reproduces only without `curl -b/-c`. MCP bridge and WS frontend both pin a `parish_sid`.
- `npcs_here[].real_name` leaked before introduction — by design; `real_name` is the stable backend id used by frontend chip dispatch (`InputField.svelte:83`). Player-visible `name` correctly remains the descriptor.

Proof bundle attached separately via `just attach-proof demo-run-fixes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)