### PR TITLE
docs(skills): file demo-audit / parish-engine bugs via parish_file_bug MCP

### DIFF
--- a/.agents/skills/parish-engine/SKILL.md
+++ b/.agents/skills/parish-engine/SKILL.md
@@ -179,6 +179,14 @@ fires), thinking blocks leaking into player actions, NPC saying nothing (429 rat
 typo), game clock paused throughout. Demo is **observational** — it surfaces live behaviour, it does not
 assert. It does not replace `just check`, the prove flow, or Playwright.
 
+`just demo` opens the MCP bridge on `--mcp-port 3030`, so while it runs (or after launching the Tauri app
+yourself with `cargo run -p parish-tauri -- --mcp-port 3030`) you can drive and inspect the live game with
+`mcp__parish__*`: `parish_world_snapshot` / `parish_npcs_here` / `parish_submit_input` to probe, and
+**`mcp__parish__parish_file_bug`** to file any bug as a GitHub issue that auto-bundles a screenshot (a native
+window capture — the minimap renders, #1160), recent logs, and game state. Dedup against open issues first
+(`gh issue list --search`); set `PARISH_BUG_REPORT_DRY_RUN=1` to write the report to disk instead of filing
+while testing. For the full bug-hunting loop see `/demo-audit`.
+
 ---
 
 ## Browser UI session
@@ -204,7 +212,8 @@ Test execution — take screenshots at key points, track pass/fail:
 - **If explicitly requested:** Debug Panel tabs; Speed Commands; Theme Updates over time.
 
 Reporting: print a pass/fail table; list bugs with repro steps; report console errors; check server logs.
-If bugs are found, ask whether to file GitHub issues. Write results to
+If bugs are found, file them with **`mcp__parish__parish_file_bug`** (auto-bundles screenshot + logs +
+state) — dedup against open issues first (`gh issue list --search`). Write results to
 `docs/reviews/chrome-testing-session.md` (append a dated section if it exists).
 
 ---

--- a/.claude/commands/demo-audit.md
+++ b/.claude/commands/demo-audit.md
@@ -1,6 +1,6 @@
 ---
-description: Run a demo-audit session — cycle `just demo` with live MCP/HTTP inspection, surface gameplay bugs, document in TODO.md
-allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TaskCreate, TaskUpdate, TaskList
+description: Run a demo-audit session — cycle `just demo` with live MCP/HTTP inspection, surface gameplay bugs, file them via the parish_file_bug MCP (screenshot + logs + state) and log in TODO.md
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TaskCreate, TaskUpdate, TaskList, mcp__parish__parish_file_bug, mcp__parish__parish_take_screenshot, mcp__parish__parish_latest_screenshot, mcp__parish__parish_world_snapshot, mcp__parish__parish_npcs_here, mcp__parish__parish_submit_input
 ---
 
 Run a demo-audit session on the Parish/Rundale engine. Goal: snapshot current gameplay quality + surface bugs via repeated `just demo` cycles combined with live MCP/HTTP inspection.
@@ -62,10 +62,49 @@ grep -c '<name>' mods/rundale/world.json
 
 Many "wrong" names are in-canon (Concannon, Niamh Darcy, Curraghboy, sídhe).
 
-## 5. Documentation rule
+## 5. File confirmed bugs via the `parish_file_bug` MCP
 
-- Maintain a `TODO.md` at repo root. One numbered entry per category, with **Symptom** / **Root cause** / **Fix** sections. Group by cycle of discovery. Revise (not delete) earlier entries when later cycles refute or refine them — keep an audit trail.
-- At the end list top-10 by impact.
+File every **confirmed, reproducible** bug as a GitHub issue with
+`mcp__parish__parish_file_bug` — it auto-bundles a live screenshot, recent
+logs, and current game state, so the issue is self-contained. As of #1160 the
+screenshot is a native window capture, so the **MapLibre minimap renders in the
+image** (the old html-to-image path captured it blank).
+
+Protocol per bug:
+
+1. **Capture context at the moment of the bug.** The bug is filed against
+   whatever state is live, so freeze it first: stop advancing the demo, then
+   `mcp__parish__parish_take_screenshot` (confirm it returns a path — the live
+   desktop window must be present and foregrounded; under heavy local-MLX load
+   it can take up to the 45 s deadline). `parish_file_bug` attaches the latest
+   screenshot automatically; an explicit capture just guarantees it shows the
+   bug.
+2. **Dedup before filing — do NOT spam.** Search open issues first:
+   `gh issue list --repo dmooney/rundale --state open --search "<keywords>"`.
+   If a matching issue exists, add a comment instead of a new issue. Many
+   "wrong" names/behaviours are in-canon (see §4) — verify before filing.
+3. **File it.** `mcp__parish__parish_file_bug` with:
+   - `title` — one line, specific (e.g. `/wait 1 narration reads "1 minutes"`).
+   - `description` — **Symptom** (observed line/behaviour), **Repro** (exact
+     inputs), **Root cause** (cite `file.rs:line` — read the code first, §Constraints),
+     **Expected**. Reference related issues by number.
+   - optional `context` — a debug-panel record (`{kind,label,detail}`) when the
+     bug is about a specific inference call / event / conversation.
+   It returns `{created, issue_number, issue_url, screenshot_url}`. Verify the
+   issue body has the inline image: `gh issue view <n> --json body | grep '!\['`.
+4. **Dry-run when probing the loop, not real bugs.** Set
+   `PARISH_BUG_REPORT_DRY_RUN=1` in the demo/backend env to write the report to
+   disk (`created:false`, `bundle_path` set) instead of filing — use while
+   testing the audit flow so you don't create throwaway issues. Real audit runs
+   file for real.
+
+## 6. Audit trail in TODO.md
+
+- Maintain a `TODO.md` at repo root as the cross-cycle audit trail. One numbered
+  entry per category, with **Symptom** / **Root cause** / **Fix** and the filed
+  **issue #** / URL. Group by cycle of discovery. Revise (not delete) earlier
+  entries when later cycles refute or refine them.
+- At the end list top-10 by impact, each linked to its issue.
 
 # Constraints
 


### PR DESCRIPTION
Update both bug-hunting skills to file confirmed bugs through the
`mcp__parish__parish_file_bug` MCP tool — it auto-bundles a live screenshot
(native window capture, so the minimap renders, #1160), recent logs, and game
state into a GitHub issue — instead of only logging to TODO.md / asking whether
to file.

- **demo-audit**: new "File confirmed bugs via parish_file_bug" step (freeze
  state → screenshot → dedup via `gh issue list` → file with
  Symptom/Repro/Root-cause/Expected → verify inline image). TODO.md kept as the
  cross-cycle audit trail linking each issue. `allowed-tools` gains the parish
  MCP tools. `PARISH_BUG_REPORT_DRY_RUN` noted for testing the loop.
- **parish-engine**: demo + browser sections point at `parish_file_bug` for
  filing (with dedup), and note `just demo` exposes `--mcp-port 3030`.

Docs / agent-instruction only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)