### PR TITLE
ci(test): flaky-test detector via nextest one-shot retry (#1176)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,15 @@ jobs:
       - name: Clippy (deny warnings)
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # `--retries 1` is the flaky-test detector (#1176): a test that fails
+      # then passes on the retry is reported as FLAKY (the run still goes
+      # green on a single blip, but the nondeterminism is surfaced in the
+      # summary instead of either hard-failing the PR or hiding silently).
+      # `--profile ci` picks up the matching retry/fail-fast policy in
+      # parish/.config/nextest.toml so the same behaviour is reproducible
+      # locally with `cargo nextest run --profile ci`.
       - name: Unit and integration tests
-        run: cargo nextest run --workspace --all-targets
+        run: cargo nextest run --workspace --all-targets --profile ci
 
   rust-coverage-ratchet:
     name: Rust coverage ratchet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
               - 'parish/Cargo.toml'
               - 'parish/Cargo.lock'
               - 'parish/testing/**'
+              - 'parish/.config/nextest.toml'
               - 'mods/**'
               - '.github/workflows/ci.yml'
             ui:
@@ -209,7 +210,12 @@ jobs:
         with:
           tool: cargo-llvm-cov,cargo-nextest
 
+      # Same one-shot retry policy as the quality gate so a single flaky blip
+      # in a coverage-ratchet test is reported FLAKY, not a hard PR failure
+      # (#1176). NEXTEST_PROFILE avoids `--profile` arg ambiguity with llvm-cov.
       - name: Enforce coverage floor
+        env:
+          NEXTEST_PROFILE: ci
         run: cargo llvm-cov nextest --workspace --all-targets --exclude parish-client --fail-under-lines 60.8
 
   rust-multi-channel:

--- a/parish/.config/nextest.toml
+++ b/parish/.config/nextest.toml
@@ -1,0 +1,14 @@
+# cargo-nextest configuration.
+#
+# The `ci` profile is a one-shot flaky-test detector (#1176): a failed test is
+# retried once, so a test that fails then passes is reported as FLAKY instead
+# of either hard-failing the PR on a single nondeterministic blip or hiding the
+# flakiness entirely. `fail-fast = false` so one failure does not mask the rest
+# of the suite. CI runs `cargo nextest run --workspace --all-targets --profile ci`;
+# reproduce locally the same way.
+#
+# The default profile keeps retries = 0 so ordinary local `cargo nextest run`
+# stays fast and a genuine failure surfaces immediately.
+[profile.ci]
+retries = 1
+fail-fast = false

--- a/parish/.config/nextest.toml
+++ b/parish/.config/nextest.toml
@@ -9,6 +9,8 @@
 #
 # The default profile keeps retries = 0 so ordinary local `cargo nextest run`
 # stays fast and a genuine failure surfaces immediately.
+# `inherits` is required for any non-default profile.
 [profile.ci]
+inherits = "default"
 retries = 1
 fail-fast = false


### PR DESCRIPTION
Part of #1176 (the flaky-detector half — see "Deterministic bus" below).

## Change

- `parish/.config/nextest.toml` — new `[profile.ci]` with `retries = 1` and `fail-fast = false`.
- `.github/workflows/ci.yml` — the "Unit and integration tests" step now runs `cargo nextest run --workspace --all-targets --profile ci`.

A failed test is retried once; a test that fails then passes is reported **FLAKY** in the summary (the run still goes green on a single blip, so flakiness is surfaced rather than either hard-failing the PR or hiding silently). Reproducible locally with `cargo nextest run --profile ci`.

## Proof (bundle in body below)

- **Flags nondeterminism:** a deliberately-flaky throwaway test → `TRY 1 FAIL` → `TRY 2 PASS` → `Summary: 1 passed (1 flaky)` → `FLAKY 2/2`, process exit 0. (Demo test removed, not committed.)
- **Stable suite stays green:** `parish-core` run twice back-to-back under `--profile ci` → `562 passed, 1 skipped` each, zero flaky, zero fail.

## Deterministic test EventBus — decision needed

#1176 also asks for a "test-mode synchronous-drain (or seeded-order) EventBus behind a flag." I did **not** build it, because the determinism it targets already holds:

- the concrete ordering bug it cited (#1035 / #1077 / #1079) was fixed by capturing `location` at publish time on the relevant `GameEvent` variants;
- `tokio::broadcast` delivers in FIFO publish order;
- `GameTestHarness` seeds its RNG (`StdRng::seed_from_u64(0)`).

The two stable runs above evidence this. Adding a second `EventBus` implementation behind a flag would touch a rule-#11 real-time-push seam to add determinism that's already present — net-negative complexity. **Recommendation:** keep #1176 open only if you want the bus regardless; otherwise this + the existing guarantees close it. Happy to build the bus if you'd prefer the belt-and-suspenders.

## Proof gate

CI/config only (`.github/**`, `parish/.config/nextest.toml`); `agent-check` reports no proof required. Bundle included for evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

$(bash parish/scripts/render-proof-comment.sh 1176-flaky-detector)