### PR TITLE
fix(input): parse first-person movement intents as Move not Talk

### DIFF
--- a/parish/crates/parish-input/src/intent_local.rs
+++ b/parish/crates/parish-input/src/intent_local.rs
@@ -15,7 +15,36 @@ pub fn parse_intent_local(raw_input: &str) -> Option<PlayerIntent> {
 
     // Movement patterns — multi-word phrases checked first (longest match wins),
     // then single-verb prefixes. Covers common, colloquial, and unusual verbs.
+    //
+    // First-person movement intents (TODO #41/#46/#53) MUST appear in this
+    // list so they match before the generic first-person narrative guard
+    // below classifies them as `Talk`. The auto-player in the demo audit
+    // produced lines like "I'll make for the Crossroads then" 9 turns in
+    // a row that vanished into Talk-no-NPC because none of these were
+    // registered as move prefixes.
     let move_phrases = [
+        // First-person movement intents — longest first.
+        "i'll be making for ",
+        "i'll be makin' for ",
+        "i'll be heading to ",
+        "i'll be walking to ",
+        "i'll be on me way to ",
+        "i'll be on my way to ",
+        "i'll be off to ",
+        "i'll make my way to ",
+        "i'll head over to ",
+        "i'll head to ",
+        "i'll make for ",
+        "i'll venture to ",
+        "i'll wander to ",
+        "i'll stroll to ",
+        "i'll walk to ",
+        "i'll go to ",
+        "i'm off to ",
+        "i'm headed to ",
+        "i'm heading to ",
+        "off i go to ",
+        // Generic multi-word movement phrases.
         "make my way to ",
         "make my way ",
         "head over to ",
@@ -459,6 +488,83 @@ mod tests {
         assert_eq!(intent.intent, IntentKind::Move);
         assert_eq!(intent.target, Some("crossroads".to_string()));
     }
+    /// TODO #41/#46/#53: first-person + movement-verb phrasings the
+    /// demo auto-player produced repeatedly that the parser silently
+    /// dropped because the first-person guard caught them first.
+    #[test]
+    fn test_local_parse_first_person_movement_intents() {
+        let cases = [
+            ("I'll make for the Crossroads", "the Crossroads"),
+            ("I'll be making for the Hedge School", "the Hedge School"),
+            ("I'll venture to the Letter Office", "the Letter Office"),
+            ("I'll head to the pub", "the pub"),
+            ("I'll go to the mill", "the mill"),
+            ("I'll walk to the church", "the church"),
+            ("I'll wander to the crossroads", "the crossroads"),
+            ("I'll stroll to the green", "the green"),
+            ("I'll make my way to the shop", "the shop"),
+            ("I'll head over to the Letter Office", "the Letter Office"),
+            ("I'll be on me way to the Crossroads", "the Crossroads"),
+            ("I'll be on my way to the Crossroads", "the Crossroads"),
+            ("I'll be off to the pub", "the pub"),
+            ("I'll be heading to the mill", "the mill"),
+            ("I'll be walking to the well", "the well"),
+            ("I'm off to the Letter Office", "the Letter Office"),
+            ("I'm heading to the green", "the green"),
+            ("Off I go to the Letter Office", "the Letter Office"),
+        ];
+        for (input, target) in cases {
+            let intent =
+                parse_intent_local(input).unwrap_or_else(|| panic!("no intent parsed: {input}"));
+            assert_eq!(
+                intent.intent,
+                IntentKind::Move,
+                "{input} must parse as Move (got {:?}): {intent:?}",
+                intent.intent
+            );
+            assert_eq!(
+                intent.target.as_deref(),
+                Some(target),
+                "{input} target mismatch"
+            );
+        }
+    }
+
+    /// TODO #41 guard: ensure the first-person narrative cases that
+    /// must STAY Talk are unaffected by the new movement patterns.
+    /// Without a movement verb, "I" / "I'm" / "I've" stay narrative.
+    #[test]
+    fn test_local_parse_first_person_narrative_still_talk_after_anchor_add() {
+        let cases = [
+            "I came from the coast",
+            "I was at the shore yesterday",
+            "I'm not from around here",
+            "I've been to the pub before",
+        ];
+        for input in cases {
+            let intent =
+                parse_intent_local(input).unwrap_or_else(|| panic!("no intent parsed: {input}"));
+            assert_eq!(
+                intent.intent,
+                IntentKind::Talk,
+                "{input} must stay Talk: got {intent:?}"
+            );
+        }
+    }
+
+    /// TODO #41 case-insensitivity guard for the new first-person move
+    /// patterns.
+    #[test]
+    fn test_local_parse_first_person_movement_case_insensitive() {
+        let intent = parse_intent_local("I'LL MAKE FOR THE CROSSROADS").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target.as_deref(), Some("THE CROSSROADS"));
+
+        let intent = parse_intent_local("Off I Go To The Mill").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+        assert_eq!(intent.target.as_deref(), Some("The Mill"));
+    }
+
     #[test]
     fn test_local_parse_bare_unusual_verbs_no_target() {
         // Bare verbs without a target should not match

--- a/parish/testing/fixtures/play_todo-41-movement-parser.txt
+++ b/parish/testing/fixtures/play_todo-41-movement-parser.txt
@@ -1,0 +1,17 @@
+# Live-proof fixture for TODO #41 / #46 / #53 — movement parser.
+#
+# Each command below is a phrasing the auto-player produced in the demo
+# audit that previously failed to trigger a move because the parser's
+# first-person guard classified them as Talk before any movement
+# prefix could match.
+#
+# Expected: every command yields {"result":"moved", ...} or similar,
+# not "ambient" / "talk" / a silent drop.
+
+I'll go to the mill
+I'll make for Kilteevan Village
+I'll head to the mill
+I'll be on me way to Kilteevan Village
+I'll venture to the mill
+I'm off to Kilteevan Village
+Off I go to the mill


### PR DESCRIPTION
## Summary

Closes TODO #41 / #46 / #53 from the demo-audit `TODO.md`. The auto-player produced 9+ consecutive turns of `"I'll make for the Crossroads then."`, `"I'll be making for the Hedge School then."`, `"I'm off to Kilteevan Village"`, `"Off I go to the Letter Office"` — none triggered a move. The first-person guard at `intent_local.rs:169` matched the `"i'll "` / `"i'm "` prefix first and classified everything as `Talk` before any move-prefix could match. With no NPC present at empty locations the input vanished silently.

## Change

Adds 18 first-person movement prefixes at the top of `move_phrases` (longest-first, so `"i'll be making for "` beats `"i'll "`):

```
i'll be making for / i'll be makin' for / i'll be heading to
i'll be walking to / i'll be on me way to / i'll be on my way to
i'll be off to / i'll make my way to / i'll head over to
i'll head to / i'll make for / i'll venture to / i'll wander to
i'll stroll to / i'll walk to / i'll go to
i'm off to / i'm headed to / i'm heading to
off i go to
```

Narrative phrasings without a movement verb continue to fall through to the first-person `Talk` guard.

## Test plan

- [x] `cargo test -p parish-input` — 157 pass
- [x] `cargo test -p parish-input -p parish-core -p parish-engine` — 983 pass
- [x] 3 new unit tests cover positive cases (18 phrasings), narrative-guard regression, and case-insensitivity
- [x] Live proof at `.proofs/todo-41-movement-parser/` — `cargo run -p parish-engine --headless --script parish/testing/fixtures/play_todo-41-movement-parser.txt` shows all 7 previously-broken phrasings now produce `"result":"moved"`
- [x] `just agent-check` passes

## Out of scope

Per `acceptance-criteria.md`: modal/interrogative forms (`"Might I venture to..."`, `"I shall go"`), empty-location "no one is here" explicit hint, and roleplay-action recognition are deferred. The first belongs in the LLM intent path; the others are separate UX features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)