### PR TITLE
fix(ci): e2e harness builds the right bundle and crate (#1179)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,9 +550,13 @@ jobs:
 
       # Prebuild parish so Playwright's webServer starts under its 120s
       # timeout — a cold `cargo run` on this job was busting the deadline.
+      # Must build the SAME crate the webServer runs (`cargo run -p
+      # parish-server` in playwright.config.ts); building parish-engine left
+      # parish-server to compile cold on first request and bust the deadline
+      # (#1179).
       - name: Prebuild parish web server binary
         working-directory: ${{ github.workspace }}/parish
-        run: cargo build -p parish-engine
+        run: cargo build -p parish-server
 
       - name: Run Playwright e2e
         run: npx playwright test

--- a/parish/justfile
+++ b/parish/justfile
@@ -211,8 +211,10 @@ ui-format-check:
 ui-test:
     eval "$(fnm env)" && cd apps/ui && npx vitest run
 
-# Run Playwright E2E tests (headless Chromium, mocked Tauri IPC)
-ui-e2e:
+# Run Playwright E2E tests (headless Chromium, mocked Tauri IPC).
+# Depends on ui-build so Playwright's webServer serves a fresh dist rather
+# than a stale (or missing) bundle from before the last src/ change (#1179).
+ui-e2e: ui-build
     cd apps/ui && npx playwright test
 
 # Update Playwright visual regression baselines

--- a/parish/justfile
+++ b/parish/justfile
@@ -215,7 +215,7 @@ ui-test:
 # Depends on ui-build so Playwright's webServer serves a fresh dist rather
 # than a stale (or missing) bundle from before the last src/ change (#1179).
 ui-e2e: ui-build
-    cd apps/ui && npx playwright test
+    eval "$(fnm env)" && cd apps/ui && npx playwright test
 
 # Update Playwright visual regression baselines
 ui-e2e-update:


### PR DESCRIPTION
Closes #1179.

Two build-correctness gaps in the Playwright e2e harness, surfaced while adding `e2e/bug-report-hotkey.spec.ts`.

## Changes

1. **Local `just ui-e2e` served a stale `dist`.** The recipe ran `npx playwright test` with no build step; Playwright's `webServer` boots `cargo run -p parish-server`, which serves the on-disk `apps/ui/dist`. Now `ui-e2e: ui-build` so `dist` is rebuilt first (mirrors the `web` recipe). Local e2e was untrustworthy whenever `src/` changed since the last build.

2. **CI prebuilt the wrong crate.** The `ui-e2e` job prebuilt `parish-engine`, but `playwright.config.ts` `webServer.command` is `cargo run -p parish-server`. Building `parish-engine` left `parish-server` to compile cold on first request, busting the 120s `webServer.timeout`. Now prebuilds `parish-server`.

## Verification

- `just -n ui-e2e` now runs `ui-build` (clears + rebuilds `dist`) before `npx playwright test`.
- `ci.yml` validates as YAML; prebuild step now `cargo build -p parish-server`.

## Proof gate

Proof-exempt: touches only `parish/justfile` and `.github/workflows/ci.yml` (CI- and harness-tooling), no runtime path. Per AGENTS.md rule #10 / `agent-check.sh` exempt-path list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)