### PR TITLE
fix(e2e): bump smoke chat-panel timeout 5s→30s for cold-start LLM round-trip

### DIFF
--- a/parish/apps/ui/e2e/smoke.spec.ts
+++ b/parish/apps/ui/e2e/smoke.spec.ts
@@ -43,9 +43,12 @@ test.describe('Parish Web UI', () => {
 		await input.fill('look');
 		await input.press('Enter');
 
-		// Chat panel should update with player input echo and system response
+		// Chat panel should update with player input echo and system response.
+		// Timeout is 30 s, not 5 s, because the chat panel only updates after
+		// the backend's first round-trip — which on a cold-start CI runner
+		// can exceed 5 s when the inference worker hasn't warmed up (#1086).
 		const chatPanel = page.locator('[data-testid="chat-panel"]');
-		await expect(chatPanel).toContainText('look', { timeout: 5_000 });
+		await expect(chatPanel).toContainText('look', { timeout: 30_000 });
 	});
 
 	test('player can move to a location', async ({ page }) => {
@@ -56,9 +59,11 @@ test.describe('Parish Web UI', () => {
 		await input.fill('go to church');
 		await input.press('Enter');
 
-		// Should see travel narration or "not found" message in the chat
+		// Should see travel narration or "not found" message in the chat.
+		// Timeout is 30 s for the same cold-start reason as the sibling
+		// 'player can type a command' test above (#1086).
 		const chatPanel = page.locator('[data-testid="chat-panel"]');
-		await expect(chatPanel).toContainText(/church|faintest notion/i, { timeout: 5_000 });
+		await expect(chatPanel).toContainText(/church|faintest notion/i, { timeout: 30_000 });
 	});
 
 	test('API endpoints return valid JSON', async ({ request }) => {

--- a/parish/testing/fixtures/play_issue-1086.txt
+++ b/parish/testing/fixtures/play_issue-1086.txt
@@ -1,0 +1,17 @@
+# play_issue-1086.txt
+#
+# Placeholder fixture for the issue-1086 task bundle.
+#
+# This task is a Playwright e2e test-infrastructure fix
+# (parish/apps/ui/e2e/smoke.spec.ts), not a gameplay change. There is
+# no parish-engine script that can demonstrate the relevant signal —
+# the bug lives in the test runner's interaction with a cold-start web
+# server.
+#
+# Real verification: run the smoke spec ten times in a loop and
+# confirm 10/10 passes. See .proofs/issue-1086/acceptance-criteria.md
+# for the exact command. The captured loop output is the
+# transcript.txt in the proof bundle.
+#
+# Kept as a non-empty fixture so /task-start conventions hold and so
+# this file shows up in any "what tasks have shipped" sweep.


### PR DESCRIPTION
## Summary

- Bump the `toContainText` timeout from 5 s to 30 s on the two chat-panel assertions in `parish/apps/ui/e2e/smoke.spec.ts` (`player can type a command` and `player can move to a location`).
- The chat panel only updates after the backend's first round-trip; on a cold-start CI runner with the inference worker not warmed up, that round-trip can exceed 5 s. PR #1084 hit this on run id `26411632995` — both Playwright attempts failed; the same SHA passed cleanly on re-run.
- Behaviour assertions unchanged. Inline comments cite #1086 and the cold-start cause so a future agent doesn't undo it.

Closes #1086

## Test plan

- [x] `npx playwright test e2e/smoke.spec.ts -g 'player can type a command'` — 10 consecutive runs against a live `parish-server`; result: `PASS=10 FAIL=0` (see `.proofs/issue-1086/transcript.txt`)
- [x] `npx playwright test e2e/smoke.spec.ts` — full smoke spec; result: 5/5 pass
- [x] `just agent-check` — gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)