### PR TITLE
test(parity): wiring-parity guard for the CLI/headless SystemCommandHost (#1174)

### DIFF
--- a/parish/crates/parish-core/tests/wiring_parity.rs
+++ b/parish/crates/parish-core/tests/wiring_parity.rs
@@ -33,14 +33,19 @@
 //! After normalisation both sets must be identical.  Any asymmetry is
 //! reported with the canonical fix message.
 //!
-//! ## CLI coverage
+//! ## CLI coverage (issue #1174)
 //!
 //! The CLI (`parish-engine`) runs the same `parish-core` game loop and exposes
 //! game commands as slash-commands typed at the prompt rather than as HTTP
-//! routes or Tauri IPC calls.  It is therefore not a third registry to
-//! diff here — its coverage is verified indirectly by the shared `parish-core`
-//! tests.  A separate tracking issue will add CLI-specific parity if a
-//! dedicated command enumeration is introduced.
+//! routes or Tauri IPC calls, so it is not a third *route* registry to diff.
+//!
+//! What it DOES share with the other two entry points is the
+//! [`parish_core::game_loop::system_command::SystemCommandHost`] trait — the
+//! backend-specific dispatcher for every `CommandEffect`. All three production
+//! hosts (`AppStateCommandHost`, `TauriCommandHost`, `CliCommandHost`) must
+//! implement every effect handler, or a backend silently inherits a trait
+//! default no-op and drifts. `system_command_host_parity` (below) enforces
+//! that by static source-scan, closing the CLI/headless gap.
 
 use std::collections::BTreeSet;
 use std::fs;
@@ -267,4 +272,233 @@ pub const BAR: &[&str] = &[
 "#;
     let vals = parse_str_array_const(src);
     assert_eq!(vals, vec!["one", "two"]);
+}
+
+// ── SystemCommandHost wiring parity (issue #1174) ───────────────────────────────
+//
+// The CLI/headless path has no HTTP/IPC registry to diff, but it shares the
+// `SystemCommandHost` trait with the server and Tauri. Two of that trait's
+// effect handlers carry default impls (`reset_byok`, `inference_log_toggle`),
+// so a backend can silently inherit a no-op and drift. This test asserts each
+// production host overrides every effect handler, with an explicit allowlist
+// for intentional default-reliance.
+
+/// Effect-handler methods every production `SystemCommandHost` is expected to
+/// override. Excludes `run_command` (the dispatcher entry point, not a
+/// per-effect handler). Kept in sync with the trait by
+/// `host_method_set_matches_trait` below — adding/removing a trait method
+/// without updating this list fails that test.
+const EXPECTED_HOST_METHODS: &[&str] = &[
+    "quit",
+    "rebuild_inference",
+    "rebuild_cloud_client",
+    "toggle_map",
+    "open_designer",
+    "save_game",
+    "fork_branch",
+    "load_branch",
+    "list_branches",
+    "show_log",
+    "show_spinner",
+    "new_game",
+    "save_flags",
+    "apply_theme",
+    "apply_tiles",
+    "handle_debug",
+    "reset_byok",
+    "inference_log_toggle",
+    "emit_text_log",
+    "emit_world_update",
+];
+
+/// The three production entry-point hosts (crate label, source path relative to
+/// the workspace root). The `MockHost` test double in `system_command.rs` is
+/// intentionally excluded — it is not an entry point.
+const PRODUCTION_HOSTS: &[(&str, &str)] = &[
+    ("parish-server", "crates/parish-server/src/command_host.rs"),
+    ("parish-tauri", "crates/parish-tauri/src/command_host.rs"),
+    ("parish-engine", "crates/parish-engine/src/command_host.rs"),
+];
+
+/// `(crate, method)` pairs that intentionally inherit the trait's default
+/// implementation instead of overriding it. Every entry needs a comment
+/// justifying why the default is correct for that backend. Anything NOT listed
+/// here must be overridden; anything listed here that IS overridden is flagged
+/// as a stale exception (see `system_command_host_parity`).
+const DEFAULT_RELIANT_ALLOWLIST: &[(&str, &str)] = &[
+    // `reset_byok` re-opens the BYOK provider picker. Only the Tauri desktop
+    // has a provider-picker overlay to re-open, so it is the sole override.
+    // The web server and headless CLI currently inherit the no-op default;
+    // wiring real BYOK-reset there is a runtime feature tracked separately
+    // (it needs its own live proof). Listing them here makes the gap an
+    // explicit, reviewed exception rather than silent drift.
+    ("parish-server", "reset_byok"),
+    ("parish-engine", "reset_byok"),
+];
+
+/// Extract the `fn <name>` declarations inside the `SystemCommandHost` trait
+/// block (brace-matched), excluding `run_command`.
+fn system_command_host_trait_methods(src: &str) -> BTreeSet<String> {
+    let mut methods = BTreeSet::new();
+    let Some(start) = src.find("trait SystemCommandHost") else {
+        return methods;
+    };
+    let mut depth: i32 = 0;
+    let mut entered = false;
+    for line in src[start..].lines() {
+        for ch in line.chars() {
+            match ch {
+                '{' => {
+                    depth += 1;
+                    entered = true;
+                }
+                '}' => depth -= 1,
+                _ => {}
+            }
+        }
+        // Only collect `fn` decls at trait-body depth (1).
+        if entered
+            && depth >= 1
+            && let Some(name) = fn_name_on_line(line)
+            && name != "run_command"
+        {
+            methods.insert(name);
+        }
+        if entered && depth <= 0 {
+            break; // end of the trait block
+        }
+    }
+    methods
+}
+
+/// If `line` declares a function, return its name. Matches `fn <name>(` and
+/// `fn <name> (`; ignores the rest of the signature (which may wrap).
+fn fn_name_on_line(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let after_fn = trimmed
+        .strip_prefix("fn ")
+        .or_else(|| trimmed.strip_prefix("pub fn "))
+        .or_else(|| trimmed.strip_prefix("async fn "))?;
+    let name: String = after_fn
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+    if name.is_empty() { None } else { Some(name) }
+}
+
+/// True if `src` (an impl file) overrides `method` (declares `fn <method>(`).
+fn impl_overrides(src: &str, method: &str) -> bool {
+    let needle_a = format!("fn {method}(");
+    let needle_b = format!("fn {method} (");
+    src.lines()
+        .any(|l| l.contains(&needle_a) || l.contains(&needle_b))
+}
+
+#[test]
+fn host_method_set_matches_trait() {
+    let ws = workspace_root();
+    let trait_src = ws.join("crates/parish-core/src/game_loop/system_command.rs");
+    let src = fs::read_to_string(&trait_src)
+        .unwrap_or_else(|e| panic!("could not read {}: {e}", trait_src.display()));
+
+    let actual = system_command_host_trait_methods(&src);
+    let expected: BTreeSet<String> = EXPECTED_HOST_METHODS
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+    let missing: Vec<&String> = expected.difference(&actual).collect();
+    let extra: Vec<&String> = actual.difference(&expected).collect();
+
+    assert!(
+        missing.is_empty() && extra.is_empty(),
+        "EXPECTED_HOST_METHODS is out of sync with the SystemCommandHost trait \
+         (issue #1174).\n  In the list but not the trait: {missing:?}\n  \
+         In the trait but not the list: {extra:?}\n\n\
+         FIX: update EXPECTED_HOST_METHODS in wiring_parity.rs to match the \
+         trait's effect-handler methods (everything except `run_command`). If \
+         you added a handler, also wire it into all three production hosts \
+         (or add a justified DEFAULT_RELIANT_ALLOWLIST entry).",
+    );
+}
+
+#[test]
+fn system_command_host_parity() {
+    let ws = workspace_root();
+    let allow: BTreeSet<(&str, &str)> = DEFAULT_RELIANT_ALLOWLIST.iter().copied().collect();
+
+    let mut violations: Vec<String> = Vec::new();
+    let mut stale_allowlist: Vec<String> = Vec::new();
+
+    for (krate, rel_path) in PRODUCTION_HOSTS {
+        let path = ws.join(rel_path);
+        let src = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("could not read {}: {e}", path.display()));
+
+        for method in EXPECTED_HOST_METHODS {
+            let overridden = impl_overrides(&src, method);
+            let allowlisted = allow.contains(&(*krate, *method));
+
+            if !overridden && !allowlisted {
+                violations.push(format!(
+                    "{krate} does not override `SystemCommandHost::{method}` \
+                     — it silently inherits the trait default.\n        FIX: \
+                     add `fn {method}(...)` to {rel_path}, or add \
+                     (\"{krate}\", \"{method}\") to DEFAULT_RELIANT_ALLOWLIST \
+                     with a justifying comment."
+                ));
+            }
+            if overridden && allowlisted {
+                stale_allowlist.push(format!(
+                    "({krate}, {method}) is in DEFAULT_RELIANT_ALLOWLIST but \
+                     {krate} DOES override it — remove the stale exception."
+                ));
+            }
+        }
+    }
+
+    let mut msg = String::new();
+    if !violations.is_empty() {
+        msg.push_str(&format!(
+            "Wiring-parity violation — a SystemCommandHost effect is not wired \
+             from every entry point (issue #1174):\n    - {}\n",
+            violations.join("\n    - ")
+        ));
+    }
+    if !stale_allowlist.is_empty() {
+        msg.push_str(&format!(
+            "\nStale allowlist entries:\n    - {}\n",
+            stale_allowlist.join("\n    - ")
+        ));
+    }
+    assert!(
+        violations.is_empty() && stale_allowlist.is_empty(),
+        "{msg}\nEvery CommandEffect must be handled identically across the web \
+         server, Tauri desktop, and headless CLI. See CLAUDE.md §Mode parity \
+         and docs/agent/architecture.md.",
+    );
+}
+
+#[test]
+fn fn_name_on_line_extracts_names() {
+    assert_eq!(
+        fn_name_on_line("    fn quit(&self) -> Foo {").as_deref(),
+        Some("quit")
+    );
+    assert_eq!(
+        fn_name_on_line("    fn inference_log_toggle(").as_deref(),
+        Some("inference_log_toggle")
+    );
+    assert_eq!(fn_name_on_line("    // not a fn").as_deref(), None);
+    assert_eq!(
+        fn_name_on_line("pub fn helper() {").as_deref(),
+        Some("helper")
+    );
+}
+
+#[test]
+fn impl_overrides_detects_declarations() {
+    let src = "impl X {\n    fn save_game(&self) -> String { String::new() }\n}";
+    assert!(impl_overrides(src, "save_game"));
+    assert!(!impl_overrides(src, "reset_byok"));
 }

--- a/parish/crates/parish-core/tests/wiring_parity.rs
+++ b/parish/crates/parish-core/tests/wiring_parity.rs
@@ -345,7 +345,11 @@ fn system_command_host_trait_methods(src: &str) -> BTreeSet<String> {
     };
     let mut depth: i32 = 0;
     let mut entered = false;
-    for line in src[start..].lines() {
+    for raw_line in src[start..].lines() {
+        // Strip line/doc comments first so braces or a `fn ...` mentioned
+        // inside `//`/`///` can't corrupt depth tracking or yield a phantom
+        // method name.
+        let line = raw_line.split("//").next().unwrap_or("");
         for ch in line.chars() {
             match ch {
                 '{' => {
@@ -387,10 +391,14 @@ fn fn_name_on_line(line: &str) -> Option<String> {
 }
 
 /// True if `src` (an impl file) overrides `method` (declares `fn <method>(`).
+///
+/// Line comments are stripped first so a commented-out or merely-mentioned
+/// `// fn <method>(` is not mistaken for a real override.
 fn impl_overrides(src: &str, method: &str) -> bool {
     let needle_a = format!("fn {method}(");
     let needle_b = format!("fn {method} (");
     src.lines()
+        .map(|l| l.split("//").next().unwrap_or(""))
         .any(|l| l.contains(&needle_a) || l.contains(&needle_b))
 }
 
@@ -501,4 +509,9 @@ fn impl_overrides_detects_declarations() {
     let src = "impl X {\n    fn save_game(&self) -> String { String::new() }\n}";
     assert!(impl_overrides(src, "save_game"));
     assert!(!impl_overrides(src, "reset_byok"));
+    // A commented-out or merely-mentioned fn must NOT count as an override.
+    assert!(!impl_overrides(
+        "impl X {\n    // fn save_game(&self) {}\n}",
+        "save_game"
+    ));
 }


### PR DESCRIPTION
Closes #1174.

## Problem

`parish-core/tests/wiring_parity.rs` diffed only the Tauri command registry vs the server route registry; its own doc comment deferred the CLI/headless path. The shared cross-runtime command surface is the `SystemCommandHost` trait, and two effect handlers (`reset_byok`, `inference_log_toggle`) carry default impls — so a backend can silently inherit a no-op and drift (exactly how `reset_byok` is wired only in Tauri today).

## Change

Two source-scan tests added to `wiring_parity.rs` (same style as the existing registry diff):

- **`host_method_set_matches_trait`** — derives the effect-handler set by parsing the `SystemCommandHost` trait and asserts `EXPECTED_HOST_METHODS` matches it, so the list cannot silently drift from the trait.
- **`system_command_host_parity`** — asserts all three production hosts (`AppStateCommandHost`, `TauriCommandHost`, `CliCommandHost`) override every effect handler, with an explicit, commented `DEFAULT_RELIANT_ALLOWLIST` for intentional default-reliance and a stale-entry check so the allowlist cannot rot.

## Acceptance

- Green on current `main` (`10 passed`), allowlist = `{(parish-server, reset_byok), (parish-engine, reset_byok)}` — only Tauri has a provider-picker overlay to re-open.
- Removing any host override (e.g. `CliCommandHost::inference_log_toggle`) turns the test RED naming the crate, method, and fix (see proof transcript B).

Wiring `reset_byok` in server + CLI is a separate runtime feature (its own live proof) and is filed as a follow-up; this PR only adds the fitness guard and records the current state honestly.

## Proof

Bundle in the PR body below. Test-only change (`parish-core/tests/`), not a runtime-shipping path, so non-live evidence (the test suite green on main + red on drift). fmt + clippy (`-D warnings`) clean.

<!-- parish-proof-bundle:1174-wiring-parity v=1 -->

## Proof: 1174-wiring-parity

### Acceptance criteria

# Acceptance criteria — #1174 wiring-parity fitness test (CLI/headless path)

## Context

`parish-core/tests/wiring_parity.rs` already diffs the Tauri command registry
against the server route registry, but its own doc comment notes the CLI /
headless path is **not** covered. The shared cross-runtime command surface is
the `SystemCommandHost` trait (`parish-core/src/game_loop/system_command.rs`):
all three entry points — `parish-server` (`AppStateCommandHost`),
`parish-tauri` (`TauriCommandHost`), `parish-engine` (`CliCommandHost`) — must
implement every effect handler, or a backend silently inherits a trait default
no-op and drifts (the exact failure mode of `reset_byok` / `inference_log_toggle`).

## Observable criteria

- **AC1 — enumeration.** A new test in `parish-core/tests/wiring_parity.rs`
  derives the set of `SystemCommandHost` effect-handler methods directly from
  the trait source (not a hand-copied list) and asserts that hand-maintained
  `EXPECTED_HOST_METHODS` matches it. Adding or removing a trait method without
  updating the test fails it.
- **AC2 — per-entry-point coverage.** For each of the three production host
  source files, the test asserts every expected method is overridden
  (`fn <name>(`), except `(crate, method)` pairs in an explicit, commented
  `DEFAULT_RELIANT_ALLOWLIST`.
- **AC3 — green on main.** `cargo test -p parish-core --test wiring_parity`
  passes on current `main`, with the allowlist documenting the only two current
  exceptions: `reset_byok` for `parish-server` and `parish-engine` (only the
  Tauri desktop has a provider-picker overlay to re-open).
- **AC4 — catches drift.** Removing an override from any one host (e.g.
  deleting `CliCommandHost::inference_log_toggle`) turns the test RED with a
  message naming the crate, the method, and the fix.
- **AC5 — allowlist can't rot.** If an allowlisted `(crate, method)` is in fact
  overridden, the test fails, forcing the stale exception to be removed.

## Out of scope (tracked separately)

Actually wiring `reset_byok` in the server + CLI (so `/byok` does more than
print "Re-opening provider picker...") is a runtime feature with its own live
proof; it is filed as a follow-up. This issue only adds the fitness guard and
records the current state honestly.

## Proof

`cargo test -p parish-core --test wiring_parity` green on main (AC1-3, AC5),
plus a transcript showing the test RED after deleting one host override (AC4).
Test-only change (`parish-core/tests/`); not a runtime-shipping path, so no live
process is required.

### Evidence

# Evidence — #1174 wiring-parity fitness test

Evidence type: gameplay transcript

Test-only change in `parish/crates/parish-core/tests/wiring_parity.rs` (not a
runtime-shipping path), so the proof is the test suite itself: green on main,
and red the moment a host override is removed. Full output in
`transcript.txt`.

## Criterion → proof

- **AC1 (enumeration derives from the trait).** `host_method_set_matches_trait`
  passes (transcript A). It parses the `SystemCommandHost` trait source and
  asserts `EXPECTED_HOST_METHODS` equals the trait's effect-handler set, so the
  list can't silently drift from the trait. Helper coverage:
  `fn_name_on_line_extracts_names`, `impl_overrides_detects_declarations` (both ok).

- **AC2 (per-entry-point coverage) + AC3 (green on main).**
  `system_command_host_parity ... ok` (transcript A): all three production
  hosts (`parish-server`, `parish-tauri`, `parish-engine`) override every
  expected method except the two allowlisted `reset_byok` exceptions. Full
  suite: `10 passed; 0 failed`.

- **AC4 (catches drift).** Transcript B: deleting
  `CliCommandHost::inference_log_toggle` (a defaulted method, so it still
  compiles) turns `system_command_host_parity` RED with a message naming the
  crate (`parish-engine`), the method (`inference_log_toggle`), and the fix.
  The override was restored via `git checkout` right after.

- **AC5 (allowlist can't rot).** Enforced by the same test: an allowlisted
  `(crate, method)` that IS overridden is reported as a stale entry. Currently
  no entry is stale (suite green); the logic is exercised by the allowlist /
  override cross-check in `system_command_host_parity`.

## Scope note

Actually wiring `reset_byok` in the server + CLI is a separate runtime feature
(its own live proof) and is filed as a follow-up. This change only adds the
fitness guard and records the current state as an explicit, commented allowlist
rather than silent drift.

### Transcript

```text
#1174 wiring-parity fitness test — proof transcript
====================================================

A) GREEN ON MAIN — cargo test -p parish-core --test wiring_parity
-----------------------------------------------------------------
running 10 tests
test fn_name_on_line_extracts_names ... ok
test http_to_canonical_rejects_non_api_paths ... ok
test http_to_canonical_strips_prefix_and_replaces_hyphens ... ok
test impl_overrides_detects_declarations ... ok
test parse_str_array_const_handles_inline_comments ... ok
test parse_str_array_const_extracts_values ... ok
test tauri_to_canonical_strips_get_prefix ... ok
test host_method_set_matches_trait ... ok
test tauri_and_server_expose_the_same_ipc_commands ... ok
test system_command_host_parity ... ok
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

  host_method_set_matches_trait  -> EXPECTED_HOST_METHODS == the trait's
      effect-handler method set (AC1).
  system_command_host_parity     -> all 3 production hosts override every
      effect handler except the 2 allowlisted reset_byok exceptions (AC2, AC3).
  impl_overrides_detects_declarations / fn_name_on_line_extracts_names ->
      unit coverage of the source-scan helpers.

B) CATCHES DRIFT (AC4) — after deleting CliCommandHost::inference_log_toggle
    (which has a trait default, so the impl still compiles and silently
     inherits the no-op):
----------------------------------------------------------------------------
test system_command_host_parity ... FAILED

---- system_command_host_parity stdout ----
thread 'system_command_host_parity' panicked at crates/parish-core/tests/wiring_parity.rs:471:5:
Wiring-parity violation — a SystemCommandHost effect is not wired from every entry point (issue #1174):
    - parish-engine does not override `SystemCommandHost::inference_log_toggle` — it silently inherits the trait default.
        FIX: add `fn inference_log_toggle(...)` to crates/parish-engine/src/command_host.rs, or add ("parish-engine", "inference_log_toggle") to DEFAULT_RELIANT_ALLOWLIST with a justifying comment.

Every CommandEffect must be handled identically across the web server, Tauri desktop, and headless CLI. See CLAUDE.md §Mode parity and docs/agent/architecture.md.

test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

  -> The override was restored immediately afterwards (git checkout); main
     stays green (run A).
```

### Judge

# Judge — #1174 wiring-parity fitness test

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

## Per-criterion verification (against transcript.txt)

- **AC1 — enumeration derives from the trait.** MET. `host_method_set_matches_trait`
  passes (transcript A) and would fail if the trait gained/lost an effect
  handler not mirrored in `EXPECTED_HOST_METHODS`. The set is computed by
  brace-matched parse of the trait block, not hand-copied at use sites.
- **AC2 — per-entry-point coverage.** MET. `system_command_host_parity`
  scans all three production host source files and asserts each expected
  method is overridden, with an explicit `DEFAULT_RELIANT_ALLOWLIST`.
- **AC3 — green on main.** MET. Transcript A: `10 passed; 0 failed`, including
  the two new parity tests, with the allowlist holding exactly the two current
  exceptions (`reset_byok` for `parish-server` and `parish-engine`).
- **AC4 — catches drift.** MET. Transcript B: removing one host override
  produces a RED test with a self-correcting message naming crate, method, and
  fix.
- **AC5 — allowlist can't rot.** MET. The test flags any allowlisted pair that
  is in fact overridden; none are stale on main (suite green).

## Debt check

No `todo!()`/`unimplemented!()`/stubs introduced. The `reset_byok`
server/CLI wiring gap is pre-existing, now made explicit via a commented
allowlist and filed as a tracked follow-up — not new debt, and the fitness
test prevents it from worsening silently. Change is confined to a test file;
no runtime path touched.

## Scope honesty

The PR does not claim to fix BYOK reset on web/CLI; it adds the guard and
documents the exception. That separation is stated in the AC and evidence.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:1174-wiring-parity -->
