### PR TITLE
fix(npc): alert NPC dialogue when player uses modern-register phrasing

### DIFF
--- a/parish/crates/parish-core/src/ipc/handlers.rs
+++ b/parish/crates/parish-core/src/ipc/handlers.rs
@@ -852,6 +852,14 @@ pub fn prepare_npc_conversation_turn(
         context.push_str(&alert);
     }
 
+    // Modern-register echo guard (TODO #55) — separate from the
+    // technology/slang anachronism path. Fires when the player uses a
+    // 21st-century phrase from MODERN_REGISTER_TERMS so the NPC doesn't
+    // echo it back and trip the post-reply validator.
+    if let Some(alert) = crate::npc::quality::format_player_register_alert(player_input) {
+        context.push_str(&alert);
+    }
+
     // Current player input — comes after conversation history as the triggering line.
     context.push_str("\n\n");
     context.push_str(&parish_npc::build_named_action_line(

--- a/parish/crates/parish-core/tests/dialogue_prompt_anchor.rs
+++ b/parish/crates/parish-core/tests/dialogue_prompt_anchor.rs
@@ -215,6 +215,81 @@ fn dialogue_context_carries_time_of_day_cue() {
     );
 }
 
+/// TODO #55: when the player input contains a modern-register
+/// phrase (e.g. "taking in the sights"), the assembled context must
+/// carry an alert telling the NPC not to echo it back. Pre-fix the
+/// alert path only fired for technology/slang anachronisms, so
+/// modern-register phrases reached the NPC unchallenged and tripped
+/// a post-reply WARN once the LLM mirrored them.
+#[test]
+fn dialogue_context_alerts_on_player_modern_register_echo() {
+    use parish_core::npc::LanguageSettings;
+
+    let (mut world, mut npc_manager) = fresh_rundale_world_and_npcs();
+    let speaker_id: NpcId = npc_manager
+        .npcs_at(world.player_location)
+        .first()
+        .map(|n| n.id)
+        .expect("Rundale fresh save should co-locate at least one NPC");
+    world.player_name = Some("Aiden Carney".to_string());
+
+    let setup = prepare_npc_conversation_turn(
+        &world,
+        &mut npc_manager,
+        "I'm just taking in the sights",
+        speaker_id,
+        &[],
+        false,
+        &LanguageSettings::english_only(),
+    )
+    .expect("turn setup");
+    assert!(
+        setup.context.contains("MODERN-REGISTER ALERT"),
+        "missing alert header:\n{}",
+        setup.context
+    );
+    assert!(
+        setup.context.contains("taking in the sights"),
+        "alert must surface the matched phrase:\n{}",
+        setup.context
+    );
+    assert!(
+        setup.context.contains("Do NOT echo"),
+        "missing echo guard:\n{}",
+        setup.context
+    );
+}
+
+/// AC2: no register alert when the player input is clean.
+#[test]
+fn dialogue_context_no_register_alert_on_clean_input() {
+    use parish_core::npc::LanguageSettings;
+
+    let (mut world, mut npc_manager) = fresh_rundale_world_and_npcs();
+    let speaker_id: NpcId = npc_manager
+        .npcs_at(world.player_location)
+        .first()
+        .map(|n| n.id)
+        .expect("Rundale fresh save should co-locate at least one NPC");
+    world.player_name = Some("Aiden Carney".to_string());
+
+    let setup = prepare_npc_conversation_turn(
+        &world,
+        &mut npc_manager,
+        "good morning to ye",
+        speaker_id,
+        &[],
+        false,
+        &LanguageSettings::english_only(),
+    )
+    .expect("turn setup");
+    assert!(
+        !setup.context.contains("MODERN-REGISTER ALERT"),
+        "alert must not fire on clean input:\n{}",
+        setup.context
+    );
+}
+
 /// TODO #21: the assembled context must pin the NPC to the player's
 /// current location with a directive forbidding substitution of any
 /// nearby canonical settlement. The bug surfaced at The Mill near

--- a/parish/crates/parish-npc/src/quality.rs
+++ b/parish/crates/parish-npc/src/quality.rs
@@ -383,6 +383,40 @@ const MODERN_REGISTER_TERMS: &[&str] = &[
     "healing properties",
 ];
 
+/// Renders a context alert for the dialogue prompt when the player's
+/// input contains any `MODERN_REGISTER_TERMS` phrase. Mirrors
+/// `anachronism::format_context_alert` in shape so the NPC dialogue
+/// prompt builder can inject both alerts alongside each other.
+///
+/// TODO #55: pre-fix the validator caught modern-register phrases on
+/// NPC *output* only, so a player saying "taking in the sights"
+/// could feed it through and trip a WARN on the NPC's echo. This
+/// alert closes the upstream gap by warning the model up front.
+pub fn format_player_register_alert(player_input: &str) -> Option<String> {
+    let issues = detect_modern_register(player_input);
+    if issues.is_empty() {
+        return None;
+    }
+    let mut alert = String::from(
+        "\nMODERN-REGISTER ALERT: The player used 21st-century phrasing. \
+         Do NOT echo any of these phrases back in your reply — paraphrase \
+         the idea in 1820 Irish-English instead. Specific phrases detected:\n",
+    );
+    for issue in &issues {
+        // QualityIssue::detail looks like "modern-register phrase: 'taking in the sights'"
+        // or "modern-register word: 'fascinating'" — surface the whole detail
+        // string so the model can see what to avoid verbatim.
+        alert.push_str(&format!("- {}\n", issue.detail));
+    }
+    alert.push_str(
+        "\nReply in your character's natural Hiberno-English register. \
+         If the player's wording would be unfamiliar to a 1820 villager, \
+         react to the *idea* (a stroll, a look around, fine sights, a \
+         day's diversion) without using the modern formulation.",
+    );
+    Some(alert)
+}
+
 pub fn detect_modern_register(text: &str) -> Vec<QualityIssue> {
     let lower = text.to_lowercase();
     let mut out = Vec::new();
@@ -610,6 +644,32 @@ mod tests {
             "poitín must be allow-listed; got {:?}",
             issues
         );
+    }
+
+    #[test]
+    fn format_player_register_alert_fires_on_hit() {
+        // TODO #55 — the exact phrase the demo audit caught Concannon
+        // echoing in cycle 12 because the player had used it first.
+        let alert = format_player_register_alert("I'm just taking in the sights")
+            .expect("alert must render when a MODERN_REGISTER_TERMS phrase is matched");
+        assert!(
+            alert.contains("MODERN-REGISTER ALERT"),
+            "missing header:\n{alert}"
+        );
+        assert!(
+            alert.contains("Do NOT echo any of these phrases"),
+            "missing echo guard:\n{alert}"
+        );
+        assert!(
+            alert.contains("taking in the sights"),
+            "alert must surface the matched phrase:\n{alert}"
+        );
+    }
+
+    #[test]
+    fn format_player_register_alert_silent_on_clean_input() {
+        assert!(format_player_register_alert("the road be long this morning").is_none());
+        assert!(format_player_register_alert("").is_none());
     }
 
     #[test]

--- a/parish/testing/fixtures/play_todo-55-player-register-echo.txt
+++ b/parish/testing/fixtures/play_todo-55-player-register-echo.txt
@@ -1,0 +1,9 @@
+# Live-proof fixture for TODO #55 — player modern-register echo guard.
+#
+# Boots Rundale, walks to The Mill where Cormac/Brendan Duffy live, and
+# issues a line containing the canonical modern-register phrase
+# "taking in the sights" (the exact phrase the demo audit caught
+# Concannon echoing in cycle 12).
+
+go to the mill
+I'm just taking in the sights


### PR DESCRIPTION
## Summary

Closes TODO #55 from the demo-audit `TODO.md`. Cycle 12 caught Concannon NPC emitting `"taking in the sights"` — flagged by the post-reply modern-register validator — but Concannon was echoing the LLM-as-player who had used the phrase in cycle 11. The validator was right; the upstream cause (player input feeding modern phrasing) had no guard.

The existing `anachronism::format_context_alert` path handles technology / slang anachronisms (telephone, railway, ...) but does not cover the separate `MODERN_REGISTER_TERMS` list (`quality.rs:369` — fascinating, taking in the sights, healing properties, etc.).

## Change

- New `format_player_register_alert(player_input) -> Option<String>` in `parish-npc/src/quality.rs` mirrors the anachronism alert's shape. Header `"MODERN-REGISTER ALERT"`, names each matched phrase verbatim, explicit `"Do NOT echo"` guard, route for the NPC to paraphrase in period English.
- `prepare_npc_conversation_turn` in `parish-core/src/ipc/handlers.rs` appends the new alert immediately after the anachronism alert. Both fire independently — either, both, or neither can render per turn.

## Test plan

- [x] `cargo test -p parish-npc -p parish-core` — 1009 pass
- [x] 2 new unit tests on the helper (fires + silent cases)
- [x] 2 new integration tests against real Rundale state (alert fires on `"I'm just taking in the sights"`, absent on `"good morning to ye"`)
- [x] Live proof at `.proofs/todo-55-player-register-echo/` — `cargo run -p parish-engine --headless --script parish/testing/fixtures/play_todo-55-player-register-echo.txt`
- [x] `just agent-check` passes

## Out of scope

Per `acceptance-criteria.md`: validating LLM-as-player output via the same checker (auto-player runs in `parish-tauri::commands::demo_turn`, separate seam — defer until prompt-side guard has been measured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)