### PR TITLE
fix(world): dedupe Kilteevan "the town" alias

### DIFF
--- a/mods/rundale/world.json
+++ b/mods/rundale/world.json
@@ -481,7 +481,6 @@
             "mythological_significance": "Kilteevan — Cill Taobháin, Teevan's Church, named for the early Christian Taobhán who once kept a cell here. The ruins of the old church stand in a field nearby, half-swallowed by ivy and elder.",
             "aliases": [
                 "town",
-                "the town",
                 "village",
                 "kilteevan"
             ],

--- a/parish/crates/parish-engine/tests/world_graph_integration.rs
+++ b/parish/crates/parish-engine/tests/world_graph_integration.rs
@@ -416,6 +416,38 @@ fn test_parish_find_by_alias_bog() {
 }
 
 #[test]
+fn test_find_by_name_kilteevan_town_aliases_resolve_after_dedup() {
+    // F15 / #1126: the redundant "the town" alias was removed; the
+    // article-strip fallback in find_by_name_with_config still resolves
+    // it to Kilteevan Village via the "town" alias.
+    let graph = load_parish_graph();
+    let kilteevan = graph
+        .find_by_name("Kilteevan Village")
+        .expect("Kilteevan Village must resolve by exact name");
+
+    assert_eq!(
+        graph.find_by_name("town"),
+        Some(kilteevan),
+        "'town' alias must resolve to Kilteevan Village",
+    );
+    assert_eq!(
+        graph.find_by_name("the town"),
+        Some(kilteevan),
+        "'the town' must still resolve to Kilteevan Village via article-strip fallback",
+    );
+    assert_eq!(
+        graph.find_by_name("village"),
+        Some(kilteevan),
+        "'village' alias must still resolve to Kilteevan Village",
+    );
+    assert_eq!(
+        graph.find_by_name("kilteevan"),
+        Some(kilteevan),
+        "'kilteevan' alias must still resolve to Kilteevan Village",
+    );
+}
+
+#[test]
 fn test_movement_go_to_coast() {
     let graph = load_parish_graph();
     let result = resolve_movement("the coast", &graph, LocationId(1), &walking());

--- a/parish/testing/fixtures/play_issue-1126.txt
+++ b/parish/testing/fixtures/play_issue-1126.txt
@@ -1,0 +1,3 @@
+# F15 / #1126 — Kilteevan alias dedup
+# ====================================
+# Pure data + unit-test fix. Placeholder fixture for convention.


### PR DESCRIPTION
## Summary

- `mods/rundale/world.json` Kilteevan Village aliases now read `["town", "village", "kilteevan"]` (was `["town", "the town", "village", "kilteevan"]`).
- `"the town"` was redundant — the article-strip fallback in `find_by_name_with_config` ([graph.rs:324-335](parish/crates/parish-world/src/graph.rs:324)) already resolves it via the `"town"` alias at `MatchLevel::ArticleAlias` (priority 4).
- Regression test in `parish/crates/parish-engine/tests/world_graph_integration.rs` loads the actual Rundale world graph and asserts both `"town"` and `"the town"` resolve to Kilteevan's `LocationId` after the removal.

F15 from the #1023 epic.

Closes #1126

## Test plan

- [x] `cargo test --manifest-path parish/Cargo.toml -p parish-engine --test world_graph_integration` — 30 passed.
- [x] `cargo test --manifest-path parish/Cargo.toml --workspace --quiet` — 2989 passed, 15 ignored.
- [x] `just check` — fmt + clippy + tests + witness-scan + doc-paths green.
- [x] `just agent-check` — gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)