### PR TITLE
feat(time): trace every Clock::advance call for movement-time audits

### DIFF
--- a/parish/crates/parish-types/src/time.rs
+++ b/parish/crates/parish-types/src/time.rs
@@ -379,13 +379,24 @@ impl GameClock {
 
     /// Advances the game clock by the given number of game minutes.
     ///
-    /// Used during travel or other time-consuming actions.
+    /// Used during travel or other time-consuming actions. Emits a
+    /// `tracing::debug` line so the per-turn clock advance is visible
+    /// in the demo log (TODO #32: the audit caught a "15 minutes on
+    /// foot" travel that appeared to consume ~5 game-hours of clock
+    /// time; the only way to localise the discrepancy is to see
+    /// every advance call with its delta).
     pub fn advance(&mut self, game_minutes: i64) {
         if self.is_frozen() {
             self.paused_game_time += Duration::minutes(game_minutes);
         } else {
             self.start_game += Duration::minutes(game_minutes);
         }
+        tracing::debug!(
+            game_minutes_advanced = game_minutes,
+            frozen = self.is_frozen(),
+            now = %self.now().format("%H:%M"),
+            "clock advance"
+        );
     }
 
     /// Pauses the game clock (player-initiated), freezing game time.

--- a/parish/testing/fixtures/play_todo-32-clock-advance-trace.txt
+++ b/parish/testing/fixtures/play_todo-32-clock-advance-trace.txt
@@ -1,0 +1,7 @@
+# Live-proof fixture for TODO #32 — clock-advance trace.
+#
+# Fix lives in parish-types/src/time.rs Clock::advance. The trace is
+# debug-level so default RUST_LOG won't surface it; this fixture just
+# confirms the engine boots cleanly under the instrumentation.
+
+look


### PR DESCRIPTION
## Summary

Closes TODO #32 (observability half) from the demo-audit `TODO.md`. Cycle 6 caught a "15 minutes on foot" travel that appeared to consume ~5 game-hours of clock time. The fix-after is unclear without seeing every clock-advance contributor in one log.

## Change

Adds a structured `tracing::debug` line at the end of `Clock::advance` carrying the delta minutes, the frozen flag, and the resulting game time. Covers all 12 call sites in the workspace (movement, system commands, NPC schedule tick, journal replay, snapshot recovery, headless catch-up, etc.) without touching their bodies.

At `RUST_LOG=parish_types=debug` an operator can grep `"clock advance"` and reconstruct the per-turn time-advance map to localise the discrepancy.

## Test plan

- [x] `cargo test -p parish-types` — 134 pass (no behaviour change)
- [x] Live proof at `.proofs/todo-32-clock-advance-trace/` — headless engine boots cleanly
- [x] `just agent-check` passes

## Out of scope

Per `acceptance-criteria.md`: fixing the underlying time-advance discrepancy (deferred to a follow-up once trace data narrows the cause); metrics counter for total minutes advanced (pairs with TODO #29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)