### PR TITLE
docs: fix MD060 table-column-style lint errors (witness.md, mods/TODO.md)

### DIFF
--- a/docs/agent/witness.md
+++ b/docs/agent/witness.md
@@ -45,6 +45,12 @@ Large AI-assisted refactors can report "done" while silently leaving placeholder
 
 `just witness-scan` inspects every file under `parish/crates/`, `parish/apps/`, `docs/`, `parish/testing/`, and `mods/` that is modified relative to the merge-base with `origin/main`. It fails loudly if any of these patterns appear:
 
+<!-- markdownlint-disable MD060 -->
+<!-- Cells embed U+200B zero-width spaces so witness-scan does not flag its own
+     example patterns. markdownlint counts ZWSP as width-0 while Prettier counts
+     it as width-1, so the two disagree on "aligned" table pipes; disable MD060
+     for this one table to keep both the lint and format gates green. -->
+
 | Pattern                                            | Catches                                                      |
 | -------------------------------------------------- | ------------------------------------------------------------ |
 | `//​ unchanged`, `//​ existing`                    | AI stubs that left original code in place                    |
@@ -54,6 +60,8 @@ Large AI-assisted refactors can report "done" while silently leaving placeholder
 | `panic!("Not implemented…")`, `panic!("todo…")`    | Rust panic stubs (case-insensitive prefix match)             |
 | `pass # TODO`                                      | Python placeholders                                          |
 | `return nil //​ placeholder`                       | Go placeholders                                              |
+
+<!-- markdownlint-enable MD060 -->
 
 ## Witness log
 

--- a/mods/TODO.md
+++ b/mods/TODO.md
@@ -2,21 +2,21 @@
 
 ## Open
 
-| ID | Category | Severity | Location | Description |
-|----|----------|----------|----------|-------------|
-| TD-001 | Content Layout | P2 | `rundale/npcs.json:1-4172` | The Rundale NPC catalog is a single 174 KB JSON file. That preserves current load simplicity, but every NPC edit risks large review diffs, field-order churn, and cascading ID/reference mistakes. Add per-NPC editing/generation tooling or split-source support that preserves the canonical checked-in output byte order. |
-| TD-002 | Content Layout | P2 | `rundale/world.json:1-699` | Geography, aliases, routes, relative coordinate metadata, and validation-sensitive location names live in one monolithic file. Extract authoring helpers or add a stronger content validation report for route/location aliases, subordinate `relative_to` clusters, and cross-file references from festivals/encounters/transport before the world grows further. |
-| TD-003 | Prompt Contract | P1 | `rundale/prompts/*.txt`, `testbed/prompts/*.txt` | Plain-text prompt variables are case-sensitive and unknown placeholders pass through at runtime. Rundale and testbed intentionally use different placeholder names, but there is no content-level contract test that every checked-in placeholder is substituted by the active prompt builder. Add a fixture test that renders every base mod prompt and fails on leftover `{placeholder}` tokens. |
-| TD-004 | Stale Comments | P3 | `rundale/demo-prompt.txt:3` | The demo movement guidance references historical `TODO #1/#30` anchors. The instruction is now intentional prompt content; convert the label to an issue/regression-test reference so debt scans do not read the prompt as unresolved work. |
-| TD-005 | Provider Config Drift | P2 | `*-provider/providers/*.toml` | The 20 provider mods manually duplicate the provider schema and preset category conventions. Add a checked-in provider-mod fixture test that validates directory/file/id naming, required fields, featured visibility, non-empty base URLs where required, and preset category coverage so provider catalog edits fail locally before UI/onboarding drift reaches runtime. |
+| ID     | Category              | Severity | Location                                         | Description                                                                                                                                                                                                                                                                                                                                                                                        |
+| ------ | --------------------- | -------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TD-001 | Content Layout        | P2       | `rundale/npcs.json:1-4172`                       | The Rundale NPC catalog is a single 174 KB JSON file. That preserves current load simplicity, but every NPC edit risks large review diffs, field-order churn, and cascading ID/reference mistakes. Add per-NPC editing/generation tooling or split-source support that preserves the canonical checked-in output byte order.                                                                       |
+| TD-002 | Content Layout        | P2       | `rundale/world.json:1-699`                       | Geography, aliases, routes, relative coordinate metadata, and validation-sensitive location names live in one monolithic file. Extract authoring helpers or add a stronger content validation report for route/location aliases, subordinate `relative_to` clusters, and cross-file references from festivals/encounters/transport before the world grows further.                                 |
+| TD-003 | Prompt Contract       | P1       | `rundale/prompts/*.txt`, `testbed/prompts/*.txt` | Plain-text prompt variables are case-sensitive and unknown placeholders pass through at runtime. Rundale and testbed intentionally use different placeholder names, but there is no content-level contract test that every checked-in placeholder is substituted by the active prompt builder. Add a fixture test that renders every base mod prompt and fails on leftover `{placeholder}` tokens. |
+| TD-004 | Stale Comments        | P3       | `rundale/demo-prompt.txt:3`                      | The demo movement guidance references historical `TODO #1/#30` anchors. The instruction is now intentional prompt content; convert the label to an issue/regression-test reference so debt scans do not read the prompt as unresolved work.                                                                                                                                                        |
+| TD-005 | Provider Config Drift | P2       | `*-provider/providers/*.toml`                    | The 20 provider mods manually duplicate the provider schema and preset category conventions. Add a checked-in provider-mod fixture test that validates directory/file/id naming, required fields, featured visibility, non-empty base URLs where required, and preset category coverage so provider catalog edits fail locally before UI/onboarding drift reaches runtime.                         |
 
 ## In Progress
 
-*(none)*
+_(none)_
 
 ## Done
 
-*(none)*
+_(none)_
 
 ## Progress Log
 


### PR DESCRIPTION
## What

Fix pre-existing MD060/table-column-style errors reported by `just lint-docs` (markdownlint-cli2) in two files that no current work touched but that fail the `lint-docs` CI gate.

| File | Problem | Fix |
| --- | --- | --- |
| `docs/agent/witness.md` | "aligned" pipes don't line up on rows whose cells embed `U+200B` zero-width spaces | Scoped inline `MD060` disable around that one table |
| `mods/TODO.md` | delimiter row missing pipe padding (compact-style violation) | Table reformatted to consistent aligned style |

## Why witness.md needs a disable rather than a re-pad

The ZWSP characters in `witness.md` are functional: they stop `witness-scan` from matching its own documented example patterns (`// unchanged`, `todo!(...)`, etc.). markdownlint counts a ZWSP as **width-0** while Prettier counts it as **width-1**, so the two tools disagree on where the "aligned" pipes should sit. Prettier already reports the file clean, so:

- re-padding to satisfy markdownlint would break the Prettier (`format:check`) gate, and
- stripping the ZWSP would break `witness-scan`.

A scoped `<!-- markdownlint-disable MD060 -->` / `enable` pair (with an explanatory comment) is the only resolution that keeps the lint, format, and witness-scan gates all green. The ZWSP content is untouched.

## Verification

```
just lint-docs        # 0 error(s), 289 files
npx prettier --check docs/agent/witness.md   # clean
```

Pure-docs change, no proof bundle (AGENTS rule 10 doc exemption).

🤖 Generated with [Claude Code](https://claude.com/claude-code)