### PR TITLE
feat: add /exit slash command as alias for /quit

### DIFF
--- a/parish/apps/ui/src/lib/slash-commands.test.ts
+++ b/parish/apps/ui/src/lib/slash-commands.test.ts
@@ -87,6 +87,7 @@ const FEATURES_MD_COMMANDS: ReadonlyArray<{
  */
 const REGISTRY_ONLY_COMMANDS = new Set<string>([
 	'/preset', // in registry; missing from features.md slash commands list
+	'/exit',   // alias for /quit
 ]);
 
 // ---------------------------------------------------------------------------

--- a/parish/apps/ui/src/lib/slash-commands.ts
+++ b/parish/apps/ui/src/lib/slash-commands.ts
@@ -40,6 +40,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
 	{ command: '/theme', description: 'Change UI theme (solarized, default)', hasArgs: true },
 	{ command: '/unexplored', description: 'Reveal or hide all unexplored locations', hasArgs: true },
 	{ command: '/quit', description: 'Take your leave', hasArgs: false },
+	{ command: '/exit', description: 'Take your leave', hasArgs: false },
 	{ command: '/flag', description: 'Feature flags: enable/disable/list', hasArgs: true },
 	{ command: '/flags', description: 'List all feature flags', hasArgs: false }
 ];

--- a/parish/crates/parish-client/src/repl.rs
+++ b/parish/crates/parish-client/src/repl.rs
@@ -14,7 +14,7 @@ pub async fn run_interactive(client: &ParishClient, json: bool) -> Result<()> {
         if text.is_empty() || text.starts_with('#') {
             continue;
         }
-        if text == "quit" || text == "/quit" {
+        if text == "quit" || text == "/quit" || text == "exit" || text == "/exit" {
             break;
         }
         send(client, text, json).await?;
@@ -30,7 +30,7 @@ pub async fn run_script(client: &ParishClient, path: &Path, json: bool) -> Resul
         if text.is_empty() || text.starts_with('#') {
             continue;
         }
-        if text == "quit" || text == "/quit" {
+        if text == "quit" || text == "/quit" || text == "exit" || text == "/exit" {
             break;
         }
         send(client, text, json).await?;

--- a/parish/crates/parish-input/src/parser.rs
+++ b/parish/crates/parish-input/src/parser.rs
@@ -98,7 +98,7 @@ fn parse_zero_arg_command(keyword: &str) -> Option<Command> {
     match keyword {
         "/pause" => Some(Command::Pause),
         "/resume" => Some(Command::Resume),
-        "/quit" => Some(Command::Quit),
+        "/quit" | "/exit" => Some(Command::Quit),
         "/save" => Some(Command::Save),
         "/branches" => Some(Command::Branches),
         "/log" => Some(Command::Log),
@@ -393,6 +393,9 @@ mod tests {
         assert_eq!(parse_system_command("/quit"), Some(Command::Quit));
         assert_eq!(parse_system_command("/QUIT"), Some(Command::Quit));
         assert_eq!(parse_system_command("  /quit  "), Some(Command::Quit));
+        assert_eq!(parse_system_command("/exit"), Some(Command::Quit));
+        assert_eq!(parse_system_command("/EXIT"), Some(Command::Quit));
+        assert_eq!(parse_system_command("  /exit  "), Some(Command::Quit));
     }
     #[test]
     fn test_parse_fork() {
@@ -430,6 +433,7 @@ mod tests {
         assert_eq!(parse_system_command("/pause foo"), None);
         assert_eq!(parse_system_command("/resume now"), None);
         assert_eq!(parse_system_command("/quit please"), None);
+        assert_eq!(parse_system_command("/exit please"), None);
         assert_eq!(parse_system_command("/save me"), None);
         assert_eq!(parse_system_command("/branches list"), None);
         assert_eq!(parse_system_command("/log all"), None);
@@ -463,6 +467,10 @@ mod tests {
     fn test_classify_system_command() {
         assert_eq!(
             classify_input("/quit"),
+            InputResult::SystemCommand(Command::Quit)
+        );
+        assert_eq!(
+            classify_input("/exit"),
             InputResult::SystemCommand(Command::Quit)
         );
         assert_eq!(


### PR DESCRIPTION
/exit works identically to /quit across all surfaces:

- **Rust parser**: parse_zero_arg_command matches both /quit and /exit
- **REPL**: bare `exit` and `/exit` break the interactive loop
- **Frontend**: /exit appears in slash-command autocomplete
- **Tests**: parser coverage for parsing, trailing-text rejection, and classify_input; TS registry drift test updated
