### PR TITLE
fix(logging): NPC departure entries include destination

### DIFF
--- a/parish/crates/parish-core/src/character_log.rs
+++ b/parish/crates/parish-core/src/character_log.rs
@@ -265,15 +265,20 @@ impl CharacterLogManager {
                 }
             }
             GameEvent::NpcDeparted {
-                npc_id, location, ..
+                npc_id,
+                location,
+                to,
+                ..
             } => {
                 let loc = loc_of(*location);
+                let to_name = loc_of(*to);
                 if let Some(npc) = npc_manager.get(*npc_id) {
+                    let body = format!("*Headed to {}*\n", to_name);
                     append_journal_entry(
                         &self.npc_log_path(npc),
                         ts,
                         Some(&format!("Departed from {}", loc)),
-                        "",
+                        &body,
                     )?;
                 }
             }

--- a/parish/crates/parish-core/src/character_log.rs
+++ b/parish/crates/parish-core/src/character_log.rs
@@ -270,9 +270,9 @@ impl CharacterLogManager {
                 to,
                 ..
             } => {
-                let loc = loc_of(*location);
-                let to_name = loc_of(*to);
                 if let Some(npc) = npc_manager.get(*npc_id) {
+                    let loc = loc_of(*location);
+                    let to_name = loc_of(*to);
                     let body = format!("*Headed to {}*\n", to_name);
                     append_journal_entry(
                         &self.npc_log_path(npc),

--- a/parish/crates/parish-core/src/location_log.rs
+++ b/parish/crates/parish-core/src/location_log.rs
@@ -175,7 +175,10 @@ impl LocationLogManager {
                 append_journal_entry(&path, ts, Some(&suffix), "")?;
             }
             GameEvent::NpcDeparted {
-                npc_id, location, ..
+                npc_id,
+                location,
+                to,
+                ..
             } => {
                 let Some(npc) = npc_manager.get(*npc_id) else {
                     return Ok(());
@@ -184,7 +187,8 @@ impl LocationLogManager {
                     return Ok(());
                 };
                 let suffix = format!("{} departed", npc.name);
-                append_journal_entry(&path, ts, Some(&suffix), "")?;
+                let body = format!("*Headed to {}*\n", loc_name(*to));
+                append_journal_entry(&path, ts, Some(&suffix), &body)?;
             }
             GameEvent::DialogueOccurred {
                 npc_id,
@@ -958,6 +962,7 @@ mod tests {
         let depart = GameEvent::NpcDeparted {
             npc_id: NpcId(7),
             location: LocationId(2),
+            to: LocationId(3),
             timestamp: Utc.with_ymd_and_hms(1820, 3, 3, 14, 35, 0).unwrap(),
         };
         let re_arrive = GameEvent::NpcArrived {

--- a/parish/crates/parish-npc/src/schedule.rs
+++ b/parish/crates/parish-npc/src/schedule.rs
@@ -187,6 +187,7 @@ pub fn tick_schedules(
                     event_bus.publish(GameEvent::NpcDeparted {
                         npc_id: id,
                         location: from,
+                        to: desired,
                         timestamp: now,
                     });
                     tracing::debug!(

--- a/parish/crates/parish-npc/src/ticks.rs
+++ b/parish/crates/parish-npc/src/ticks.rs
@@ -1408,6 +1408,7 @@ pub fn apply_tier3_updates(
                     event_bus.publish(parish_types::events::GameEvent::NpcDeparted {
                         npc_id: update.npc_id,
                         location: from,
+                        to: new_loc,
                         timestamp: game_time,
                     });
                     event_bus.publish(parish_types::events::GameEvent::NpcArrived {

--- a/parish/crates/parish-persistence/src/journal_bridge.rs
+++ b/parish/crates/parish-persistence/src/journal_bridge.rs
@@ -199,6 +199,7 @@ mod tests {
         let event = GameEvent::NpcDeparted {
             npc_id: NpcId(5),
             location: LocationId(10),
+            to: LocationId(11),
             timestamp: test_time(),
         };
         assert!(to_journal_event(&event).is_none());

--- a/parish/crates/parish-types/src/events.rs
+++ b/parish/crates/parish-types/src/events.rs
@@ -99,6 +99,8 @@ pub enum GameEvent {
         npc_id: NpcId,
         /// Where they departed from.
         location: LocationId,
+        /// Where they are heading.
+        to: LocationId,
         /// When they departed.
         timestamp: DateTime<Utc>,
     },
@@ -380,6 +382,7 @@ mod tests {
         let event = GameEvent::NpcDeparted {
             npc_id: NpcId(3),
             location: LocationId(7),
+            to: LocationId(8),
             timestamp: test_timestamp(),
         };
         let json = serde_json::to_string(&event).unwrap();

--- a/parish/testing/fixtures/play_issue-1091.txt
+++ b/parish/testing/fixtures/play_issue-1091.txt
@@ -1,0 +1,26 @@
+# F3 / #1091 — NPC departure log body must include destination
+# ============================================================
+# Before the fix the per-character log for any departing NPC reads:
+#   ### <ts> — Departed from <loc>
+# with an empty body. After the fix the body line is:
+#   *Headed to <to_name>*
+#
+# We can't trigger a Tier-1 transit directly from the player, but the
+# Rundale schedule fires several scheduled departures every in-game
+# hour. `/wait 90` straddles a full schedule tick, so by the second
+# /debug clock at least one NPC has departed and the markdown log
+# file should contain a `*Headed to ...*` body line.
+#
+# Observability: the harness writes NPC logs to the configured user
+# data dir. The proof step (outside this fixture) reads those files
+# and `grep -A1 'Departed from'` confirms the body.
+
+/status
+/debug clock
+/debug npcs
+
+/wait 90
+
+/status
+/debug clock
+/debug npcs


### PR DESCRIPTION
## Summary

- `GameEvent::NpcDeparted` now carries `to: LocationId`. Both publishers (`parish-npc/src/schedule.rs:187` for scheduled transits, `parish-npc/src/ticks.rs:1374` for tier-3 batch moves) had the destination in scope and were dropping it.
- `parish-core/src/character_log.rs` and `parish-core/src/location_log.rs` now emit `*Headed to <name>*` as the body for NPC departures, next to the existing heading.
- Match sites that bind via `{ .. }` (`chat_transcript`, `debug_snapshot`, `transitions`, `journal_bridge` bus filter, `events.rs` self-match arms) absorb the new field unchanged.

F3 from the #1023 epic.

Closes #1091

## Before / after

Before (`npc-019-brigid-ni-fhatharta.md`):

```
### Monday 20 March 1820, 08:00 — Departed from Kilteevan Village
```

After:

```
### Monday 20 March 1820, 08:00 — Departed from Kilteevan Village
*Headed to The Holy Well*
```

## Test plan

- [x] `cargo build --manifest-path parish/Cargo.toml --workspace` — clean.
- [x] `cargo test --manifest-path parish/Cargo.toml --workspace --quiet` — 2962 passed, 15 ignored.
- [x] `cargo test -p parish-core --test architecture_fitness` — 3 passed.
- [x] `just check` — fmt + clippy + tests + witness-scan + doc-paths green.
- [x] Live proof: `parish-engine --headless --script parish/testing/fixtures/play_issue-1091.txt` over `/wait 90` against an isolated `PARISH_USER_DATA_DIR`. Resulting `npc-*.md` / `loc-*.md` files contain 10+ `Departed from <X>` / `*Headed to <Y>*` pairs across real Rundale locations (no `?` or empty names). Bundle: `.proofs/issue-1091/`.
- [x] `just agent-check` — gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)