### PR TITLE
test: lock in /wait singular minute narration (#1163)

### DIFF
--- a/parish/crates/parish-core/src/ipc/commands/tests.rs
+++ b/parish/crates/parish-core/src/ipc/commands/tests.rs
@@ -84,6 +84,37 @@ fn status_command() {
 }
 
 #[test]
+fn wait_one_minute_uses_singular_narration() {
+    // #1163: `/wait 1` must read "You wait for 1 minute...", not the
+    // hardcoded plural "1 minutes". The pluralization lives in
+    // `minute_word`, but this guards the Wait handler's call site so a
+    // future edit can't silently re-hardcode the plural.
+    let (mut world, mut npc, mut config) = default_state();
+    let result = handle_command(Command::Wait(1), &mut world, &mut npc, &mut config);
+    assert!(
+        result.response.contains("You wait for 1 minute..."),
+        "expected singular minute, got {:?}",
+        result.response
+    );
+    assert!(
+        !result.response.contains("1 minutes"),
+        "1-minute wait must not use the plural, got {:?}",
+        result.response
+    );
+}
+
+#[test]
+fn wait_multiple_minutes_uses_plural_narration() {
+    let (mut world, mut npc, mut config) = default_state();
+    let result = handle_command(Command::Wait(5), &mut world, &mut npc, &mut config);
+    assert!(
+        result.response.contains("You wait for 5 minutes..."),
+        "expected plural minutes, got {:?}",
+        result.response
+    );
+}
+
+#[test]
 fn toggle_improv() {
     let (mut world, mut npc, mut config) = default_state();
     assert!(!config.improv_enabled);


### PR DESCRIPTION
## Summary

Closes #1163.

Issue #1163 reported `/wait 1` printing `You wait for 1 minutes...` (missing singular). On investigation, **the underlying defect was already fixed by #1156** (commit `b76ff2b`), which routed the wait, travel-arrival, and headless narration call sites through the shared `parish_types::minute_word` helper. Issue #1163 was filed from an in-app bug-report snapshot taken ~3 hours *before* that fix merged, so the fix was already on `main` by the time the issue existed.

All three call sites the issue names already use `minute_word`:
- `parish-core/src/ipc/commands/time.rs:85` (the `/wait` handler)
- `parish-world/src/movement.rs:321/338` (travel arrival)
- `parish-engine/src/headless.rs:1269/1282` (headless weather/travel)

What was missing was **a dedicated regression test at the `/wait` dispatch layer** — `minute_word` itself is unit-tested, but nothing guarded the Wait handler's call site against someone re-hardcoding the plural in a future edit.

## Change

Adds two tests to `parish-core/src/ipc/commands/tests.rs`, exercising `handle_command` directly:
- `wait_one_minute_uses_singular_narration` → asserts `You wait for 1 minute...` and the absence of `1 minutes`.
- `wait_multiple_minutes_uses_plural_narration` → asserts `You wait for 5 minutes...`.

Test-only; no production behavior change.

## Verification

- `cargo test -p parish-core --lib wait_` → 3 passed.
- `cargo clippy -p parish-core --lib` clean; `cargo fmt` clean.
- **Live transcript** against a running `parish-server` (the same shared IPC path the bug was reported on):
  - `/wait 1` → `You wait for 1 minute...`
  - `/wait 5` → `You wait for 5 minutes...`

Proof bundle (acceptance criteria + live transcript + judge verdict) attached separately via `attach-proof`.

## Commands run

```
cargo test --manifest-path parish/Cargo.toml -p parish-core --lib wait_
cargo clippy --manifest-path parish/Cargo.toml -p parish-core --lib
cargo fmt --manifest-path parish/Cargo.toml -p parish-core
bash parish/scripts/agent-check.sh   # passed
```

https://claude.ai/code/session_0174QCuJCZ6opcG5dhTmjwLj

---
_Generated by [Claude Code](https://claude.ai/code/session_0174QCuJCZ6opcG5dhTmjwLj)_