### PR TITLE
fix(logging): player.md visited section uses first-visit order

### DIFF
--- a/parish/crates/parish-core/src/character_log.rs
+++ b/parish/crates/parish-core/src/character_log.rs
@@ -488,9 +488,18 @@ pub fn format_player_profile(world: &WorldState) -> String {
     if world.visited_locations.is_empty() {
         out.push_str("*(none yet)*\n\n");
     } else {
-        let mut visited: Vec<&LocationId> = world.visited_locations.iter().collect();
-        visited.sort_by_key(|id| id.0);
-        for id in visited {
+        // Iterate first-visit order so the player's playthrough route
+        // is visible. Older saves loaded before #1130 land with an
+        // empty `visited_order`; fall back to sorted-by-id in that
+        // case so the section is never empty when locations exist.
+        let order: Vec<LocationId> = if world.visited_order.is_empty() {
+            let mut v: Vec<LocationId> = world.visited_locations.iter().copied().collect();
+            v.sort_by_key(|id| id.0);
+            v
+        } else {
+            world.visited_order.clone()
+        };
+        for id in &order {
             let n = world
                 .graph
                 .get(*id)
@@ -860,6 +869,46 @@ mod tests {
         assert!(profile.contains("Age 40"), "profile = {}", profile);
         assert!(profile.contains("## Intelligence"), "profile = {}", profile);
         assert!(profile.contains("## Schedule"), "profile = {}", profile);
+    }
+
+    #[test]
+    fn player_profile_visited_locations_use_first_visit_order() {
+        // #1130 / F14: visited locations render in the order
+        // `mark_visited` recorded them, not by numeric LocationId.
+        // WorldState::new()'s graph is empty, so the renderer falls
+        // back to `format!("location {}", id.0)` for each id — the
+        // ordering check is what's under test, not the rendered
+        // names.
+        let mut world = WorldState::new();
+        // WorldState::new() seeds visited with LocationId(1). Visit
+        // three more in a deliberately-out-of-order sequence: 5, 3, 2.
+        world.mark_visited(LocationId(5));
+        world.mark_visited(LocationId(3));
+        world.mark_visited(LocationId(2));
+
+        let profile = format_player_profile(&world);
+        let visited_section = profile
+            .split("## Visited locations\n\n")
+            .nth(1)
+            .expect("profile must have the Visited locations section");
+        let p1 = visited_section
+            .find("- location 1")
+            .expect("LocationId(1) missing from visited section");
+        let p5 = visited_section
+            .find("- location 5")
+            .expect("LocationId(5) missing from visited section");
+        let p3 = visited_section
+            .find("- location 3")
+            .expect("LocationId(3) missing from visited section");
+        let p2 = visited_section
+            .find("- location 2")
+            .expect("LocationId(2) missing from visited section");
+        assert!(
+            p1 < p5 && p5 < p3 && p3 < p2,
+            "visited locations must render in first-visit order \
+             (1, 5, 3, 2), got positions 1@{p1} 5@{p5} 3@{p3} 2@{p2}.\n\
+             section:\n{visited_section}",
+        );
     }
 
     #[test]

--- a/parish/crates/parish-core/src/editor/live_reload.rs
+++ b/parish/crates/parish-core/src/editor/live_reload.rs
@@ -33,7 +33,10 @@ fn apply_world_graph_refresh(world: &mut WorldState, fresh_world: WorldState) {
     world
         .visited_locations
         .retain(|id| world.locations.contains_key(id));
-    world.visited_locations.insert(world.player_location);
+    world
+        .visited_order
+        .retain(|id| world.locations.contains_key(id));
+    world.mark_visited(world.player_location);
 
     world
         .edge_traversals
@@ -202,8 +205,8 @@ tier2_system = "prompts/tier2_system.txt"
         let game_mod = GameMod::load(dir.path()).unwrap();
         let mut world = world_state_from_mod(&game_mod).unwrap();
         world.player_location = LocationId(2);
-        world.visited_locations.insert(LocationId(2));
-        world.visited_locations.insert(LocationId(999));
+        world.mark_visited(LocationId(2));
+        world.mark_visited(LocationId(999));
         world
             .edge_traversals
             .insert((LocationId(1), LocationId(2)), 3);

--- a/parish/crates/parish-core/tests/db_session_store.rs
+++ b/parish/crates/parish-core/tests/db_session_store.rs
@@ -23,6 +23,7 @@ fn make_test_snapshot() -> GameSnapshot {
         last_tier4_game_time: None,
         introduced_npcs: Default::default(),
         visited_locations: std::collections::HashSet::from([LocationId(1)]),
+        visited_order: vec![LocationId(1)],
         edge_traversals: Default::default(),
         gossip_network: Default::default(),
         conversation_log: Default::default(),

--- a/parish/crates/parish-persistence/src/database.rs
+++ b/parish/crates/parish-persistence/src/database.rs
@@ -603,6 +603,7 @@ mod tests {
             last_tier4_game_time: None,
             introduced_npcs: Default::default(),
             visited_locations: std::collections::HashSet::from([parish_types::LocationId(1)]),
+            visited_order: vec![parish_types::LocationId(1)],
             edge_traversals: Default::default(),
             gossip_network: Default::default(),
             conversation_log: Default::default(),

--- a/parish/crates/parish-persistence/src/journal.rs
+++ b/parish/crates/parish-persistence/src/journal.rs
@@ -128,7 +128,7 @@ fn apply_player_moved(
         world.clock.advance(m);
     }
     world.player_location = to;
-    world.visited_locations.insert(to);
+    world.mark_visited(to);
     *player_moved = true;
 }
 

--- a/parish/crates/parish-persistence/src/snapshot.rs
+++ b/parish/crates/parish-persistence/src/snapshot.rs
@@ -430,13 +430,32 @@ impl GameSnapshot {
             });
         world.visited_locations = visited_locations;
         // Restore first-visit order from the snapshot, retaining only ids
-        // also present in the set (legacy saves may have set entries
-        // without a corresponding order entry, in which case
-        // `visited_order` defaults to empty).
-        world.visited_order = visited_order
+        // also present in the set. Legacy saves carry an empty
+        // `visited_order` even when `visited_locations` is populated; in
+        // that case backfill from the set (sorted by id for determinism)
+        // so that a subsequent `mark_visited(new_id)` doesn't shrink the
+        // renderer's output to only the freshly-visited locations
+        // (#1130 / codex review).
+        let mut restored: Vec<parish_types::LocationId> = visited_order
             .into_iter()
             .filter(|id| world.visited_locations.contains(id))
             .collect();
+        if restored.is_empty() && !world.visited_locations.is_empty() {
+            restored = world.visited_locations.iter().copied().collect();
+            restored.sort_by_key(|id| id.0);
+        } else {
+            // Append any visited-set entries the order vector missed
+            // (mismatched save). Sorted by id for determinism.
+            let mut missing: Vec<parish_types::LocationId> = world
+                .visited_locations
+                .iter()
+                .copied()
+                .filter(|id| !restored.contains(id))
+                .collect();
+            missing.sort_by_key(|id| id.0);
+            restored.extend(missing);
+        }
+        world.visited_order = restored;
         // The player's current location must always be marked visited.
         // `mark_visited` updates both fields, preserving the no-op
         // contract when already present.

--- a/parish/crates/parish-persistence/src/snapshot.rs
+++ b/parish/crates/parish-persistence/src/snapshot.rs
@@ -310,6 +310,13 @@ pub struct GameSnapshot {
     /// Set of location IDs the player has visited (fog-of-war map).
     #[serde(default)]
     pub visited_locations: HashSet<LocationId>,
+    /// First-visit order, parallel to `visited_locations`. Used by
+    /// `character_log` to render `player.md`'s visited section in
+    /// playthrough order instead of by numeric id (#1130). Defaults to
+    /// empty for older saves; in that case the player profile falls
+    /// back to id order until the next visit appends a fresh entry.
+    #[serde(default)]
+    pub visited_order: Vec<LocationId>,
     /// Edge traversal counts for "worn path" footprints on the map.
     #[serde(default, with = "edge_traversals_serde")]
     pub edge_traversals: HashMap<(LocationId, LocationId), u32>,
@@ -352,6 +359,7 @@ impl GameSnapshot {
             last_tier4_game_time: npc_manager.last_tier4_game_time(),
             introduced_npcs: npc_manager.introduced_set(),
             visited_locations: world.visited_locations.clone(),
+            visited_order: world.visited_order.clone(),
             edge_traversals: world.edge_traversals.clone(),
             gossip_network: world.gossip_network.clone(),
             conversation_log: world.conversation_log.clone(),
@@ -388,6 +396,7 @@ impl GameSnapshot {
         world: &mut parish_world::WorldState,
         player_location: parish_types::LocationId,
         visited_locations: std::collections::HashSet<parish_types::LocationId>,
+        visited_order: Vec<parish_types::LocationId>,
         edge_traversals: std::collections::HashMap<
             (parish_types::LocationId, parish_types::LocationId),
             u32,
@@ -420,7 +429,18 @@ impl GameSnapshot {
                 lon: 0.0,
             });
         world.visited_locations = visited_locations;
-        world.visited_locations.insert(player_location);
+        // Restore first-visit order from the snapshot, retaining only ids
+        // also present in the set (legacy saves may have set entries
+        // without a corresponding order entry, in which case
+        // `visited_order` defaults to empty).
+        world.visited_order = visited_order
+            .into_iter()
+            .filter(|id| world.visited_locations.contains(id))
+            .collect();
+        // The player's current location must always be marked visited.
+        // `mark_visited` updates both fields, preserving the no-op
+        // contract when already present.
+        world.mark_visited(player_location);
         world.edge_traversals = edge_traversals;
     }
 
@@ -472,6 +492,7 @@ impl GameSnapshot {
             world,
             self.player_location,
             self.visited_locations,
+            self.visited_order,
             self.edge_traversals,
         );
         Self::restore_npcs(

--- a/parish/crates/parish-server/src/session.rs
+++ b/parish/crates/parish-server/src/session.rs
@@ -1905,6 +1905,7 @@ mod tests {
                 last_tier4_game_time: None,
                 introduced_npcs: Default::default(),
                 visited_locations: std::collections::HashSet::new(),
+                visited_order: Vec::new(),
                 edge_traversals: Default::default(),
                 gossip_network: Default::default(),
                 conversation_log: Default::default(),

--- a/parish/crates/parish-server/src/session_store_impl.rs
+++ b/parish/crates/parish-server/src/session_store_impl.rs
@@ -392,6 +392,7 @@ mod tests {
             last_tier4_game_time: None,
             introduced_npcs: Default::default(),
             visited_locations: std::collections::HashSet::new(),
+            visited_order: Vec::new(),
             edge_traversals: Default::default(),
             gossip_network: Default::default(),
             conversation_log: Default::default(),

--- a/parish/crates/parish-world/src/lib.rs
+++ b/parish/crates/parish-world/src/lib.rs
@@ -58,6 +58,11 @@ pub struct WorldState {
     pub event_bus: EventBus,
     /// Set of location IDs the player has visited (for fog-of-war map).
     pub visited_locations: HashSet<LocationId>,
+    /// First-visit order, parallel to `visited_locations`. Each id appears
+    /// at most once, in the order [`mark_visited`] first inserted it. Used
+    /// by `character_log`'s player-profile renderer to list visited
+    /// locations in playthrough order rather than by numeric id (#1130).
+    pub visited_order: Vec<LocationId>,
     /// Edge traversal counts for "worn path" footprints on the map.
     ///
     /// Keys are canonically ordered `(min_id, max_id)` pairs. The count
@@ -127,6 +132,7 @@ impl WorldState {
             text_log: Vec::new(),
             event_bus: EventBus::new(),
             visited_locations: HashSet::from([player_location]),
+            visited_order: vec![player_location],
             edge_traversals: HashMap::new(),
             gossip_network: GossipNetwork::new(),
             conversation_log: ConversationLog::new(),
@@ -180,8 +186,13 @@ impl WorldState {
     }
 
     /// Marks a location as visited for the fog-of-war map.
+    ///
+    /// Idempotent: a second call with the same id is a no-op for both
+    /// the set and the first-visit-order vector (#1130).
     pub fn mark_visited(&mut self, id: LocationId) {
-        self.visited_locations.insert(id);
+        if self.visited_locations.insert(id) {
+            self.visited_order.push(id);
+        }
     }
 
     /// Records a traversal along a path of locations, incrementing edge counts.

--- a/parish/testing/fixtures/play_issue-1130.txt
+++ b/parish/testing/fixtures/play_issue-1130.txt
@@ -1,0 +1,12 @@
+# F14 / #1130 — player.md visited locations in first-visit order
+# ===============================================================
+# Walk a deliberate non-id-order route. The proof step inspects
+# player.md's "## Visited locations" section to confirm the
+# entries appear in the order visited, not sorted by LocationId.
+
+/status
+go to The Forge
+go to The Mill
+go to Connolly's Shop
+go to The Crossroads
+/status


### PR DESCRIPTION
## Summary

- `format_player_profile` was sorting `visited_locations` by `LocationId.0`, hiding the player's playthrough route behind numeric id order.
- Add `WorldState.visited_order: Vec<LocationId>` parallel to the existing HashSet. `mark_visited` uses `HashSet::insert`'s `true` return as the first-visit signal and pushes to the vector only then — idempotent + ordered.
- Renderer iterates `visited_order` when non-empty; legacy saves with an empty vector fall back to id-sort so the section is never blank.
- Snapshot persistence adds `visited_order` with `#[serde(default)]`. Restore filters against the loaded HashSet and re-asserts the player's current location via `mark_visited`.

F14 from the #1023 epic.

Closes #1130

## Test plan

- [x] New unit test `parish-core::character_log::tests::player_profile_visited_locations_use_first_visit_order` — walks non-id-order sequence (1, 5, 3, 2), asserts rendered position order matches.
- [x] `cargo test --manifest-path parish/Cargo.toml --workspace --quiet` — 2987 passed, 15 ignored.
- [x] `just check` — fmt + clippy + tests + witness-scan + doc-paths green.
- [x] Live: `parish-engine --headless --script play_issue-1130.txt` walks a deliberate non-id-order route; rc=0.
- [x] `just agent-check` — gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)