### PR TITLE
fix(ui): resolve top GUI code-audit findings

### DIFF
--- a/parish/apps/ui/src/components/AuthStatus.svelte
+++ b/parish/apps/ui/src/components/AuthStatus.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-
-	interface AuthStatus {
-		oauth_enabled: boolean;
-		logged_in: boolean;
-		provider?: string;
-		display_name?: string;
-	}
+	import { getAuthStatus } from '$lib/ipc';
+	import type { AuthStatus } from '$lib/types';
 
 	let status = $state<AuthStatus | null>(null);
 
@@ -17,15 +12,9 @@
 	);
 
 	onMount(async () => {
-		// Skip fetch if in Tauri (no /api server running)
-		if (typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window) return;
-
-		try {
-			const resp = await fetch('/api/auth/status');
-			if (resp.ok) status = await resp.json();
-		} catch {
-			// Not critical — auth UI is optional
-		}
+		// getAuthStatus routes through the IPC seam: returns null in Tauri (no
+		// /api server) and on any failure — the auth UI is optional chrome.
+		status = await getAuthStatus();
 	});
 </script>
 

--- a/parish/apps/ui/src/components/AuthStatus.test.ts
+++ b/parish/apps/ui/src/components/AuthStatus.test.ts
@@ -1,34 +1,48 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/svelte';
 import AuthStatus from './AuthStatus.svelte';
+import { getAuthStatus } from '$lib/ipc';
+
+// AuthStatus now routes through the IPC seam (getAuthStatus) instead of a raw
+// fetch('/api/auth/status'); see audit finding M7. Tauri-vs-web forking and the
+// fetch itself are covered in ipc.test.ts; here we mock the binding and assert
+// the rendered output for each status shape.
+vi.mock('$lib/ipc', () => ({
+	getAuthStatus: vi.fn()
+}));
+
+const mockGetAuthStatus = vi.mocked(getAuthStatus);
 
 beforeEach(() => {
-	vi.restoreAllMocks();
+	mockGetAuthStatus.mockReset();
 });
 
 describe('AuthStatus', () => {
 	it('shows nothing when oauth is not enabled', async () => {
-		vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-			new Response(JSON.stringify({ oauth_enabled: false, logged_in: false })),
-		);
+		mockGetAuthStatus.mockResolvedValueOnce({ oauth_enabled: false, logged_in: false });
 		const { container } = render(AuthStatus);
-		// Wait for the onMount fetch
 		await vi.waitFor(() => {
 			expect(container.querySelector('.auth-indicator')).toBeNull();
 			expect(container.querySelector('.auth-link')).toBeNull();
 		});
 	});
 
+	it('shows nothing when getAuthStatus returns null (Tauri / failure)', async () => {
+		mockGetAuthStatus.mockResolvedValueOnce(null);
+		const { container } = render(AuthStatus);
+		await vi.waitFor(() => {
+			expect(mockGetAuthStatus).toHaveBeenCalled();
+			expect(container.querySelector('.auth-indicator')).toBeNull();
+			expect(container.querySelector('.auth-link')).toBeNull();
+		});
+	});
+
 	it('shows a login link when oauth is enabled but not logged in', async () => {
-		vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-			new Response(
-				JSON.stringify({
-					oauth_enabled: true,
-					logged_in: false,
-					provider: 'google',
-				}),
-			),
-		);
+		mockGetAuthStatus.mockResolvedValueOnce({
+			oauth_enabled: true,
+			logged_in: false,
+			provider: 'google'
+		});
 		const { container } = render(AuthStatus);
 		await vi.waitFor(() => {
 			const link = container.querySelector('.auth-link');
@@ -38,16 +52,12 @@ describe('AuthStatus', () => {
 	});
 
 	it('shows display name and sign out when logged in', async () => {
-		vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-			new Response(
-				JSON.stringify({
-					oauth_enabled: true,
-					logged_in: true,
-					display_name: 'TestUser',
-					provider: 'google',
-				}),
-			),
-		);
+		mockGetAuthStatus.mockResolvedValueOnce({
+			oauth_enabled: true,
+			logged_in: true,
+			display_name: 'TestUser',
+			provider: 'google'
+		});
 		const { container } = render(AuthStatus);
 		await vi.waitFor(() => {
 			const indicator = container.querySelector('.auth-indicator');
@@ -55,15 +65,5 @@ describe('AuthStatus', () => {
 			expect(indicator!.textContent).toMatch(/TestUser/);
 			expect(container.querySelectorAll('.auth-link').length).toBe(1);
 		});
-	});
-
-	it('does not fetch in Tauri environment', async () => {
-		const fetchSpy = vi.spyOn(globalThis, 'fetch');
-		(window as any).__TAURI_INTERNALS__ = {};
-		render(AuthStatus);
-		await vi.waitFor(() => {
-			expect(fetchSpy).not.toHaveBeenCalled();
-		});
-		delete (window as any).__TAURI_INTERNALS__;
 	});
 });

--- a/parish/apps/ui/src/components/FullMapOverlay.test.ts
+++ b/parish/apps/ui/src/components/FullMapOverlay.test.ts
@@ -54,8 +54,8 @@ const testMap = {
 	],
 	edges: [['loc1', 'loc2']] as [string, string][],
 	player_location: 'loc1',
-	player_lat: 53.8,
-	player_lon: -8.15,
+	transport_label: 'on foot',
+	transport_id: 'walking',
 };
 
 describe('FullMapOverlay', () => {

--- a/parish/apps/ui/src/components/InputField.test.ts
+++ b/parish/apps/ui/src/components/InputField.test.ts
@@ -679,8 +679,8 @@ describe('InputField', () => {
 				['crossroads', 'church'],
 			] as [string, string][],
 			player_location: 'crossroads',
-			player_lat: 0,
-			player_lon: 0,
+			transport_label: 'on foot',
+			transport_id: 'walking',
 		};
 
 		it('renders chips for adjacent locations', () => {
@@ -897,8 +897,8 @@ describe('InputField', () => {
 				['crossroads', 'church'],
 			] as [string, string][],
 			player_location: 'crossroads',
-			player_lat: 0,
-			player_lon: 0,
+			transport_label: 'on foot',
+			transport_id: 'walking',
 		};
 
 		const testNpcs = [
@@ -1080,8 +1080,8 @@ describe('InputField', () => {
 				],
 				edges: [['crossroads', 'pub']] as [string, string][],
 				player_location: 'crossroads',
-				player_lat: 0,
-				player_lon: 0,
+				transport_label: 'on foot',
+				transport_id: 'walking',
 			};
 			mapData.set(testMap);
 			mockSubmitInput.mockImplementationOnce(async () => {

--- a/parish/apps/ui/src/components/MapPanel.test.ts
+++ b/parish/apps/ui/src/components/MapPanel.test.ts
@@ -29,8 +29,8 @@ const testMap = {
 	],
 	edges: [['loc1', 'loc2']] as [string, string][],
 	player_location: 'loc1',
-	player_lat: 53.35,
-	player_lon: -6.26,
+	transport_label: 'on foot',
+	transport_id: 'walking',
 };
 
 describe('MapPanel', () => {

--- a/parish/apps/ui/src/lib/byokProviders.test.ts
+++ b/parish/apps/ui/src/lib/byokProviders.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { toByokMeta } from './byokProviders';
+import type { AvailableProviderInfo } from './ipc';
+
+function info(signup_url: string | null): AvailableProviderInfo {
+	return {
+		id: 'evil',
+		display_name: 'Evil Co',
+		blurb: 'mod-supplied',
+		signup_url,
+		needs_base_url: false,
+		keyless: false
+	} as AvailableProviderInfo;
+}
+
+describe('toByokMeta signup_url scheme gate (audit security)', () => {
+	it('passes through https and http URLs unchanged', () => {
+		expect(toByokMeta(info('https://example.com/key')).signupUrl).toBe('https://example.com/key');
+		expect(toByokMeta(info('http://example.com/key')).signupUrl).toBe('http://example.com/key');
+	});
+
+	it('drops a javascript: URL (would execute on click if bound to href)', () => {
+		expect(toByokMeta(info('javascript:alert(document.cookie)')).signupUrl).toBe('');
+	});
+
+	it('drops data: and file: URLs', () => {
+		expect(toByokMeta(info('data:text/html,<script>alert(1)</script>')).signupUrl).toBe('');
+		expect(toByokMeta(info('file:///etc/passwd')).signupUrl).toBe('');
+	});
+
+	it('returns empty string for null/empty signup_url', () => {
+		expect(toByokMeta(info(null)).signupUrl).toBe('');
+		expect(toByokMeta(info('')).signupUrl).toBe('');
+	});
+
+	it('returns empty string for an unparseable URL', () => {
+		expect(toByokMeta(info('http://[::bad')).signupUrl).toBe('');
+	});
+});

--- a/parish/apps/ui/src/lib/byokProviders.ts
+++ b/parish/apps/ui/src/lib/byokProviders.ts
@@ -27,12 +27,31 @@ export interface ByokProviderMeta {
 	keyless: boolean;
 }
 
+/**
+ * Returns `url` only if it is a safe `http:`/`https:` link, else `''`.
+ *
+ * `signup_url` is sourced from `mods/<id>/providers/<id>.toml`, so a hostile or
+ * compromised mod could set `javascript:...` (or `data:`/`file:`). Svelte does
+ * not sanitize URL-attribute bindings, so binding such a value to the "Get a
+ * key" `<a href>` in ByokOnboarding would execute script on click. Dropping any
+ * non-http(s) scheme here closes that vector at the boundary (audit security).
+ */
+function safeSignupUrl(url: string | null | undefined): string {
+	if (!url) return '';
+	try {
+		const scheme = new URL(url, 'https://example.invalid').protocol;
+		return scheme === 'http:' || scheme === 'https:' ? url : '';
+	} catch {
+		return '';
+	}
+}
+
 export function toByokMeta(p: AvailableProviderInfo): ByokProviderMeta {
 	return {
 		id: p.id,
 		label: p.display_name,
 		blurb: p.blurb ?? '',
-		signupUrl: p.signup_url ?? '',
+		signupUrl: safeSignupUrl(p.signup_url),
 		needsBaseUrl: p.needs_base_url,
 		keyless: p.keyless
 	};

--- a/parish/apps/ui/src/lib/ipc.test.ts
+++ b/parish/apps/ui/src/lib/ipc.test.ts
@@ -221,6 +221,27 @@ describe('ipc command() HTTP path (audit M6 / M7)', () => {
 		await assertion;
 	});
 
+	it('times out when the response body stalls after headers arrive', async () => {
+		vi.useFakeTimers();
+		// Headers resolve immediately, but resp.text() only settles on abort.
+		vi.stubGlobal('fetch', (_url: string, init?: RequestInit) =>
+			Promise.resolve({
+				ok: true,
+				text: () =>
+					new Promise<string>((_resolve, reject) => {
+						init?.signal?.addEventListener('abort', () =>
+							reject(new DOMException('aborted', 'AbortError'))
+						);
+					})
+			} as unknown as Response)
+		);
+		const ipc = await loadIpc();
+		const p = ipc.command('get_map');
+		const assertion = expect(p).rejects.toThrow(/timeout/);
+		await vi.advanceTimersByTimeAsync(31_000);
+		await assertion;
+	});
+
 	it('does NOT time out POST mutations (e.g. submit_input with a slow NPC turn)', async () => {
 		vi.useFakeTimers();
 		let aborted = false;

--- a/parish/apps/ui/src/lib/ipc.test.ts
+++ b/parish/apps/ui/src/lib/ipc.test.ts
@@ -221,6 +221,25 @@ describe('ipc command() HTTP path (audit M6 / M7)', () => {
 		await assertion;
 	});
 
+	it('does NOT time out POST mutations (e.g. submit_input with a slow NPC turn)', async () => {
+		vi.useFakeTimers();
+		let aborted = false;
+		// A slow POST that resolves only after 60s and records any abort.
+		vi.stubGlobal('fetch', (_url: string, init?: RequestInit) =>
+			new Promise<Response>((resolve) => {
+				init?.signal?.addEventListener('abort', () => {
+					aborted = true;
+				});
+				setTimeout(() => resolve(new Response('')), 60_000);
+			})
+		);
+		const ipc = await loadIpc();
+		const p = ipc.command('submit_input', { text: 'hello', addressedTo: [] });
+		await vi.advanceTimersByTimeAsync(60_000);
+		await expect(p).resolves.toBeUndefined();
+		expect(aborted).toBe(false);
+	});
+
 	it('getAuthStatus returns parsed status in web mode', async () => {
 		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
 			new Response(JSON.stringify({ oauth_enabled: true, logged_in: false }))

--- a/parish/apps/ui/src/lib/ipc.test.ts
+++ b/parish/apps/ui/src/lib/ipc.test.ts
@@ -153,3 +153,86 @@ describe('ipc WebSocket transport lifecycle', () => {
 		expect(openSockets.length).toBe(2);
 	});
 });
+
+describe('ipc reconnect resync (audit M4)', () => {
+	it('does not fire onReconnect callbacks on the first connection', async () => {
+		const ipc = await loadIpc();
+		const resync = vi.fn();
+		ipc.onReconnect(resync);
+		await ipc.onTextLog(() => {});
+		// Initial open — the mount already loaded state, so no resync.
+		openSockets[0].simulateOpen();
+		expect(resync).not.toHaveBeenCalled();
+	});
+
+	it('fires onReconnect callbacks when the socket re-opens after a drop', async () => {
+		vi.useFakeTimers();
+		const ipc = await loadIpc();
+		const resync = vi.fn();
+		ipc.onReconnect(resync);
+		await ipc.onTextLog(() => {});
+
+		openSockets[0].simulateOpen(); // initial connect
+		openSockets[0].simulateClose(); // drop → schedule reconnect
+		vi.advanceTimersByTime(2_000); // reconnect timer fires → socket #2
+		expect(openSockets.length).toBe(2);
+
+		openSockets[1].simulateOpen(); // reconnect succeeds
+		expect(resync).toHaveBeenCalledTimes(1);
+	});
+
+	it('stops firing after the listener unsubscribes', async () => {
+		vi.useFakeTimers();
+		const ipc = await loadIpc();
+		const resync = vi.fn();
+		const off = ipc.onReconnect(resync);
+		await ipc.onTextLog(() => {});
+		openSockets[0].simulateOpen();
+		off();
+		openSockets[0].simulateClose();
+		vi.advanceTimersByTime(2_000);
+		openSockets[1].simulateOpen();
+		expect(resync).not.toHaveBeenCalled();
+	});
+});
+
+describe('ipc command() HTTP path (audit M6 / M7)', () => {
+	beforeEach(() => {
+		vi.unstubAllGlobals();
+	});
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('rejects with a timeout error when fetch never settles', async () => {
+		vi.useFakeTimers();
+		// A fetch that rejects with an AbortError once its signal aborts.
+		vi.stubGlobal('fetch', (_url: string, init?: RequestInit) =>
+			new Promise((_resolve, reject) => {
+				init?.signal?.addEventListener('abort', () =>
+					reject(new DOMException('aborted', 'AbortError'))
+				);
+			})
+		);
+		const ipc = await loadIpc();
+		const p = ipc.command('get_world_snapshot');
+		const assertion = expect(p).rejects.toThrow(/timeout/);
+		await vi.advanceTimersByTimeAsync(31_000);
+		await assertion;
+	});
+
+	it('getAuthStatus returns parsed status in web mode', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ oauth_enabled: true, logged_in: false }))
+		));
+		const ipc = await loadIpc();
+		const status = await ipc.getAuthStatus();
+		expect(status).toEqual({ oauth_enabled: true, logged_in: false });
+	});
+
+	it('getAuthStatus returns null when the request fails', async () => {
+		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+		const ipc = await loadIpc();
+		expect(await ipc.getAuthStatus()).toBeNull();
+	});
+});

--- a/parish/apps/ui/src/lib/ipc.ts
+++ b/parish/apps/ui/src/lib/ipc.ts
@@ -27,12 +27,25 @@ import type {
 	DemoContextSnapshot,
 	DemoConfigPayload,
 	BugContext,
-	BugReportResult
+	BugReportResult,
+	AuthStatus
 } from './types';
 
 // ── Transport detection ─────────────────────────────────────────────────────
 
 const IS_TAURI = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+
+/**
+ * Hard ceiling for a single HTTP command in web mode.
+ *
+ * The synchronous `/api/*` endpoints are all fast reads or fire-and-forget
+ * posts (NPC inference streams back over the WebSocket, not the POST body), so
+ * a request that runs this long means the server is wedged. Without a bound a
+ * hung server leaves the mount-time `Promise.allSettled` pending forever and
+ * the UI shows a permanent partial load with no error (audit M6). On abort we
+ * reject so the caller's error path runs.
+ */
+const COMMAND_TIMEOUT_MS = 30_000;
 
 // ── Commands ────────────────────────────────────────────────────────────────
 
@@ -43,11 +56,24 @@ export async function command<T>(name: string, args?: Record<string, unknown>): 
 	}
 	// Web mode: REST API
 	const endpoint = `/api/${name.replace(/^get_/, '').replace(/_/g, '-')}`;
-	const resp = await fetch(endpoint, {
-		method: args ? 'POST' : 'GET',
-		headers: args ? { 'Content-Type': 'application/json' } : {},
-		body: args ? JSON.stringify(args) : undefined
-	});
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), COMMAND_TIMEOUT_MS);
+	let resp: Response;
+	try {
+		resp = await fetch(endpoint, {
+			method: args ? 'POST' : 'GET',
+			headers: args ? { 'Content-Type': 'application/json' } : {},
+			body: args ? JSON.stringify(args) : undefined,
+			signal: controller.signal
+		});
+	} catch (e) {
+		if (controller.signal.aborted) {
+			throw new Error(`API timeout after ${COMMAND_TIMEOUT_MS}ms: ${name}`);
+		}
+		throw e;
+	} finally {
+		clearTimeout(timer);
+	}
 	if (!resp.ok) {
 		throw new Error(`API error: ${resp.status} ${resp.statusText}`);
 	}
@@ -94,6 +120,29 @@ export const switchMod = (modId: string): Promise<{ ok: boolean; error?: string 
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify({ mod_id: modId })
 	}).then((r) => r.json());
+};
+
+// ── Auth status (web-only OAuth UI) ──────────────────────────────────────────
+
+/**
+ * Fetches OAuth status for the web server's optional Google sign-in indicator.
+ *
+ * Forks inside the seam (like getMods/switchMod): Tauri desktop has no auth
+ * server, so it resolves to `null`; web mode hits `GET /api/auth/status` — a
+ * slash route that doesn't fit `command()`'s kebab-cased `/api/<name>` mapping.
+ * Returns `null` on any failure; the auth indicator is non-critical chrome.
+ * Centralising it here keeps AuthStatus.svelte off the raw transport (the
+ * "don't fork transports in components" seam rule).
+ */
+export const getAuthStatus = async (): Promise<AuthStatus | null> => {
+	if (IS_TAURI) return null;
+	try {
+		const resp = await fetch('/api/auth/status');
+		return resp.ok ? ((await resp.json()) as AuthStatus) : null;
+	} catch {
+		// Non-critical — auth UI is optional.
+		return null;
+	}
 };
 
 // ── Persistence commands ────────────────────────────────────────────────────
@@ -217,6 +266,30 @@ let ws: WebSocket | null = null;
 let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 const wsListeners = new Map<string, Set<EventCallback<unknown>>>();
 
+// Reconnect-resync hooks. Any event emitted while the socket was down is lost
+// (unlike Tauri's `listen`, which never disconnects), so a dropped
+// `stream-end` could leave the HUD desynced — e.g. `streamingActive` stuck
+// true. Callers register here to re-fetch authoritative state when the socket
+// re-opens after a drop (audit M4). The very first connection does NOT fire
+// these — the mount already loads initial state.
+const wsReconnectListeners = new Set<() => void>();
+let wsHasConnected = false;
+
+/**
+ * Registers a callback fired after the browser WebSocket reconnects following a
+ * drop (never on the initial connection). Use it to re-fetch world snapshot /
+ * map / npcs so events missed during the gap can't leave the UI out of sync.
+ * No-op in Tauri (the desktop transport never disconnects). Returns an
+ * unsubscribe function.
+ */
+export function onReconnect(cb: () => void): UnlistenFn {
+	if (IS_TAURI) return () => {};
+	wsReconnectListeners.add(cb);
+	return () => {
+		wsReconnectListeners.delete(cb);
+	};
+}
+
 function clearReconnectTimer(): void {
 	if (wsReconnectTimer !== null) {
 		clearTimeout(wsReconnectTimer);
@@ -274,12 +347,30 @@ function ensureWebSocket(): void {
 }
 
 function attachHandlers(socket: WebSocket): void {
+	socket.onopen = () => {
+		if (wsHasConnected) {
+			// This is a reconnect, not the first connection — replay-resync any
+			// state lost during the gap. Snapshot the set so a callback that
+			// unsubscribes mid-flush can't perturb iteration.
+			for (const cb of [...wsReconnectListeners]) {
+				try {
+					cb();
+				} catch (e) {
+					console.warn('Reconnect resync callback failed:', e);
+				}
+			}
+		}
+		wsHasConnected = true;
+	};
+
 	socket.onmessage = (event) => {
 		try {
 			const data = JSON.parse(event.data) as { event: string; payload: unknown };
 			const callbacks = wsListeners.get(data.event);
 			if (callbacks) {
-				for (const cb of callbacks) {
+				// Snapshot before iterating: a callback may unlisten (and thus
+				// mutate this Set) during dispatch.
+				for (const cb of [...callbacks]) {
 					cb(data.payload);
 				}
 			}
@@ -321,6 +412,7 @@ export function disposeTransport(): void {
 	clearReconnectTimer();
 	if (ws) {
 		// Detach handlers so the `onclose` reconnect path doesn't fire.
+		ws.onopen = null;
 		ws.onclose = null;
 		ws.onerror = null;
 		ws.onmessage = null;
@@ -331,6 +423,8 @@ export function disposeTransport(): void {
 		}
 		ws = null;
 	}
+	// Reset so the next mount's first connection isn't treated as a reconnect.
+	wsHasConnected = false;
 }
 
 async function onEvent<T>(event: string, cb: EventCallback<T>): Promise<UnlistenFn> {

--- a/parish/apps/ui/src/lib/ipc.ts
+++ b/parish/apps/ui/src/lib/ipc.ts
@@ -36,14 +36,20 @@ import type {
 const IS_TAURI = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
 
 /**
- * Hard ceiling for a single HTTP command in web mode.
+ * Hard ceiling for a single HTTP **read** in web mode.
  *
- * The synchronous `/api/*` endpoints are all fast reads or fire-and-forget
- * posts (NPC inference streams back over the WebSocket, not the POST body), so
- * a request that runs this long means the server is wedged. Without a bound a
- * hung server leaves the mount-time `Promise.allSettled` pending forever and
- * the UI shows a permanent partial load with no error (audit M6). On abort we
- * reject so the caller's error path runs.
+ * Bounds only argless GET reads (world snapshot, map, npcs, theme, ui-config,
+ * debug snapshot — the mount-time load). Without a bound a hung server leaves
+ * the mount `Promise.allSettled` pending forever and the UI shows a permanent
+ * partial load with no error (audit M6). On abort we reject so the caller's
+ * error path runs.
+ *
+ * POST mutations are deliberately NOT bounded: `submit_input` awaits the full
+ * server-side game loop (NPC inference can legitimately run far longer than
+ * this even though tokens stream over the WebSocket), and provider-config /
+ * bug-report posts dial external services. Aborting those mid-flight would
+ * surface a spurious "timeout", re-enable the input, and risk duplicate turns
+ * while the backend is still working.
  */
 const COMMAND_TIMEOUT_MS = 30_000;
 
@@ -56,23 +62,24 @@ export async function command<T>(name: string, args?: Record<string, unknown>): 
 	}
 	// Web mode: REST API
 	const endpoint = `/api/${name.replace(/^get_/, '').replace(/_/g, '-')}`;
-	const controller = new AbortController();
-	const timer = setTimeout(() => controller.abort(), COMMAND_TIMEOUT_MS);
+	// Bound reads only (see COMMAND_TIMEOUT_MS): a GET has no args, a mutation does.
+	const controller = args ? null : new AbortController();
+	const timer = controller ? setTimeout(() => controller.abort(), COMMAND_TIMEOUT_MS) : null;
 	let resp: Response;
 	try {
 		resp = await fetch(endpoint, {
 			method: args ? 'POST' : 'GET',
 			headers: args ? { 'Content-Type': 'application/json' } : {},
 			body: args ? JSON.stringify(args) : undefined,
-			signal: controller.signal
+			signal: controller?.signal
 		});
 	} catch (e) {
-		if (controller.signal.aborted) {
+		if (controller?.signal.aborted) {
 			throw new Error(`API timeout after ${COMMAND_TIMEOUT_MS}ms: ${name}`);
 		}
 		throw e;
 	} finally {
-		clearTimeout(timer);
+		if (timer) clearTimeout(timer);
 	}
 	if (!resp.ok) {
 		throw new Error(`API error: ${resp.status} ${resp.statusText}`);

--- a/parish/apps/ui/src/lib/ipc.ts
+++ b/parish/apps/ui/src/lib/ipc.ts
@@ -65,30 +65,43 @@ export async function command<T>(name: string, args?: Record<string, unknown>): 
 	// Bound reads only (see COMMAND_TIMEOUT_MS): a GET has no args, a mutation does.
 	const controller = args ? null : new AbortController();
 	const timer = controller ? setTimeout(() => controller.abort(), COMMAND_TIMEOUT_MS) : null;
-	let resp: Response;
 	try {
-		resp = await fetch(endpoint, {
-			method: args ? 'POST' : 'GET',
-			headers: args ? { 'Content-Type': 'application/json' } : {},
-			body: args ? JSON.stringify(args) : undefined,
-			signal: controller?.signal
-		});
-	} catch (e) {
-		if (controller?.signal.aborted) {
-			throw new Error(`API timeout after ${COMMAND_TIMEOUT_MS}ms: ${name}`);
+		let resp: Response;
+		try {
+			resp = await fetch(endpoint, {
+				method: args ? 'POST' : 'GET',
+				headers: args ? { 'Content-Type': 'application/json' } : {},
+				body: args ? JSON.stringify(args) : undefined,
+				signal: controller?.signal
+			});
+		} catch (e) {
+			if (controller?.signal.aborted) {
+				throw new Error(`API timeout after ${COMMAND_TIMEOUT_MS}ms: ${name}`);
+			}
+			throw e;
 		}
-		throw e;
+		if (!resp.ok) {
+			throw new Error(`API error: ${resp.status} ${resp.statusText}`);
+		}
+		// Read the body under the same timer: if headers arrive but the body
+		// stalls (proxy / partially-hung response), the abort signal cancels
+		// resp.text() too, so the timeout bounds the whole read — not just the
+		// headers. submit_input returns 200 with no body; the two-step cast
+		// makes the unsoundness explicit and searchable rather than hiding it (#755).
+		let text: string;
+		try {
+			text = await resp.text();
+		} catch (e) {
+			if (controller?.signal.aborted) {
+				throw new Error(`API timeout after ${COMMAND_TIMEOUT_MS}ms: ${name}`);
+			}
+			throw e;
+		}
+		if (!text) return undefined as unknown as T;
+		return JSON.parse(text) as T;
 	} finally {
 		if (timer) clearTimeout(timer);
 	}
-	if (!resp.ok) {
-		throw new Error(`API error: ${resp.status} ${resp.statusText}`);
-	}
-	// submit_input returns 200 with no body; the two-step cast makes the
-	// unsoundness explicit and searchable rather than hiding it (#755).
-	const text = await resp.text();
-	if (!text) return undefined as unknown as T;
-	return JSON.parse(text) as T;
 }
 
 export const getWorldSnapshot = () => command<WorldSnapshot>('get_world_snapshot');

--- a/parish/apps/ui/src/lib/ipc.ts
+++ b/parish/apps/ui/src/lib/ipc.ts
@@ -136,12 +136,18 @@ export const switchMod = (modId: string): Promise<{ ok: boolean; error?: string 
  */
 export const getAuthStatus = async (): Promise<AuthStatus | null> => {
 	if (IS_TAURI) return null;
+	// Bound the fetch like command() does (M6): a wedged server must not hang
+	// the mount flow on this optional call. Any failure (including abort)
+	// resolves to null rather than throwing — the auth UI is non-critical.
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), COMMAND_TIMEOUT_MS);
 	try {
-		const resp = await fetch('/api/auth/status');
+		const resp = await fetch('/api/auth/status', { signal: controller.signal });
 		return resp.ok ? ((await resp.json()) as AuthStatus) : null;
 	} catch {
-		// Non-critical — auth UI is optional.
 		return null;
+	} finally {
+		clearTimeout(timer);
 	}
 };
 

--- a/parish/apps/ui/src/lib/map/geojson.test.ts
+++ b/parish/apps/ui/src/lib/map/geojson.test.ts
@@ -27,8 +27,8 @@ function buildMap(overrides: Partial<MapData> = {}): MapData {
 			['b', 'c']
 		],
 		player_location: 'a',
-		player_lat: 53.59,
-		player_lon: -8.15,
+		transport_label: 'on foot',
+		transport_id: 'walking',
 		edge_traversals: [['a', 'b', 4]],
 		...overrides
 	};

--- a/parish/apps/ui/src/lib/setup/stream-manager.test.ts
+++ b/parish/apps/ui/src/lib/setup/stream-manager.test.ts
@@ -221,3 +221,49 @@ describe('createStreamManager — chainInProgress (#991)', () => {
 		expect(get(streamingActive)).toBe(false);
 	});
 });
+
+describe('createStreamManager — reset() finalizes orphaned stream entries', () => {
+	it('clears streaming flags on a half-streamed entry (reconnect mid-turn)', () => {
+		const sm = createStreamManager();
+		// A partially-streamed NPC bubble: content present, still streaming.
+		textLog.set([
+			{ id: 'm1', source: 'Padraig', content: 'Dia dh', streaming: true, latest_chunk: 'dh', stream_chunk_id: 3 }
+		]);
+
+		sm.reset();
+
+		const log = get(textLog);
+		expect(log.length).toBe(1);
+		expect(log[0].content).toBe('Dia dh'); // partial text preserved
+		expect(log[0].streaming).toBe(false);
+		expect(log[0].latest_chunk).toBeUndefined();
+		expect(log[0].stream_chunk_id).toBeUndefined();
+	});
+
+	it('drops an empty streaming placeholder on reset', () => {
+		const sm = createStreamManager();
+		textLog.set([
+			{ id: 'p1', source: 'Siobhan', content: '', streaming: true, stream_turn_id: 7 },
+			{ id: 'm2', source: 'system', content: 'A scene line.' }
+		]);
+
+		sm.reset();
+
+		const log = get(textLog);
+		expect(log.length).toBe(1);
+		expect(log[0].id).toBe('m2'); // empty placeholder removed, real entry kept
+	});
+
+	it('leaves non-streaming entries untouched', () => {
+		const sm = createStreamManager();
+		const entries = [
+			{ id: 'a', source: 'player', content: '> hello' },
+			{ id: 'b', source: 'Padraig', content: 'Finished reply.' }
+		];
+		textLog.set(entries);
+
+		sm.reset();
+
+		expect(get(textLog)).toEqual(entries);
+	});
+});

--- a/parish/apps/ui/src/lib/setup/stream-manager.ts
+++ b/parish/apps/ui/src/lib/setup/stream-manager.ts
@@ -308,6 +308,29 @@ export function createStreamManager(): StreamManager {
 		pendingStreamEndHints = null;
 		chainInProgress = false;
 		activeTurnId = null;
+		// Finalize any half-streamed log entry orphaned by the reset (e.g. a
+		// reconnect after stream-token but before stream-end): without this the
+		// entry keeps `streaming: true`/`latest_chunk` forever — a frozen cursor
+		// bubble with reactions disabled. Clear the streaming flags (or drop an
+		// empty placeholder), mirroring finalizeStreamingEntry across all turns.
+		textLog.update((log) => {
+			let changed = false;
+			const out: typeof log = [];
+			for (const entry of log) {
+				const isStreaming =
+					entry.streaming ||
+					entry.latest_chunk !== undefined ||
+					entry.stream_chunk_id !== undefined;
+				if (!isStreaming) {
+					out.push(entry);
+					continue;
+				}
+				changed = true;
+				if (entry.content === '') continue; // drop empty placeholder
+				out.push({ ...entry, streaming: false, latest_chunk: undefined, stream_chunk_id: undefined });
+			}
+			return changed ? out : log;
+		});
 	}
 
 	function dispose() {

--- a/parish/apps/ui/src/lib/setup/stream-manager.ts
+++ b/parish/apps/ui/src/lib/setup/stream-manager.ts
@@ -67,6 +67,10 @@ export interface StreamManager {
 	pendingTurnCount: () => number;
 	hasPendingEndHints: () => boolean;
 	isChainInProgress: () => boolean;
+	/** Discards all in-flight stream state without tearing the manager down.
+	 *  Used on WebSocket reconnect, where any pending turn is orphaned (the
+	 *  remaining tokens / stream-end were lost during the gap). */
+	reset: () => void;
 	dispose: () => void;
 }
 
@@ -298,12 +302,16 @@ export function createStreamManager(): StreamManager {
 		return chainInProgress;
 	}
 
-	function dispose() {
+	function reset() {
 		pendingNpcTurns.forEach((turn) => stopTurnPump(turn));
 		pendingNpcTurns.clear();
 		pendingStreamEndHints = null;
 		chainInProgress = false;
 		activeTurnId = null;
+	}
+
+	function dispose() {
+		reset();
 	}
 
 	return {
@@ -322,6 +330,7 @@ export function createStreamManager(): StreamManager {
 		pendingTurnCount,
 		hasPendingEndHints,
 		isChainInProgress,
+		reset,
 		dispose
 	};
 }

--- a/parish/apps/ui/src/lib/types.ts
+++ b/parish/apps/ui/src/lib/types.ts
@@ -34,14 +34,15 @@ export interface MapData {
 	locations: MapLocation[];
 	edges: [string, string][];
 	player_location: string;
-	player_lat: number;
-	player_lon: number;
-	/** Edge traversal counts for footprint rendering: [src_id, dst_id, count]. */
+	/** Edge traversal counts for footprint rendering: [src_id, dst_id, count].
+	 *  Rust skips this when empty (`skip_serializing_if = "Vec::is_empty"`). */
 	edge_traversals?: [string, string, number][];
-	/** Human-readable transport mode label (e.g. "on foot"). */
-	transport_label?: string;
-	/** Machine identifier for the active transport mode (e.g. "walking"). */
-	transport_id?: string;
+	/** Human-readable transport mode label (e.g. "on foot").
+	 *  Always serialized by Rust `MapData` (`pub transport_label: String`). */
+	transport_label: string;
+	/** Machine identifier for the active transport mode (e.g. "walking").
+	 *  Always serialized by Rust `MapData` (`pub transport_id: String`). */
+	transport_id: string;
 }
 
 /** Tooltip data shown when hovering a map location marker.
@@ -163,7 +164,10 @@ export interface StreamEndPayload {
 }
 
 export interface TextLogPayload {
-	id?: string;
+	/** Unique message id for reaction targeting. Rust always serializes this
+	 *  (`#[serde(default)] pub id: String`); `#[serde(default)]` only affects
+	 *  deserialization, so the wire payload always carries a (possibly empty) id. */
+	id: string;
 	stream_turn_id?: number;
 	source: string;
 	content: string;
@@ -207,6 +211,20 @@ export interface AuthDebug {
 	provider: string | null;
 	display_name: string | null;
 	session_id: string | null;
+}
+
+/**
+ * Response body for `GET /api/auth/status` (web server only).
+ *
+ * Mirrors `parish_server::auth::AuthStatus` — keep in sync with that struct.
+ * Distinct from {@link AuthDebug} (the debug-snapshot shape, which also carries
+ * `session_id`); this is the narrower public auth-status payload.
+ */
+export interface AuthStatus {
+	oauth_enabled: boolean;
+	logged_in: boolean;
+	provider?: string | null;
+	display_name?: string | null;
 }
 
 export interface ClockDebug {

--- a/parish/apps/ui/src/routes/+page.svelte
+++ b/parish/apps/ui/src/routes/+page.svelte
@@ -485,24 +485,28 @@
 			// the input field and demo loop don't hang (audit M4). No-op in
 			// Tauri (the desktop transport never disconnects).
 			listeners.push(onReconnect(async () => {
-				try {
-					const [snap, map, npcs] = await Promise.all([
-						getWorldSnapshot(),
-						getMap(),
-						getNpcsHere()
-					]);
+				// allSettled (matching the mount-time fetch): a transient failure
+				// on one endpoint right after reconnect must not discard the
+				// other successful updates.
+				const [snapRes, mapRes, npcsRes] = await Promise.allSettled([
+					getWorldSnapshot(),
+					getMap(),
+					getNpcsHere()
+				]);
+				if (snapRes.status === 'fulfilled') {
+					const snap = snapRes.value;
 					worldState.set(snap);
 					palette.applyGameHour(snap.hour);
 					if (snap.name_hints) nameHints.set(snap.name_hints);
-					mapData.set(map);
-					npcsHere.set(npcs);
-				} catch (e) {
-					console.warn('Reconnect resync failed:', e);
-				} finally {
-					// If a stream-end was dropped, nothing else will clear this.
-					if (!sm.isChainInProgress() && sm.pendingTurnCount() === 0) {
-						streamingActive.set(false);
-					}
+				}
+				if (mapRes.status === 'fulfilled') mapData.set(mapRes.value);
+				if (npcsRes.status === 'fulfilled') npcsHere.set(npcsRes.value);
+				for (const r of [snapRes, mapRes, npcsRes]) {
+					if (r.status === 'rejected') console.warn('Reconnect resync partial failure:', r.reason);
+				}
+				// If a stream-end was dropped during the gap, nothing else clears this.
+				if (!sm.isChainInProgress() && sm.pendingTurnCount() === 0) {
+					streamingActive.set(false);
 				}
 			}));
 

--- a/parish/apps/ui/src/routes/+page.svelte
+++ b/parish/apps/ui/src/routes/+page.svelte
@@ -399,6 +399,13 @@
 			}));
 
 			listeners.push(await onStreamToken((payload) => {
+				// Re-assert the busy flag whenever tokens actually flow. Normally
+				// loading{active:true} already set it, but after a mid-turn
+				// reconnect (where we cleared it to recover from a possibly-dead
+				// stream) a resumed stream would otherwise leave input enabled
+				// mid-turn, allowing a duplicate send. finishNpcStream clears it
+				// authoritatively once the pump drains. (Codex reconnect-resume.)
+				streamingActive.set(true);
 				const turn = sm.queuePendingTurn(payload.turn_id, payload.source);
 				turn.buffer += payload.token;
 				sm.startTurnPumpIfNeeded(turn);

--- a/parish/apps/ui/src/routes/+page.svelte
+++ b/parish/apps/ui/src/routes/+page.svelte
@@ -56,6 +56,7 @@
 		onOpenDesigner,
 		onNpcReaction,
 		onTravelStart,
+		onReconnect,
 		submitInput,
 		saveScreenshot,
 		disposeTransport,
@@ -476,6 +477,33 @@
 
 			listeners.push(await onSavePicker(() => {
 				savePickerVisible.set(true);
+			}));
+
+			// Resync authoritative state after a WebSocket reconnect: events
+			// emitted during the gap (e.g. a terminal stream-end) are lost, so
+			// re-fetch snapshot/map/npcs and clear any stuck streaming flag so
+			// the input field and demo loop don't hang (audit M4). No-op in
+			// Tauri (the desktop transport never disconnects).
+			listeners.push(onReconnect(async () => {
+				try {
+					const [snap, map, npcs] = await Promise.all([
+						getWorldSnapshot(),
+						getMap(),
+						getNpcsHere()
+					]);
+					worldState.set(snap);
+					palette.applyGameHour(snap.hour);
+					if (snap.name_hints) nameHints.set(snap.name_hints);
+					mapData.set(map);
+					npcsHere.set(npcs);
+				} catch (e) {
+					console.warn('Reconnect resync failed:', e);
+				} finally {
+					// If a stream-end was dropped, nothing else will clear this.
+					if (!sm.isChainInProgress() && sm.pendingTurnCount() === 0) {
+						streamingActive.set(false);
+					}
+				}
 			}));
 
 		} catch (e) {

--- a/parish/apps/ui/src/routes/+page.svelte
+++ b/parish/apps/ui/src/routes/+page.svelte
@@ -504,10 +504,14 @@
 				for (const r of [snapRes, mapRes, npcsRes]) {
 					if (r.status === 'rejected') console.warn('Reconnect resync partial failure:', r.reason);
 				}
-				// If a stream-end was dropped during the gap, nothing else clears this.
-				if (!sm.isChainInProgress() && sm.pendingTurnCount() === 0) {
-					streamingActive.set(false);
-				}
+				// Any turn that was streaming when the socket dropped is now
+				// orphaned — its remaining tokens and stream-end were lost during
+				// the gap, so pendingTurnCount()/chainInProgress would otherwise
+				// stay non-zero forever and leave the input disabled. The refetched
+				// snapshot is authoritative, so discard the stale stream state and
+				// clear the streaming flag unconditionally.
+				sm.reset();
+				streamingActive.set(false);
 			}));
 
 		} catch (e) {

--- a/parish/apps/ui/src/routes/+page.svelte
+++ b/parish/apps/ui/src/routes/+page.svelte
@@ -485,6 +485,18 @@
 			// the input field and demo loop don't hang (audit M4). No-op in
 			// Tauri (the desktop transport never disconnects).
 			listeners.push(onReconnect(async () => {
+				// Discard the orphaned pre-reconnect stream SYNCHRONOUSLY, before
+				// awaiting anything. The turn that was streaming when the socket
+				// dropped lost its remaining tokens / stream-end during the gap,
+				// so pendingTurnCount()/chainInProgress would otherwise stay
+				// non-zero forever and leave the input disabled. Doing this before
+				// the first await means it runs inside the onopen dispatch — ahead
+				// of any onmessage on the new socket — so a stream the backend
+				// resumes after reconnect queues a fresh turn that this reset can't
+				// clobber (the late-reset race Codex flagged).
+				sm.reset();
+				streamingActive.set(false);
+
 				// allSettled (matching the mount-time fetch): a transient failure
 				// on one endpoint right after reconnect must not discard the
 				// other successful updates.
@@ -504,14 +516,6 @@
 				for (const r of [snapRes, mapRes, npcsRes]) {
 					if (r.status === 'rejected') console.warn('Reconnect resync partial failure:', r.reason);
 				}
-				// Any turn that was streaming when the socket dropped is now
-				// orphaned — its remaining tokens and stream-end were lost during
-				// the gap, so pendingTurnCount()/chainInProgress would otherwise
-				// stay non-zero forever and leave the input disabled. The refetched
-				// snapshot is authoritative, so discard the stale stream state and
-				// clear the streaming flag unconditionally.
-				sm.reset();
-				streamingActive.set(false);
 			}));
 
 		} catch (e) {

--- a/parish/apps/ui/src/stores/game.test.ts
+++ b/parish/apps/ui/src/stores/game.test.ts
@@ -7,7 +7,13 @@ import {
 	loadingColor,
 	focailOpen,
 	syncFocailOnViewportChange,
+	messageHints,
+	pruneMessageHints,
+	trimTextLog,
 } from './game';
+import type { LanguageHint } from '$lib/types';
+
+const hint: LanguageHint[] = [{ word: 'dia dhuit', pronunciation: 'jee-ah gwit', meaning: 'hello' }];
 
 describe('pushErrorLog', () => {
 	beforeEach(() => {
@@ -114,5 +120,51 @@ describe('syncFocailOnViewportChange (regression #600)', () => {
 		expect(get(focailOpen)).toBe(false);
 		syncFocailOnViewportChange(false);
 		expect(get(focailOpen)).toBe(false);
+	});
+});
+
+describe('messageHints eviction (audit H3)', () => {
+	beforeEach(() => {
+		messageHints.set(new Map());
+		textLog.set([]);
+	});
+
+	it('drops hint entries whose message is no longer in the log', () => {
+		messageHints.set(new Map([['m1', hint], ['m2', hint]]));
+		// Only m2 survives in the log.
+		pruneMessageHints([{ id: 'm2', source: 'Saoirse', content: 'hi' }]);
+		const m = get(messageHints);
+		expect(m.has('m1')).toBe(false);
+		expect(m.has('m2')).toBe(true);
+	});
+
+	it('keeps all entries when every keyed message is still present', () => {
+		messageHints.set(new Map([['m1', hint]]));
+		pruneMessageHints([{ id: 'm1', source: 'Saoirse', content: 'hi' }]);
+		expect(get(messageHints).size).toBe(1);
+	});
+
+	it('stays bounded once textLog is trimmed past its cap (no unbounded growth)', () => {
+		// Simulate a long session: 600 NPC turns, each appended to the log AND
+		// recorded in messageHints. The textLog subscriber prunes on every
+		// trimmed update, so messageHints must not exceed the surviving log.
+		for (let i = 0; i < 600; i++) {
+			const id = `turn-${i}`;
+			textLog.update((log) => trimTextLog([...log, { id, source: 'Saoirse', content: 'x' }]));
+			messageHints.update((m) => {
+				m.set(id, hint);
+				return m;
+			});
+		}
+		const hints = get(messageHints);
+		const log = get(textLog);
+		// Without eviction this would be 600; bounded to the live (trimmed) log.
+		expect(hints.size).toBeLessThanOrEqual(log.length);
+		expect(hints.size).toBeLessThan(600);
+		// Every retained hint key must correspond to a live log entry.
+		const liveIds = new Set(log.map((e) => e.id));
+		for (const key of hints.keys()) {
+			expect(liveIds.has(key)).toBe(true);
+		}
 	});
 });

--- a/parish/apps/ui/src/stores/game.ts
+++ b/parish/apps/ui/src/stores/game.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { writable, get } from 'svelte/store';
 import type { WorldSnapshot, MapData, NpcInfo, LanguageHint, TextLogEntry, UiConfig } from '$lib/types';
 
 export const worldState = writable<WorldSnapshot | null>(null);
@@ -76,6 +76,40 @@ export function syncFocailOnViewportChange(matches: boolean): void {
 
 /** Maps message ID → Irish word hints for that completed NPC response. */
 export const messageHints = writable<Map<string, LanguageHint[]>>(new Map());
+
+/**
+ * Drops hint entries whose message is no longer present in `log`.
+ *
+ * `messageHints` is keyed by message id and was previously only ever added to
+ * (`finishNpcStream` calls `messageHints.set` on every NPC turn) with no
+ * eviction, so it grew without bound over a long session while the `textLog`
+ * it keys into is capped at MAX_TEXT_LOG_SIZE (audit finding H3). Pruning to
+ * the live log keeps it bounded by the same cap. Only notifies subscribers
+ * when something is actually removed, so it can be wired to every `textLog`
+ * change without churning `ChatPanel` reactivity.
+ */
+export function pruneMessageHints(log: TextLogEntry[]): void {
+	const current = get(messageHints);
+	if (current.size === 0) return;
+	const live = new Set<string>();
+	for (const entry of log) {
+		if (entry.id) live.add(entry.id);
+	}
+	let toDelete: string[] | null = null;
+	for (const key of current.keys()) {
+		if (!live.has(key)) (toDelete ??= []).push(key);
+	}
+	if (!toDelete) return;
+	messageHints.update((map) => {
+		for (const key of toDelete) map.delete(key);
+		return map;
+	});
+}
+
+// Keep messageHints bounded to messages still present in the log: every time
+// the log changes (including when trimTextLog drops old entries) prune the
+// orphaned hint keys. This is the single chokepoint for all trim sites.
+textLog.subscribe((log) => pruneMessageHints(log));
 
 /**
  * Appends a user-visible error entry to the text log.

--- a/parish/testing/fixtures/play_gui-audit-fixes.txt
+++ b/parish/testing/fixtures/play_gui-audit-fixes.txt
@@ -1,0 +1,22 @@
+# Fixture for task gui-audit-fixes.
+#
+# These are frontend-only fixes (parish/apps/ui/src/**): type-drift removal,
+# a memory-leak trim, a URL-scheme guard, an IPC-seam reroute, an HTTP timeout,
+# and a WS-reconnect resync. None changes a gameplay rule, so the bulk of
+# verification is vitest, not the CLI harness:
+#
+#   pnpm --dir parish/apps/ui run test     # H3, security, M6, M4 unit tests
+#   pnpm --dir parish/apps/ui run check    # C1, H2 type-seam (svelte-check + tsc)
+#
+# The live tier (rule #10) is a real browser session + screenshot proving the
+# map still renders the player marker after the C1 type change — captured to
+# .proofs/gui-audit-fixes/.
+#
+# The commands below exist so the CLI harness exercises the *backend* MapData /
+# world-snapshot serialization the frontend consumes, confirming the wire format
+# carries player_location + locations[] and never player_lat / player_lon (C1).
+look
+/status
+go to the crossroads
+look
+/status


### PR DESCRIPTION
## Summary

Audited the Svelte 5 frontend (`parish/apps/ui`, ~24k LOC) across security, code-quality/conventions, the IPC/type seam, and accessibility. The codebase is healthy (no `{@html}`/`eval`, no `any`/`@ts-ignore` in prod, no leaking listeners, no legacy Svelte 4 patterns). This PR fixes the **highest-impact findings**. All changes are frontend-only and behaviour-preserving.

### Fixes
- **C1 — phantom type fields.** `MapData.player_lat`/`player_lon` were declared **required** in `types.ts` but the Rust `MapData` struct never emits them → always `undefined`. Removed them (the player marker derives from `player_location`) and updated the 5 test fixtures that set them.
- **H2 — type-seam drift.** `transport_label`/`transport_id` and `TextLogPayload.id` are always serialized by Rust, so they are now required (with doc comments citing the source struct).
- **H3 — memory leak.** `messageHints` was only ever added to (one entry per NPC turn) while its sibling `textLog` is capped at 500, so it grew without bound over a long session. A single `textLog` subscriber now prunes orphaned hint keys on every trim.
- **Security — `javascript:` URL via hostile mod.** A mod-supplied `signup_url` was bound unsanitized to the BYOK "Get a key" `<a href>`. Svelte doesn't sanitize URL bindings, so `javascript:…` would execute on click. `byokProviders.ts` now drops any non-`http(s)` scheme at the boundary.
- **M7 — IPC seam violation.** `AuthStatus.svelte` did a raw `fetch('/api/auth/status')` with inline Tauri detection. Routed through a new `getAuthStatus()` binding in `ipc.ts` and shared the `AuthStatus` type.
- **M6 — hung-server hang.** `command()`'s HTTP path had no timeout; a wedged server left the mount load pending forever. Added a 30s `AbortController` ceiling.
- **M4 — WS reconnect desync.** Events emitted while the browser socket was down were lost (a dropped `stream-end` could wedge `streamingActive`). Added an `onReconnect` hook; `+page.svelte` re-fetches snapshot/map/npcs and clears stuck streaming on reconnect.
- **M5 (free hardening).** WS `onmessage` dispatch now snapshots the listener Set before iterating.

### Out of scope (documented in the audit, deferred to their own PRs)
- Accessibility: focus-trap/restore for the 4 modals + `SetupOverlay` dialog semantics.
- Theme hygiene: migrate ~10 hardcoded status colors to the existing `--color-ok/-error/-warning` tokens.
- `MapLocation.visited` left optional-in-TS (defensive fog-of-war field) to avoid churning ~15 fixture literals; documented.

## Testing
- `npx vitest run` → **454 passed / 38 files** (new tests for H3, security, M6, M4; reworked M7 component test).
- `pnpm run check` (svelte-check + tsc) → **zero new errors** vs. baseline.
- **Live proof:** drove a headless `parish-server` over HTTP and rendered the built app in Chromium. Confirmed the live `MapData` wire keys are `edges, locations, player_location, transport_id, transport_label` (no `player_lat/lon`) and the minimap renders the player marker + "on foot" transport label. Proof bundle attached separately.

## Commands run
- `npx vitest run`, `pnpm run check`, `npx vite build`
- `parish-mcp-backend.sh start` + `curl /api/command`, Chromium screenshot

https://claude.ai/code/session_012dwkrQtZGs9nY96dba93B5

---
_Generated by [Claude Code](https://claude.ai/code/session_012dwkrQtZGs9nY96dba93B5)_