### PR TITLE
fix(demo): drop redundant Weather line from user prompt

### DIFF
--- a/parish/crates/parish-core/src/ipc/demo.rs
+++ b/parish/crates/parish-core/src/ipc/demo.rs
@@ -174,7 +174,15 @@ pub fn render_user_prompt(ctx: &DemoContextSnapshot) -> String {
         parts.push(ctx.location_description.clone());
     }
     parts.push(format!("Date and time: {} | {}", ctx.game_time, ctx.season));
-    parts.push(format!("Weather: {}", ctx.weather));
+    // TODO #15: weather is already carried in `location_description` via the
+    // {weather} placeholder substitution (14 of the 22 Rundale location
+    // templates include it inline). A standalone `Weather: ...` line here
+    // duplicated that signal for those locations and confused the demo
+    // auto-player into "the weather is X. ... the weather is X." parroting.
+    // For the 8 templates that don't carry weather inline, the prompt's
+    // `Date and time:` line still anchors the broader sky/season context,
+    // and the in-game NPC dialogue layer surfaces weather independently
+    // via `ANACHRONISM ALERT` / NPC personality.
 
     if ctx.npcs_here.is_empty() {
         parts.push("NPCs here: none".to_string());
@@ -481,6 +489,33 @@ mod tests {
         assert!(
             ctx.recent_actions.is_empty(),
             "Tauri/server build path must leave recent_actions empty; frontend fills it"
+        );
+    }
+
+    /// TODO #15 — the standalone `Weather: ...` line was removed
+    /// because every Rundale location template that mentions weather
+    /// already substitutes `{weather}` inside its
+    /// `location_description`. Keeping the duplicate line caused the
+    /// demo auto-player to parrot weather adjectives.
+    #[test]
+    fn render_user_prompt_drops_standalone_weather_line() {
+        let ctx = build_demo_context(
+            &world_snapshot(),
+            &[],
+            &map_data(vec![], vec![]),
+            "Wednesday".to_string(),
+            "spring".to_string(),
+            None,
+        );
+        let prompt = render_user_prompt(&ctx);
+        assert!(
+            !prompt.contains("Weather:"),
+            "Weather: line should be absent — templates already carry weather inline:\n{prompt}"
+        );
+        // Date and time line still present.
+        assert!(
+            prompt.contains("Date and time:"),
+            "Date and time: line must remain:\n{prompt}"
         );
     }
 

--- a/parish/testing/fixtures/play_todo-15-weather-dedupe.txt
+++ b/parish/testing/fixtures/play_todo-15-weather-dedupe.txt
@@ -1,0 +1,7 @@
+# Live-proof fixture for TODO #15 — dedupe Weather line in demo prompt.
+#
+# Fix lives in parish-core/src/ipc/demo.rs::render_user_prompt — pure
+# prompt-builder change. cargo test covers all 521 cases including the
+# new render_user_prompt_drops_standalone_weather_line assertion.
+
+look


### PR DESCRIPTION
## Summary

Closes TODO #15 from the demo-audit `TODO.md`. Demo prompt showed weather twice: embedded in `location_description` (via `{weather}` placeholder substitution in 14/22 Rundale templates) AND as a standalone `Weather: X` line. Duplication caused the auto-player to parrot weather adjectives.

## Change

Drops the standalone `Weather:` line from `render_user_prompt`. The 14 templates that carry `{weather}` inline still surface weather naturally; the 8 that don't lose that one signal, but `Date and time:` still anchors the sky/season context.

The TODO's "same for time-of-day" point is intentionally NOT addressed — `Date and time:` carries unique signal (weekday, year, season, HH:MM) that the inline `{time}` placeholder doesn't.

## Test plan

- [x] `cargo test -p parish-core` — 521 pass
- [x] New `render_user_prompt_drops_standalone_weather_line` test pins absence + Date-and-time presence
- [x] Live proof at `.proofs/todo-15-weather-dedupe/` — headless engine boots cleanly
- [x] `just agent-check` passes

## Out of scope

Per `acceptance-criteria.md`: stripping `{weather}` from world.json templates (wider mods/** change); dropping `Date and time:` (unique signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)