### PR TITLE
fix(core): announce pause/resume only on a real clock edge (TODO #6, #31)

### DIFF
--- a/parish/crates/parish-core/src/ipc/commands/tests.rs
+++ b/parish/crates/parish-core/src/ipc/commands/tests.rs
@@ -29,6 +29,54 @@ fn resume_command() {
 }
 
 #[test]
+fn redundant_pause_is_silent_no_edge() {
+    // TODO #6 / #31: a second /pause while already paused must not re-emit the
+    // "stand still" line. The clock stays paused; the response is empty.
+    let (mut world, mut npc, mut config) = default_state();
+    let first = handle_command(Command::Pause, &mut world, &mut npc, &mut config);
+    assert!(first.response.contains("stand still"));
+    assert!(world.clock.is_paused());
+
+    let second = handle_command(Command::Pause, &mut world, &mut npc, &mut config);
+    assert!(
+        second.response.is_empty(),
+        "redundant pause must emit no text; got {:?}",
+        second.response
+    );
+    assert!(world.clock.is_paused());
+}
+
+#[test]
+fn redundant_resume_is_silent_no_edge() {
+    // TODO #6 / #31: /resume while already running must not emit "stirs again".
+    // This is the back-to-back duplicate the demo audit captured.
+    let (mut world, mut npc, mut config) = default_state();
+    assert!(!world.clock.is_paused());
+    let result = handle_command(Command::Resume, &mut world, &mut npc, &mut config);
+    assert!(
+        result.response.is_empty(),
+        "redundant resume must emit no text; got {:?}",
+        result.response
+    );
+    assert!(!world.clock.is_paused());
+}
+
+#[test]
+fn pause_resume_sequence_emits_each_edge_once() {
+    // /pause /pause /resume /resume → exactly one edge message each direction.
+    let (mut world, mut npc, mut config) = default_state();
+    let p1 = handle_command(Command::Pause, &mut world, &mut npc, &mut config);
+    let p2 = handle_command(Command::Pause, &mut world, &mut npc, &mut config);
+    let r1 = handle_command(Command::Resume, &mut world, &mut npc, &mut config);
+    let r2 = handle_command(Command::Resume, &mut world, &mut npc, &mut config);
+    assert!(p1.response.contains("stand still"));
+    assert!(p2.response.is_empty());
+    assert!(r1.response.contains("stirs again"));
+    assert!(r2.response.is_empty());
+    assert!(!world.clock.is_paused());
+}
+
+#[test]
 fn status_command() {
     let (mut world, mut npc, mut config) = default_state();
     let result = handle_command(Command::Status, &mut world, &mut npc, &mut config);

--- a/parish/crates/parish-core/src/ipc/commands/time.rs
+++ b/parish/crates/parish-core/src/ipc/commands/time.rs
@@ -16,12 +16,26 @@ pub(super) fn handle_time_control_command(
 ) -> CommandResult {
     match cmd {
         Command::Pause => {
-            world.clock.pause();
-            CommandResult::text("The clocks of the parish stand still.")
+            // Only announce on the running->paused edge. The frontend
+            // auto-pause tracker dispatches /pause repeatedly on user-idle
+            // edges; without this gate a redundant /pause re-emits the system
+            // line, producing the duplicate messages the demo audit caught
+            // (TODO #6 / #31). An empty response is not emitted.
+            if world.clock.is_paused() {
+                CommandResult::text("")
+            } else {
+                world.clock.pause();
+                CommandResult::text("The clocks of the parish stand still.")
+            }
         }
         Command::Resume => {
-            world.clock.resume();
-            CommandResult::text("Time stirs again in the parish.")
+            // Symmetric edge-gating: only announce on the paused->running edge.
+            if world.clock.is_paused() {
+                world.clock.resume();
+                CommandResult::text("Time stirs again in the parish.")
+            } else {
+                CommandResult::text("")
+            }
         }
         Command::Status => {
             let tod = world.clock.time_of_day();

--- a/parish/testing/fixtures/play_todo-31.txt
+++ b/parish/testing/fixtures/play_todo-31.txt
@@ -1,0 +1,18 @@
+# TODO #6 / #31 — pause/resume must only announce on a real state edge
+# ====================================================================
+# Before the fix, every /pause and /resume emitted its system line even when
+# the clock state didn't change, producing duplicate "Time stirs again" lines
+# with no intervening "stand still" (demo audit cycle 6).
+#
+# Expected after the fix:
+#   /pause   -> "The clocks of the parish stand still."   (edge: running->paused)
+#   /pause   -> empty response                            (no edge; already paused)
+#   /resume  -> "Time stirs again in the parish."         (edge: paused->running)
+#   /resume  -> empty response                            (no edge; already running)
+
+/status
+/pause
+/pause
+/resume
+/resume
+/status


### PR DESCRIPTION
## Summary

- `handle_time_control_command` (parish-core `ipc/commands/time.rs`) emitted the pause/resume system line on **every** `Command::Pause` / `Command::Resume`, even when the clock state was unchanged. `GameClock::pause`/`resume` are idempotent at the state level, but the announcement wasn't.
- The frontend auto-pause tracker (`auto-pause.ts`) dispatches `/pause` and `/resume` on user idle/active edges, so redundant same-direction dispatches re-emitted the message — producing the demo audit's back-to-back `Time stirs again` lines with no intervening `stand still` (TODO #31 lines 167-178) and the per-turn bursts in TODO #6.
- Fix: gate the message on the real running↔paused edge. A redundant `/pause` (already paused) or `/resume` (already running) now returns an empty response (no text emitted). Clock state behaviour is identical.

## Test plan

- [x] `cargo test -p parish-core --lib ipc::commands::tests` — 90 passed, incl. 3 new: `redundant_pause_is_silent_no_edge`, `redundant_resume_is_silent_no_edge`, `pause_resume_sequence_emits_each_edge_once`
- [x] `cargo fmt -p parish-core -- --check` — clean
- [x] `cargo clippy -p parish-core --all-targets -- -D warnings` — clean
- [x] Live transcript (`ipc/**` is in the live-proof tier): headless `/pause /pause /resume /resume` emits each edge message once; the redundant repeats carry an empty `response` with no `new_log_lines`

Note: the frontend `auto-pause.ts` focus guard (TODO #31a) is already shipped; this is the complementary server-side edge-gating.

Proof bundle: `.proofs/todo-31/` posted via attach-proof.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4pE56kMP2GfE86UVUACFK)_