### PR TITLE
fix(demo): strengthen auto-player movement directive (TODO #1/#30)

### DIFF
--- a/mods/rundale/demo-prompt.txt
+++ b/mods/rundale/demo-prompt.txt
@@ -1,5 +1,13 @@
 You are wandering through rural Roscommon in 1820, curious and unhurried. Speak to villagers about their lives, ask about the land and local events, and travel widely to discover new places. Vary your approach — sometimes greet people directly, sometimes observe first. Be warm but not intrusive.
 
+MOVEMENT (TODO #1/#30): A travelling stranger does not loiter. After 3–5 turns at one location, choose to move on — even if you are mid-conversation, ye can take your leave politely and head somewhere new. The user prompt always lists adjacent destinations under "You can go to: ..." with the travel time. Pick one of those names and emit a movement command on its own:
+
+  go to The Mill
+  walk to St. Brigid's Church
+  head to Connolly's Shop
+
+These are real player commands the engine parses as movement — not stage directions and not dialogue. Do not embed movement intent inside a spoken line; emit it as the entire action. Once you have moved, the new location is described to you in the next user prompt; resume conversation with whoever is there. Aim to visit at least 3 distinct locations across any 8-turn span.
+
 Your character's name is Aiden Carney — a young east-Connacht traveller. If anyone asks your name, what to call you, who ye are, or where ye're from, answer with this exact name (or "Aiden" alone) and that you've come from over by the Shannon. Never invent a different name, never give a single letter or single syllable as a name, and use the same name every time. Do not use the words "Br Q" or any one- or two-letter capitalised tokens as a name.
 
-CRITICAL: Always respond with first-person speech or direct commands. NEVER use command-form intent descriptions like "ask about X", "tell Name Y", "whisper to X", "look at Y", "go to Z". These are instructions, not dialogue. Instead, speak naturally in first person (e.g., "Good mornin'. Might I ask about the harvest?" instead of "ask about the harvest"). Never use stage directions or third-person narration.
+CRITICAL: Always respond with first-person speech or direct commands. NEVER use command-form intent descriptions like "ask about X", "tell Name Y", "whisper to X", "look at Y". These are instructions, not dialogue. Speak naturally in first person (e.g., "Good mornin'. Might I ask about the harvest?" instead of "ask about the harvest"). Movement is the one exception — bare "go to X" / "walk to X" / "head to X" IS the correct shape, since the engine parses these as movement intents. Never use stage directions or third-person narration.

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -2482,11 +2482,21 @@ their own voice — they may use stock tags like \"Just askin', mind ye\", \"so 
 plain Hiberno-English without adopting another character's verbal tics. If an NPC \
 ends every line with \"so it is\", do not start ending yours with it too.\n\
 \n\
+MOVEMENT CADENCE (TODO #1/#30): A traveller does not loiter. After 3–5 turns \
+at one location, move to a new place — pick a name from the \"You can go to: \
+...\" line in the user prompt and emit a movement command on its own (no \
+spoken line wrapped around it). Bare \"go to X\" / \"walk to X\" / \"head to X\" \
+is the correct shape: the engine parses these as movement, not dialogue. If \
+you have visited only one location in the last 5 turns, your next action \
+should be a movement command.\n\
+\n\
 Examples:\n\
   {{\"action\": \"Good mornin' to ye. A fair day for the road.\"}}\n\
   {{\"action\": \"I've come from up the road. What news do ye have hereabouts?\"}}\n\
   {{\"action\": \"Might I ask about the harvest, then?\"}}\n\
-  {{\"action\": \"go to the mill\"}}\n\
+  {{\"action\": \"go to The Mill\"}}\n\
+  {{\"action\": \"walk to St. Brigid's Church\"}}\n\
+  {{\"action\": \"head to Connolly's Shop\"}}\n\
 \n\
 Your entire response must be a single JSON object — nothing before or after it.",
         extra = extra_section,
@@ -2709,6 +2719,44 @@ mod demo_tests {
         assert!(
             prompt.contains("Just askin', mind ye"),
             "system prompt should name the canonical example phrase:\n{prompt}"
+        );
+    }
+
+    #[test]
+    fn demo_system_prompt_carries_movement_cadence_directive() {
+        // TODO #1/#30: auto-player produced exactly 1 movement in 38+
+        // turns because the prompt has no explicit cadence rule and
+        // movement is 1 of 4 few-shot examples. Prompt must (a) name
+        // movement as a first-class action, (b) carry a "move after
+        // N turns" cadence rule, (c) show ≥ 2 movement few-shots
+        // alongside the dialogue ones, and (d) cite all three canonical
+        // movement verbs so the model picks across them.
+        let prompt = build_demo_system_prompt(None);
+        assert!(
+            prompt.contains("MOVEMENT CADENCE"),
+            "system prompt missing movement-cadence header:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("After 3–5 turns"),
+            "system prompt missing 3-5 turn cadence rule:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("go to The Mill"),
+            "system prompt missing 'go to' movement example:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("walk to St. Brigid's Church"),
+            "system prompt missing 'walk to' movement example:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("head to Connolly's Shop"),
+            "system prompt missing 'head to' movement example:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("the engine parses these as movement"),
+            "system prompt must distinguish movement commands from \
+             dialogue so the model emits bare 'go to X' rather than \
+             wrapping it in a spoken line:\n{prompt}"
         );
     }
 

--- a/parish/testing/fixtures/play_todo-1-30-auto-player-movement.txt
+++ b/parish/testing/fixtures/play_todo-1-30-auto-player-movement.txt
@@ -1,0 +1,17 @@
+# Live-proof fixture for TODO #1 / #30 — auto-player movement directive.
+#
+# The auto-player LLM lives in `parish_tauri::commands::get_llm_player_action`
+# (only callable from the Tauri/server entry points). The headless harness
+# does not drive it. This fixture instead exercises the engine loop with
+# the simulator backend so the updated demo-prompt file and updated
+# `build_demo_system_prompt` template load end-to-end without panics —
+# regression cover for prompt-template changes.
+#
+# Real-world auto-player movement validation happens in a follow-up
+# `just demo 2 8` cycle against a real LLM.
+
+look
+go to the forge
+look
+go to the holy well
+look


### PR DESCRIPTION
## Summary

- Prompt-side fix: strengthens the demo-player movement directive in `mods/rundale/demo-prompt.txt` and in `parish-tauri::build_demo_system_prompt` so the LLM-as-player actually emits movement commands.
- Per TODO #30: the action grammar already accepts `go to X` (parsed as `Move` since round-4 movement-parser landed). Across 38+ observed demo turns the auto-player emitted exactly 1 movement — the blocker was prompt shape, including a contradiction where the CRITICAL paragraph listed `"go to Z"` among forbidden command-form intents.
- Few-shot expanded 4→6 examples with 3 movement verbs (`go to`/`walk to`/`head to`); new MOVEMENT CADENCE section with 3-5-turn rule.

Fixes TODO #1 and #30.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test -p parish-tauri --lib demo_system_prompt` — 5 passed (incl. new `demo_system_prompt_carries_movement_cadence_directive`)
- [x] Live: `cargo run -p parish-engine -- --headless --script testing/fixtures/play_todo-1-30-auto-player-movement.txt` — 2 movement commands both resolved to `result:"moved"` with proper destination + minutes-elapsed; 3 distinct locations visited (Kilteevan → Forge → Holy Well).

Proof bundle: `.proofs/todo-1-30-auto-player-movement/`. Posted via `just attach-proof`.

LLM-emits-movement evidence requires a follow-up `just demo 2 8` cycle against a real model — documented in `acceptance-criteria.md` as a post-merge observable, not a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)