### PR TITLE
fix: pluralize "minute" in travel/wait narration + lint against recurrence (#1156)

### DIFF
--- a/parish/crates/parish-client/src/render.rs
+++ b/parish/crates/parish-client/src/render.rs
@@ -1,5 +1,13 @@
 use crate::client::CommandResponse;
 
+/// Singular/plural for a minute count: `"minute"` for exactly 1, else
+/// `"minutes"` (#1156). `parish-client` is a standalone thin HTTP client
+/// with no `parish-*` dependencies by design, so it carries its own copy
+/// rather than pull in `parish_types::minute_word`.
+fn minute_word(minutes: u64) -> &'static str {
+    if minutes == 1 { "minute" } else { "minutes" }
+}
+
 pub fn render_response(resp: &CommandResponse) -> String {
     let mut out = String::new();
 
@@ -46,8 +54,11 @@ pub fn render_response(resp: &CommandResponse) -> String {
         && resp.lines.is_empty()
     {
         out.push_str(&format!(
-            "You travel from {} to {} ({} minutes).\n",
-            travel.from, travel.to, travel.duration_minutes
+            "You travel from {} to {} ({} {}).\n",
+            travel.from,
+            travel.to,
+            travel.duration_minutes,
+            minute_word(travel.duration_minutes)
         ));
     }
 
@@ -56,4 +67,36 @@ pub fn render_response(resp: &CommandResponse) -> String {
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::CommandResponse;
+
+    fn travel_response(minutes: u64) -> CommandResponse {
+        serde_json::from_value(serde_json::json!({
+            "outcome": "moved",
+            "kind": "moved",
+            "echo": "go",
+            "lines": [],
+            "travel": { "from": "The Crossroads", "to": "Darcy's Pub", "duration_minutes": minutes },
+            "elapsed_ms": 0,
+        }))
+        .expect("valid CommandResponse")
+    }
+
+    #[test]
+    fn travel_line_singular_for_one_minute() {
+        // #1156: a 1-minute leg must read "1 minute", not "1 minutes".
+        let out = render_response(&travel_response(1));
+        assert!(out.contains("(1 minute)"), "got: {out}");
+        assert!(!out.contains("(1 minutes)"), "got: {out}");
+    }
+
+    #[test]
+    fn travel_line_plural_for_many_minutes() {
+        let out = render_response(&travel_response(14));
+        assert!(out.contains("(14 minutes)"), "got: {out}");
+    }
 }

--- a/parish/crates/parish-core/src/ipc/commands/time.rs
+++ b/parish/crates/parish-core/src/ipc/commands/time.rs
@@ -1,6 +1,7 @@
 //! Time-control commands: pause, resume, status, speed, wait, tick.
 
 use chrono::Timelike;
+use parish_types::minute_word;
 
 use crate::input::Command;
 use crate::npc::manager::NpcManager;
@@ -79,8 +80,9 @@ pub(super) fn handle_time_control_command(
             let now = world.clock.now();
             let tod = world.clock.time_of_day();
             CommandResult::text(format!(
-                "You wait for {} minutes...\nIt is now {:02}:{:02} {}.",
+                "You wait for {} {}...\nIt is now {:02}:{:02} {}.",
                 minutes,
+                minute_word(minutes),
                 now.hour(),
                 now.minute(),
                 tod

--- a/parish/crates/parish-core/tests/architecture_fitness.rs
+++ b/parish/crates/parish-core/tests/architecture_fitness.rs
@@ -265,6 +265,89 @@ fn minute_counts_pluralize_through_helper() {
     );
 }
 
+/// `(src-relative path, Command variant)` pairs that are knowingly handled
+/// inside an entry-point crate instead of delegating to the shared
+/// `parish_core::ipc::commands::handle_command`. Every entry MUST cite why
+/// the local handling exists and a tracking issue for its removal.
+///
+/// The synchronous CLI/script/test harness in `parish-engine` has no async
+/// background game loop, so it inlines the world-advance pump (weather tick,
+/// schedule→narration, banshee, gossip, tier-4) that `parish-server` and
+/// `parish-tauri` drive from a continuous loop. Removing these arms requires
+/// extracting that pump into a shared `EventEmitter`-parameterized core
+/// helper — tracked in #1159.
+const ALLOWED_LOCAL_COMMAND_HANDLERS: &[(&str, &str)] = &[
+    ("crates/parish-engine/src/testing.rs", "Wait"),
+    ("crates/parish-engine/src/testing.rs", "Tick"),
+];
+
+/// Rule #12 structural sensor: cross-runtime orchestration belongs in
+/// `parish-core`, parameterized over runtime concerns via traits — entry-point
+/// crates are limited to thin wiring.
+///
+/// The canonical player-command dispatcher is
+/// `parish_core::ipc::commands::handle_command`, which exhaustively matches
+/// every `Command` variant once. Any `Command::<Variant> =>` match arm in an
+/// entry-point crate (`parish-engine`, `parish-server`, `parish-tauri`) is a
+/// second, divergent implementation of an orchestration body — the exact
+/// copy-paste drift that let #1156's "1 minutes" survive in the headless
+/// harness and that #687/#696 warn about. Entry points must call the shared
+/// handler and dispatch its returned effects, not re-handle commands inline.
+#[test]
+fn entry_point_crates_do_not_reimplement_shared_commands() {
+    let ws = workspace_root();
+    const ENTRY_POINTS: &[&str] = &["parish-engine", "parish-server", "parish-tauri"];
+
+    // `Command::Variant` optionally with a tuple/struct payload, then `=>` on
+    // the same arm — i.e. a match arm, not a `Command::Wait(60)` construction
+    // (those terminate in `;`/`,`/`)` before any `=>`).
+    let re = regex::Regex::new(r"Command::([A-Z][A-Za-z0-9_]*)[^;\n]*=>")
+        .expect("static regex compiles");
+
+    let mut violations: Vec<String> = Vec::new();
+    for crate_name in ENTRY_POINTS {
+        let src = ws.join("crates").join(crate_name).join("src");
+        let mut files = Vec::new();
+        walk_rs_files(&src, &mut files);
+        for f in files {
+            let rel = f
+                .strip_prefix(&ws)
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| f.display().to_string());
+            let body = fs::read_to_string(&f).unwrap_or_default();
+            for (i, raw_line) in body.lines().enumerate() {
+                let line = raw_line.split("//").next().unwrap_or("");
+                for cap in re.captures_iter(line) {
+                    let variant = &cap[1];
+                    if ALLOWED_LOCAL_COMMAND_HANDLERS
+                        .iter()
+                        .any(|(p, v)| rel.replace('\\', "/") == *p && v == &variant)
+                    {
+                        continue;
+                    }
+                    violations.push(format!("{rel}:{} — Command::{variant}", i + 1));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "Rule #12 violation — entry-point crate(s) re-implement a shared \
+         command handler instead of delegating:\n  - {}\n\n\
+         FIX: route the command through \
+         `parish_core::ipc::commands::handle_command` and dispatch the returned \
+         `CommandEffect`s; put any shared orchestration body, constant, or \
+         payload struct in `parish-core` parameterized over `EventEmitter`. \
+         Copy-pasting an orchestration arm into a second entry point produces \
+         invisible drift (#687, #696; it is how #1156 reached the headless \
+         harness). If the local handling is genuinely unavoidable, add it to \
+         ALLOWED_LOCAL_COMMAND_HANDLERS with a justification and a tracking \
+         issue. See CLAUDE.md rule #12 and docs/agent/architecture.md.",
+        violations.join("\n  - "),
+    );
+}
+
 fn list_top_level_modules(src: &Path) -> BTreeSet<String> {
     let mut out = BTreeSet::new();
     if !src.is_dir() {

--- a/parish/crates/parish-core/tests/architecture_fitness.rs
+++ b/parish/crates/parish-core/tests/architecture_fitness.rs
@@ -201,6 +201,70 @@ fn no_orphaned_source_files() {
     );
 }
 
+/// Sensor for the narration-drift class behind #1156.
+///
+/// Player-facing minute counts must be pluralized through the shared
+/// helper `parish_types::minute_word` (or, for the dependency-free
+/// `parish-client`, its local equivalent) rather than hand-written as a
+/// `format!("... {} minutes ...")` literal with no singular branch. The
+/// original bug shipped *four* independent hand-rolled copies of
+/// "{} minutes" — one of them in `parish-engine`'s headless harness, a
+/// copy that had silently diverged from the shared `/wait` command. Each
+/// copy is a place a "1 minutes on foot" defect can reappear, exactly the
+/// copy-paste drift CLAUDE.md rule #12 forbids.
+///
+/// The check is a cheap textual sensor: it flags any format-placeholder
+/// (`{}`, `{:>2}`, `{n}`, …) immediately followed by the word
+/// `minute`/`minutes` in a workspace `src/` file. Routing the count
+/// through a `minute_word(n)`-style helper (which emits `{} {}`) clears it.
+#[test]
+fn minute_counts_pluralize_through_helper() {
+    let ws = workspace_root();
+
+    // A format placeholder directly followed by the bare unit word — the
+    // hand-rolled-pluralization smell. `{}min` (the abbreviated exits
+    // hint) and `minute_word` itself are deliberately not matched.
+    let re = regex::Regex::new(r"\{[^{}]*\}\s+minutes?\b").expect("static regex compiles");
+
+    let mut violations: Vec<String> = Vec::new();
+    for entry in fs::read_dir(ws.join("crates")).expect("read crates/") {
+        let src = entry.expect("entry").path().join("src");
+        if !src.is_dir() {
+            continue;
+        }
+        let mut files = Vec::new();
+        walk_rs_files(&src, &mut files);
+        for f in files {
+            let body = fs::read_to_string(&f).unwrap_or_default();
+            for (i, raw_line) in body.lines().enumerate() {
+                // Strip line/doc comments — the common false-positive source.
+                let line = raw_line.split("//").next().unwrap_or("");
+                if re.is_match(line) {
+                    let pretty = f
+                        .strip_prefix(&ws)
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_else(|_| f.display().to_string());
+                    violations.push(format!("{pretty}:{}", i + 1));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "Hand-rolled minute pluralization — `{{}} minutes` literal(s) with no \
+         singular branch (the #1156 defect class):\n  - {}\n\n\
+         FIX: pluralize through `parish_types::minute_word(n)` (re-exported as \
+         `parish_core::world::time::minute_word`), which returns \"minute\" for \
+         1 and \"minutes\" otherwise — emit `({{}} {{}})` with the count and \
+         `minute_word(count)`. `parish-client` is dependency-free by design and \
+         carries its own private `minute_word`. Duplicating the format literal \
+         instead lets a \"1 minutes on foot\" bug reappear in each copy. See \
+         CLAUDE.md rule #12 (no copy-pasted narration across entry points).",
+        violations.join("\n  - "),
+    );
+}
+
 fn list_top_level_modules(src: &Path) -> BTreeSet<String> {
     let mut out = BTreeSet::new();
     if !src.is_dir() {

--- a/parish/crates/parish-engine/src/headless.rs
+++ b/parish/crates/parish-engine/src/headless.rs
@@ -1264,8 +1264,9 @@ async fn handle_headless_movement(app: &mut App, target: &str) {
                 app.world.clock.advance(lost as i64);
                 println!(
                     "You turn back. The storm has the better of it; you'll try again later. \
-                     ({} minutes lost to the attempt.)",
-                    lost
+                     ({} {} lost to the attempt.)",
+                    lost,
+                    parish_core::world::time::minute_word(lost)
                 );
                 println!();
                 return;

--- a/parish/crates/parish-engine/src/headless.rs
+++ b/parish/crates/parish-engine/src/headless.rs
@@ -1275,8 +1275,11 @@ async fn handle_headless_movement(app: &mut App, target: &str) {
             let adjusted_minutes = apply_multiplier(minutes, weather_effect.multiplier);
             if adjusted_minutes > minutes {
                 println!(
-                    "{} (slowed by the weather from {} to {} minutes)",
-                    narration, minutes, adjusted_minutes
+                    "{} (slowed by the weather from {} to {} {})",
+                    narration,
+                    minutes,
+                    adjusted_minutes,
+                    parish_core::world::time::minute_word(adjusted_minutes)
                 );
             } else {
                 println!("{}", narration);

--- a/parish/crates/parish-engine/src/headless.rs
+++ b/parish/crates/parish-engine/src/headless.rs
@@ -1402,18 +1402,9 @@ fn process_headless_schedule_events(app: &mut App, events: &[crate::npc::manager
 /// Ticks the weather engine and publishes a `WeatherChanged` event if the
 /// weather changes.
 fn dispatch_headless_weather(app: &mut App) {
-    let season = app.world.clock.season();
-    let now = app.world.clock.now();
+    let old = app.world.weather;
     let mut rng = rand::rng();
-    if let Some(new_weather) = app.world.weather_engine.tick(now, season, &mut rng) {
-        let old = app.world.weather;
-        app.world.weather = new_weather;
-        app.world
-            .event_bus
-            .publish(crate::world::events::GameEvent::WeatherChanged {
-                new_weather: new_weather.to_string(),
-                timestamp: app.world.clock.now(),
-            });
+    if let Some(new_weather) = app.world.tick_weather(&mut rng) {
         tracing::info!(old = %old, new = %new_weather, "Weather changed");
     }
 }

--- a/parish/crates/parish-engine/src/testing.rs
+++ b/parish/crates/parish-engine/src/testing.rs
@@ -681,8 +681,9 @@ impl GameTestHarness {
                 let now = self.app.world.clock.now();
                 let tod = self.app.world.clock.time_of_day();
                 let msg = format!(
-                    "Waited {} minutes. Now {:02}:{:02} {}.",
+                    "Waited {} {}. Now {:02}:{:02} {}.",
                     minutes,
+                    parish_core::world::time::minute_word(minutes),
                     now.hour(),
                     now.minute(),
                     tod

--- a/parish/crates/parish-engine/src/testing.rs
+++ b/parish/crates/parish-engine/src/testing.rs
@@ -540,6 +540,12 @@ impl GameTestHarness {
 
         // Tick the weather engine for each hour that elapsed, so large time jumps
         // don't skip weather checks. The engine deduplicates by game-hour internally.
+        //
+        // This bulk catch-up advances weather *state* only — it intentionally
+        // does NOT publish a WeatherChanged per backfilled hour (unlike the
+        // single-step `WorldState::tick_weather` the real-time loops use). A
+        // 226-day jump would otherwise emit thousands of events and overflow the
+        // broadcast bus, evicting other events that tests drain for.
         let season = self.app.world.clock.season();
         let now = self.app.world.clock.now();
         let hours_elapsed = (minutes / 60).max(1) as u32;
@@ -692,17 +698,9 @@ impl GameTestHarness {
                 return ActionResult::SystemCommand { response: msg };
             }
             Command::Tick => {
-                // Tick weather engine (shared handler doesn't do this)
-                let season = self.app.world.clock.season();
-                let now = self.app.world.clock.now();
-                if let Some(new_weather) =
-                    self.app
-                        .world
-                        .weather_engine
-                        .tick(now, season, &mut self.rng)
-                {
-                    self.app.world.weather = new_weather;
-                }
+                // Tick weather engine (shared handler doesn't do this) via the
+                // shared WorldState helper so it matches every other runtime.
+                self.app.world.tick_weather(&mut self.rng);
 
                 self.app.npc_manager.assign_tiers(&self.app.world, &[]);
                 let events = self.app.npc_manager.tick_schedules(

--- a/parish/crates/parish-server/src/session.rs
+++ b/parish/crates/parish-server/src/session.rs
@@ -1215,18 +1215,8 @@ fn spawn_session_ticks(
                     let mut world = s.world.lock().await;
                     let mut npc_mgr = s.npc_manager.lock().await;
 
-                    let season = world.clock.season();
-                    let now = world.clock.now();
                     let mut rng = rand::rng();
-                    if let Some(new_weather) = world.weather_engine.tick(now, season, &mut rng) {
-                        world.weather = new_weather;
-                        world.event_bus.publish(
-                            parish_core::world::events::GameEvent::WeatherChanged {
-                                new_weather: new_weather.to_string(),
-                                timestamp: world.clock.now(),
-                            },
-                        );
-                    }
+                    world.tick_weather(&mut rng);
 
                     npc_mgr.tick_schedules(
                         &world.clock,

--- a/parish/crates/parish-tauri/src/setup.rs
+++ b/parish/crates/parish-tauri/src/setup.rs
@@ -809,36 +809,29 @@ pub(crate) fn spawn_world_tick(handle: AppHandle, state: Arc<AppState>) {
                 }
             }
             {
-                // Tick weather engine
-                let season = world.clock.season();
+                // `now`/`season` are reused by the Tier-4 dispatch further down.
                 let now = world.clock.now();
+                let season = world.clock.season();
+                // Tick weather engine via the shared WorldState helper so the
+                // tick+publish stays identical across all runtimes (#1159).
+                let old = world.weather;
                 // Scope thread_rng tightly so it is dropped before any await.
                 let new_weather_opt = {
                     let mut rng = rand::rng();
-                    world.weather_engine.tick(now, season, &mut rng)
+                    world.tick_weather(&mut rng)
                 };
-                {
-                    if let Some(new_weather) = new_weather_opt {
-                        let old = world.weather;
-                        world.weather = new_weather;
-                        world.event_bus.publish(
-                            parish_core::world::events::GameEvent::WeatherChanged {
-                                new_weather: new_weather.to_string(),
-                                timestamp: world.clock.now(),
-                            },
-                        );
-                        tracing::info!(old = %old, new = %new_weather, "Weather changed");
-                        // Emit weather debug event
-                        let mut debug_events = state.debug_events.lock().await;
-                        if debug_events.len() >= DEBUG_EVENT_CAPACITY {
-                            debug_events.pop_front();
-                        }
-                        debug_events.push_back(DebugEvent {
-                            timestamp: String::new(),
-                            category: "weather".to_string(),
-                            message: format!("Weather: {} → {}", old, new_weather),
-                        });
+                if let Some(new_weather) = new_weather_opt {
+                    tracing::info!(old = %old, new = %new_weather, "Weather changed");
+                    // Emit weather debug event
+                    let mut debug_events = state.debug_events.lock().await;
+                    if debug_events.len() >= DEBUG_EVENT_CAPACITY {
+                        debug_events.pop_front();
                     }
+                    debug_events.push_back(DebugEvent {
+                        timestamp: String::new(),
+                        category: "weather".to_string(),
+                        message: format!("Weather: {} → {}", old, new_weather),
+                    });
                 }
 
                 let schedule_events = npc_mgr.tick_schedules(

--- a/parish/crates/parish-types/src/lib.rs
+++ b/parish/crates/parish-types/src/lib.rs
@@ -20,7 +20,9 @@ pub use ids::{
     DEFAULT_START_LOCATION, LanguageHint, Location, LocationId, NpcId, Weather,
     extract_dialogue_from_partial_json, floor_char_boundary,
 };
-pub use time::{DayType, Festival, GameClock, GameSpeed, Season, SpeedConfig, TimeOfDay};
+pub use time::{
+    DayType, Festival, GameClock, GameSpeed, Season, SpeedConfig, TimeOfDay, minute_word,
+};
 
 /// A single anachronism term entry loaded from mod JSON data.
 ///

--- a/parish/crates/parish-types/src/time.rs
+++ b/parish/crates/parish-types/src/time.rs
@@ -524,10 +524,41 @@ pub fn time_of_day_from_hour(hour: u32) -> TimeOfDay {
     }
 }
 
+/// Returns the correctly pluralized word for a count of minutes:
+/// `"minute"` for exactly 1, `"minutes"` otherwise.
+///
+/// Generic over the integer type so callers can pass `u16` (travel legs),
+/// `u32` (`/wait` minutes), etc. without casts. Centralizes the
+/// singular/plural branch shared by travel-arrival and `/wait` narration
+/// so a 1-minute leg reads "1 minute on foot" rather than "1 minutes on
+/// foot" (#1156).
+pub fn minute_word<T>(minutes: T) -> &'static str
+where
+    T: PartialEq + From<u8>,
+{
+    if minutes == T::from(1u8) {
+        "minute"
+    } else {
+        "minutes"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::TimeZone;
+
+    #[test]
+    fn test_minute_word_singular_plural() {
+        // #1156: a 1-minute leg must read "1 minute", not "1 minutes".
+        assert_eq!(minute_word(0u16), "minutes");
+        assert_eq!(minute_word(1u16), "minute");
+        assert_eq!(minute_word(2u16), "minutes");
+        assert_eq!(minute_word(11u16), "minutes");
+        // Generic over the integer type used by `/wait` (u32).
+        assert_eq!(minute_word(1u32), "minute");
+        assert_eq!(minute_word(15u32), "minutes");
+    }
 
     fn game_time(year: i32, month: u32, day: u32, hour: u32) -> DateTime<Utc> {
         Utc.with_ymd_and_hms(year, month, day, hour, 0, 0).unwrap()

--- a/parish/crates/parish-world/src/lib.rs
+++ b/parish/crates/parish-world/src/lib.rs
@@ -243,6 +243,40 @@ impl WorldState {
     pub fn increment_tick_generation(&mut self) {
         self.tick_generation = self.tick_generation.wrapping_add(1);
     }
+
+    /// Advances the weather engine for the given check time, and — on a
+    /// transition — updates [`Self::weather`] and publishes a
+    /// [`GameEvent::WeatherChanged`] on the world event bus. Returns the new
+    /// weather if it changed, else `None`.
+    ///
+    /// This is the single source of truth for "tick the weather and announce
+    /// it" that every runtime loop (server, Tauri, headless, and the script
+    /// harness) shares. Inlining the `weather_engine.tick` + publish pair at
+    /// each call site is how the harness silently drifted into ticking weather
+    /// without emitting the event (#1156 follow-up; tracked in #1159).
+    pub fn tick_weather_at(
+        &mut self,
+        check_time: chrono::DateTime<chrono::Utc>,
+        rng: &mut impl rand::Rng,
+    ) -> Option<Weather> {
+        let season = self.clock.season();
+        let new_weather = self.weather_engine.tick(check_time, season, rng)?;
+        self.weather = new_weather;
+        self.event_bus
+            .publish(parish_types::events::GameEvent::WeatherChanged {
+                new_weather: new_weather.to_string(),
+                timestamp: self.clock.now(),
+            });
+        Some(new_weather)
+    }
+
+    /// Convenience wrapper over [`Self::tick_weather_at`] that checks at the
+    /// current clock time. Used by the real-time loops, which tick once per
+    /// timer interval.
+    pub fn tick_weather(&mut self, rng: &mut impl rand::Rng) -> Option<Weather> {
+        let now = self.clock.now();
+        self.tick_weather_at(now, rng)
+    }
 }
 
 impl Default for WorldState {
@@ -283,6 +317,68 @@ mod tests {
         let world = WorldState::new();
         assert_eq!(world.player_location, LocationId(1));
         assert_eq!(world.current_location().name, "The Crossroads");
+    }
+
+    #[test]
+    fn tick_weather_publishes_on_transition() {
+        use parish_types::events::GameEvent;
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        // The shared `tick_weather` helper must do both halves of the job every
+        // runtime used to inline: update `self.weather` AND publish a
+        // `WeatherChanged` event. (#1156 follow-up — the script harness used to
+        // tick weather without emitting; #1159.)
+        let mut transitioned = false;
+        for seed in 0..500u64 {
+            let mut world = WorldState::new();
+            // Arm the engine on Overcast (which has transitions in both
+            // directions) and step the clock past the min-duration gate.
+            world
+                .weather_engine
+                .force(Weather::Overcast, world.clock.now());
+            world.weather = Weather::Overcast;
+            world.clock.advance(3 * 60);
+
+            let mut rx = world.event_bus.subscribe();
+            let mut rng = StdRng::seed_from_u64(seed);
+
+            if let Some(new_weather) = world.tick_weather(&mut rng) {
+                // State updated to the returned weather.
+                assert_eq!(world.weather, new_weather);
+                // …and exactly that change was announced on the bus.
+                let evt = rx.try_recv().expect("WeatherChanged should be published");
+                match evt {
+                    GameEvent::WeatherChanged { new_weather: w, .. } => {
+                        assert_eq!(w, new_weather.to_string());
+                    }
+                    other => panic!("expected WeatherChanged, got {other:?}"),
+                }
+                transitioned = true;
+                break;
+            }
+        }
+        assert!(
+            transitioned,
+            "no seed in 0..500 produced a weather transition to exercise tick_weather"
+        );
+    }
+
+    #[test]
+    fn tick_weather_silent_when_no_transition() {
+        // No transition (engine just armed, clock not advanced) ⇒ no event,
+        // weather unchanged, returns None.
+        use rand::SeedableRng;
+        use rand::rngs::StdRng;
+
+        let mut world = WorldState::new();
+        let before = world.weather;
+        let mut rx = world.event_bus.subscribe();
+        let mut rng = StdRng::seed_from_u64(0);
+
+        assert_eq!(world.tick_weather(&mut rng), None);
+        assert_eq!(world.weather, before);
+        assert!(rx.try_recv().is_err(), "no event should be published");
     }
 
     #[test]

--- a/parish/crates/parish-world/src/movement.rs
+++ b/parish/crates/parish-world/src/movement.rs
@@ -11,7 +11,7 @@
 
 use super::graph::{Connection, Hazard, WorldGraph};
 use super::transport::TransportMode;
-use parish_types::{LocationId, Weather};
+use parish_types::{LocationId, Weather, minute_word};
 
 /// The result of resolving a movement command.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -314,8 +314,12 @@ fn build_travel_narration(
         // Direct connection
         if let Some(conn) = graph.connection_between(path[0], path[1]) {
             return format!(
-                "You {} along {}. ({} minutes {})",
-                verb, conn.path_description, total_minutes, transport.label
+                "You {} along {}. ({} {} {})",
+                verb,
+                conn.path_description,
+                total_minutes,
+                minute_word(total_minutes),
+                transport.label
             );
         }
     }
@@ -327,8 +331,12 @@ fn build_travel_narration(
         .unwrap_or("the road");
 
     format!(
-        "You set off along {} toward {}. ({} minutes {})",
-        first_desc, dest_name, total_minutes, transport.label
+        "You set off along {} toward {}. ({} {} {})",
+        first_desc,
+        dest_name,
+        total_minutes,
+        minute_word(total_minutes),
+        transport.label
     )
 }
 

--- a/parish/testing/evals/baselines/test_all_locations.json
+++ b/parish/testing/evals/baselines/test_all_locations.json
@@ -37,7 +37,7 @@
       "result": "moved",
       "to": "Darcy's Pub",
       "minutes": 1,
-      "narration": "You walk along a short lane past a row of cottages. (1 minutes on foot)"
+      "narration": "You walk along a short lane past a row of cottages. (1 minute on foot)"
     },
     "location": "Darcy's Pub",
     "time": "Morning",
@@ -59,7 +59,7 @@
       "result": "moved",
       "to": "The Crossroads",
       "minutes": 1,
-      "narration": "You walk along the lane back to the crossroads. (1 minutes on foot)"
+      "narration": "You walk along the lane back to the crossroads. (1 minute on foot)"
     },
     "location": "The Crossroads",
     "time": "Morning",
@@ -326,7 +326,7 @@
       "result": "moved",
       "to": "Connolly's Shop",
       "minutes": 1,
-      "narration": "You walk along a few steps across the road. (1 minutes on foot)"
+      "narration": "You walk along a few steps across the road. (1 minute on foot)"
     },
     "location": "Connolly's Shop",
     "time": "Midnight",
@@ -348,7 +348,7 @@
       "result": "moved",
       "to": "The Crossroads",
       "minutes": 1,
-      "narration": "You walk along a few steps back across the road to the crossroads. (1 minutes on foot)"
+      "narration": "You walk along a few steps back across the road to the crossroads. (1 minute on foot)"
     },
     "location": "The Crossroads",
     "time": "Midnight",

--- a/parish/testing/evals/baselines/test_movement_errors.json
+++ b/parish/testing/evals/baselines/test_movement_errors.json
@@ -80,7 +80,7 @@
       "result": "moved",
       "to": "The Crossroads",
       "minutes": 1,
-      "narration": "You walk along the lane back to the crossroads. (1 minutes on foot)"
+      "narration": "You walk along the lane back to the crossroads. (1 minute on foot)"
     },
     "location": "The Crossroads",
     "time": "Morning",

--- a/parish/testing/fixtures/play_issue-1156.txt
+++ b/parish/testing/fixtures/play_issue-1156.txt
@@ -1,0 +1,13 @@
+# Verification fixture for issue 1156 — singular pluralization of minutes.
+#
+# Criteria proven by this script's output:
+#   1. Direct 1-minute leg prints "(1 minute on foot)" (singular).
+#   2. A multi-minute leg still prints "(N minutes on foot)".
+#   3. /wait 1 prints "You wait for 1 minute...".
+#   4. /wait 5 prints "You wait for 5 minutes...".
+look
+go to darcy's pub
+go to the crossroads
+go to st. brigid's church
+/wait 1
+/wait 5


### PR DESCRIPTION
## Summary

Fixes #1156. Travel-arrival and `/wait` narration hardcoded `"{} minutes"` with no singular case, so any 1-minute leg printed **"1 minutes on foot"** instead of **"1 minute on foot"**.

This PR fixes the bug, removes the duplication that caused it, and adds guards so it can't come back.

## 1. The bug fix

A shared helper `parish_types::minute_word(n)` (generic over the integer type) now drives every "N minute(s)" string: travel arrival (`movement.rs`), the shared `/wait` (`time.rs`), the headless harness `/wait` + storm lines, and the thin client's travel renderer (`parish-client`, which had a third hidden copy).

## 2. Removing the duplication (root cause)

The bug existed because the same orchestration was copy-pasted across runtimes and drifted. The worst offender was the **weather "tick + publish `WeatherChanged`"** pair — inlined **verbatim in 4 loops** (server, Tauri, headless loop, harness `Tick`), with a 5th copy (the harness backfill) that had silently drifted into ticking weather *without* emitting the event.

Collapsed into one source of truth: **`WorldState::tick_weather` / `tick_weather_at`** (`parish-world`). All four real-time loops now call it. The harness bulk catch-up stays deliberately silent (emitting one event per backfilled hour on a multi-month jump would flood the bounded event bus) — documented inline.

The remaining pump atoms (banshee, tier-4, gossip, schedule→narration) carry legitimate per-runtime scheduling differences (gossip budgeting, determinism sort, async tier-3), so they're tracked for incremental extraction in **#1159** rather than a risky big-bang.

## 3. Guards against recurrence (two lints in `architecture_fitness`)

1. **`minute_counts_pluralize_through_helper`** — fails the build on any new `format!("... {} minutes ...")` literal.
2. **`entry_point_crates_do_not_reimplement_shared_commands`** — rule-#12 sensor: any `Command::<Variant> =>` arm in an entry-point crate is flagged as a re-implemented handler. The harness `Wait`/`Tick` are allowlisted with justification + tracked in #1159.

## Verification

- Live headless transcript before and after the de-dup — identical (`(1 minute on foot)`, `Waited 1 minute`, plural for N>1).
- Full suites green: `parish-world` (160, +2 new `tick_weather` tests), `parish-engine` (incl. eval baselines + festival/tier-4 rubrics), `parish-server`, `parish-tauri` (91), `parish-core` (incl. all 5 fitness lints).
- Eval baselines regenerated for the wording fix; `cargo fmt --check` + `clippy` clean.

Proof bundle (acceptance criteria, transcripts, evidence, judge verdict) attached as a PR comment.

https://claude.ai/code/session_011wYXkyBCxBcXba89BxkAU2