### PR TITLE
fix(npc): constrain dialogue reply to a single addressee

### DIFF
--- a/parish/crates/parish-core/src/ipc/handlers.rs
+++ b/parish/crates/parish-core/src/ipc/handlers.rs
@@ -867,7 +867,11 @@ pub fn prepare_npc_conversation_turn(
         player_name_for_npc,
     ));
     context.push_str(
-        "\n\nRespond to the live exchange above. You may answer the player or another nearby NPC by name when it feels natural.\n",
+        "\n\nRespond to the live exchange above. Address ONLY ONE person in your \
+         reply — either the player or one specific co-located NPC by name. Do NOT \
+         say goodbye to one person and then continue speaking to another in the \
+         same reply, and do NOT mix farewells with ongoing chat. One addressee, \
+         one tone, one beat.\n",
     );
 
     Some(NpcConversationSetup {

--- a/parish/crates/parish-core/tests/dialogue_prompt_anchor.rs
+++ b/parish/crates/parish-core/tests/dialogue_prompt_anchor.rs
@@ -290,6 +290,28 @@ fn dialogue_context_no_register_alert_on_clean_input() {
     );
 }
 
+/// TODO #14: the assembled context must instruct the NPC to address
+/// only one person per reply. Brendan was mixing multiple Slán*
+/// farewells in a single message because the prompt tail invited
+/// "may answer the player or another nearby NPC" with no upper limit.
+#[test]
+fn dialogue_context_carries_single_addressee_anchor() {
+    let context = build_dialogue_context_with_first_npc(Some("Aiden Carney"), true);
+
+    assert!(
+        context.contains("Address ONLY ONE person"),
+        "missing single-addressee directive:\n{context}"
+    );
+    assert!(
+        context.contains("do NOT mix farewells with ongoing chat"),
+        "missing mixed-farewell guard:\n{context}"
+    );
+    assert!(
+        context.contains("Do NOT say goodbye to one person"),
+        "missing goodbye-then-continue guard:\n{context}"
+    );
+}
+
 /// TODO #21: the assembled context must pin the NPC to the player's
 /// current location with a directive forbidding substitution of any
 /// nearby canonical settlement. The bug surfaced at The Mill near

--- a/parish/testing/fixtures/play_todo-14-single-addressee.txt
+++ b/parish/testing/fixtures/play_todo-14-single-addressee.txt
@@ -1,0 +1,7 @@
+# Live-proof fixture for TODO #14 — single-addressee dialogue anchor.
+#
+# Walks to The Mill where Cormac + Brendan Duffy live (the location
+# where the demo audit caught Brendan mixing multiple Slán* farewells
+# in a single reply).
+
+go to the mill


### PR DESCRIPTION
## Summary

Closes TODO #14 from the demo-audit `TODO.md`. Cycle 6 caught Brendan mixing multiple `Slán*` farewells in one reply: `"Slán abhaile, Father, I'll be back soon..."` + `"Slán leat, stranger..."` + back to chatting about the wheel — NPC stage-direction leakage from a single completion.

The dialogue prompt's trailing instruction allowed the NPC to address multiple people without an upper limit:

```
Respond to the live exchange above. You may answer the player or
another nearby NPC by name when it feels natural.
```

## Change

Tightens the directive in `prepare_npc_conversation_turn`:

```
Respond to the live exchange above. Address ONLY ONE person in your
reply — either the player or one specific co-located NPC by name.
Do NOT say goodbye to one person and then continue speaking to
another in the same reply, and do NOT mix farewells with ongoing
chat. One addressee, one tone, one beat.
```

## Test plan

- [x] `cargo test -p parish-core --test dialogue_prompt_anchor` — 9 pass
- [x] New integration test pins the directive substrings against real Rundale state
- [x] Live proof at `.proofs/todo-14-single-addressee/` — headless engine walks to The Mill
- [x] `just agent-check` passes

## Out of scope

Per `acceptance-criteria.md`: post-filter that rejects multiple `Slán*` tokens; structured `addressed_to` field on the response schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)