### PR TITLE
feat(npc): publish NpcActivity event on schedule arrival

### DIFF
--- a/parish/crates/parish-core/src/character_log.rs
+++ b/parish/crates/parish-core/src/character_log.rs
@@ -282,6 +282,26 @@ impl CharacterLogManager {
                     )?;
                 }
             }
+            GameEvent::NpcActivity {
+                npc_id,
+                location,
+                activity,
+                ..
+            } => {
+                if activity.trim().is_empty() {
+                    return Ok(());
+                }
+                if let Some(npc) = npc_manager.get(*npc_id) {
+                    let loc = loc_of(*location);
+                    let body = format!("*{}*\n", activity);
+                    append_journal_entry(
+                        &self.npc_log_path(npc),
+                        ts,
+                        Some(&format!("Activity at {}", loc)),
+                        &body,
+                    )?;
+                }
+            }
             GameEvent::PlayerMoved { from, to, .. } => {
                 let to_n = loc_of(*to);
                 let from_n = loc_of(*from);

--- a/parish/crates/parish-core/src/chat_transcript.rs
+++ b/parish/crates/parish-core/src/chat_transcript.rs
@@ -278,6 +278,7 @@ impl ChatTranscriptLog {
             | GameEvent::RelationshipChanged { .. }
             | GameEvent::NpcArrived { .. }
             | GameEvent::NpcDeparted { .. }
+            | GameEvent::NpcActivity { .. }
             | GameEvent::LifeEvent { .. } => {}
         }
     }

--- a/parish/crates/parish-core/src/debug_snapshot.rs
+++ b/parish/crates/parish-core/src/debug_snapshot.rs
@@ -710,6 +710,12 @@ fn build_event_bus_debug(
                 GameEvent::NpcDeparted {
                     npc_id, location, ..
                 } => format!("{} departed from {}", name_of(*npc_id), loc_of(*location)),
+                GameEvent::NpcActivity {
+                    npc_id,
+                    location,
+                    activity,
+                    ..
+                } => format!("{} @ {}: {}", name_of(*npc_id), loc_of(*location), activity),
                 GameEvent::WeatherChanged { new_weather, .. } => {
                     format!("Weather: {}", new_weather)
                 }

--- a/parish/crates/parish-core/src/location_log.rs
+++ b/parish/crates/parish-core/src/location_log.rs
@@ -190,6 +190,25 @@ impl LocationLogManager {
                 let body = format!("*Headed to {}*\n", loc_name(*to));
                 append_journal_entry(&path, ts, Some(&suffix), &body)?;
             }
+            GameEvent::NpcActivity {
+                npc_id,
+                location,
+                activity,
+                ..
+            } => {
+                if activity.trim().is_empty() {
+                    return Ok(());
+                }
+                let Some(npc) = npc_manager.get(*npc_id) else {
+                    return Ok(());
+                };
+                let Some(path) = path_for(*location) else {
+                    return Ok(());
+                };
+                let suffix = format!("{} activity", npc.name);
+                let body = format!("*{}*\n", activity);
+                append_journal_entry(&path, ts, Some(&suffix), &body)?;
+            }
             GameEvent::DialogueOccurred {
                 npc_id,
                 location,

--- a/parish/crates/parish-npc/src/manager.rs
+++ b/parish/crates/parish-npc/src/manager.rs
@@ -821,6 +821,7 @@ mod tests {
             from: LocationId(2),
             to: LocationId(3),
             arrives_at: chrono::Utc.with_ymd_and_hms(1820, 3, 20, 12, 0, 0).unwrap(),
+            activity: None,
         };
         mgr.add_npc(npc);
 

--- a/parish/crates/parish-npc/src/schedule.rs
+++ b/parish/crates/parish-npc/src/schedule.rs
@@ -174,6 +174,17 @@ pub fn tick_schedules(
                         .get(desired)
                         .map(|d| d.name.clone())
                         .unwrap_or_else(|| "?".to_string());
+                    // Capture the authored activity for this trip only
+                    // when the trip is heading to the *scheduled*
+                    // location — cuaird/weather-shelter reroutes mean
+                    // the authored activity no longer matches the
+                    // destination and should be suppressed.
+                    let scheduled_activity = npc
+                        .schedule_entry(current_hour, season, day_type)
+                        .filter(|entry| {
+                            entry.location == desired && !entry.activity.trim().is_empty()
+                        })
+                        .map(|entry| entry.activity.clone());
                     events.push(ScheduleEvent {
                         npc_id: id,
                         npc_name,
@@ -204,12 +215,19 @@ pub fn tick_schedules(
                         from,
                         to: desired,
                         arrives_at,
+                        activity: scheduled_activity,
                     };
                 }
             }
-            NpcState::InTransit { to, arrives_at, .. } => {
+            NpcState::InTransit {
+                to,
+                arrives_at,
+                activity,
+                ..
+            } => {
                 if now >= *arrives_at {
                     let destination = *to;
+                    let activity = activity.clone();
                     let dest_name = graph
                         .get(destination)
                         .map(|d| d.name.clone())
@@ -227,13 +245,11 @@ pub fn tick_schedules(
                         location: destination,
                         timestamp: now,
                     });
-                    if let Some(entry) = npc.schedule_entry(current_hour, season, day_type)
-                        && !entry.activity.trim().is_empty()
-                    {
+                    if let Some(activity) = activity {
                         event_bus.publish(GameEvent::NpcActivity {
                             npc_id: id,
                             location: destination,
-                            activity: entry.activity.clone(),
+                            activity,
                             timestamp: now,
                         });
                     }

--- a/parish/crates/parish-npc/src/schedule.rs
+++ b/parish/crates/parish-npc/src/schedule.rs
@@ -227,6 +227,16 @@ pub fn tick_schedules(
                         location: destination,
                         timestamp: now,
                     });
+                    if let Some(entry) = npc.schedule_entry(current_hour, season, day_type)
+                        && !entry.activity.trim().is_empty()
+                    {
+                        event_bus.publish(GameEvent::NpcActivity {
+                            npc_id: id,
+                            location: destination,
+                            activity: entry.activity.clone(),
+                            timestamp: now,
+                        });
+                    }
                     tracing::debug!(npc = %npc.name, location = destination.0, "NPC arrived");
                     let Some(npc_mut) = npcs.get_mut(&id) else {
                         continue;

--- a/parish/crates/parish-npc/src/transitions.rs
+++ b/parish/crates/parish-npc/src/transitions.rs
@@ -137,6 +137,7 @@ fn event_involves_npc(npc_id: NpcId, event: &GameEvent) -> bool {
         | GameEvent::MoodChanged { npc_id: id, .. }
         | GameEvent::NpcArrived { npc_id: id, .. }
         | GameEvent::NpcDeparted { npc_id: id, .. }
+        | GameEvent::NpcActivity { npc_id: id, .. }
         | GameEvent::LifeEvent { npc_id: id, .. } => *id == npc_id,
         GameEvent::RelationshipChanged { npc_a, npc_b, .. } => *npc_a == npc_id || *npc_b == npc_id,
         GameEvent::NpcInteraction { participants, .. } => participants.contains(&npc_id),
@@ -175,6 +176,7 @@ fn summarize_event_for_npc(npc_id: NpcId, event: &GameEvent) -> String {
         GameEvent::NpcDeparted { location, .. } => {
             format!("Left location {}.", location.0)
         }
+        GameEvent::NpcActivity { activity, .. } => activity.clone(),
         GameEvent::LifeEvent { description, .. } => {
             format!("Experienced: {description}")
         }

--- a/parish/crates/parish-npc/src/types.rs
+++ b/parish/crates/parish-npc/src/types.rs
@@ -506,6 +506,17 @@ pub enum NpcState {
         to: LocationId,
         /// Game time when they will arrive.
         arrives_at: DateTime<Utc>,
+        /// Authored `ScheduleEntry::activity` text resolved at the
+        /// moment of departure. Captured here so the activity
+        /// published on arrival reflects the schedule entry that
+        /// triggered the move — independent of any subsequent
+        /// schedule-window boundary the NPC may cross while in
+        /// transit. `None` when the trip was rerouted away from the
+        /// scheduled `entry.location` (cuaird visit, weather
+        /// shelter) — in that case the authored activity does not
+        /// match the destination and is suppressed.
+        #[serde(default)]
+        activity: Option<String>,
     },
 }
 
@@ -776,6 +787,7 @@ mod tests {
             from: LocationId(1),
             to: LocationId(2),
             arrives_at: arrives,
+            activity: None,
         };
         match state {
             NpcState::InTransit { from, to, .. } => {

--- a/parish/crates/parish-persistence/src/journal_bridge.rs
+++ b/parish/crates/parish-persistence/src/journal_bridge.rs
@@ -57,6 +57,7 @@ pub(crate) fn to_journal_event(event: &GameEvent) -> Option<WorldEvent> {
         | GameEvent::LifeEvent { .. }
         | GameEvent::NpcArrived { .. }
         | GameEvent::NpcDeparted { .. }
+        | GameEvent::NpcActivity { .. }
         | GameEvent::PlayerMoved { .. }
         | GameEvent::NpcInteraction { .. } => None,
     }

--- a/parish/crates/parish-types/src/events.rs
+++ b/parish/crates/parish-types/src/events.rs
@@ -104,6 +104,22 @@ pub enum GameEvent {
         /// When they departed.
         timestamp: DateTime<Utc>,
     },
+    /// An NPC's authored schedule activity at a location.
+    ///
+    /// Distinct from tier-3 LLM-summarised `last_activity`: this carries
+    /// the authored `ScheduleEntry::activity` text (e.g. "tending bar",
+    /// "praying", "cuaird visiting") fired deterministically when the
+    /// NPC arrives at the location for that schedule window.
+    NpcActivity {
+        /// Which NPC.
+        npc_id: NpcId,
+        /// Where they are.
+        location: LocationId,
+        /// Authored activity text from the NPC's schedule.
+        activity: String,
+        /// When the activity began.
+        timestamp: DateTime<Utc>,
+    },
     /// The weather changed.
     WeatherChanged {
         /// The new weather description.
@@ -173,6 +189,7 @@ impl GameEvent {
             | GameEvent::RelationshipChanged { timestamp, .. }
             | GameEvent::NpcArrived { timestamp, .. }
             | GameEvent::NpcDeparted { timestamp, .. }
+            | GameEvent::NpcActivity { timestamp, .. }
             | GameEvent::WeatherChanged { timestamp, .. }
             | GameEvent::FestivalStarted { timestamp, .. }
             | GameEvent::PlayerMoved { timestamp, .. }
@@ -189,6 +206,7 @@ impl GameEvent {
             GameEvent::RelationshipChanged { .. } => "RelationshipChanged",
             GameEvent::NpcArrived { .. } => "NpcArrived",
             GameEvent::NpcDeparted { .. } => "NpcDeparted",
+            GameEvent::NpcActivity { .. } => "NpcActivity",
             GameEvent::WeatherChanged { .. } => "WeatherChanged",
             GameEvent::FestivalStarted { .. } => "FestivalStarted",
             GameEvent::PlayerMoved { .. } => "PlayerMoved",

--- a/parish/testing/fixtures/play_issue-1102.txt
+++ b/parish/testing/fixtures/play_issue-1102.txt
@@ -1,0 +1,21 @@
+# F5 / #1102 — schedule activity text reaches the bus + logs
+# ============================================================
+# Before the fix, ScheduleEntry::activity is loaded from
+# mods/rundale/world.json but never published. After the fix,
+# tick_schedules emits GameEvent::NpcActivity on arrival, and both
+# character_log and location_log render the authored activity text
+# as a journal body.
+#
+# `/wait 90` straddles a full schedule tick — Rundale's morning
+# schedule has multiple Tier-1 NPCs starting transit at 08:00 and
+# arriving in the 8:00-9:30 window.
+
+/status
+/debug clock
+/debug npcs
+
+/wait 90
+
+/status
+/debug clock
+/debug npcs


### PR DESCRIPTION
## Summary

- New `GameEvent::NpcActivity { npc_id, location, activity, timestamp }` ([events.rs:107](parish/crates/parish-types/src/events.rs:107)) carries authored `ScheduleEntry::activity` text from `mods/rundale/world.json` (e.g. "tending bar", "gathering watercress and praying").
- `tick_schedules` ([schedule.rs:229](parish/crates/parish-npc/src/schedule.rs:229)) publishes the event on arrival, immediately after `NpcArrived`. Suppresses empty-activity windows.
- `character_log` and `location_log` render the event as a markdown journal entry next to existing Arrived/Departed entries.
- `journal_bridge` classifies the new variant as bus-informational (no crash-recovery state) — same policy as `NpcArrived` / `NpcDeparted`.

Distinct from Tier-3 LLM `last_activity` paraphrase: this is deterministic authored Tier-1 text.

F5 from the #1023 epic.

Closes #1102

## Test plan

- [x] `cargo build --manifest-path parish/Cargo.toml --workspace` — clean.
- [x] `cargo test --manifest-path parish/Cargo.toml --workspace --quiet` — 2970 passed, 15 ignored.
- [x] `just check` — fmt + clippy + tests + witness-scan + doc-paths green.
- [x] Live proof: `parish-engine --headless --script parish/testing/fixtures/play_issue-1102.txt` over `/wait 90`. 8 distinct NPCs arrive at 09:30 and emit `NpcActivity`. Per-NPC + per-location logs both contain `Activity at <loc>` / `*<authored text>*` pairs including the canonical `*at the holy well, gathering watercress and praying*`. Bundle: `.proofs/issue-1102/`.
- [x] `just agent-check` — gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)