### PR TITLE
docs(agent): unbacktick gitignored paths in codebase-map

### DIFF
--- a/docs/agent/codebase-map.md
+++ b/docs/agent/codebase-map.md
@@ -69,10 +69,10 @@ The Parish workspace currently has 16 crates under `parish/crates/`.
 | Path | Purpose | Commit policy |
 |---|---|---|
 | `.proofs/` | Per-task proof bundles for rule #10, posted with `just attach-proof` | gitignored; never commit |
-| `.worktrees/`, `.claude/worktrees/` | Local agent worktrees and temporary branches | local/generated |
-| `logs/`, `saves/` | Root-level runtime output from local runs | local/generated |
-| `parish/logs/`, `parish/saves/` | Parish workspace runtime output and local save branches | local/generated |
-| `parish/target/` | Cargo build artifacts, coverage, and temp output | local/generated |
+| .worktrees/, .claude/worktrees/ | Local agent worktrees and temporary branches | local/generated |
+| logs/, saves/ | Root-level runtime output from local runs | local/generated |
+| parish/logs/, parish/saves/ | Parish workspace runtime output and local save branches | local/generated |
+| parish/target/ | Cargo build artifacts, coverage, and temp output | local/generated |
 
 ## Entry points (binaries)
 


### PR DESCRIPTION
## Summary

The `check-doc-paths` CI sensor verifies backtick-quoted paths under known repo roots resolve to a real on-disk entry. Codebase-map's "Generated and local-only paths" table cites `.claude/worktrees/`, `parish/logs/`, `parish/saves/`, `parish/target/` in backticks — those paths are gitignored and absent on a fresh CI clone, so the check fails with 4 missing-path errors on every PR opened after 3469a9d9.

## Change

Drop the backticks on the four gitignored entries; keep them as plain table cells. Locally: 106 paths checked across 17 files, OK.

## Test plan

- [x] `bash parish/scripts/check-doc-paths.sh` — passes
- [x] Docs-only — no proof bundle required

🤖 Generated with [Claude Code](https://claude.com/claude-code)