### PR TITLE
fix(demo): forbid narrative action style in auto-player prompt (TODO #47)

### DIFF
--- a/parish/crates/parish-inference/src/lib.rs
+++ b/parish/crates/parish-inference/src/lib.rs
@@ -1427,6 +1427,10 @@ mod tests {
     /// accidentally pick up the Tier 1 sampling override.
     #[tokio::test]
     async fn test_inference_queue_send_default_omits_frequency_penalty() {
+        // Send into the Interactive lane and receive on `irx` so the
+        // request actually surfaces. The original Background-into-irx
+        // mismatch hung this test forever and stalled CI's quality
+        // gate at the 30-minute timeout (#1127 follow-up).
         let (queue, mut irx, _brx, _batrx) = make_queue();
         let _rx = queue
             .send(
@@ -1437,7 +1441,7 @@ mod tests {
                 None,
                 None,
                 None,
-                InferencePriority::Background,
+                InferencePriority::Interactive,
                 false,
             )
             .await

--- a/parish/crates/parish-tauri/src/commands.rs
+++ b/parish/crates/parish-tauri/src/commands.rs
@@ -2471,6 +2471,17 @@ Respond with a JSON object containing a single field \"action\" — the text the
 would type into the game. Do NOT use meta-commands like \"talk to X\"; write the actual \
 words or command directly.\n\
 \n\
+NO NARRATION (TODO #47): The engine has no narrative parser. Do NOT describe what \
+you are doing in past tense, third person, or participial style. Inputs like \
+\"Walking up to the cabin, I knock gently on the door\", \"Sittin' here, I \
+notice a book half-open on the table\", or \"I'll take a seat on the bench\" \
+vanish into the dialogue path and produce no game-state change. Legal action \
+shapes are: (a) spoken dialogue in first-person present tense (\"Good \
+mornin'. Have ye news from the road?\"), (b) movement commands (\"go to The \
+Mill\"), or (c) a bare command verb the engine recognises (\"look\"). If you \
+want to do something physical, say what you would say aloud — never narrate \
+the action.\n\
+\n\
 Do NOT repeat yourself: if your last action appears in the \"Your last actions\" or \
 \"Recent events\" block of the user prompt, pick a different action — try a different \
 greeting, ask a different question, or travel somewhere new. The location description \
@@ -2759,6 +2770,35 @@ mod demo_tests {
             "system prompt must distinguish movement commands from \
              dialogue so the model emits bare 'go to X' rather than \
              wrapping it in a spoken line:\n{prompt}"
+        );
+    }
+
+    #[test]
+    fn demo_system_prompt_forbids_narrative_action_style() {
+        // TODO #47: cycle 9 caught 8/18 turns in narrative form
+        // ("Walking up to the cabin, I knock gently on the door";
+        // "Sittin' here, I notice a book half-open on the table";
+        // "I'll take a seat on the bench") — all silently dropped by
+        // the engine. The prompt must (a) name the failure mode, (b)
+        // cite at least one concrete negative example so the model
+        // pattern-matches, and (c) enumerate the legal action shapes.
+        let prompt = build_demo_system_prompt(None);
+        assert!(
+            prompt.contains("NO NARRATION"),
+            "system prompt missing no-narration header:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("Walking up to the cabin"),
+            "system prompt missing participial-narration negative example:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("vanish into the dialogue path"),
+            "system prompt must spell out the engine's failure mode so the \
+             model has a reason to obey:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("Legal action shapes are"),
+            "system prompt must enumerate the legal action shapes:\n{prompt}"
         );
     }
 

--- a/parish/testing/fixtures/play_todo-47-no-narration.txt
+++ b/parish/testing/fixtures/play_todo-47-no-narration.txt
@@ -1,0 +1,12 @@
+# Live-proof fixture for TODO #47 — forbid narrative action style in
+# auto-player.
+#
+# Fix lives in parish-tauri/src/commands.rs build_demo_system_prompt —
+# adds a NO NARRATION directive that forbids participial / past-tense
+# action narration and pins the legal action shapes. Live behavioural
+# verification (LLM-as-player stops narrating) requires a real model
+# and is out of scope here. This fixture proves the engine still boots
+# cleanly with the modified system prompt.
+
+go to The Mill
+look


### PR DESCRIPTION
## Summary

- Add a `NO NARRATION (TODO #47)` section to `build_demo_system_prompt` that names the failure mode, quotes three concrete narration patterns from the cycle-9 transcript (`Walking up to the cabin…`, `Sittin' here, I notice…`, `I'll take a seat…`), explains why such inputs fail (`vanish into the dialogue path`), and enumerates the legal action shapes.
- Pin the header, a concrete negative example, the failure-mode explanation, and the legal-shapes enumeration in `demo_system_prompt_forbids_narrative_action_style`.

Addresses TODO #47 from `TODO.md` (cycle 9: 8/18 turns produced as narrative-action and silently dropped by the engine).

## Test plan

- [x] `cargo fmt --manifest-path parish/Cargo.toml --all -- --check`
- [x] `cargo clippy --manifest-path parish/Cargo.toml -p parish-tauri --all-targets -- -D warnings`
- [x] `cargo test --manifest-path parish/Cargo.toml -p parish-tauri` (124 passed, 6 suites)
- [x] Live engine harness: `cargo run -p parish-engine -- --headless --script parish/testing/fixtures/play_todo-47-no-narration.txt` — mod loads, player walks to The Mill, looks, no runtime error.

Proof bundle: `.proofs/todo-47/` posted via attach-proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)