### PR TITLE
feat(themes): collapse rundale palette to day/night with 2s snap fade

### DIFF
--- a/mods/rundale/ui.toml
+++ b/mods/rundale/ui.toml
@@ -14,36 +14,26 @@ input_bg = "#f0f0ce"
 border = "#cec293"
 muted = "#76663b"
 
-# Time-of-day keyframes — engine smoothly interpolates between these to
-# produce the live palette. Anchor hours are midpoints of each named slot.
-# Moved here from parish-palette during the rundale-extraction refactor;
-# any base mod can ship its own (omit to fall back to the static palette
-# above, as testbed does for its static blueprint look).
+# Day/night keyframes — engine interpolates linearly between adjacent
+# anchors. Snap transitions: 1-game-minute windows at 05:59→06:00 and
+# 19:59→20:00 give effectively atomic palette swaps at each backend
+# tick. The visible fade duration is governed by the CSS transition
+# in app.css (2s). Day palette mirrors the static [theme.palette]
+# above. Omit this block in a base mod to fall back to that static
+# palette (as testbed does).
 
 [[theme.keyframes]]
-hour = 1.5  # Midnight (23:00–4:59)
-palette = { bg = "#0a0c14", fg = "#9696a5", accent = "#464b64", panel_bg = "#0f121c", input_bg = "#141824", border = "#2d3041", muted = "#646473" }
+hour = 5.9999  # End of night — interpolation window to the next anchor is < 1 game-second
+palette = { bg = "#141928", fg = "#b4b4be", accent = "#646e8c", panel_bg = "#191e30", input_bg = "#1e2337", border = "#3c415a", muted = "#787887" }
 
 [[theme.keyframes]]
-hour = 5.5  # Dawn (5:00–6:59)
-palette = { bg = "#ffdcb4", fg = "#3c2814", accent = "#c88c3c", panel_bg = "#fad7af", input_bg = "#f5d2aa", border = "#c8aa82", muted = "#786446" }
+hour = 6.0  # 06:00 — snap to day
+palette = { bg = "#fafad8", fg = "#31240f", accent = "#b08531", panel_bg = "#f5f5d3", input_bg = "#f0f0ce", border = "#cec293", muted = "#76663b" }
 
 [[theme.keyframes]]
-hour = 8.5  # Morning (7:00–9:59)
-palette = { bg = "#fff5dc", fg = "#32230f", accent = "#b48232", panel_bg = "#faf0d7", input_bg = "#f5ebd2", border = "#d2be96", muted = "#78643c" }
+hour = 19.9999  # End of day — interpolation window to the next anchor is < 1 game-second
+palette = { bg = "#fafad8", fg = "#31240f", accent = "#b08531", panel_bg = "#f5f5d3", input_bg = "#f0f0ce", border = "#cec293", muted = "#76663b" }
 
 [[theme.keyframes]]
-hour = 12.0  # Midday (10:00–13:59)
-palette = { bg = "#fffff0", fg = "#281e0a", accent = "#a07828", panel_bg = "#fafaeb", input_bg = "#f5f5e6", border = "#d2c8aa", muted = "#6e643c" }
-
-[[theme.keyframes]]
-hour = 15.5  # Afternoon (14:00–16:59)
-palette = { bg = "#f0dcaa", fg = "#32230f", accent = "#b48232", panel_bg = "#ebd7a5", input_bg = "#e6d2a0", border = "#c8b482", muted = "#78643c" }
-
-[[theme.keyframes]]
-hour = 18.0  # Dusk (17:00–18:59)
-palette = { bg = "#3c466e", fg = "#dcd2be", accent = "#c8a050", panel_bg = "#374164", input_bg = "#323c5f", border = "#5a648c", muted = "#a0968c" }
-
-[[theme.keyframes]]
-hour = 21.0  # Night (19:00–22:59)
+hour = 20.0  # 20:00 — snap to night
 palette = { bg = "#141928", fg = "#b4b4be", accent = "#646e8c", panel_bg = "#191e30", input_bg = "#1e2337", border = "#3c415a", muted = "#787887" }

--- a/parish/apps/ui/src/app.css
+++ b/parish/apps/ui/src/app.css
@@ -34,10 +34,10 @@
 *::after {
 	box-sizing: border-box;
 	transition:
-		background-color 1.5s ease,
-		background 1.5s ease,
-		color 1.5s ease,
-		border-color 1.5s ease;
+		background-color 2s ease,
+		background 2s ease,
+		color 2s ease,
+		border-color 2s ease;
 }
 
 html,


### PR DESCRIPTION
## Summary

- Replace the 7-keyframe time-of-day palette in `mods/rundale/ui.toml` with a 4-keyframe day/night schedule that **snaps** at 06:00 and 20:00.
- Bump the universal CSS transition in `parish/apps/ui/src/app.css` from `1.5s` → `2s` so the visible fade on a snap-driven palette swap lasts ~2 real-world seconds.

The prior schedule walked the UI through midnight / dawn / morning / midday / afternoon / dusk / night anchors with smooth interpolation between them — colour drift was visible throughout play. The new schedule holds day constant from 06:00–20:00 and night constant from 20:00–06:00; the keyframe pairs `5.9999/6.0` and `19.9999/20.0` collapse the engine-side interpolation window to sub-game-second so the backend emits a discrete palette swap at each boundary, and the 2s CSS transition fades the visible UI smoothly.

## Test plan

- [x] `just check` — fmt + clippy + tests + witness-scan + doc-path scan: pass
- [x] `cargo test -p parish-palette --lib` — 25 pass (interpolation engine)
- [x] `cargo test -p parish-core --test mod_artefact_malformed_input` — 14 pass (mod loader schema)
- [x] Live `parish-server` driven through the dawn (06:00) and dusk (20:00) boundaries; `GET /api/theme` returns pure day at 19:59 and pure night at 20:01 with no interpolated midpoint (see proof bundle).
- [x] CSS transition verified live on the running Svelte dev server via the Claude Preview MCP: `transition-duration: 2s, 2s, 2s, 2s` on the `<body>` element.

## Proof bundle

Live gameplay transcript + judge verdict attached as a structured PR comment via `just attach-proof day-night-snap-fade` (per AGENTS.md rule #10).

## Out of scope

- Mid-session `theme-update` WebSocket push from `parish-server`. Time-of-day push still lives only in `parish-tauri::spawn_world_tick`. The new snap palette is visible in Tauri desktop continuously, and in the web client at page load. Mirroring the tick into the server is rule #12 territory — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)