### PR TITLE
fix(prompt): include HH:MM + time-of-day cue for greeting register

### DIFF
--- a/parish/crates/parish-core/tests/dialogue_prompt_anchor.rs
+++ b/parish/crates/parish-core/tests/dialogue_prompt_anchor.rs
@@ -109,6 +109,34 @@ fn dialogue_context_forbids_borrowed_name_when_unknown() {
     );
 }
 
+/// TODO #13: assembled context must carry an explicit time-of-day
+/// cue naming both the bucket (Morning/Dusk/Night/...) and HH:MM, so
+/// the model has an unambiguous signal for greeting register. The bug:
+/// NPCs at Dusk were greeting with "good mornin'" because the only
+/// time signal was the bare 17:30 timestamp.
+#[test]
+fn dialogue_context_carries_time_of_day_cue() {
+    let context = build_dialogue_context_with_first_npc(Some("Aiden Carney"), true);
+
+    assert!(
+        context.contains("Time of day:"),
+        "missing Time of day cue:\n{context}"
+    );
+    assert!(
+        context.contains("greet and refer to the time of day accordingly"),
+        "missing greeting-register directive:\n{context}"
+    );
+    // Rundale fresh save loads at 08:00 → Morning bucket.
+    assert!(
+        context.contains("Morning"),
+        "time-of-day label missing:\n{context}"
+    );
+    assert!(
+        context.contains("(08:"),
+        "HH:MM must accompany the cue:\n{context}"
+    );
+}
+
 /// TODO #21: the assembled context must pin the NPC to the player's
 /// current location with a directive forbidding substitution of any
 /// nearby canonical settlement. The bug surfaced at The Mill near

--- a/parish/crates/parish-npc/src/lib.rs
+++ b/parish/crates/parish-npc/src/lib.rs
@@ -785,12 +785,23 @@ pub fn build_tier1_context(world: &WorldState) -> String {
         season = season,
     );
 
+    // TODO #13: explicit time-of-day cue so the model picks the
+    // right greeting register. NPCs were saying "good morning" at
+    // Dusk because the only time signal in the context was the bare
+    // 17:30 HH:MM — without an English label the model defaulted
+    // to "morning". Spell out the bucket and direct the model to
+    // greet accordingly.
+    let time_of_day_label = time_of_day.to_string();
     format!(
         "Your Location: {loc_name} — {loc_desc}\n\
-        Date and time: {date_time}",
+        Date and time: {date_time}\n\
+        Time of day: {tod} ({hour:02}:{minute:02}) — greet and refer to the time of day accordingly.",
         loc_name = world.current_location().name,
         loc_desc = rendered_desc,
         date_time = date_time_str,
+        tod = time_of_day_label,
+        hour = now.hour(),
+        minute = now.minute(),
     )
 }
 
@@ -859,14 +870,31 @@ mod tests {
         let world = WorldState::new();
         let context = build_tier1_context(&world);
         assert!(context.contains("The Crossroads"));
-        // Time of day is conveyed by the clock time (e.g. 08:00), not a separate label
         assert!(context.contains("Spring"));
         assert!(context.contains("1820"));
         assert!(context.contains("Your Location:"));
         assert!(context.contains("Date and time:"));
+        // TODO #13 — explicit time-of-day cue with both the bucket
+        // label and HH:MM so the model picks the right greeting
+        // register (NPCs were saying "good morning" at Dusk because
+        // the only time signal was 17:30 with no English label).
+        assert!(
+            context.contains("Time of day:"),
+            "missing time-of-day greeting cue:\n{context}"
+        );
+        // WorldState::new() starts at 08:00 → TimeOfDay::Morning
+        assert!(
+            context.contains("Time of day: Morning (08:00)"),
+            "time-of-day cue must include both label and HH:MM:\n{context}"
+        );
+        assert!(
+            context.contains("greet and refer to the time of day accordingly"),
+            "missing greeting-register directive:\n{context}"
+        );
         assert!(!context.contains("is here"));
-        // Weather is now embedded in the rendered description, not a standalone line
         assert!(!context.contains("\nWeather:"));
+        // Old "\nTime:" / "\nSeason:" standalone lines must stay absent.
+        // (The new "\nTime of day:" line is allowed — note the space.)
         assert!(!context.contains("\nTime:"));
         assert!(!context.contains("\nSeason:"));
     }

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -2143,14 +2143,19 @@ pub async fn get_demo_context(
     let map =
         parish_core::ipc::handlers::build_map_data(&world, state.transport.default_mode(), false);
 
-    use chrono::Datelike;
+    use chrono::{Datelike, Timelike};
     let now = world.clock.now();
+    // TODO #5: include HH:MM alongside the time-of-day word so the
+    // demo auto-player can see clock progression between turns and
+    // pick an appropriate greeting register.
     let game_time = format!(
-        "{}, {} {} {}, {}",
+        "{}, {} {} {}, {:02}:{:02} ({})",
         now.format("%A"),
         now.day(),
         now.format("%B"),
         now.year(),
+        now.hour(),
+        now.minute(),
         world.clock.time_of_day(),
     );
     let season = format!("{}", world.clock.season());

--- a/parish/testing/fixtures/play_todo-5-13-time-signal.txt
+++ b/parish/testing/fixtures/play_todo-5-13-time-signal.txt
@@ -1,0 +1,11 @@
+# Live-proof fixture for TODO #5 / #13 — HH:MM + time-of-day signal.
+#
+# Boots Rundale at 08:00 (Morning), advances the clock by 9 hours 30
+# minutes to 17:30 (Dusk per time_of_day_from_hour buckets 17-18), and
+# looks. The /time output should show "17:30 Dusk"; the eval
+# infrastructure can confirm the dialogue context emits
+# Time of day: Dusk (17:30).
+
+/wait 570
+look
+/time


### PR DESCRIPTION
## Summary

Closes TODO #5 (no HH:MM in demo prompt) and TODO #13 (NPCs greet "good mornin'" at Dusk) from the demo-audit `TODO.md`.

Two seams disagreed on the time signal:

- **Demo auto-player prompt** (`parish-tauri/src/commands.rs`) built `game_time = "Wednesday, 14 May 1820, morning"` — no HH:MM, so the demo loop couldn't observe the 36× clock progression between turns (#5).
- **NPC Tier 1 dialogue context** (`parish-npc/src/lib.rs build_tier1_context`) carried HH:MM but no English label for the time-of-day bucket. With only `17:30` the model defaulted to "good morning" greetings at Dusk (#13).

## Changes

- `parish-tauri/src/commands.rs` `game_time` formatter now produces `"Wednesday, 14 May 1820, 17:30 (Dusk)"`.
- `parish-npc/src/lib.rs build_tier1_context` appends a sibling line:
  ```
  Time of day: {Dawn |Morning|...|Midnight} (HH:MM) — greet and refer to the time of day accordingly.
  ```
  Existing `Date and time:` line is unchanged.

## Test plan

- [x] `cargo test -p parish-npc -p parish-core -p parish-tauri` — 1117 pass
- [x] Updated unit test `test_build_context` (parish-npc) asserts `"Time of day: Morning (08:00)"` and the greeting directive
- [x] New integration test `dialogue_context_carries_time_of_day_cue` exercises the cue against real Rundale mod data
- [x] Live proof at `.proofs/todo-5-13-time-signal/` — headless run advances clock to 17:30 (Dusk bucket), `/time` confirms `"17:30 Dusk"`
- [x] `just agent-check` passes

## Wiring parity

Only `parish-tauri` builds the demo `game_time` today (the axum server has no `/demo_turn` route). NPC Tier 1 lives in `parish-npc` and is re-exported via `parish-core`, so all backends pick up the cue automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)