### PR TITLE
fix(rundale): allow-list poitín, align Night time-of-day word

### DIFF
--- a/parish/crates/parish-npc/src/quality.rs
+++ b/parish/crates/parish-npc/src/quality.rs
@@ -288,6 +288,7 @@ const GAELIC_VOCAB: &[&str] = &[
     "seisiún",
     "amhrán",
     "rince",
+    "poitín",
     "sídhe",
     "sídh",
     "síthe",
@@ -596,6 +597,19 @@ mod tests {
     fn gaelic_fada_name_passes() {
         let s = "Séamus is after telling me.";
         assert!(detect_hallucinated_gaelic(s).is_empty());
+    }
+
+    #[test]
+    fn gaelic_poitin_passes() {
+        // poitín is a real 1820-period Irish word for home-distilled spirits;
+        // must not trip the hallucinated-Gaelic detector.
+        let s = "A drop of poitín warms the bones.";
+        let issues = detect_hallucinated_gaelic(s);
+        assert!(
+            issues.is_empty(),
+            "poitín must be allow-listed; got {:?}",
+            issues
+        );
     }
 
     #[test]

--- a/parish/crates/parish-world/src/description.rs
+++ b/parish/crates/parish-world/src/description.rs
@@ -76,6 +76,12 @@ fn weather_display(weather: &str) -> String {
 }
 
 /// Converts a `TimeOfDay` to a human-friendly lowercase string for templates.
+///
+/// Words match the lowercase form of `TimeOfDay`'s `Display` impl
+/// (used in the demo prompt's `Date and time: ... | Season` line) so that
+/// "It is night." in the rendered description doesn't disagree with
+/// "Night | Spring" in the same prompt block (TODO #28). `arrival_reactions`
+/// keeps its own `Night => "evening"` mapping for greeting register.
 fn time_display(tod: TimeOfDay) -> String {
     match tod {
         TimeOfDay::Dawn => "dawn".to_string(),
@@ -83,7 +89,7 @@ fn time_display(tod: TimeOfDay) -> String {
         TimeOfDay::Midday => "midday".to_string(),
         TimeOfDay::Afternoon => "afternoon".to_string(),
         TimeOfDay::Dusk => "dusk".to_string(),
-        TimeOfDay::Night => "evening".to_string(),
+        TimeOfDay::Night => "night".to_string(),
         TimeOfDay::Midnight => "late night".to_string(),
     }
 }
@@ -163,7 +169,7 @@ mod tests {
             (TimeOfDay::Midday, "midday"),
             (TimeOfDay::Afternoon, "afternoon"),
             (TimeOfDay::Dusk, "dusk"),
-            (TimeOfDay::Night, "evening"),
+            (TimeOfDay::Night, "night"),
             (TimeOfDay::Midnight, "late night"),
         ];
         for (tod, expected) in &times {

--- a/parish/testing/evals/baselines/test_all_locations.json
+++ b/parish/testing/evals/baselines/test_all_locations.json
@@ -191,7 +191,7 @@
     "command": "look",
     "result": {
       "result": "looked",
-      "description": "A working farm with a whitewashed house and stone outbuildings roofed in thatch. Cattle graze in the near field. A sheepdog watches from the gate. It is evening. The sky is clear."
+      "description": "A working farm with a whitewashed house and stone outbuildings roofed in thatch. Cattle graze in the near field. A sheepdog watches from the gate. It is night. The sky is clear."
     },
     "location": "Murphy's Farm",
     "time": "Night",
@@ -213,7 +213,7 @@
     "command": "look",
     "result": {
       "result": "looked",
-      "description": "A tidy farm with stone outbuildings and a well-kept garden. Hens scratch in the yard. A donkey stands patiently by the barn. It is evening. Weather: clear."
+      "description": "A tidy farm with stone outbuildings and a well-kept garden. Hens scratch in the yard. A donkey stands patiently by the barn. It is night. Weather: clear."
     },
     "location": "O'Brien's Farm",
     "time": "Night",
@@ -235,7 +235,7 @@
     "command": "look",
     "result": {
       "result": "looked",
-      "description": "A squat stone lime kiln standing at the edge of the bog. On burning days the smoke rises thick and white. A flat patch of ground beside it serves as a gathering place. It is evening. The weather is clear."
+      "description": "A squat stone lime kiln standing at the edge of the bog. On burning days the smoke rises thick and white. A flat patch of ground beside it serves as a gathering place. It is night. The weather is clear."
     },
     "location": "The Lime Kiln",
     "time": "Night",

--- a/parish/testing/fixtures/play_todo-28-night-word.txt
+++ b/parish/testing/fixtures/play_todo-28-night-word.txt
@@ -1,0 +1,10 @@
+# Live-proof fixture for TODO #28 — Night time-of-day word
+#
+# Boots Rundale at the default 1820-03-20 08:00 (Morning), advances the
+# clock by 12 game-hours to 20:00 (Night, per time_of_day_from_hour: 19-22),
+# and looks at the current location. Acceptance criterion AC1 requires
+# the rendered description to contain "It is night" (not "It is evening").
+
+/wait 720
+look
+/time


### PR DESCRIPTION
## Summary

Two quick-wins from `TODO.md`:

- **#22 — Gaelic allow-list:** `detect_hallucinated_gaelic` was flagging
  `poitín` as an unrecognized Gaelic word. Poitín is a real Irish word
  for home-distilled spirits, period-appropriate for 1820. Added to
  `GAELIC_VOCAB` + a regression test.
- **#28 — Night word mismatch:** `render_description`'s `time_display(Night)`
  returned `"evening"`, so `location_description` said `"It is evening."`
  while the demo prompt's `Date and time: ... | Night | Spring` line said
  `Night`. Changed Night → `"night"` so both agree. `arrival_reactions`
  keeps its own `Night => "evening"` for greeting register (independent
  code path, intentional).

## Test plan

- [x] `cargo test -p parish-world -p parish-npc` — 641 pass
- [x] `cargo test -p parish-core` — 511 pass
- [x] `cargo test -p parish-engine` — 311 pass (incl. regenerated
      `test_all_locations.json` baseline; 3 lines updated, all at
      `time: "Night"`)
- [x] Live proof at `.proofs/todo-28-night-word/` — `cargo run -p parish-engine
      -- --headless --script parish/testing/fixtures/play_todo-28-night-word.txt`
      produces `"description":"... It is night.","time":"Night"` at 20:00.
- [x] `just agent-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)