### PR TITLE
fix(logging): location-log dialogue heading names the partner

### DIFF
--- a/parish/crates/parish-core/src/location_log.rs
+++ b/parish/crates/parish-core/src/location_log.rs
@@ -261,7 +261,8 @@ impl LocationLogManager {
                 if !npc_line.is_empty() {
                     body.push_str(&format!("**{}:** {}\n", npc.name, npc_line));
                 }
-                append_journal_entry(&path, ts, Some("Dialogue"), &body)?;
+                let heading = format!("Dialogue with {}", npc.name);
+                append_journal_entry(&path, ts, Some(&heading), &body)?;
             }
             GameEvent::WeatherChanged { new_weather, .. } => {
                 // Weather is world-wide — every location experiences the
@@ -865,7 +866,11 @@ mod tests {
 
         let path = mgr.location_log_path(world.graph.get(LocationId(2)).unwrap());
         let contents = std::fs::read_to_string(&path).unwrap();
-        assert!(contents.contains("Dialogue"), "{}", contents);
+        assert!(
+            contents.contains("Dialogue with Padraig Darcy"),
+            "dialogue heading should name the partner: {}",
+            contents,
+        );
         assert!(
             contents.contains("Good afternoon, Padraig."),
             "{}",

--- a/parish/testing/fixtures/play_issue-1118.txt
+++ b/parish/testing/fixtures/play_issue-1118.txt
@@ -1,0 +1,4 @@
+# F16 / #1118 — location-log dialogue heading names the partner
+# ==============================================================
+# Pure heading change; unit-test-driven verification.
+# This fixture is a placeholder so /task-start conventions hold.


### PR DESCRIPTION
## Summary

- `location_log::process_event` for `DialogueOccurred` ([location_log.rs:264](parish/crates/parish-core/src/location_log.rs:264)) now writes `Dialogue with <NPC name>` as the heading. The `npc` binding was already in scope from the `npc_manager.get(*npc_id)` guard a few lines above.
- Existing `dialogue_routes_to_event_location` unit test updated to assert the new heading shape.

F16 from the #1023 epic.

Closes #1118

## Test plan

- [x] `cargo test --manifest-path parish/Cargo.toml --workspace --quiet` — 2988 passed, 15 ignored.
- [x] `just check` — fmt + clippy + tests + witness-scan + doc-paths green.
- [x] `just agent-check` — gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)