### PR TITLE
docs: add AGENTS.md for remaining crates and directories

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,150 @@
+# .github/workflows — agent scope
+
+CI/CD pipeline definitions covering Rust quality gates, UI builds, e2e tests,
+inference evals, security scanning, releases, and housekeeping. The primary CI
+gate is `ci.yml` which enforces the proof-evidence gate (rule #10 in root
+[`AGENTS.md`](../../AGENTS.md)). See [`docs/agent/act-local.md`](../../docs/agent/act-local.md)
+for running workflows locally with `act`.
+
+## Scoped commands
+
+```sh
+just check          # fmt + clippy + tests (mirrors rust-quality-gate)
+just agent-check    # proof-evidence gate (mirrors agent-check job)
+just verify         # check + harness walkthrough
+
+# act-local — run CI workflows in Docker (see docs/agent/act-local.md)
+just act-list       # enumerate all jobs (no Docker execution)
+just act-ci         # full ci.yml — matches what PRs see
+just act-audit      # audit.yml cargo-audit job — fastest smoke test
+just act-fmt        # ci.yml rust-quality-gate (fmt + clippy + tests)
+just act-harness    # ci.yml game-harness fixture sweep
+just act-ui         # ci.yml ui-quality (svelte-check + vitest + build)
+just act-e2e        # ci.yml ui-e2e (Playwright)
+just act-pr         # simulate the pull_request event
+```
+
+## Local gotchas
+
+- **Agent-check job only runs on PRs from non-dependabot actors.** Push events to
+  `main`/`develop` skip the gate — the gate already ran on the PR that produced
+  the commit. Dependabot bumps are exempt from proof-evidence (root AGENTS.md
+  rule #10).
+- **CI-only edits skip the proof gate per root rule #10.** `.github/**` path
+  changes that carry no source-code diff do not require proof bundles.
+- **Linux native deps pattern is repeated across jobs.** The `libgtk-3-dev`,
+  `libwebkit2gtk-4.1-dev`, `libappindicator3-dev`, `librsvg2-dev` apt install
+  block appears in every Rust job. When the dep list changes, update every
+  workflow that has it.
+- **Rust toolchain is pinned to 1.95.0** in `ci.yml` and `release.yml`. Bump
+  deliberately in a dedicated PR alongside any lint fixes the new version
+  surfaces.
+- **No YAML anchors in current workflows.** Setup steps (checkout, toolchain,
+  cache, native deps) are inlined per job rather than factored into anchors.
+- **Convention: `concurrency` groups with `cancel-in-progress: true`** on most
+  workflows to avoid wasted runs on stale branches. `release.yml` explicitly
+  sets `cancel-in-progress: false` (releases must not be cancelled).
+- **Secrets used across workflows:** `GITHUB_TOKEN` (all), `GEMINI_API_KEY` /
+  `GOOGLE_API_KEY` / `APP_PRIVATE_KEY` (Gemini review), `OPENROUTER_API_KEY`
+  (inference eval — via `secrets: inherit`). Add new secrets to the repo-level
+  GitHub secrets and the `env:` block of the consuming job.
+- **Workflow concurrency group with `pages`** in `publish-bench-site.yml` —
+  do not rename without checking the `deploy-pages` action's concurrency
+  expectations.
+- **`act` reproduces most jobs but not GitHub-side concerns.** Concurrency
+  groups, branch protections, required-check status, and `permissions:`
+  enforcement are server-side only. See `docs/agent/act-local.md` for caveats.
+
+## Workflow index
+
+### `ci.yml` — Main CI pipeline
+- **Triggers:** `pull_request`, `push` to `main`/`develop`, `workflow_dispatch`.
+- **Jobs:** agent-check, rust-quality-gate (fmt+clippy+tests),
+  rust-coverage-ratchet (tarpaulin, floor 60.8%), rust-multi-channel
+  (stable+beta check), docs-consistency (doc path validation),
+  game-harness (fixture sweep), ui-quality (svelte-check+build+vitest),
+  ui-e2e (Playwright).
+- **Key detail:** The `agent-check` job runs
+  `bash parish/scripts/agent-check.sh --source=pr "$PR_NUMBER"`, validates
+  proof evidence in PR comments. Skipped for dependabot.
+- **Concurrency:** `ci-${{ github.workflow }}-${{ github.ref }}`,
+  cancel-in-progress.
+
+### `gemini-dispatch.yml` — Gemini review dispatch
+- **Triggers:** PR opened, PR review submitted, PR review comment, issue comment.
+- **Key detail:** Routes requests to `gemini-review.yml` via `workflow_call`.
+  Only dispatches for non-fork PRs or `@gemini-cli` mentions from
+  OWNER/MEMBER/COLLABORATOR users. Uses GitHub App identity token for API
+  calls.
+- **Permissions:** `issues: write`, `pull-requests: write` on dispatch job.
+
+### `gemini-review.yml` — Gemini code review
+- **Trigger:** `workflow_call` from `gemini-dispatch.yml`.
+- **Key detail:** Runs `google-github-actions/run-gemini-cli` with Gemini Code
+  Assist. Configured with GCP workload identity federation, MCP server for
+  GitHub tools, and code-review extension.
+- **Timeout:** 7 minutes.
+
+### `audit.yml` — Security audit (cargo-audit)
+- **Triggers:** `schedule` (daily 06:17 UTC), `push` to `main` when
+  `Cargo.lock`/`Cargo.toml` changes, `workflow_dispatch`.
+- **Key detail:** Installs `cargo-audit` via `cargo install --locked`, caches
+  the binary across runs with `Swatinem/rust-cache` (no target dir).
+- **Concurrency:** `audit-${{ github.workflow }}-${{ github.ref }}`,
+  cancel-in-progress.
+
+### `osv-scanner.yml` — OSV vulnerability scanner
+- **Triggers:** `pull_request`/`push`/`merge_group` to `main`, `schedule`
+  (weekly 22:42 UTC Saturday).
+- **Key detail:** Uses Google's reusable OSV-Scanner workflows
+  (`osv-scanner-reusable.yml` / `osv-scanner-reusable-pr.yml` v2.3.5).
+  Scan args: `-r --skip-git ./`.
+- **Permissions:** `security-events: write` (uploads SARIF to Security tab).
+
+### `build-vllm-mlx-bundle.yml` — Build vllm-mlx distribution bundle
+- **Trigger:** `workflow_dispatch` only (manual, ~80-100 MB compressed).
+- **Key detail:** Runs on `macos-14` (Apple Silicon). Calls
+  `just build-vllm-mlx-bundle`. Produces a `.tar.zst` artifact consumed by the
+  Tauri `.dmg` build step. Re-run when vllm-mlx, python-build-standalone, or
+  HfModelDownloader cache layout changes.
+- **Retention:** 90 days, compression-level 0 (already zstd-compressed).
+
+### `eval-inference.yml` — Inference evaluation
+- **Triggers:** `schedule` (nightly 02:00 UTC), `workflow_dispatch` with
+  scenario selection.
+- **Key detail:** Builds `parish-server` on ubuntu-latest, spawns it with
+  `PARISH_PROVIDER=github_models` and `PLAYER_MODEL=microsoft/Phi-4`, runs a
+  Python player agent across scenarios (smoke=10t, intent=25t, reactions=15t,
+  tier2=12t, dialogue=20t, full_session=50t). Judges with gpt-4o via
+  `actions/ai-inference@v1`. Aggregates results into a CI summary table.
+- **Concurrency:** `eval-inference-${{ github.ref }}`, cancel-in-progress.
+
+### `publish-bench-site.yml` — Publish rundale-bench leaderboard
+- **Triggers:** `push` to `main` when `docs/proofs/rundale-bench/**`,
+  `rundale-bench/**`, or the workflow itself changes; `workflow_dispatch`.
+- **Key detail:** Builds site data via Python, builds with pnpm, deploys to
+  GitHub Pages with `actions/deploy-pages@v4`. Uses `pnpm/action-setup@v4`.
+- **Concurrency:** `pages`, cancel-in-progress.
+
+### `release.yml` — Tag-driven release pipeline
+- **Triggers:** `push` tags matching `v[0-9]+.[0-9]+.[0-9]+*`; `workflow_dispatch`
+  with `dry_run: true` (default) to test the build without publishing.
+- **Key detail:** Validates tag matches `parish-engine/Cargo.toml` version.
+  Builds Linux x86_64 release binary, packages tarball with `LICENSE`,
+  `NOTICE`, `README.md`, creates GitHub Release via `softprops/action-gh-release`.
+- **Permissions:** `contents: write` (required for release creation).
+- **Concurrency:** `release-${{ github.ref }}`, cancel-in-progress: **false**.
+
+### `stale.yml` — Stale issue/PR management
+- **Trigger:** `schedule` (daily 04:36 UTC).
+- **Key detail:** Marks issues/PRs stale after 90 days, closes after 14 more.
+  Labels: `no-issue-activity`, `no-pr-activity`.
+- **Permissions:** `issues: write`, `pull-requests: write`.
+
+### `triage-audit.yml` — Issue triage label audit
+- **Triggers:** `schedule` (weekly Monday 09:00 UTC), `issues` opened/reopened,
+  `workflow_dispatch`, `pull_request` to `main` on workflow changes.
+- **Key detail:** Checks every open issue against `triage-labels.json` for
+  missing P0-P3 priority or theme labels. On issue open/reopened, checks the
+  triggering issue. Reports via CI step summary and warning annotations.
+- **Permissions:** `contents: read`, `issues: read`, `pull-requests: read`.

--- a/docs/agent/AGENTS.md
+++ b/docs/agent/AGENTS.md
@@ -1,0 +1,46 @@
+# docs/agent — agent scope
+
+Deep reference directory for AI coding agents and human contributors. Invoked by the root [`AGENTS.md`](../../AGENTS.md) line _Start with the detailed agent docs in [docs/agent/README.md](README.md)_. This file is a machine-parseable index; the human-facing entry point is [`README.md`](README.md).
+
+Proof archives, screenshots, design records, and audit artifacts live outside this directory but are cross-referenced from these docs: `docs/proofs/`, `docs/screenshots/`, `docs/adr/`, `docs/design/`, `docs/plans/`, `docs/research/`, `docs/reviews/`, `docs/audits/`.
+
+## Scoped commands
+
+```sh
+just screenshots                                    # regenerate docs/screenshots/*.png
+bash parish/scripts/check-doc-paths.sh              # validate backtick-quoted paths in docs
+just agent-check                                    # proof evidence + judge verdict gate
+witness-scan                                        # catch AI partial-completion markers
+```
+
+## Local gotchas
+
+- **Docs must stay in sync with code.** The `check-doc-paths.sh` script (part of `just check` / CI `docs-consistency`) rejects backtick-quoted tokens in any doc that don't resolve to real files on disk. When renaming a file or module cited in a doc, update the doc before committing.
+- **Codebase map is the starting point.** [`codebase-map.md`](codebase-map.md) provides the top-level directory index and is the first doc agents should consult when orienting. Keep its `Parish Crates` table and repository-layout table fresh.
+- **Gotchas evolve with platform support.** [`gotchas.md`](gotchas.md) is the most mutation-prone file in this directory — Tokio, SQLite, Ollama, and mode-parity pitfalls change as tooling and platform support evolve.
+- **Screenshots live in `docs/screenshots/`**, not in this directory. Regenerate with `just screenshots` when UI changes.
+- **Proof archives live in `docs/proofs/`** — two long-lived bench areas (`local-perf/`, `rundale-bench/`) are exempt from the proof-evidence gate (rule #10). Per-task bundles go in `.proofs/<task-id>/` (gitignored).
+- **Witness scan blocks merge.** Any doc that contains partial-completion markers (`[...]`, `TODO` in code blocks, unfinished sentences followed by stop-tokens) fails `witness-scan`, which gates `just check` and `just verify`.
+- **Scaling guardrails (rule #11)** reference [scaling-rules.md](scaling-rules.md) for the seam review checklist. Every entry-point crate `AGENTS.md` links here — edits ripple across the workspace.
+- **`act-local.md`** describes running CI with `nektos/act`. It's the source of truth for `.actrc` and the `act-*` recipes in the justfile.
+
+## Doc index
+
+| File | Purpose | Cross-references from |
+|------|---------|----------------------|
+| [`README.md`](README.md) | Human-facing table of contents for this directory | root `AGENTS.md`, entry point |
+| [`build-test.md`](build-test.md) | Cargo, harness, frontend, web, and Tauri commands | `codebase-map.md`, root `AGENTS.md`, crate AGENTS.md files |
+| [`architecture.md`](architecture.md) | Workspace layout, 16-crate dependency graph, module ownership | `codebase-map.md`, `code-style.md`, design docs (`docs/design/overview.md`) |
+| [`code-style.md`](code-style.md) | Rust + Svelte conventions, naming, formatting, dep rules | `architecture.md`, crate AGENTS.md files |
+| [`gotchas.md`](gotchas.md) | Tokio, SQLite, Ollama, mode parity, platform pitfalls | root `AGENTS.md` rule block, `parish-engine/AGENTS.md`, every crate AGENTS.md |
+| [`git-workflow.md`](git-workflow.md) | Commits, tests, PR standards, review expectations | root `AGENTS.md` commit section |
+| [`witness.md`](witness.md) | Witness-style completion gates (AI partial-completion markers) | `harness.md` witness row, `justfile` witness-scan recipe |
+| [`agent-check.md`](agent-check.md) | PR proof-evidence gate (rule #10), local and CI source modes | root `AGENTS.md` rule #10, `harness.md`, `justfile` |
+| [`skills.md`](skills.md) | Agent slash commands (`/check`, `/parish-engine`, `/task-start`, `/backlog`, ...) | root `AGENTS.md` skill list, `harness.md` skills section, `.agents/skills/` |
+| [`harness.md`](harness.md) | One-page map of every sensor, skill, gate — what fires when | root `AGENTS.md`, `codebase-map.md`, `agent-check.md`, `skills.md`, `witness.md` |
+| [`act-local.md`](act-local.md) | Running CI workflows locally with `nektos/act` | `justfile` act-* recipes, `.actrc` |
+| [`idempotency.md`](idempotency.md) | `Idempotency-Key` header support (#619) on mutating routes | `parish-server/AGENTS.md`, scaling review (#614–#622) |
+| [`scaling-rules.md`](scaling-rules.md) | Scaling guardrails — per-session state, seam review checklist (rule #11) | root `AGENTS.md` rule #11, `parish-core/AGENTS.md`, `parish-server/AGENTS.md` |
+| [`codebase-map.md`](codebase-map.md) | Top-level directory index, Parish crate table, entry points | root `AGENTS.md`, every AGENTS.md file across workspace |
+| [`triage-vocabulary.md`](triage-vocabulary.md) | Canonical labels for issue triage (priorities + themes) | `.github/triage-labels.json`, `/backlog` skill |
+| [`tracing.md`](tracing.md) | `tracing` / OpenTelemetry OTLP conventions (#621) | `parish-server/AGENTS.md`, scaling review |

--- a/mods/AGENTS.md
+++ b/mods/AGENTS.md
@@ -1,0 +1,32 @@
+# mods/ — agent scope
+
+Root mod registry for the Parish engine. Contains game-world mods (`kind = "base"`) and provider-registration mods (`kind = "providers"`), each in its own subdirectory with a `mod.toml` manifest. The active mod is selected by `mod-list.toml`. See root [`AGENTS.md`](../AGENTS.md) for non-negotiable rules.
+
+## Scoped commands
+
+```sh
+cargo test -p parish-core --test mod_loading       # schema validation + load round-trip
+cargo run  -p parish-client -- --script ...        # live gameplay against active mod
+parish --list-mods                                  # available mods (if exposed)
+```
+
+## Local gotchas
+
+- **`mod-list.toml` controls the active mod.** `active_setting = "rundale"` selects the Rundale game world. Switching to a different `base` mod changes the world, NPC catalog, prompts, and save root.
+- **Two mod kinds.** `kind = "base"` for game worlds (`rundale`, `testbed`); `kind = "providers"` for LLM provider registrations. The kind is set in `mod.toml` and distinguishes game content from provider configuration.
+- **`save_root` controls per-user data directory resolution (rule #9).** The `save_root` field in each base mod's `mod.toml` becomes the app name for `parish_persistence::paths::resolve_user_data_dir()`. Existing saves live under `<save_root>` — changing it silently relocates saves. Provider mods omit `save_root`.
+- **Provider mod naming convention.** Each provider is `<name>-provider/` containing a `mod.toml` manifest and a `providers/<name>.toml` config. The provider config defines `id`, `display_name`, `default_base_url`, `api_key_env_var`, `requires_api_key`, and `[[presets]]` entries with per-model-tier keys (`recommended`, `budget`, `mini`).
+- **Provider configs follow OpenAI-compat schema.** Even Anthropic and other non-OpenAI providers use the same TOML layout with `kind = "anthropic"` or `kind = "openai-compat"`. The `featured` boolean gates visibility in the UI picker.
+- **`mod.toml` schema is additive only.** Adding new fields is safe; renaming or removing existing fields breaks deserialisation for saves that store the schema. Base mod `mod.toml` carries `[mod]`, `[setting]`, `[files]`, and `[prompts]` sections; provider mods only carry `[mod]`.
+- **Mod loading pipeline lives in `parish-core::loading`.** See `parish/crates/parish-core/src/loading/` for the `ModLoader`, schema validation, provider registry, and mod resolution logic. Adding a new mod kind requires changes in the loading pipeline.
+- **`rundale/` has its own `AGENTS.md`** at `mods/rundale/AGENTS.md` with game-content-specific gotchas (coordinate rules, NPC catalogue size, prompt variable casing).
+
+## What belongs here
+
+**1 game mod:** `rundale/` — Irish living world, 1820. Kind = `base`. Full game content (world, NPCs, prompts, schedules, festivals, encounters, transport).
+
+**1 test mod:** `testbed/` — minimal engine test harness (5-location grid). Kind = `base`. Used by integration tests; pig Latin code-switch for dialogue testing.
+
+**20 provider mods:** `anthropic-provider/`, `cohere-provider/`, `deepseek-provider/`, `github_models-provider/`, `google-provider/`, `groq-provider/`, `lmstudio-provider/`, `mistral-provider/`, `moonshot-provider/`, `nvidia-nim-provider/`, `openai-provider/`, `openrouter-provider/`, `qwen-provider/`, `scaleway-provider/`, `siliconflow-provider/`, `together-provider/`, `vercel-ai-provider/`, `xai-provider/`, `zhipu-provider/`, and others. Each is `kind = "providers"` with a `mod.toml` manifest and `providers/*.toml` config file.
+
+**Registry file:** `mod-list.toml` — selects the active mod setting via `active_setting`.

--- a/mods/rundale/prompts/AGENTS.md
+++ b/mods/rundale/prompts/AGENTS.md
@@ -1,0 +1,46 @@
+# mods/rundale/prompts — agent scope
+
+Game dialogue prompt templates for the Rundale mod. Loaded by `parish-core::prompts` during mod loading — paths are declared in `mods/rundale/mod.toml` under `[prompts]`, and the engine reads the files at startup through `GameMod::load_prompts()`. See root [`AGENTS.md`](../../../AGENTS.md), [`mods/AGENTS.md`](../../AGENTS.md), and [`mods/rundale/AGENTS.md`](../AGENTS.md) for non-negotiable rules.
+
+These are **plain-text Jinja-like templates** (not `.prompt.yml`), using `{variable}` syntax with case-sensitive names. Each variable is substituted by the NPC dialogue manager at runtime (`parish-npc::manager`).
+
+## Scoped commands
+
+```sh
+cargo test -p parish-core                                # unit + arch fitness (prompt loading)
+cargo test -p parish-npc                                 # NPC manager + anachronism tests
+cargo run  -p parish-engine -- --script ...              # live gameplay with this mod's prompts
+```
+
+## Local gotchas
+
+- **Variable names are case-sensitive.** `{player_name}` works, `{PlayerName}` does not. A misspelled or wrong-case variable passes through verbatim in the rendered prompt — the engine does not warn about unknown placeholders in plain-text templates.
+- **Tier 1 NPCs get the full system + context prompt assembled by `parish-npc::manager`.** `tier1_system.txt` is the character definition; `tier1_context.txt` is appended with runtime scene data (location, time, weather, the player's last action). Tier 2 NPCs receive only the system prompt (`tier2_system.txt`) — no context injection.
+- **`tier1_system.txt` expects a JSON metadata block** after `---` on every response. The format is `{"action": "...", "mood": "...", "internal_thought": "...", "language_hints": [...]}`. The dialogue manager parses this; malformed blocks will be rejected or silently dropped.
+- **Keep prompt templates in sync with `parish-npc::manager`.** Adding a new variable to a template requires a corresponding substitution in `parish-npc::manager::build_tier1_system_prompt` and friends. Adding a new tier requires a new `[prompts]` entry in `mod.toml` and loading logic in `parish-core::loading::game_mod`.
+- **The anachronism subsystem (`parish-npc::anachronism`) watches NPC dialogue output.** If a generated response contains a term from `anachronisms.json`, the system flags it and injects a corrective context alert into the next prompt. Editing `tier1_system.txt` to add new period language guidance should be cross-checked against the anachronism word list.
+- **Testbed mod (`mods/testbed/prompts/`) demonstrates the mod override pattern.** Any base mod can supply its own `prompts/` directory with the same filenames; the engine loads whichever the active mod provides. Testbed uses pig Latin versions to make the override visible in tests.
+- **These are plain-text files, not `.prompt.yml`.** The engine reads them via `std::fs::read_to_string()` (not `include_str!`), so they can vary per mod without recompilation. This means a missing file at startup produces a runtime error (`PromptsLoadError`), not a compile-time panic.
+- **The `{improv_section}` variable** in `tier1_system.txt` is pre-rendered by the NPC manager and may be empty — the template author must account for that (it is already appended with no conditional guard in the template).
+
+## Prompt index
+
+Three template files, all declared in `mods/rundale/mod.toml`:
+
+### `tier1_system.txt` — Tier 1 NPC system prompt
+
+Character definition for high-fidelity LLM-driven NPCs. Contains the role assignment (`name`, `age`, `occupation`), world-fact grounding (1820 Roscommon history), cultural and language guidelines (Hiberno-English dialect, permitted Irish phrases, banned anachronisms), personality injection (`personality`, `intel_guidance`, `tone_guidance`, `mood`), and output format specification (dialogue + JSON metadata block).
+
+**Variables:** `{name}`, `{age}`, `{occupation}`, `{personality}`, `{intel_guidance}`, `{tone_guidance}`, `{mood}`, `{improv_section}`.
+
+### `tier1_context.txt` — Tier 1 NPC scene context
+
+Runtime context injected into the Tier 1 prompt after the system message. Provides the NPC with awareness of their current location, the time of day, season, weather, and whatever the player just said or did. This is the only prompt template that includes player-action context.
+
+**Variables:** `{location_name}`, `{location_description}`, `{time}`, `{season}`, `{weather}`, `{scene_context}`, `{player_action}`.
+
+### `tier2_system.txt` — Tier 2 NPC system prompt
+
+System prompt for medium-fidelity NPC background conversations. Instructs the model to generate a brief summary of ambient character interactions (1-2 sentences) plus structured JSON output for mood and relationship changes between background NPCs. Does not receive player-action context.
+
+**Variables:** `{location}`, `{time}`, `{weather}`, `{characters}`.

--- a/parish/apps/ui/AGENTS.md
+++ b/parish/apps/ui/AGENTS.md
@@ -17,7 +17,7 @@ pnpm --dir parish/apps/ui run check    # svelte-check + tsc
 - **`src/lib/types.ts` must match Rust serde output exactly.** snake_case field names. Drift is silent — frontend gets `undefined` for renamed fields.
 - **Svelte 5 runes everywhere** (`$state`, `$derived`, `$effect`, `$props`). No legacy `let:reactive` blocks.
 - **Playwright snapshot baselines are committed.** UI changes require regenerating baselines (`just ui-e2e -- -u`) and including diffs in the PR per rule #10.
-- **Tauri IPC vs HTTP**: same store layer dispatches both. Don't fork transports — use the single `invoke`/`fetch` adapter in `src/lib/ipc/`.
+- **Tauri IPC vs HTTP**: same store layer dispatches both. Don't fork transports — use the single `invoke`/`fetch` adapter in `src/lib/ipc.ts`.
 - **`__mocks__/` is for vitest only**, not Playwright. E2E hits a real server.
 - **`license-clarifications.json` must stay current** — `just notices` rebuilds third-party notices when deps change (rule #7).
 

--- a/parish/apps/ui/src/AGENTS.md
+++ b/parish/apps/ui/src/AGENTS.md
@@ -1,0 +1,45 @@
+# parish/apps/ui/src -- agent scope
+
+Svelte 5 + TypeScript application source. The actual frontend code backing the project shell described in [`../AGENTS.md`](../AGENTS.md). See root [`AGENTS.md`](../../../../AGENTS.md) and [`docs/agent/code-style.md`](../../../../docs/agent/code-style.md).
+
+## Scoped commands
+
+```sh
+pnpm --dir parish/apps/ui run check    # svelte-check + tsc (from project root)
+pnpm --dir parish/apps/ui run test     # vitest (from project root)
+```
+
+Commands are run from the workspace root. Use `pnpm --dir parish/apps/ui` -- do not `cd` into this subtree.
+
+## Local gotchas
+
+- **`src/lib/types.ts` must match Rust serde output exactly.** snake_case field names. Drift is silent -- frontend gets `undefined` for renamed fields. This is the single most critical seam in the frontend.
+- **Svelte 5 runes everywhere** (`$state`, `$derived`, `$effect`, `$props`). No legacy `let:` reactive blocks. Stores in `src/stores/` also use runes-based state (`game.ts` is the primary game state store).
+- **IPC bridge (`src/lib/ipc.ts`) dispatches transparently to both Tauri `invoke` and HTTP `fetch`.** Do not fork transports or import Tauri/HTTP adapters directly in components -- always go through this single adapter.
+- **Tests are co-located.** Every `.svelte` component with logic should have a `*.test.ts` beside it. Vitest only -- `__mocks__/` is for vitest stubs, not Playwright.
+- **Editor components live under `components/editor/`**, the Designer page route under `routes/editor/`. Editor IPC and types are in `lib/editor-ipc.ts`, `lib/editor-map.ts`, `lib/editor-types.ts`.
+- **Map rendering utilities** live under `lib/map/` (controller, GeoJSON, style, tile sync).
+- **Save-picker logic** lives under `lib/save-picker/` (DAG tree, ledger list).
+- **Setup/onboarding logic** lives under `lib/setup/` (download rate, setup messages, storage, stream manager).
+- **Build-time assets** go in `lib/assets/` (only `favicon.svg` currently).
+- **`app.css`** is global styles; `app.d.ts` is TypeScript declarations; `app.html` is the SvelteKit HTML shell; `test-setup.ts` is vitest test setup.
+
+## Module map
+
+`components/` Svelte components, `lib/` shared utilities + types + IPC, `routes/` SvelteKit pages, `stores/` runes-based state stores, `__mocks__/` vitest stubs.
+
+### Components (43 entries)
+
+`ChatPanel.svelte`, `InputField.svelte`, `Sidebar.svelte`, `MapPanel.svelte`, `StatusBar.svelte` -- the primary game HUD. `DebugPanel.svelte` with `<Debug*Tab>` sub-components (Overview, Npcs, Events, Conversations, Gossip, Inference, Weather, World). `FullMapOverlay.svelte`, `MapTooltip.svelte` -- map interactions. `SetupOverlay.svelte`, `SavePicker.svelte`, `ByokOnboarding.svelte`, `ByokFork.svelte`, `LocalInferenceFork.svelte`, `ModSelectorOverlay.svelte` -- onboarding and configuration. `MentionDropdown.svelte`, `SlashDropdown.svelte`, `ModelDropdown.svelte` -- input helpers. `AuthStatus.svelte`, `MoodIcon.svelte` -- status indicators. `DemoBanner.svelte`, `DemoPanel.svelte` -- demo mode UI. `components/editor/` contains the Parish Designer component tree (8 entries: `LocationDetail`, `LocationList`, `ModBrowser`, `NpcDetail`, `NpcList`, `SaveInspector`, `ValidatorPanel`).
+
+### Shared library (37 entries)
+
+`lib/types.ts` -- Rust-backed IPC types (the seam). `lib/ipc.ts` -- single adapter for Tauri `invoke` and HTTP `fetch`. `lib/map/` -- map rendering (controller, GeoJSON, style, tileSync). `lib/save-picker/` -- save DAG and ledger UI. `lib/setup/` -- onboarding orchestration (stream manager, download rate, setup messages, storage). `lib/assets/` -- build-embedded static assets. Individual utility modules: `app-icon`, `auto-pause`, `byokProviders`, `demo-player`, `editor-ipc`, `editor-map`, `editor-types`, `map-icons`, `model-catalog`, `reactions`, `rich-text`, `scene-dedup`, `screenshot`, `setupWaitMessages`, `slash-commands`, `stream-pacing`, `theme`. Each utility with logic has a co-located `.test.ts`.
+
+### Routes
+
+`+layout.svelte` + `+layout.ts` -- root layout and loader. `+page.svelte` -- main game page. `routes/editor/` (with `+page.svelte` + `+page.ts`) -- the Parish Designer page.
+
+### Stores (12 entries)
+
+`game.ts` -- primary game state store (`+game.test.ts`). `debug.ts`, `demo.ts`, `editor.ts`, `nouns.ts`, `save.ts`, `theme.ts`, `tiles.ts` (`+tiles.test.ts`), `travel.ts` (`+travel.test.ts`). All use Svelte 5 runes.

--- a/parish/crates/parish-client/AGENTS.md
+++ b/parish/crates/parish-client/AGENTS.md
@@ -1,0 +1,27 @@
+# parish-client — agent scope
+
+Synchronous CLI client for the Parish game server. Binary name: `parish`. Thin HTTP client speaking to a running `parish-server` via `POST /api/command` and `GET /api/state`. Three modes: single-shot, script batch (`--script`), and interactive REPL. See root [`AGENTS.md`](../../../AGENTS.md) for non-negotiable rules.
+
+## Scoped commands
+
+```sh
+cargo run  -p parish-client "look"                          # single-shot against localhost:3001
+cargo run  -p parish-client --script testing/fixtures/...    # batch script mode
+cargo run  -p parish-client                                  # interactive REPL
+cargo run  -p parish-client --json "go to the church"        # raw JSON output
+cargo test -p parish-client                                  # unit
+```
+
+Set `PARISH_SERVER=http://localhost:3030` to target a different backend (default: `http://localhost:3001`).
+
+## Local gotchas
+
+- **Wire types must stay in sync with `parish-server`.** The `CommandResponse` shape in `src/client.rs` must match `parish-server`'s `sync_types::CommandResponse` exactly. Change both in the same PR or the client deserializes silently into partial/missing fields (#771).
+- **Binary-only crate (no lib).** This crate ships no library surface — only the `parish` binary at `src/main.rs`. Embedders should talk to `parish-server`'s library or use `parish-client` as a subprocess.
+- **Synchronous per-call, not streaming.** Uses `reqwest` with JSON + cookies per request. No WebSocket, no event stream. For real-time pushes, use `parish-server`'s WS endpoints or Tauri IPC.
+- **REPL builds history in memory only.** Session history is not persisted between invocations. Use `--script` for repeatable batch workflows.
+- **`PARISH_SERVER` env var is the only configuration surface.** No config file, no CLI flag for the URL beyond `--server`. The env-var default matches `parish-server`'s default port.
+
+## Module map
+
+`main.rs` CLI entry (clap parser, three-mode dispatch), `client.rs` `ParishClient` HTTP wrapper, `render.rs` response→prose rendering, `repl.rs` script runner + interactive REPL loop, `session.rs` session token management.

--- a/parish/crates/parish-config/AGENTS.md
+++ b/parish/crates/parish-config/AGENTS.md
@@ -1,0 +1,25 @@
+# parish-config — agent scope
+
+Engine and LLM-provider configuration loader for the Parish engine. Backend-agnostic leaf crate — depends only on `parish-types`. Loads and validates `parish.toml`, manages provider configs (API keys, base URLs, model names), feature flags, per-user config, and built-in provider definitions. See root [`AGENTS.md`](../../../AGENTS.md).
+
+## Scoped commands
+
+```sh
+cargo test -p parish-config                       # unit + integration
+cargo test -p parish-config -- --nocapture        # with stdout (feature-flag persistence, env-serialised tests)
+```
+
+## Local gotchas
+
+- **Leaf crate constraint.** `parish-config` may never depend on any non-leaf parish crate. Adding a dependency on `parish-core`, `parish-inference`, etc. violates the architecture-fitness test (rule #1).
+- **Config merging order (4-layer priority).** Compiled default → TOML file → env var → CLI flag. Each layer overrides the previous. The `PARISH_OLLAMA_URL` env var is deprecated in favour of `PARISH_BASE_URL`.
+- **Feature flags are default-on.** `config.flags.is_enabled("feature")` returns `false` for unknown flags (opt-in). `config.flags.is_disabled("feature")` returns `true` only when the flag has been explicitly set to `false` — use `is_disabled` for kill-switch features that ship enabled by default.
+- **`Provider::recommended_for_platform()` is platform-aware.** macOS: vllm-mlx with two-slot Qwen loadout (needs >=16 GB unified memory; below that falls back to simulator). Linux/Windows: vllm. Cross-platform code that picks a provider at startup should use this rather than hardcoding an id.
+- **`MapConfig::apply_defaults()` prevents tile-source wipe.** serde replaces the whole `BTreeMap` on deserialisation, so a partial `[engine.map.tile_sources.osm]` override in `parish.toml` silently drops the `historic` source. Always call `apply_defaults()` after loading to fold baked-in defaults back.
+- **Provider registry is write-once after bootstrap.** Builtins (`simulator`, `ollama`, `vllm`, `vllmmlx`, `custom`) are compiled in via `include_str!` TOMLs. Cloud providers are loaded from `mods/<id>/providers/<id>.toml` via `register_mod_providers` after `discover_mods`. After bootstrap the registry is effectively read-only; existing `Arc<ProviderMod>` handles keep pointing at their snapshot.
+- **`UserConfig` must never store an `api_key` field.** Secrets belong in the OS keychain (`parish_core::secret_store`). The `save_does_not_write_api_key_field` test guards against accidental inclusion.
+- **`#[serial(provider_registry)]` and `#[serial(parish_env)]` test attributes.** Tests that mutate the global provider registry or environment variables are annotated with `serial_test` to prevent inter-test poisoning. Adding a new test of that kind must include the matching `#[serial(...)]`.
+
+## Module map
+
+`engine.rs` engine-level structs (inference, NPC, encounter, palette, world, map, session tuning), `user_config.rs` per-user BYOK prefs + onboarding marker, `provider.rs` `ProviderKind`/`Provider`/`ProviderRegistry` + 4-layer resolution, `flags.rs` runtime feature flags persistence, `builtin_providers/` five built-in provider TOMLs loaded at compile time.

--- a/parish/crates/parish-core/AGENTS.md
+++ b/parish/crates/parish-core/AGENTS.md
@@ -13,10 +13,10 @@ cargo doc  -p parish-core --no-deps --open               # composed surface
 ## Local gotchas
 
 - **Architecture-fitness test enforces rules #1, #2, #12.** Backend-agnostic crates may not depend on `tauri`, `axum`, `tower*`, `wry`, `tao`. Orphan source files (on disk, no `mod` decl) are rejected. Run before any commit that adds `mod` declarations or new crate deps.
-- **`EventEmitter` trait is the seam.** Any new orchestration (game loop, IPC handler, payload struct) must be defined here parameterized over `EventEmitter`; entry-point crates wire their own emitter (#687, #696). No copy-paste into `parish-server` / `parish-tauri` / `parish-engine`.
+- **`EventEmitter` trait is the seam.** Any new orchestration (`game_loop/`, IPC handler, payload struct) must be defined here parameterized over `EventEmitter`; entry-point crates wire their own emitter (#687, #696). No copy-paste into `parish-server` / `parish-tauri` / `parish-engine`.
 - **Re-exports are load-bearing.** Sub-crates are re-exported (`parish_core::config`, `parish_core::npc`, ...) — preserve names when refactoring or you break every entry point.
 - **Scaling guardrails (rule #11).** Edits to `AppState`, session persistence, real-time push, inference calls, identity lookups, or mod loading require checklist review against [`docs/agent/scaling-rules.md`](../../../docs/agent/scaling-rules.md).
 
 ## Module map
 
-`game_session/` runtime, `loading/`+`game_mod/` mod loading, `ipc/` shared types, `editor/` Designer support, `prompts/` templates, `debug_snapshot/` introspection.
+`game_session.rs` runtime session, `game_loop/` game tick + movement loop, `loading.rs`+`game_mod.rs` mod loading, `ipc/` shared types, `editor/` Designer support, `prompts/` templates, `debug_snapshot.rs` introspection.

--- a/parish/crates/parish-engine/AGENTS.md
+++ b/parish/crates/parish-engine/AGENTS.md
@@ -1,0 +1,29 @@
+# parish-engine — agent scope
+
+In-process engine entry point. Primary binary target and library. One of three mode-parity entry points (alongside `parish-server` and `parish-tauri`) — supports headless REPL (`--headless`), script runner (`--script FILE`), and default Tauri-launch. Re-exports all of `parish-core` under its own namespace for consumer convenience. See root [`AGENTS.md`](../../../AGENTS.md) and [`docs/agent/`](../../../docs/agent/) for repo-wide rules.
+
+## Scoped commands
+
+```sh
+cargo test -p parish-engine                    # unit + integration
+cargo run  -p parish-engine                    # default (launches Tauri)
+cargo run  -p parish-engine -- --headless      # stdin/stdout REPL
+cargo run  -p parish-engine -- --script FILE   # script harness (JSON output, no LLM)
+just check                                     # full fmt+clippy+tests (workspace)
+just run-headless                              # headless via justfile shortcut
+```
+
+The crate ships **both** a library (`parish_engine`) and a binary (`parish-engine`). The binary is `src/main.rs` (clap parser + launch dispatch); everything else lives under the library surface so embedders (tests, the script harness, future embedders) can keep using the module surface directly.
+
+## Local gotchas
+
+- **Cross-runtime orchestration belongs in `parish-core`** (rule #12). New game-loop / IPC handlers must live in `parish-core` parameterized over `EventEmitter`; this crate provides only the CLI adapter (`StdoutEmitter` in `emitter.rs`, `CliCommandHost` in `command_host.rs`). Copy-pasting orchestration from `parish-server` or `parish-tauri` is forbidden (#687, #696).
+- **Re-exports are load-bearing.** `parish_engine::world`, `parish_engine::npc`, `parish_engine::config`, etc. all re-export from `parish_core`. External consumers (tests, tool crates) import through `parish_engine`. Never remove a re-export without auditing every downstream crate.
+- **Testing harness is shared infrastructure.** `GameTestHarness` and `run_script_mode` in `src/testing.rs` are used by integration tests across the workspace — changes to their API or behaviour break tests in `parish-core`, `parish-server`, and play-fixture crates.
+- **Mode parity.** Every gameplay action available over Tauri IPC or WebSocket must also be reachable via the headless CLI. When adding a new command or system action to `parish-core::ipc`, ensure the headless REPL loop (`src/headless.rs`) dispatches it.
+- **Script mode skips LLM init entirely.** `--script FILE` invokes `run_script_mode` in `src/testing.rs`, which uses the `SimulatorClient` and never touches Ollama or any cloud provider — the script fixture provides canned responses.
+- **`#[deprecated]` `find_data_dir()` violates rule #9.** This cwd-relative path resolution in `src/main.rs` is marked `#[deprecated]` — new code must resolve runtime paths from explicit config stored on `AppState`, not `std::env::current_dir()`. The deprecated function exists only until every code path has been migrated to the `saves_dir` / `log_app_name` fields on `App`.
+
+## Module map
+
+`app.rs` state + lifecycle, `headless.rs` REPL runtime (stdin→out, 2400+ lines), `testing.rs` harness + script runner (2700+ lines), `config.rs` engine-specific per-category config re-exports, `command_host.rs` `CliCommandHost` — `SystemCommandHost` impl for the CLI, `emitter.rs` `StdoutEmitter` — `EventEmitter` impl for the CLI, `debug.rs` `/debug` command handlers, `main.rs` + `lib.rs` startup wiring + re-exports.

--- a/parish/crates/parish-geo-tool/AGENTS.md
+++ b/parish/crates/parish-geo-tool/AGENTS.md
@@ -1,0 +1,26 @@
+# parish-geo-tool — agent scope
+
+OSM data download + Parish world graph conversion. Two binaries: the main `parish-geo-tool` (Overpass query pipeline) and `realign_rundale_coords` (coordinate drift correction for Rundale). Documented in depth by the `rundale-geo-tool` agent skill at [`.agents/skills/rundale-geo-tool/SKILL.md`](../../../.agents/skills/rundale-geo-tool/SKILL.md). See root [`AGENTS.md`](../../../AGENTS.md) for repo-wide rules.
+
+## Scoped commands
+
+```sh
+cargo test -p parish-geo-tool                                # unit + integration
+cargo run  -p parish-geo-tool -- --area "Kiltoom"            # OSM extract pipeline
+cargo run  -p parish-geo-tool -- --bbox 53.45,-8.05,53.55,-7.95
+just realign-coords                                           # run realign_rundale_coords in-place
+just realign-coords-run -- --baseline-world <path>            # realign from baseline delta
+```
+
+## Local gotchas
+
+- **Nominatim alone is the wrong primary source for 1820s Irish geography.** Prefer historical OS maps (6-inch First Edition, ~1837) for real-world pinning. Nominatim returns modern coordinates; buildings, roads, and coastlines have shifted. Use `--set-coord` with a known historical coordinate + `--set-source "OS 6-inch ca. 1837"` to pin a location and mark it `Manual` so future geocode passes skip it.
+- **Three coordinate modes: absolute, relative, and graph-delta.** `geo_kind: Real` locations get geocoded from Nominatim. `Manual` locations are author-pinned with a provenance `geo_source`. `relative_to` locations derive from an anchor + (dnorth_m, deast_m) offset. `Fictional` locations with no `relative_to` get realigned by a BFS-weighted average of nearby anchor deltas — the `infer_delta` algorithm walks the connection graph up to 6 hops.
+- **OSM data must be cached.** The `cache.rs` module caches Overpass responses to disk (`--cache-dir`, default `data/cache/geo`). Avoids hammering the Overpass API during iterative development. Pass `--no-cache` to bypass reads (still writes). Cache entries are plain JSON keyed by normalized query hash.
+- **World file indent convention is 4 spaces.** Both the pipeline output and `realign_rundale_coords` write with `serde_json`'s 4-space `PrettyFormatter`. This keeps `world.json` byte-identical through Designer editor round-trips.
+- **`realign_rundale_coords` has a baseline mode.** Pass `--baseline-world <path>` pointing to a pre-geocode world file. The tool computes deltas for `Real` locations (excluding `Fictional` and `relative_to`), applies them to the current world, and realigns connected fictionals. Useful when you want to apply known drifts without hitting Nominatim again.
+- **Cycle detection in `relative_to` resolution.** The `resolve_relative_positions` function detects cyclic references and bails with a descriptive error. It also catches references to missing anchor IDs.
+
+## Module map
+
+`src/main.rs` CLI entry + `AdminLevel` enum, `src/bin/realign_rundale_coords.rs` coordinate realignment utility, `src/lib.rs` library surface (re-exports `osm_model`), `src/world_file_shared.inc` shared world-file serde types, `src/osm_model.rs` OSM data model types, `src/extract.rs` feature extraction from Overpass responses, `src/overpass.rs` Overpass API query builder + HTTP client, `src/merge.rs` merge OSM extracts with hand-authored data, `src/pipeline.rs` end-to-end download→extract→connect→describe→merge→output workflow, `src/lod.rs` level-of-detail density filtering, `src/output.rs` world.json output formatting, `src/descriptions.rs` location description template generation, `src/connections.rs` graph edge/connection building from road network, `src/cache.rs` HTTP response caching, `src/test_utils.rs` test helpers.

--- a/parish/crates/parish-input/AGENTS.md
+++ b/parish/crates/parish-input/AGENTS.md
@@ -1,0 +1,22 @@
+# parish-input — agent scope
+
+Player input parsing and command interpretation for the Parish engine. Backend-agnostic leaf crate — consumed by every entry point via `parish-core`. See root [`AGENTS.md`](../../../AGENTS.md).
+
+## Scoped commands
+
+```sh
+cargo test -p parish-input                       # unit tests
+cargo test -p parish-input --test '*'            # integration (llm fallback)
+```
+
+## Local gotchas
+
+- **Leaf-crate dependency rule.** Depends only on `parish-types`, `parish-config`, `parish-inference`. Never take a dependency on `parish-core` or any runtime crate (tauri, axum, engine).
+- **LLM is the fallback, not the primary path.** `intent_local.rs` + `parser.rs` handle all known command forms (movement, look, take, inventory, etc.) first. `intent_llm.rs` is only invoked for unrecognised input — keep local coverage broad to avoid unnecessary inference calls.
+- **Intent type additions require `parish-core` wiring.** Adding a new `IntentKind` variant means adding a handler in `parish_core::game_session` — the two crates are coupled by the enum surface. Update both in the same commit.
+- **Mention detection is for dialogue scoping.** `@name` syntax in user input is parsed by `mention.rs` and used to direct NPC responses. It does not affect movement or item interaction — only dialogue targeting.
+- **Slash commands (`/save`, `/quit` etc.) are parsed in `parser.rs`** and bypass both intent paths entirely. They map directly to `Command` variants.
+
+## Module map
+
+`parser.rs` token classification + system commands, `commands.rs` command defs + handlers, `intent_types.rs` intent enums, `intent_local.rs` rule-based intent, `intent_llm.rs` LLM fallback, `mention.rs` @name dialogue scoping.

--- a/parish/crates/parish-mcp/AGENTS.md
+++ b/parish/crates/parish-mcp/AGENTS.md
@@ -1,0 +1,24 @@
+# parish-mcp — agent scope
+
+Model Context Protocol (MCP) server — stdio JSON-RPC 2.0 bridge that lets LLM clients (Claude Code, Claude Desktop) drive a running Parish/Tauri instance over HTTP. Registered in the repo root `.mcp.json`. See root [`AGENTS.md`](../../../AGENTS.md) for non-negotiable rules and [`README.md`](README.md) for transport rationale, architecture diagram, and full tool reference.
+
+## Scoped commands
+
+```sh
+cargo test -p parish-mcp                                    # unit (JSON-RPC, backend mock, tool dispatch)
+cargo run  -p parish-mcp -- --base-url http://127.0.0.1:3030  # attach to a running backend
+```
+
+The MCP server expects a backend on `127.0.0.1:3030` — call `bash parish/scripts/parish-mcp-backend.sh start` first, or run `parish-tauri --mcp-port 3030` / `parish-server --port 3030`.
+
+## Local gotchas
+
+- **Bridge, not backend.** `parish-mcp` never touches game state directly. All mutations flow through HTTP to a running backend (`parish-tauri --mcp-port` or `parish-server`). The backend must be up before any `mcp__parish__*` tool call or you get `transport error`.
+- **Two backends, one trait.** `ParishHttpBackend` (HTTP `/api/*`) is the production impl; `GenericTauriBackend` (WebDriver / `tauri-driver`) is a stub wired through `BackendError::Unimplemented`. Adding a new backend requires no MCP protocol changes — just implement `TauriBackend`.
+- **Mode-parity inherited from `sync_routes`.** Because `ParishHttpBackend` wraps `POST /api/command` and `GET /api/state`, it inherits the mode-parity contract — every gameplay action available over Tauri IPC or WebSocket must also be reachable through this layer. Wire-type changes are breaking for every downstream consumer.
+- **Stdio-only transport.** The binary speaks line-delimited JSON-RPC 2.0 on stdin/stdout; logs go to stderr. The `serve()` function in `jsonrpc.rs` is generic over `AsyncRead`/`AsyncWrite` so an HTTP/SSE transport can reuse it unchanged — only `main.rs` would need a second wiring path.
+- **BYOK tools only work against a running Tauri desktop session, not headless server.** `parish_setup_status` / `parish_setup_byok` rely on in-process `AppState` sharing with the Tauri bridge — `parish-server` does not yet expose the matching HTTP routes (see README future work).
+
+## Module map
+
+`jsonrpc.rs` JSON-RPC 2.0 framing (transport layer), `mcp.rs` MCP handshake + tool registry (protocol layer), `backend.rs` `TauriBackend` trait + `ParishHttpBackend` impl (adapter layer), `tools.rs` tool definitions and JSON Schema parameter shapes.

--- a/parish/crates/parish-npc-tool/AGENTS.md
+++ b/parish/crates/parish-npc-tool/AGENTS.md
@@ -1,0 +1,26 @@
+# parish-npc-tool — agent scope
+
+SQLite-backed NPC world builder and inspection utility for Parish/Rundale (#433). Standalone build-time binary — generates and inspects NPC populations at design time, ahead of shipping a mod. Does **not** participate in the runtime game loop or mode parity. See root [`AGENTS.md`](../../../AGENTS.md) for non-negotiable rules.
+
+## Scoped commands
+
+```sh
+cargo run  -p parish-npc-tool -- generate-world --counties roscommon,galway
+cargo run  -p parish-npc-tool -- generate-parish Kiltoom --pop 2000
+cargo run  -p parish-npc-tool -- validate --all
+cargo run  -p parish-npc-tool -- export --parish Kiltoom
+cargo test -p parish-npc-tool                              # unit
+```
+
+## Local gotchas
+
+- **Standalone tool — no mode parity.** `parish-npc-tool` is a dev-time binary, not part of the game loop. It does not participate in mode parity (rule #2) and is not wired into `parish-engine`, `parish-server`, or `parish-tauri`.
+- **Binary-only crate (no lib).** All logic lives in `src/main.rs`. There is no library surface for embedders — consume the output JSON or use as a subprocess.
+- **No dependency on `parish-core` or other Parish crates.** This crate is intentionally isolated from the runtime workspace to avoid pulling `rusqlite` and generation-time deps into the engine. It shares JSON schema conventions with `parish-npc` but no Rust code.
+- **Owns its own SQLite schema.** The DB schema (parish/household/NPC tables, see #434) diverges from `parish-persistence`'s branch-keyed game-snapshot format. Schema migrations are managed independently — no migration framework shared with the runtime.
+- **Output must be hand-massaged into the mod.** The tool produces NPC JSON that authors review and commit into the mod's `npcs.json` (or future `parish-world.db`). Generated output is authoritative only after human validation — use `validate` before committing.
+- **No inference dependency at build time.** The `elaborate` subcommand reaches out to an LLM at invocation time, but the crate itself does not depend on `parish-inference` or wire into the engine's inference worker.
+
+## Module map
+
+`main.rs` — all logic (single binary file, clap-driven subcommands).

--- a/parish/crates/parish-palette/AGENTS.md
+++ b/parish/crates/parish-palette/AGENTS.md
@@ -1,0 +1,23 @@
+# parish-palette — agent scope
+
+Backend-agnostic time-of-day color interpolation for Parish. Leaf crate with a single responsibility: compute color values (sky, ambient light, foreground, background) based on the current in-game hour and minute. Minimal dependency footprint — depends only on `parish-config`. Consumed by the Svelte UI for ambient rendering. See root [`AGENTS.md`](../../../AGENTS.md).
+
+## Scoped commands
+
+```sh
+cargo test -p parish-palette                   # unit (interpolation + contrast)
+cargo test -p parish-palette -- --nocapture     # with stdout
+```
+
+## Local gotchas
+
+- **Single-file leaf crate.** All logic lives in `src/lib.rs` — no submodules, no split. Should never grow beyond a single file.
+- **No new dependencies without scrutiny.** Only `parish-config` is allowed. Adding `parish-core`, `parish-types`, or any other parish crate violates the architecture-fitness test (rule #1). Adding any third-party dependency must be justified by measurable need.
+- **Color values cross the IPC boundary to the Svelte UI.** `RawPalette` and `RawColor` are serialised as `ThemePalette` in `parish-core`'s IPC types. Changing the slot layout breaks the frontend contract.
+- **No built-in keyframes.** The engine ships no hardcoded palettes — mods supply them via `ui.toml`'s `[[theme.keyframes]]`. `neutral_grey_palette()` is the sole fallback for the boot/empty-mod state.
+- **Platform-agnostic by design.** No platform-specific code, no conditional compilation targets, no runtime feature detection. If a platform needs different colour interpolation, that belongs in the mod's `ui.toml`.
+- **No world or NPC dependency.** `parish-palette` computes colour from (hour, minute, keyframes, config) alone — it must never read world state, NPC state, or any game simulation.
+
+## Module map
+
+`lib.rs` — all logic: `RawColor`/`RawPalette`/`Keyframe` types, hex parsing, linear interpolation, wrap-around midnight handling, luminance contrast enforcement, and the public `compute_palette_with_keyframes` entry point.

--- a/parish/crates/parish-persistence/AGENTS.md
+++ b/parish/crates/parish-persistence/AGENTS.md
@@ -1,0 +1,27 @@
+# parish-persistence — agent scope
+
+SQLite save/load with WAL journal and branching saves for the Parish engine. Backend-agnostic leaf crate — manages all persistent state: save files with branching (multiple save branches), WAL journal for crash resilience, path resolution for platform user-data directories, snapshot serialization, file locking, and the database schema. See root [`AGENTS.md`](../../../AGENTS.md).
+
+## Scoped commands
+
+```sh
+cargo test -p parish-persistence                    # unit tests (database, journal, snapshot, lock, paths, picker)
+cargo test -p parish-persistence -- --nocapture     # with stdout for debugging
+```
+
+## Local gotchas
+
+- **Leaf-crate dependency rule.** Depends only on `parish-types`, `parish-world`, `parish-npc`, `rusqlite`, `serde`, `chrono`, `tokio`. Never take a dependency on `parish-core` or any runtime crate (tauri, axum, engine).
+- **Resolve runtime paths from explicit config, not cwd (rule #9).** `resolve_user_data_dir(app_name)` checks `PARISH_USER_DATA_DIR` env var first, then platform-native roots. `resolve_project_saves_dir(app_name)` checks `PARISH_SAVES_DIR` env var. Both are called once at startup and stored on `AppState` — never from request handlers.
+- **App name fallback chain.** The data-directory app name comes from `ModMeta::app_name()`. If that's absent it falls back to `ModMeta.name`, then `DEFAULT_APP_NAME` (`"Parish"`).
+- **WAL journal mode requires careful concurrent access.** `Database::open()` enables `PRAGMA journal_mode=WAL` + `PRAGMA synchronous=NORMAL`. WAL permits concurrent reads during writes, but `AsyncDatabase` serialises all operations through `Arc<Mutex<Database>>` via `run_blocking` / `spawn_blocking`.
+- **Poison recovery on database mutex.** `lock_recovered()` wraps `Mutex::lock()` to transparently recover from a poisoned mutex (issue #82). Without this, a single thread panic while holding the database lock would cascade into every subsequent call panicking.
+- **`IntoParishDbError` is crate-local.** `parish-types` dropped its `rusqlite` dependency (issue #699), so `database.rs` uses the local `IntoParishDbError` trait for `.db_err()?` shorthand. This satisfies the orphan rule while keeping ergonomic error conversion.
+- **Atomic sequence assignment prevents duplicate journal sequences.** `append_event` uses a single `INSERT ... SELECT COALESCE(MAX(sequence),0)+1` statement with a UNIQUE index on `(branch_id, after_snapshot_id, sequence)` as a second line of defence. Concurrent appends produce correct, non-overlapping sequences.
+- **Compaction must be scoped to `(branch_id, snapshot_id)`.** `clear_journal()` deletes only events for the exact pair. Events tied to a different snapshot or a different branch on the same database survive the prune. The compaction lifecycle: save snapshot A → append events → save snapshot B → clear_journal(A) → load_latest_snapshot returns B.
+- **Lock sidecar files are reference-counted.** `SaveFileLock` writes a PID to `<save_path>.lock` and tracks live owners via `Arc`. The lock file is removed on `Drop` only when the last reference drops.
+- **Unix-only `libc` dependency.** `lock.rs` uses `libc::getpid()` on Unix targets. Windows uses `std::process::id()` — keep conditional compilation correct when adding new locking logic.
+
+## Module map
+
+`lib.rs` crate root + re-exports + `IntoParishDbError` trait + `format_timestamp` helper, `database.rs` SQLite schema + `Database` + `AsyncDatabase` + CRUD, `journal.rs` `WorldEvent` enum + event types + replay, `journal_bridge.rs` `GameEvent`→`WorldEvent` conversion for the event bus, `snapshot.rs` `GameSnapshot` + `ClockSnapshot` + `NpcSnapshot` serialization, `paths.rs` `resolve_user_data_dir(app_name)`, `picker.rs` `resolve_project_saves_dir(app_name)` + save slot grid, `lock.rs` cross-platform `SaveFileLock` with sidecar PID files.

--- a/parish/crates/parish-server/AGENTS.md
+++ b/parish/crates/parish-server/AGENTS.md
@@ -22,7 +22,7 @@ The crate ships **both** a library (`parish_server::run_server`) and a binary (`
 
 ## Module map
 
-`routes/` HTTP, `ws/` real-time channel, `sync_routes/` + `sync_types/` + `drain/` synchronous `POST /api/command` + `GET /api/state` endpoints for thin clients, `editor_routes/` mod editor surface, `session/`+`state/` lifecycle, `auth/`+`cf_auth/`+`middleware/` policy.
+`routes.rs` HTTP, `ws.rs` real-time channel, `sync_routes.rs` + `sync_types.rs` + `drain.rs` synchronous `POST /api/command` + `GET /api/state` endpoints for thin clients, `editor_routes.rs` mod editor surface, `session.rs`+`state.rs` lifecycle, `auth.rs`+`cf_auth.rs`+`middleware.rs` policy.
 
 ## Thin-client surface (`sync_routes.rs`)
 

--- a/parish/crates/parish-types/AGENTS.md
+++ b/parish/crates/parish-types/AGENTS.md
@@ -1,0 +1,23 @@
+# parish-types — agent scope
+
+Foundational shared types for the Parish engine. Backend-agnostic leaf crate with **zero internal dependencies** — every other Parish crate depends on this one. Defines core types: IDs (entity, location, NPC), time (in-game clock), events (game events stream), conversations (dialogue state), gossip, dice/random, and error types. See root [`AGENTS.md`](../../../AGENTS.md) for non-negotiable rules.
+
+## Scoped commands
+
+```sh
+cargo test -p parish-types                        # unit tests
+cargo doc  -p parish-types --no-deps --open       # type docs
+```
+
+## Local gotchas
+
+- **Zero internal dependencies — transitive impact.** `parish-types` is the dependency root. Never add a dependency on another Parish crate here. Adding types to this crate has workspace-wide implications because every crate depends on them — consider whether a type belongs in a higher leaf crate first.
+- **Serialization types are load-bearing.** All types should derive `Serialize`/`Deserialize` where appropriate. Changing serialized field names, types, or semantics may break save compatibility — check `parish-persistence` schema before and after such changes.
+- **`#[serde(default)]` for schema evolution.** Use on optional fields to handle forward-compatible deserialization of old save data when new fields are added.
+- **`GameTime` is canonical.** `parish_types::time::GameTime` is the in-game clock type used everywhere — game loop, NPC schedules, events, persistence. Do not introduce alternative in-game time representations.
+- **Adding `AnachronismEntry` here is load-bearing.** It lives in `lib.rs` directly (not a module) because it is shared between `parish-npc` (detection) and `parish-core` (mod loading). Changes must update both consumers.
+- **No runtime-specific code.** As a backend-agnostic leaf crate, must never depend on `tauri`, `axum`, `tower*`, `wry`, or `tao` (enforced by architecture-fitness test).
+
+## Module map
+
+`ids.rs` entity/location/NPC identifier types, `time.rs` in-game clock (`GameTime`, `GameClock`, `GameSpeed`, `Season`, `TimeOfDay`), `events.rs` game event types + `EventBus`, `conversation.rs` dialogue/conversation state (`ConversationExchange`, `ConversationLog`), `gossip.rs` gossip and rumor spreading types (`GossipItem`, `GossipNetwork`), `dice.rs` dice rolling and RNG utilities (`DiceRoll`, `roll_n`, `fixed_n`), `error.rs` thiserror-based error types (`ParishError`).

--- a/parish/crates/parish-world/AGENTS.md
+++ b/parish/crates/parish-world/AGENTS.md
@@ -1,0 +1,28 @@
+# parish-world — agent scope
+
+World graph, movement, weather, and environment state for the Parish engine. Backend-agnostic leaf crate. Owns the location graph (nodes + edges), player movement through the world, weather generation and effects, environmental descriptions, transport between locations, encounters during travel, wayfarers (travelling NPCs), and geographic coordinate resolution. See root [`AGENTS.md`](../../../AGENTS.md).
+
+## Scoped commands
+
+```sh
+cargo test -p parish-world                       # unit tests
+cargo test -p parish-world -- --nocapture        # with stdout (weather seeds, coordinate resolution)
+```
+
+Integration tests reference `../../testing/fixtures/...` and `../../../mods/rundale/...` — cwd = crate root.
+
+## Local gotchas
+
+- **Leaf-crate dependency rule.** Depends only on `parish-types` and `parish-config`. Never take a dependency on `parish-core` or any runtime crate (tauri, axum, engine). Adding a dep on a non-leaf crate violates the architecture-fitness test (rule #1).
+- **World graph is loaded from `world.json` in the active mod's directory.** The graph is deserialised at session start; any structural change to graph types (nodes, edges, paths) must be reflected in mod fixture files under `mods/rundale/world.json`.
+- **Coordinate resolution has three tiers.** Absolute (lat/lon) is tried first, then relative (`relative_to` parent offset), then graph-delta fallback (inferring position from graph topology). Always test each tier separately when adding a new location type.
+- **Weather generation is deterministic from a seed.** Same seed + same time-of-day produces identical weather. Do not use `rand::thread_rng()` — the seed is derived from the world clock. Tests asserting weather snapshots must fix the clock.
+- **`strsim` is used for fuzzy matching of location names.** Player input like "go to the churh" is resolved via Jaro-Winkler distance. The similarity threshold is tuned in `graph.rs` — lowering it increases false positives, raising it increases false negatives for colloquial names.
+- **Movement edges may have transport restrictions.** Some edges require a specific transport type (e.g., horse, ferry). Walking is the default fallback. Adding a new transport variant requires updating both `transport.rs` and the edge validation in `movement.rs`.
+- **`description.rs` generates the "you see..." prose for each location.** This is the player-facing "look" output. It composes the location's static description, current weather, time-of-day lighting, nearby NPCs (via `parish-npc`), and available exits. Changes here directly affect every entry point's `look` command output.
+- **Wayfarers are NPCs travelling on roads, not stationary NPCs.** `wayfarers.rs` manages transient encounters between settlements — they appear on edges during travel, not at nodes. Wayfarers are separate from the NPC tier system in `parish-npc`.
+- **Encounters are random events during travel between locations.** `encounter.rs` defines encounter tables per-region and per-transport-type. Encounter outcomes are resolved by `parish-npc` and `parish-inference` — this crate only triggers and classifies them.
+
+## Module map
+
+`graph.rs` location graph (nodes, edges, paths), `movement.rs` player movement, `session.rs` world session state, `weather.rs` weather generation + state, `weather_travel.rs` weather effects on travel, `description.rs` location description prose, `transport.rs` transport type definitions, `encounter.rs` random travel encounters, `wayfarers.rs` travelling NPCs on roads, `geo.rs` geographic coordinate resolution.

--- a/parish/scripts/AGENTS.md
+++ b/parish/scripts/AGENTS.md
@@ -1,0 +1,59 @@
+# parish/scripts — agent scope
+
+Shell and Python dev scripts used by CI, agents, and local development. Most enforce or support the proof-evidence gate (rule #10 in root [`AGENTS.md`](../../AGENTS.md)). Scripts are invoked from the repo root via `bash parish/scripts/<name>` or through `just` recipes.
+
+## Scoped commands
+
+```sh
+bash parish/scripts/agent-check.sh --source=local          # validate .proofs/ on disk
+bash parish/scripts/parish-mcp-backend.sh start            # boot backend for mcp__parish__* tools
+just attach-proof <task-id>                                # post proof bundle as PR comment
+```
+
+## Local gotchas
+
+- **`agent-check.sh` runs before Rust/Node/just are installed.** It is fully self-contained — no dependencies beyond POSIX shell and (for `--source=pr`) `gh`.
+- **Proof-gate convention.** The three-pipeline — `agent-check.sh` + `attach-proof.sh` + `render-proof-comment.sh` — enforces the acceptance-criteria-first workflow (rule #13). Any change to these scripts risks breaking CI's proof validation.
+- **`parish-mcp-backend.sh` is the standard backend boot.** Referenced in root `AGENTS.md` as the prerequisite before using `mcp__parish__*` tools. Spawns `parish-server --port 3030` in background with pid and log files under `parish/`.
+- **`gh` is required** by `agent-check.sh` (PR mode), `attach-proof.sh`, and `render-proof-comment.sh`. Not installed in minimal sandboxes — those scripts degrade gracefully with clear error messages.
+- **Convention.** Shell scripts use `set -euo pipefail`; Python scripts use `#!/usr/bin/env python3` and are invoked directly (`python3 parish/scripts/...`).
+- **Scripts are not library code.** They are standalone scripts meant to be read end-to-end. Avoid extracting shared shell libraries — duplicate small helpers inline for clarity.
+
+## Script index
+
+### `agent-check.sh` — PR proof gate for agent-assisted changes
+- Two modes: `--source=local` (validate `.proofs/` on disk, used by `just agent-check` and Stop hook) and `--source=pr <number>` (validate PR comments via `gh`, used by CI).
+- Diffs the working tree against the base ref, categorises changed files into proof-relevant / runtime-shipping, validates proof artifacts exist with required headers, rejects placeholder debt markers and `.proofs/` paths in diff.
+- Self-contained (no Rust/Node/just needed).
+
+### `attach-proof.sh` — Post proof bundle as PR comment
+- Reads `.proofs/<task-id>/` artifacts, formats them into a structured comment, and posts via `gh pr comment`.
+- Used by `just attach-proof <task-id>`. Depends on `render-proof-comment.sh`.
+
+### `render-proof-comment.sh` — Render proof artifacts into PR comment format
+- Reads evidence, judge verdict, and acceptance-criteria markdown from a task bundle and produces a structured comment body for `gh`.
+
+### `parish-mcp-backend.sh` — Start/stop/status/log helper for parish-mcp backend
+- Subcommands: `start`, `stop`, `status`, `logs`. Spawns `parish-server --port 3030` in background.
+- Config: `PARISH_MCP_BACKEND_PORT` (default 3030), pid in `parish/.parish-mcp-backend.pid`, log in `parish/.parish-mcp-backend.log`.
+
+### `release.sh` — Release workflow script
+- Orchestrates the release process. Invoked by CI or manually.
+
+### `reset-onboarding.sh` — Reset first-run onboarding state
+- Clears keychain entries and config file sections that track first-run setup. Useful for testing the BYOK flow end-to-end.
+
+### `check-doc-paths.sh` — Validate documentation cross-reference paths
+- Scans `docs/` for broken relative links and missing cross-references. Run after restructuring documentation.
+
+### `harness-audit.sh` — Audit the game harness
+- Validates harness configuration and checks for drift between harness tests and the actual game state.
+
+### `profile-demo-requests.py` — Profile inference request volume during `just demo`
+- Python script that starts a local OpenAI-compatible proxy, points Parish at it with `PARISH_PROVIDER=custom`, runs `just demo`, and records every request/response pair for analysis.
+
+### `project_stats.py` — Project statistics dashboard
+- Python script that produces a comprehensive health dashboard: LOC by language, commit frequency, crate dependency graph, and test coverage summaries.
+
+### `local-eval/` — Local evaluation tooling directory
+- Contains `eval_lib.py` (shared eval library), `flaw_scan.py` (flaw scanning), `gen_dlg.py` (dialogue generation), `gen_samples.py` (sample generation), and a `README.md`.

--- a/parish/testing/AGENTS.md
+++ b/parish/testing/AGENTS.md
@@ -15,10 +15,10 @@ just agent-check     # proof-evidence + judge verdict gate
 
 - **Integration-test cwd = crate root**, not workspace root. Fixture paths are `../../testing/fixtures/...` from `parish/crates/<name>/`.
 - **`fixtures/` scripts are harness-syntax**, not shell. One command per line. Comments with `#`. Read [`docs/agent/harness.md`](../../docs/agent/harness.md) before adding new ones.
-- **`rundale-bench/` Phase 1 corpus is frozen** for ELO comparability. Append-only — never edit existing prompts. Use `/eval-dialogue` to score new candidates.
+- **`rundale-bench/` (repo root, `../../rundale-bench/`) Phase 1 corpus is frozen** for ELO comparability. Append-only — never edit existing prompts. Use `/eval-dialogue` to score new candidates.
 - **`evals/` rubrics gate gameplay PRs.** Touching a rubric retroactively invalidates baselines — bump the version + note in PR.
 - **Proof-bundle judge.md must be independent.** A judge written by the same agent that wrote the proof = no signal (rule #10).
 
 ## Layout
 
-`fixtures/` harness scripts, `evals/` rubric configs, `rundale-bench/` ELO corpus + runner.
+`fixtures/` harness scripts, `evals/` rubric configs, `eval/` judge + player agent + rubrics + scenarios.

--- a/rundale-bench/AGENTS.md
+++ b/rundale-bench/AGENTS.md
@@ -1,0 +1,59 @@
+# rundale-bench — agent scope
+
+Frozen, reproducible benchmark for in-character 1820 Irish gameplay inference. Drives model + provider choices in `parish-config::presets::preset_models()`. See root [`AGENTS.md`](../AGENTS.md) for non-negotiable rules. The `/rundale-bench` agent skill at [`.agents/skills/rundale-bench/SKILL.md`](../.agents/skills/rundale-bench/SKILL.md) drives this tooling from Claude Code.
+
+## Scoped commands
+
+```sh
+# Bench one target on one slice (dev split):
+python3 rundale-bench/rundale_bench.py \
+    --target '<spec>' --suite v1 --slice intent --split dev --limit 30
+
+# Full sweep — every slice, dev split:
+python3 rundale-bench/rundale_bench.py \
+    --target '<spec>' --suite v1 --slice all --split dev
+
+# Holdout (gates leaderboard submission):
+python3 rundale-bench/rundale_bench.py \
+    --target '<spec>' --suite v1 --slice all --split holdout
+
+# Benchmark every slice + perf in one go (sonnet subagent judge, queued):
+just -f rundale-bench/justfile bench-it '<target-spec>'
+
+# Then drain the judge queue and finalise:
+#   /rundale-bench drain-queue
+#   python3 rundale-bench/rundale_bench.py ingest --finalize
+
+# Rebuild manifest after dataset edit:
+python3 rundale-bench/build_manifest.py v1
+
+# Regenerate static leaderboard:
+python3 rundale-bench/build_leaderboard_page.py
+
+# Perf probe:
+python3 rundale-bench/bench_perf.py --target '<spec>' --prompts 10
+
+# Local MLX sweep (requires MLX_PY env var for venv python):
+just -f rundale-bench/justfile local slot=tiny slice=intent limit=25
+
+# Unit tests (no API calls):
+python3 rundale-bench/test_grade.py
+```
+
+## Local gotchas
+
+- **`v1-dev` — not frozen.** Dataset is intentionally undersized (155 prompts vs 1100 target). Freeze (`frozen=true` + `git tag rundale-bench-v1.0`) deferred until corpus growth and 3+ leaderboard targets on holdout.
+- **SHA-256 verified loader.** Every `load_slice()` call verifies the file's SHA-256 against `MANIFEST.json`. Drift surfaces as `RuntimeError` rather than silent score change.
+- **Slice record schema.** Each `*.jsonl` line: `{id, tier, persona, prompt, schema?, gold?}`. `dialogue` slice has neither `schema` nor `gold` — LLM-judge-only.
+- **Two judge paths.** Default `judge_sonnet_v1` queues bundles for Sonnet subagent scoring; `judge_v1` uses the HTTP judge directly. Judge JSON files in `v1/` carry `rubric_sha256` for integrity verification.
+- **Judge system prompt lives in `v1/judge_sonnet_v1.system.md`** — referenced by the bundle's `system_prompt_file` field, loaded by the `/rundale-bench-judge` subagent skill.
+- **Local MLX runner** (`local_runner.py`) requires `mlx_lm` from a dedicated venv. Set `MLX_PY` env var (defaults to sibling `.venv-mlx/bin/python3`). The runner enforces a 4 GB headroom check and skips candidates whose `peak_ram_gb_est` exceeds available unified memory.
+- **Output artifact naming.** `rundale-bench/artifacts/run_<target>_<slice>_<UTC>.json` per-slice; `rundale-bench/artifacts/local_<UTC>.json` for sweep aggregates. Local MLX appends a row to `artifacts/local_leaderboard.md`.
+- **No modern terms.** Bench prompts stay in-character for 1820 rural Ireland — no anachronisms, no modern vocabulary.
+- **English + optional Irish (ga-IE) only.** Non-Latin scripts (Cyrillic, Han, Hangul) are grounds for a score floor. The Gaeilge fluency slice explicitly tests translation, idiom, grammar, comprehension, and English-leakage resistance.
+- **Models catalog** at `v1/models.toml` binds model IDs to providers with prices. Logical IDs resolved from this file in bench mode. Inferring `env:VAR` name; verify it is exported before hitting HTTP.
+- **Scalability.** On a 32 GB Mac, judge + 2 local targets is comfortable; 3 pushes memory. Cloud targets use no local RAM.
+
+## Layout
+
+`rundale_bench.py` single-entry orchestrator, `grade.py` graders (intent, schema, dialogue, reaction, simulation, gaeilge), `catalog.py` candidate-model catalog loader, `judge_bundle.py` judge bundle dispatch, `score_multiaxis.py` multi-axis 0-10 scoring, `bench_perf.py` performance probes (ttft, tok/s, JSON compliance), `rubric_lab.py` offline rubric scoring, `local_runner.py` MLX sweep, `build_leaderboard_page.py` static HTML, `build_manifest.py` + `split_holdout.py` dataset tooling, `cache_dialogue_replies.py` + `cache.py` caching, `candidates_local_mlx.toml` local MLX fleet, `summarize_local.py` local-run summary. `v1/` holds the benchmark dataset (6 slices, judge configs, `MANIFEST.json`, `models.toml`). `artifacts/` holds generated run/perf JSON and leaderboard pages. `bench-site/` holds the static leaderboard site. `tests/` holds additional test data.


### PR DESCRIPTION
## Summary

Completes AGENTS.md coverage across the entire workspace. Every Rust
crate, major top-level directory, and key subdirectory now has an
agent-scope reference documenting its role, scoped commands, local
gotchas, and module map.

## Changes

### 18 new AGENTS.md files
- All 11 previously-missing Rust crates: `parish-client`, `parish-config`,
  `parish-engine`, `parish-geo-tool`, `parish-input`, `parish-mcp`,
  `parish-npc-tool`, `parish-palette`, `parish-persistence`, `parish-types`,
  `parish-world`
- Top-level directories: `mods/`, `rundale-bench/`, `parish/scripts/`,
  `parish/apps/ui/src/`, `docs/agent/`, `mods/rundale/prompts/`,
  `.github/workflows/`

### 4 modified AGENTS.md files (fixes)
- `parish/testing/AGENTS.md` — fixed stale directory reference
  (`rundale-bench/` lives at repo root, not under `parish/testing/`)
- `parish/crates/parish-core/AGENTS.md` — fixed `/` → `.rs` notation in
  module map, added missing `game_loop/` entry
- `parish/crates/parish-server/AGENTS.md` — fixed `/` → `.rs` notation in
  module references
- `parish/apps/ui/AGENTS.md` — fixed `ipc/` → `ipc.ts` path

### Audit
All 8 pre-existing AGENTS.md files were verified for accuracy and are
current.