### PR TITLE
fix(npc): anchor NPCs to current location in dialogue prompt

### DIFF
--- a/parish/crates/parish-core/tests/dialogue_prompt_anchor.rs
+++ b/parish/crates/parish-core/tests/dialogue_prompt_anchor.rs
@@ -109,6 +109,28 @@ fn dialogue_context_forbids_borrowed_name_when_unknown() {
     );
 }
 
+/// TODO #21: the assembled context must pin the NPC to the player's
+/// current location with a directive forbidding substitution of any
+/// nearby canonical settlement. The bug surfaced at The Mill near
+/// Kilteevan when Cormac/Nora kept saying "here in Curraghboy".
+#[test]
+fn dialogue_context_pins_current_location() {
+    let context = build_dialogue_context_with_first_npc(Some("Aiden Carney"), true);
+
+    assert!(
+        context.contains("WHERE YOU ARE RIGHT NOW"),
+        "location anchor header missing:\n{context}"
+    );
+    assert!(
+        context.contains("no other settlement"),
+        "no-other-settlement directive missing:\n{context}"
+    );
+    assert!(
+        context.contains("you are NOT at any of them"),
+        "not-elsewhere guard missing:\n{context}"
+    );
+}
+
 /// AC2/AC3: the assembled context must always carry a present-only
 /// anchor — either listing co-located NPCs as the exclusive set or
 /// declaring nobody else is here. TODO #11 captured the failure mode

--- a/parish/crates/parish-npc/src/ticks.rs
+++ b/parish/crates/parish-npc/src/ticks.rs
@@ -200,6 +200,26 @@ pub fn build_enhanced_system_prompt_with_config(
     prompt
 }
 
+/// "Where you are right now" anchor — pins the NPC to the player's
+/// current location so they don't substitute a nearby canonical
+/// settlement from their backstory or short-term memory.
+///
+/// TODO #21 surfaced this: Cormac and Nora Duffy, who work at The Mill
+/// near Kilteevan, repeatedly told the player they were "here in
+/// Curraghboy" because Curraghboy Village is real, neighbouring, and
+/// mentioned in their family backstory. The base location label
+/// (`"Your Location: ..."`) is informative — this block is directive.
+fn location_anchor_block(world: &WorldState) -> String {
+    let name = &world.current_location().name;
+    format!(
+        "\n\nWHERE YOU ARE RIGHT NOW:\n{name}.\n\
+         When you say 'here', 'this place', 'this village', or 'this town' \
+         you mean {name} — no other settlement. Other nearby places (mentioned \
+         in your memory or backstory) exist, but you are NOT at any of them \
+         right now."
+    )
+}
+
 /// Interlocutor label — who the NPC is speaking with.
 ///
 /// The anchor sentence forbids the model from addressing the player by any
@@ -361,6 +381,8 @@ pub fn build_enhanced_context_with_config(
     player_name_for_npc: Option<&str>,
 ) -> String {
     let mut context = build_tier1_context(world);
+
+    context.push_str(&location_anchor_block(world));
 
     context.push_str(&interlocutor_block(player_name_for_npc));
 
@@ -1497,6 +1519,31 @@ mod tests {
         assert!(
             block.contains("do not borrow a name"),
             "missing borrow-from-history guard:\n{block}"
+        );
+    }
+
+    #[test]
+    fn test_location_anchor_block_pins_current_location() {
+        // Location anchor (TODO #21) — block must name the current
+        // location and forbid substituting any other settlement.
+        let world = WorldState::new();
+        let block = location_anchor_block(&world);
+        let name = &world.current_location().name;
+        assert!(
+            block.contains("WHERE YOU ARE RIGHT NOW"),
+            "missing anchor header:\n{block}"
+        );
+        assert!(
+            block.contains(name.as_str()),
+            "anchor must name current location ({name}):\n{block}"
+        );
+        assert!(
+            block.contains("no other settlement"),
+            "missing no-other-settlement directive:\n{block}"
+        );
+        assert!(
+            block.contains("you are NOT at any of them"),
+            "missing not-elsewhere guard:\n{block}"
         );
     }
 

--- a/parish/testing/fixtures/play_todo-21-location-anchor.txt
+++ b/parish/testing/fixtures/play_todo-21-location-anchor.txt
@@ -1,0 +1,9 @@
+# Live-proof fixture for TODO #21 — NPC location anchor
+#
+# Walks the player from Kilteevan to The Mill — the location where
+# cycle-4 of the demo audit caught Cormac and Nora Duffy referring to
+# "their" village as Curraghboy (the canon townland mentioned in their
+# backstory) instead of Kilteevan/The Mill where they actually are.
+
+go to the mill
+look


### PR DESCRIPTION
## Summary

Closes TODO #21 from the demo-audit `TODO.md`. Cycle 4 of the audit caught Cormac and Nora Duffy repeatedly saying they were "here in Curraghboy" — a real neighbouring townland that appears in their backstory — when they're actually at The Mill near Kilteevan. The base `Your Location: ...` line in the Tier 1 context was informative but not directive.

## Change

Adds a new `location_anchor_block` rendered just before `interlocutor_block` in the dialogue context:

```
WHERE YOU ARE RIGHT NOW:
{location_name}.
When you say 'here', 'this place', 'this village', or 'this town'
you mean {location_name} — no other settlement. Other nearby places
(mentioned in your memory or backstory) exist, but you are NOT at
any of them right now.
```

Block is unconditional and uses `WorldState::current_location().name`, so it re-renders correctly as the player moves.

## Test plan

- [x] `cargo test -p parish-npc -p parish-core` — 1002 pass
- [x] New unit test `test_location_anchor_block_pins_current_location` (parish-npc)
- [x] New integration test `dialogue_context_pins_current_location` (parish-core) exercises full `prepare_npc_conversation_turn` against real Rundale data
- [x] Live proof at `.proofs/todo-21-location-anchor/` — `cargo run -p parish-engine --headless --script parish/testing/fixtures/play_todo-21-location-anchor.txt` (player walks to The Mill, the canonical Curraghboy-confusion site)
- [x] `just agent-check` passes

## Out of scope

Per `acceptance-criteria.md`:
1. Post-filter rejecting NPC replies that name a different in-canon settlement as the current location.
2. Memory-tier pruning that hides nearby-townland references from STM.
3. Parent-settlement labeling (`"The Mill, in Kilteevan"`) — needs a schema field on `LocationData`.

Will measure with `/rundale-bench` after this lands to decide whether the post-filter is still needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)