### PR TITLE
fix(npc): raise recent-events memory cap + switch suffix to "…" (TODO #7)

### DIFF
--- a/parish/crates/parish-config/src/engine.rs
+++ b/parish/crates/parish-config/src/engine.rs
@@ -455,10 +455,20 @@ fn default_memory_context_count() -> usize {
     5
 }
 fn default_memory_truncation_dialogue() -> usize {
-    250
+    // TODO #7: 250 trimmed in-spec replies mid-sentence in the
+    // recent-events buffer fed to subsequent NPC turns. After the
+    // round-22 repetition_penalty fix, Tier 1 replies stabilise
+    // around 400–600 chars; 600 keeps them intact so downstream
+    // NPCs read the full prior dialogue, and only degenerate-loop
+    // outliers clip.
+    600
 }
 fn default_memory_truncation_event_log() -> usize {
-    150
+    // TODO #7: 150 was too tight given the dialogue cap raise.
+    // 300 leaves headroom for the outer
+    // `"{speaker} said: '{input}'. Responded: {dialogue}"` wrapper
+    // around the now-larger dialogue body without double-clipping.
+    300
 }
 fn default_event_summary_truncation() -> usize {
     100

--- a/parish/crates/parish-npc/src/ticks.rs
+++ b/parish/crates/parish-npc/src/ticks.rs
@@ -1571,14 +1571,26 @@ pub fn apply_tier3_updates(
     debug_events
 }
 
-/// Truncates a string to a maximum length, adding "..." if truncated.
+/// Truncates a string to a maximum length, adding `…` (single
+/// codepoint, 3-byte UTF-8) if truncated.
+///
+/// TODO #7: the previous suffix `...` (three ASCII dots) doubled as a
+/// truncation signal but was indistinguishable from a model-emitted
+/// ellipsis-as-punctuation in the recent-events buffer fed to
+/// subsequent NPC turns. The single `…` codepoint is unambiguously
+/// "the system trimmed this" and is also 0 bytes cheaper in the
+/// prompt budget (3 vs 3 bytes for `...` but 1 vs 3 visual chars).
 fn truncate_for_memory(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         s.to_string()
     } else {
-        let boundary = crate::floor_char_boundary(s, max_len.saturating_sub(3));
+        // `…` is 3 bytes UTF-8 (`0xE2 0x80 0xA6`); reserve that many
+        // so the resulting string still satisfies the caller's
+        // `max_len` byte cap.
+        const ELLIPSIS_BYTES: usize = 3;
+        let boundary = crate::floor_char_boundary(s, max_len.saturating_sub(ELLIPSIS_BYTES));
         let safe_boundary = boundary.min(s.len());
-        format!("{}...", &s[..safe_boundary])
+        format!("{}…", &s[..safe_boundary])
     }
 }
 
@@ -2068,11 +2080,27 @@ mod tests {
 
     #[test]
     fn test_truncate_for_memory() {
+        // Under cap: passes through unchanged.
         assert_eq!(truncate_for_memory("short", 10), "short");
+
+        // At cap exactly: passes through unchanged.
+        let at_cap = "a".repeat(20);
+        assert_eq!(truncate_for_memory(&at_cap, 20), at_cap);
+
+        // Over cap: clips and appends single-codepoint `…`.
+        // TODO #7: suffix changed from "..." to "…" so the trim
+        // marker is unambiguous vs model-emitted ellipsis.
         let long = "a".repeat(100);
         let truncated = truncate_for_memory(&long, 20);
         assert!(truncated.len() <= 20);
-        assert!(truncated.ends_with("..."));
+        assert!(
+            truncated.ends_with('…'),
+            "truncation must end with single-codepoint ellipsis, got {truncated:?}"
+        );
+        assert!(
+            !truncated.ends_with("..."),
+            "truncation must not use legacy three-dot suffix"
+        );
     }
 
     #[test]
@@ -2242,21 +2270,23 @@ mod tests {
     #[test]
     fn test_truncate_for_memory_one_over() {
         let result = truncate_for_memory("123456", 5);
-        assert!(result.ends_with("..."));
+        assert!(result.ends_with('…'));
+        // `…` is 3 bytes UTF-8; result fits in the byte cap.
         assert!(result.len() <= 5);
     }
 
     #[test]
     fn test_truncate_for_memory_max_len_zero() {
+        // max_len=0 leaves no room — result is the bare ellipsis (3 bytes).
         let result = truncate_for_memory("hello", 0);
-        assert_eq!(result, "...");
+        assert_eq!(result, "…");
     }
 
     #[test]
     fn test_truncate_for_memory_max_len_three() {
-        // max_len=3 means only room for "..."
+        // max_len=3 means only room for `…` (3 bytes).
         let result = truncate_for_memory("hello world", 3);
-        assert_eq!(result, "...");
+        assert_eq!(result, "…");
     }
 
     #[test]
@@ -2264,7 +2294,7 @@ mod tests {
         // Ensure truncation doesn't split multi-byte characters
         let irish = "Dia dhuit, a chara. Cén chaoi a bhfuil tú?";
         let result = truncate_for_memory(irish, 15);
-        assert!(result.ends_with("..."));
+        assert!(result.ends_with('…'));
         assert!(result.len() <= 18); // slightly over due to char boundary
         // Should be valid UTF-8 (no panic)
         let _ = result.chars().count();
@@ -2275,7 +2305,7 @@ mod tests {
         let long = "x".repeat(10000);
         let result = truncate_for_memory(&long, 50);
         assert!(result.len() <= 50);
-        assert!(result.ends_with("..."));
+        assert!(result.ends_with('…'));
     }
 
     // --- apply_tier2_event edge cases ---

--- a/parish/testing/fixtures/play_todo-7-recent-events-cap.txt
+++ b/parish/testing/fixtures/play_todo-7-recent-events-cap.txt
@@ -1,0 +1,11 @@
+# Live-proof fixture for TODO #7 — raise recent-events memory cap +
+# switch truncation suffix to single-codepoint ellipsis.
+#
+# The change is config-only (default constants in parish-config) plus
+# a one-char swap in `truncate_for_memory`. The fixture exercises the
+# engine harness so the new defaults load end-to-end without panics.
+# Memory-entry truncation behaviour is unit-tested.
+
+look
+go to The Mill
+look


### PR DESCRIPTION
## Summary

- `default_memory_truncation_dialogue` 250 → 600. Round-22's repetition_penalty fix lands Tier 1 replies at 400–600 chars; 600 keeps them intact in the recent-events buffer fed to subsequent NPC turns. Downstream NPCs now read full prior dialogue instead of truncated stubs.
- `default_memory_truncation_event_log` 150 → 300. Keeps the outer `"{speaker} said: '{input}'. Responded: {dialogue}"` wrapper from double-clipping the larger dialogue body.
- Truncation suffix `...` → `…` (single codepoint). Legacy `...` was indistinguishable from model-emitted ellipsis-as-punctuation; `…` is unambiguous "system trimmed this". Byte cost unchanged (3 vs 3).

Fixes TODO #7.

## Test plan

- [x] `cargo test -p parish-npc --lib truncate_for_memory` — 8 passed (all 6 truncate tests now assert `'…'`, explicit regression guard against legacy `...`)
- [x] `cargo test -p parish-npc -p parish-config` — 630 passed
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Live: `cargo run -p parish-engine -- --headless --script testing/fixtures/play_todo-7-recent-events-cap.txt` — 3 commands, NPCs resolve at The Mill, NpcConfig loads with new defaults.

Proof bundle: `.proofs/todo-7-recent-events-cap/`. Posted via `just attach-proof`.

Save file compatibility: `MemoryEntry.content` is `String` — no schema change. Existing saves load fine; old `...` entries naturally evict within `memory_capacity = 20` turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)