### PR TITLE
test(ui): regression e2e for bug-report textarea hotkey isolation

### DIFF
--- a/parish/apps/ui/e2e/bug-report-hotkey.spec.ts
+++ b/parish/apps/ui/e2e/bug-report-hotkey.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression: the bug-report description must not leak global hotkeys.
+ *
+ * The global "M" key toggles the full map, but only when focus is not in a
+ * text field. The guard originally exempted INPUT and contentEditable but not
+ * TEXTAREA, so typing "M" in the bug-report description (`#bug-description`,
+ * a <textarea>) opened the map instead of inserting the character.
+ */
+
+import { test, expect, installTauriMock } from './fixtures';
+
+test.describe('Bug report modal — hotkey isolation', () => {
+	test.beforeEach(async ({ page }) => {
+		await installTauriMock(page, 'morning');
+		await page.goto('/');
+		await page.waitForLoadState('networkidle');
+	});
+
+	test('typing "m" in the description does not open the map', async ({ page }) => {
+		// Open the bug-report modal from the status-bar 🐛 button.
+		const bugButton = page.locator('.bug-toggle');
+		await expect(bugButton).toBeVisible();
+		await bugButton.click();
+		await expect(page.locator('[data-testid="bug-report-modal"]')).toBeVisible({ timeout: 10_000 });
+		await expect(page.locator('[data-testid="full-map"]')).toBeHidden();
+
+		// Type text containing "m"/"M" into the description textarea.
+		const description = page.locator('#bug-description');
+		await description.click();
+		await page.keyboard.type('Map breaks when I press m');
+
+		// The "M" hotkey must NOT have toggled the map, and every character
+		// must have landed in the field.
+		await expect(page.locator('[data-testid="full-map"]')).toBeHidden();
+		await expect(description).toHaveValue('Map breaks when I press m');
+	});
+
+	test('"m" still toggles the map when not typing in a field', async ({ page }) => {
+		await expect(page.locator('[data-testid="full-map"]')).toBeHidden();
+		// Ensure focus is not in any input/textarea.
+		await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+		await page.keyboard.press('m');
+		await expect(page.locator('[data-testid="full-map"]')).toBeVisible();
+	});
+});

--- a/parish/apps/ui/e2e/bug-report-hotkey.spec.ts
+++ b/parish/apps/ui/e2e/bug-report-hotkey.spec.ts
@@ -7,16 +7,13 @@
  * a <textarea>) opened the map instead of inserting the character.
  */
 
-import { test, expect, installTauriMock } from './fixtures';
+import { test, expect } from './fixtures';
 
+// `parishPage` is the shared fixture: it installs the Tauri mock ('morning'),
+// navigates to '/', and waits for network idle — the same setup every other
+// e2e spec uses. Aliasing it to `page` keeps the bodies below unchanged.
 test.describe('Bug report modal — hotkey isolation', () => {
-	test.beforeEach(async ({ page }) => {
-		await installTauriMock(page, 'morning');
-		await page.goto('/');
-		await page.waitForLoadState('networkidle');
-	});
-
-	test('typing "m" in the description does not open the map', async ({ page }) => {
+	test('typing "m" in the description does not open the map', async ({ parishPage: page }) => {
 		// Open the bug-report modal from the status-bar 🐛 button.
 		const bugButton = page.locator('.bug-toggle');
 		await expect(bugButton).toBeVisible();
@@ -35,7 +32,7 @@ test.describe('Bug report modal — hotkey isolation', () => {
 		await expect(description).toHaveValue('Map breaks when I press m');
 	});
 
-	test('"m" still toggles the map when not typing in a field', async ({ page }) => {
+	test('"m" still toggles the map when not typing in a field', async ({ parishPage: page }) => {
 		await expect(page.locator('[data-testid="full-map"]')).toBeHidden();
 		// Ensure focus is not in any input/textarea.
 		await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());

--- a/parish/apps/ui/src/components/FullMapOverlay.svelte
+++ b/parish/apps/ui/src/components/FullMapOverlay.svelte
@@ -127,7 +127,7 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div class="map-embed">
+<div class="map-embed" data-testid="full-map">
 	<button
 		type="button"
 		class="close-btn"


### PR DESCRIPTION
## What

Adds a Playwright regression test locking in the fix from #1154 (`M`-key map-toggle guard now exempts `<textarea>`, not just `<input>`/contentEditable): typing "m" in the bug-report description (`#bug-description`) must insert the character, not open the full map.

- `parish/apps/ui/e2e/bug-report-hotkey.spec.ts` — opens the bug modal from the status-bar 🐛 button, types into `#bug-description`, asserts the map stays hidden and the full text lands; plus the inverse (pressing `m` with no field focused still toggles the map).
- `FullMapOverlay.svelte` — adds `data-testid="full-map"` to the overlay root so the spec can assert overlay visibility. No behavior change.

## Why

#1154 fixed the guard but shipped no e2e coverage; this is the missing regression guard so the textarea exemption can't silently regress.

## Exercised

`npx playwright test e2e/bug-report-hotkey.spec.ts` — real Chromium against a live `cargo run -p parish-server` (Playwright `webServer`), fresh `dist`. **2/2 passing.**

## Notes

- Branched fresh off `main` — the original `fix/bug-reporter-textarea-and-real-filing` branch's substantive commits already landed via #1154 (squash `a72fcee`); this PR carries only the new test + testid.
- Build-harness gaps found while writing this (local `just ui-e2e` serves stale `dist`; CI prebuilds the wrong crate): #1179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)