### PR TITLE
fix(npc): map bitter and sharp moods to distinct emoji (TODO #3)

### DIFF
--- a/parish/crates/parish-npc/src/mood.rs
+++ b/parish/crates/parish-npc/src/mood.rs
@@ -57,8 +57,19 @@ pub fn mood_emoji(mood: &str) -> &'static str {
         || m.contains("frustrat")
         || m.contains("annoyed")
         || m.contains("grumpy")
+        || m.contains("sharp")
+        || m.contains("caustic")
+        || m.contains("acerbic")
+        || m.contains("curt")
     {
         return "😤";
+    }
+    if m.contains("bitter")
+        || m.contains("resentful")
+        || m.contains("embittered")
+        || m.contains("sour")
+    {
+        return "😒";
     }
     if m.contains("suspicious") || m.contains("wary") || m.contains("distrustful") {
         return "🤨";
@@ -184,6 +195,15 @@ mod tests {
         assert_eq!(mood_emoji("irritated"), "😤");
         assert_eq!(mood_emoji("frustrated"), "😤");
         assert_eq!(mood_emoji("melancholy"), "😔");
+        // TODO #3: `bitter` and `sharp` previously fell through to the 🙂
+        // fallback. Sean Ruadh Kelly ships with mood "bitter", Peig Hannigan
+        // with mood "sharp" in mods/rundale/npcs.json.
+        assert_eq!(mood_emoji("bitter"), "😒");
+        assert_eq!(mood_emoji("resentful"), "😒");
+        assert_eq!(mood_emoji("sour"), "😒");
+        assert_eq!(mood_emoji("sharp"), "😤");
+        assert_eq!(mood_emoji("caustic"), "😤");
+        assert_eq!(mood_emoji("curt"), "😤");
     }
 
     #[test]
@@ -219,6 +239,8 @@ mod tests {
         // More specific/intense emotions should win over milder ones
         assert_eq!(mood_emoji("restlessly angry"), "😡");
         assert_eq!(mood_emoji("anxiously sad"), "😰");
+        // The `angry` arm precedes the new `bitter` arm, so explicit anger wins.
+        assert_eq!(mood_emoji("bitterly angry"), "😡");
     }
 
     #[test]
@@ -238,6 +260,7 @@ mod tests {
             ("sad", "😢"),
             ("melancholy", "😔"),
             ("irritated", "😤"),
+            ("bitter", "😒"),
             ("suspicious", "🤨"),
             ("joyful", "😄"),
             ("cheerful", "😊"),

--- a/parish/testing/fixtures/play_todo-3.txt
+++ b/parish/testing/fixtures/play_todo-3.txt
@@ -1,0 +1,14 @@
+# TODO #3 / #20 — mood→emoji miscategorises `bitter` and `sharp`
+# ==============================================================
+# mood_emoji() had no arm for `bitter` or `sharp`, so both fell through to the
+# 🙂 fallback. Sean Ruadh Kelly (mood `bitter`) and Peig Hannigan (mood `sharp`)
+# are shipped in mods/rundale/npcs.json with exactly those moods.
+#
+# `/debug npcs` lists every NPC with `Mood: <emoji> <label>`. After the fix,
+# Sean Ruadh Kelly must render with 😒 and Peig Hannigan with 😤 — never 🙂.
+#
+# mood.rs is not in the live-proof tier list, so this transcript is regression
+# cover; the behavioural assertions live in parish-npc mood unit tests.
+
+/status
+/debug npcs


### PR DESCRIPTION
## Summary

- `parish_npc::mood::mood_emoji` had no arm for `bitter` or `sharp`, so both fell through to the `🙂` unrecognised-mood fallback. The Rundale demo audit recorded this for `Sean Ruadh Kelly` (mood `bitter`) and `Peig Hannigan` (mood `sharp`) — both are shipped initial moods in `mods/rundale/npcs.json`.
- Add `bitter`/`resentful`/`embittered`/`sour` → `😒` and extend the `😤` arm with `sharp`/`caustic`/`acerbic`/`curt`, both placed after the `angry` arm so explicit stronger emotions keep priority.
- The static `mood_emoji` table remains the single source of truth for the mood badge (addresses #20's premise); per-turn reaction emoji are a separate signal, left untouched.

## Test plan

- [x] `cargo test -p parish-npc mood` — 18 passed (new asserts for `bitter`/`sharp`/synonyms, `bitterly angry → 😡` priority, `bitter → 😒` reachability)
- [x] `cargo fmt -p parish-npc -- --check` — clean
- [x] `cargo clippy -p parish-npc --all-targets -- -D warnings` — clean
- [x] Live regression cover: headless `/debug npcs` renders `Sean Ruadh Kelly → 😒 bitter` and `Peig Hannigan → 😤 sharp` (was `🙂` for both)

Proof bundle: `.proofs/todo-3/` posted via attach-proof.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4pE56kMP2GfE86UVUACFK)_