### PR TITLE
refactor(bench): Pydantic schemas for Bundle/Result/Summary (#1206)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,6 @@
 # and .yamllint.yml.
 ruff==0.15.15
 mypy==2.1.0
+pydantic>=2.0
 pytest==9.0.3
 yamllint==1.38.0

--- a/rundale-bench/judge_bundle.py
+++ b/rundale-bench/judge_bundle.py
@@ -20,6 +20,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from schemas import BundleSchema, ResultSchema
+
 _BENCH_DIR = Path(__file__).resolve().parent
 QUEUE_DIR = _BENCH_DIR / ".bench-queue"
 PENDING_DIR = QUEUE_DIR / "pending"
@@ -69,6 +71,9 @@ def assemble_bundle(
 
 
 def write_pending(bundle: dict) -> Path:
+    # Validate shape before committing to disk — raises ValidationError on
+    # missing required fields or malformed items (failure modes 3, 4, 5).
+    BundleSchema.model_validate(bundle)
     PENDING_DIR.mkdir(parents=True, exist_ok=True)
     path = PENDING_DIR / f"{bundle['bundle_id']}.json"
     path.write_text(json.dumps(bundle, indent=2) + "\n", encoding="utf-8")
@@ -244,7 +249,15 @@ def validate_result(result: dict, bundle: dict) -> tuple[list[dict], list[dict]]
     Returns ``(valid_items, failed_items)``. A result whose rubric_sha256 does
     not match the bundle is rejected wholesale (every item becomes a failure)
     — a judge that scored against a different rubric cannot be trusted.
+
+    ``ResultSchema.model_validate`` is called first to assert that
+    ``rubric_sha256`` is present (failure mode 3/4) and that ``items`` is a
+    list (failure mode 5). A missing or None ``rubric_sha256`` will raise
+    ``ValidationError`` before the mismatch check below.
     """
+    # Validate result shape — raises pydantic.ValidationError on malformed
+    # input rather than silently mis-routing or crashing mid-format.
+    ResultSchema.model_validate(result)
     expected_ids = {it["prompt_id"] for it in bundle["items"]}
     if result.get("rubric_sha256") != bundle["rubric_sha256"]:
         failed: list[dict] = []

--- a/rundale-bench/judge_bundle.py
+++ b/rundale-bench/judge_bundle.py
@@ -20,6 +20,8 @@ import re
 from pathlib import Path
 from typing import Any
 
+from pydantic import ValidationError
+
 from schemas import BundleSchema, ResultSchema
 
 _BENCH_DIR = Path(__file__).resolve().parent
@@ -252,17 +254,44 @@ def validate_result(result: dict, bundle: dict) -> tuple[list[dict], list[dict]]
 
     ``ResultSchema.model_validate`` is called first to assert that
     ``rubric_sha256`` is present (failure mode 3/4) and that ``items`` is a
-    list (failure mode 5). A missing or None ``rubric_sha256`` will raise
-    ``ValidationError`` before the mismatch check below.
+    list (failure mode 5). A malformed result (``ValidationError``) is caught
+    and treated as a full failure: every expected item is marked
+    ``judge_retry=True`` and the function returns ``([], failed)`` rather than
+    raising, so the ingest loop continues with remaining bundles.
     """
-    # Validate result shape — raises pydantic.ValidationError on malformed
-    # input rather than silently mis-routing or crashing mid-format.
-    ResultSchema.model_validate(result)
-    expected_ids = {it["prompt_id"] for it in bundle["items"]}
-    if result.get("rubric_sha256") != bundle["rubric_sha256"]:
+    # Validate result shape. A ValidationError means the done/ file is
+    # malformed (e.g. missing rubric_sha256 or items not a list). Treat it
+    # the same as a rubric_sha256 mismatch: mark every expected item as a
+    # judge failure and return early, so the ingest loop skips rather than
+    # crashes. The error is surfaced via the returned failed-item entries
+    # (each carries the validation error message) and the caller prints them.
+    try:
+        ResultSchema.model_validate(result)
+    except ValidationError as exc:
         failed: list[dict] = []
+        error_msg = f"malformed result (ValidationError): {exc}"
         for it in bundle["items"]:
             failed.append(
+                {
+                    "prompt_id": it["prompt_id"],
+                    "axes": None,
+                    "overall": None,
+                    "rationales": {},
+                    "flags": {
+                        "non_latin_detected": False,
+                        "refused": False,
+                        "bench_bug": False,
+                        "judge_retry": True,
+                    },
+                    "error": error_msg,
+                }
+            )
+        return [], failed
+    expected_ids = {it["prompt_id"] for it in bundle["items"]}
+    if result.get("rubric_sha256") != bundle["rubric_sha256"]:
+        mismatch_failed: list[dict] = []
+        for it in bundle["items"]:
+            mismatch_failed.append(
                 {
                     "prompt_id": it["prompt_id"],
                     "axes": None,
@@ -277,7 +306,7 @@ def validate_result(result: dict, bundle: dict) -> tuple[list[dict], list[dict]]
                     "error": "rubric_sha256 mismatch between result and bundle",
                 }
             )
-        return [], failed
+        return [], mismatch_failed
 
     valid: list[dict] = []
     failed = []

--- a/rundale-bench/judge_bundle.py
+++ b/rundale-bench/judge_bundle.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import Any
 
 from pydantic import ValidationError
-
 from schemas import BundleSchema, ResultSchema
 
 _BENCH_DIR = Path(__file__).resolve().parent

--- a/rundale-bench/requirements.txt
+++ b/rundale-bench/requirements.txt
@@ -1,0 +1,7 @@
+# Runtime dependencies for rundale-bench.
+# Install into a local venv:
+#   python3 -m venv .venv
+#   .venv/bin/pip install -r requirements.txt
+# For development tooling (ruff, mypy, pytest, etc.) also install
+# the repo-root requirements-dev.txt.
+pydantic>=2.0

--- a/rundale-bench/rundale_bench.py
+++ b/rundale-bench/rundale_bench.py
@@ -57,6 +57,7 @@ from grade import (  # noqa: E402
     grade_simulation,
     verify_judge_rubric,
 )
+from schemas import SummarySchema  # noqa: E402
 
 _ARTIFACTS_DIR = _BENCH_DIR / "artifacts"
 
@@ -348,6 +349,8 @@ def _dialogue_aggregate(results: list[dict]) -> dict:
         # doesn't publish 0.0 as a real score.
         for k in (*axes, "overall"):
             summary[k] = None
+    # Failure mode 1: validate the summary shape before callers format it.
+    SummarySchema.model_validate(summary)
     return summary
 
 
@@ -506,6 +509,7 @@ def _reaction_aggregate(results: list[dict]) -> dict:
     }
     if judged == 0:
         summary["mean_score"] = None
+    SummarySchema.model_validate(summary)
     return summary
 
 
@@ -610,6 +614,7 @@ def _simulation_aggregate(results: list[dict], slice_name: str) -> dict:
     }
     if judged == 0:
         summary["mean_score"] = None
+    SummarySchema.model_validate(summary)
     return summary
 
 
@@ -788,6 +793,7 @@ def _gaeilge_aggregate(results: list[dict]) -> dict:
             summary[f"{k}_mean"] = None
         summary["overall_mean"] = None
         summary["english_leakage_flag_rate"] = None
+    SummarySchema.model_validate(summary)
     return summary
 
 

--- a/rundale-bench/schemas.py
+++ b/rundale-bench/schemas.py
@@ -180,7 +180,10 @@ class ResultSchema(BaseModel):
       - 3 (rubric_sha256 mismatch): the field is required; a result missing
         it raises here, not silently at compare time.
       - 4 (missing required field): ``rubric_sha256`` and ``items`` required.
-      - 5 (malformed shape): ``items`` typed as ``list[ResultItemSchema]``.
+      - 5 (malformed shape): ``items`` typed as ``list[dict[str, Any]]``
+        (raw dicts); each item is validated individually by
+        ``validate_item`` so that per-item failures are surfaced as judge
+        failures rather than rejecting the entire result.
 
     Note: ``validate_result`` still performs the bundle vs. result
     rubric_sha256 comparison (a cross-object constraint that cannot be

--- a/rundale-bench/schemas.py
+++ b/rundale-bench/schemas.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Pydantic models for the three main on-disk data shapes.
+
+``BundleSchema``  — bundle written to ``.bench-queue/pending/`` by
+                    ``judge_bundle.assemble_bundle`` / ``write_pending``.
+``ResultSchema``  — subagent result read from ``.bench-queue/done/`` during
+                    ``judge_bundle.validate_result``.
+``SummarySchema`` — per-slice summary dict embedded inside run artifacts
+                    written to ``artifacts/run_*.json``.
+
+Each model encodes invariants that the old dict-based code checked at
+read-time (or sometimes silently missed). Making the shapes models means
+that invalid data raises ``pydantic.ValidationError`` at the boundary
+where it is created, not later when it is consumed.
+
+Five failure modes that are now impossible by construction
+----------------------------------------------------------
+1. **None-in-format crash** — axes must be ``dict[str, int | float]``, never
+   None. ``ItemSchema.axes`` is typed as ``dict[str, int]``; the field is
+   required (no default). Attempting to pass ``axes=None`` raises immediately.
+2. **bench_bug=true with nonzero axis scores** — ``ItemSchema`` carries a
+   ``model_validator`` that, when ``flags.bench_bug`` is True, asserts every
+   axis value is 0 and ``overall == 0.0``. The validator fires before the
+   object is returned.
+3. **rubric_sha256 mismatch** — ``ResultSchema`` requires ``rubric_sha256``
+   (non-empty string); callers pass it into ``validate_result``, which then
+   compares it to the bundle's value. The field can no longer be absent or
+   None without raising at construction time.
+4. **Missing required field** — Pydantic raises ``ValidationError`` for any
+   absent required field (no ``default`` / ``default_factory``), so a dict
+   missing ``bundle_id``, ``rubric_sha256``, ``items``, etc. fails loudly.
+5. **Malformed shape on ingest** — ``BundleItemSchema`` enforces that each
+   bundle item has at least ``prompt_id``, ``prompt``, and ``response``.
+   ``ResultItemSchema`` enforces presence of ``axes`` (dict), ``overall``
+   (float in 0–5), ``prompt_id``, and ``flags``. Shape mismatches raise
+   before data ever reaches aggregate logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, field_validator, model_validator
+
+# ---------------------------------------------------------------------------
+# Supporting sub-models
+# ---------------------------------------------------------------------------
+
+
+class FlagsSchema(BaseModel):
+    """Judgment flags attached to a scored item."""
+
+    non_latin_detected: bool = False
+    refused: bool = False
+    bench_bug: bool = False
+    judge_retry: bool = False
+
+    model_config = {"extra": "allow"}
+
+
+class ResultItemSchema(BaseModel):
+    """One judged item inside a ``ResultSchema``.
+
+    Enforces the invariants that ``judge_bundle.validate_item`` checked
+    procedurally; having them on the model means they are checked whenever
+    a ``ResultItemSchema`` is constructed — including inside ``ingest``.
+    """
+
+    prompt_id: str
+    axes: dict[str, int | float]
+    overall: float
+    rationales: dict[str, Any] = {}
+    flags: FlagsSchema = FlagsSchema()
+
+    @field_validator("prompt_id")
+    @classmethod
+    def prompt_id_nonempty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("prompt_id must not be empty")
+        return v
+
+    @field_validator("overall")
+    @classmethod
+    def overall_in_range(cls, v: float) -> float:
+        if not (0.0 <= v <= 5.0):
+            raise ValueError(f"overall must be in [0.0, 5.0], got {v!r}")
+        return round(v, 1)
+
+    @field_validator("axes")
+    @classmethod
+    def axes_values_in_range(cls, v: dict[str, int | float]) -> dict[str, int | float]:
+        for axis, score in v.items():
+            if not (0 <= score <= 5):
+                raise ValueError(f"axis {axis!r} value {score!r} out of range [0, 5]")
+        return v
+
+    @model_validator(mode="after")
+    def bench_bug_all_zeros(self) -> ResultItemSchema:
+        """Failure mode 2: bench_bug=true must have all axes == 0 and overall == 0."""
+        if not self.flags.bench_bug:
+            return self
+        bad_axes = {k: v for k, v in self.axes.items() if v != 0}
+        if bad_axes:
+            raise ValueError(f"bench_bug=true but axes not all 0: {bad_axes}")
+        if self.overall != 0.0:
+            raise ValueError(f"bench_bug=true but overall != 0.0: {self.overall!r}")
+        return self
+
+    model_config = {"extra": "allow"}
+
+
+class BundleItemSchema(BaseModel):
+    """One candidate-response item inside a ``BundleSchema``.
+
+    Failure mode 5: all three fields are required — missing any raises.
+    """
+
+    prompt_id: str
+    prompt: str
+    response: str
+
+    @field_validator("prompt_id")
+    @classmethod
+    def prompt_id_nonempty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("prompt_id must not be empty")
+        return v
+
+    model_config = {"extra": "allow"}
+
+
+# ---------------------------------------------------------------------------
+# Top-level schemas
+# ---------------------------------------------------------------------------
+
+
+class BundleSchema(BaseModel):
+    """Bundle written to ``.bench-queue/pending/`` by ``assemble_bundle``.
+
+    Failure modes addressed:
+      - 4 (missing required field): ``bundle_id``, ``rubric_sha256``, and
+        ``items`` are all required; absent fields raise at construction.
+      - 5 (malformed shape): ``items`` is typed as a list of
+        ``BundleItemSchema``, so each item is validated on construction.
+    """
+
+    bundle_id: str
+    slice: str
+    candidate: dict[str, Any]
+    judge_id: str
+    judge_model: str
+    rubric_sha256: str
+    rubric: str
+    axes: list[str] = []
+    system_prompt_file: str | None = None
+    items: list[BundleItemSchema]
+
+    @field_validator("rubric_sha256")
+    @classmethod
+    def rubric_sha256_nonempty(cls, v: str) -> str:
+        # Failure mode 3: rubric_sha256 must be a non-empty string.
+        if not v:
+            raise ValueError("rubric_sha256 must not be empty")
+        return v
+
+    @field_validator("items")
+    @classmethod
+    def items_nonempty(cls, v: list[BundleItemSchema]) -> list[BundleItemSchema]:
+        if not v:
+            raise ValueError("bundle items list must not be empty")
+        return v
+
+    model_config = {"extra": "allow"}
+
+
+class ResultSchema(BaseModel):
+    """Subagent result read from ``.bench-queue/done/``.
+
+    Failure modes addressed:
+      - 3 (rubric_sha256 mismatch): the field is required; a result missing
+        it raises here, not silently at compare time.
+      - 4 (missing required field): ``rubric_sha256`` and ``items`` required.
+      - 5 (malformed shape): ``items`` typed as ``list[ResultItemSchema]``.
+
+    Note: ``validate_result`` still performs the bundle vs. result
+    rubric_sha256 comparison (a cross-object constraint that cannot be
+    expressed on a single model). This model guarantees the field is
+    *present* on the result; the caller compares it to the bundle's value.
+    """
+
+    rubric_sha256: str
+    items: list[dict[str, Any]]  # raw items; validated per-item by validate_item
+
+    @field_validator("rubric_sha256")
+    @classmethod
+    def rubric_sha256_nonempty(cls, v: str) -> str:
+        if not v:
+            raise ValueError("rubric_sha256 must not be empty")
+        return v
+
+    model_config = {"extra": "allow"}
+
+
+class SummarySchema(BaseModel):
+    """Per-slice summary embedded in run artifacts.
+
+    Failure mode 1: numeric score fields that should never be None when
+    judgments are complete are typed as ``float | None``. Code that formats
+    them (e.g. ``f"{v:.3f}"``) without a None-guard crashes; the model makes
+    the optionality *explicit* and discoverable rather than a hidden runtime
+    surprise.  Callers that need a non-None value can assert or branch on it.
+
+    The model is intentionally permissive about extra fields because
+    different slice aggregators produce slice-specific keys (e.g.
+    ``schema_valid_rate`` for simulation, ``english_leakage_flag_rate`` for
+    Gaeilge). Extra fields are passed through unchanged.
+    """
+
+    slice: str
+    records: int
+    judged: int = 0
+    bench_bugs: int = 0
+    judge_failures: int = 0
+    errors: int = 0
+    # All numeric score fields are optional (None when no items were judged).
+    overall: float | None = None
+    # Dialogue axes
+    character: float | None = None
+    authenticity: float | None = None
+    language: float | None = None
+    responsiveness: float | None = None
+    craft: float | None = None
+    # Reaction / simulation
+    mean_score: float | None = None
+
+    @field_validator("records", "judged", "bench_bugs", "judge_failures", "errors")
+    @classmethod
+    def non_negative_int(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError(f"count field must be non-negative, got {v!r}")
+        return v
+
+    model_config = {"extra": "allow"}

--- a/rundale-bench/test_schemas.py
+++ b/rundale-bench/test_schemas.py
@@ -24,6 +24,7 @@ from pydantic import ValidationError
 _BENCH_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_BENCH_DIR))
 
+from judge_bundle import validate_result  # noqa: E402
 from schemas import (  # noqa: E402
     BundleSchema,
     ResultItemSchema,
@@ -285,3 +286,73 @@ def test_summary_schema_none_scores_allowed():
     """None axis scores are valid (represents 'no judged items yet')."""
     summary = SummarySchema(slice="dialogue", records=5, judged=0, overall=None)
     assert summary.overall is None
+
+
+# ---------------------------------------------------------------------------
+# Malformed done/ result: validate_result must not raise, must return failures
+# ---------------------------------------------------------------------------
+
+
+def _minimal_bundle_for_validate() -> dict:
+    return {
+        "bundle_id": "test__stub",
+        "slice": "dialogue",
+        "candidate": {"model_id": "stub"},
+        "judge_id": "judge_sonnet_v1",
+        "judge_model": "claude-sonnet-4-5",
+        "rubric_sha256": "a" * 64,
+        "rubric": "Score the response.",
+        "axes": ["character", "authenticity", "language", "responsiveness", "craft"],
+        "items": [
+            {"prompt_id": "p1", "prompt": "Hello", "response": "World"},
+        ],
+    }
+
+
+def test_malformed_result_missing_rubric_sha256_returns_failures():
+    """A done/ result missing rubric_sha256 must NOT raise; validate_result
+    must return ([], failed) where every expected prompt_id is a failure."""
+    bundle = _minimal_bundle_for_validate()
+    malformed = {"items": [{"prompt_id": "p1", "axes": {"character": 3}, "overall": 3.0}]}
+    # rubric_sha256 absent — pydantic ValidationError must be caught internally
+    valid, failed = validate_result(malformed, bundle)
+    assert valid == []
+    assert len(failed) == 1
+    assert failed[0]["prompt_id"] == "p1"
+    assert failed[0]["flags"]["judge_retry"] is True
+    assert "ValidationError" in failed[0]["error"] or "malformed" in failed[0]["error"]
+
+
+def test_malformed_result_items_not_a_list_returns_failures():
+    """A done/ result with items as a dict (wrong shape) must not raise."""
+    bundle = _minimal_bundle_for_validate()
+    malformed = {"rubric_sha256": "a" * 64, "items": {"p1": {}}}
+    valid, failed = validate_result(malformed, bundle)
+    assert valid == []
+    assert len(failed) == 1
+    assert failed[0]["flags"]["judge_retry"] is True
+
+
+def test_validate_result_does_not_raise_on_valid_result():
+    """A well-formed result is processed normally — not treated as malformed."""
+    bundle = _minimal_bundle_for_validate()
+    result = {
+        "rubric_sha256": "a" * 64,
+        "items": [
+            {
+                "prompt_id": "p1",
+                "axes": {
+                    "character": 3,
+                    "authenticity": 3,
+                    "language": 3,
+                    "responsiveness": 3,
+                    "craft": 3,
+                },
+                "overall": 3.0,
+                "flags": {},
+            }
+        ],
+    }
+    valid, failed = validate_result(result, bundle)
+    assert len(valid) == 1
+    assert failed == []

--- a/rundale-bench/test_schemas.py
+++ b/rundale-bench/test_schemas.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Tests asserting that each of the 5 known failure modes now raises
+``pydantic.ValidationError`` by construction rather than crashing mid-format
+or being silently ignored.
+
+Failure modes under test
+-------------------------
+1. None-in-format crash — axes=None on a ResultItemSchema
+2. bench_bug=true with nonzero axis scores
+3. rubric_sha256 mismatch between result and bundle (tested via
+   validate_result when rubric_sha256 is absent/empty on the result)
+4. Missing required field (e.g. missing bundle_id on BundleSchema)
+5. Malformed shape on ingest (e.g. items is not a list of proper objects)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+_BENCH_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_BENCH_DIR))
+
+from schemas import (  # noqa: E402
+    BundleSchema,
+    ResultItemSchema,
+    ResultSchema,
+    SummarySchema,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _minimal_bundle_dict(**overrides) -> dict:
+    base = {
+        "bundle_id": "test__stub",
+        "slice": "dialogue",
+        "candidate": {"model_id": "stub"},
+        "judge_id": "judge_sonnet_v1",
+        "judge_model": "claude-sonnet-4-5",
+        "rubric_sha256": "a" * 64,
+        "rubric": "Score the response.",
+        "items": [
+            {"prompt_id": "p1", "prompt": "Hello", "response": "World"},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def _minimal_result_dict(**overrides) -> dict:
+    base = {
+        "rubric_sha256": "a" * 64,
+        "items": [
+            {
+                "prompt_id": "p1",
+                "axes": {"character": 3},
+                "overall": 3.0,
+                "flags": {},
+            }
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def _minimal_result_item(**overrides) -> dict:
+    base = {
+        "prompt_id": "p1",
+        "axes": {"character": 3, "authenticity": 3, "language": 3, "responsiveness": 3, "craft": 3},
+        "overall": 3.0,
+        "flags": {"bench_bug": False},
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Failure mode 1: None-in-format crash (axes=None on ResultItemSchema)
+# ---------------------------------------------------------------------------
+
+
+def test_failure_mode_1_axes_none_raises():
+    """axes=None must raise ValidationError rather than passing through and
+    crashing later when code does ``j['axes'].get('character', 0)``."""
+    with pytest.raises(ValidationError):
+        ResultItemSchema(**{**_minimal_result_item(), "axes": None})
+
+
+def test_failure_mode_1_axes_non_dict_raises():
+    """axes as a list (wrong shape) must also raise."""
+    with pytest.raises(ValidationError):
+        ResultItemSchema(**{**_minimal_result_item(), "axes": [3, 3, 3]})
+
+
+def test_failure_mode_1_valid_axes_accepted():
+    """Sanity: a well-formed item with dict axes passes validation."""
+    item = ResultItemSchema(**_minimal_result_item())
+    assert item.axes["character"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Failure mode 2: bench_bug=true with nonzero axis scores
+# ---------------------------------------------------------------------------
+
+
+def test_failure_mode_2_bench_bug_nonzero_axes_raises():
+    """bench_bug=true but axes not all zero must raise ValidationError."""
+    payload = {
+        **_minimal_result_item(),
+        "axes": {"character": 1, "authenticity": 0, "language": 0, "responsiveness": 0, "craft": 0},
+        "overall": 0.0,
+        "flags": {"bench_bug": True},
+    }
+    with pytest.raises(ValidationError, match="bench_bug=true but axes not all 0"):
+        ResultItemSchema(**payload)
+
+
+def test_failure_mode_2_bench_bug_nonzero_overall_raises():
+    """bench_bug=true but overall != 0.0 must raise ValidationError."""
+    payload = {
+        **_minimal_result_item(),
+        "axes": {"character": 0, "authenticity": 0, "language": 0, "responsiveness": 0, "craft": 0},
+        "overall": 2.5,
+        "flags": {"bench_bug": True},
+    }
+    with pytest.raises(ValidationError, match="bench_bug=true but overall != 0.0"):
+        ResultItemSchema(**payload)
+
+
+def test_failure_mode_2_bench_bug_all_zeros_accepted():
+    """bench_bug=true with every axis and overall == 0 is valid."""
+    payload = {
+        **_minimal_result_item(),
+        "axes": {"character": 0, "authenticity": 0, "language": 0, "responsiveness": 0, "craft": 0},
+        "overall": 0.0,
+        "flags": {"bench_bug": True},
+    }
+    item = ResultItemSchema(**payload)
+    assert item.flags.bench_bug is True
+    assert all(v == 0 for v in item.axes.values())
+
+
+# ---------------------------------------------------------------------------
+# Failure mode 3: rubric_sha256 absent/empty on result
+# ---------------------------------------------------------------------------
+
+
+def test_failure_mode_3_missing_rubric_sha256_raises():
+    """A result with no rubric_sha256 must raise ValidationError before any
+    comparison against the bundle is attempted."""
+    payload = _minimal_result_dict()
+    del payload["rubric_sha256"]
+    with pytest.raises(ValidationError):
+        ResultSchema.model_validate(payload)
+
+
+def test_failure_mode_3_empty_rubric_sha256_raises():
+    """Empty string rubric_sha256 is also rejected."""
+    payload = {**_minimal_result_dict(), "rubric_sha256": ""}
+    with pytest.raises(ValidationError, match="rubric_sha256 must not be empty"):
+        ResultSchema.model_validate(payload)
+
+
+def test_failure_mode_3_valid_result_accepted():
+    """A well-formed result dict passes ResultSchema validation."""
+    result = ResultSchema.model_validate(_minimal_result_dict())
+    assert result.rubric_sha256 == "a" * 64
+
+
+# ---------------------------------------------------------------------------
+# Failure mode 4: missing required field on BundleSchema
+# ---------------------------------------------------------------------------
+
+
+def test_failure_mode_4_missing_bundle_id_raises():
+    payload = _minimal_bundle_dict()
+    del payload["bundle_id"]
+    with pytest.raises(ValidationError):
+        BundleSchema.model_validate(payload)
+
+
+def test_failure_mode_4_missing_rubric_sha256_raises():
+    payload = _minimal_bundle_dict()
+    del payload["rubric_sha256"]
+    with pytest.raises(ValidationError):
+        BundleSchema.model_validate(payload)
+
+
+def test_failure_mode_4_missing_items_raises():
+    payload = _minimal_bundle_dict()
+    del payload["items"]
+    with pytest.raises(ValidationError):
+        BundleSchema.model_validate(payload)
+
+
+def test_failure_mode_4_empty_items_raises():
+    payload = _minimal_bundle_dict(items=[])
+    with pytest.raises(ValidationError, match="bundle items list must not be empty"):
+        BundleSchema.model_validate(payload)
+
+
+def test_failure_mode_4_valid_bundle_accepted():
+    bundle = BundleSchema.model_validate(_minimal_bundle_dict())
+    assert bundle.bundle_id == "test__stub"
+    assert len(bundle.items) == 1
+
+
+# ---------------------------------------------------------------------------
+# Failure mode 5: malformed shape on ingest (bundle or result items)
+# ---------------------------------------------------------------------------
+
+
+def test_failure_mode_5_bundle_item_missing_response_raises():
+    """A bundle item without 'response' must fail BundleItemSchema."""
+    payload = _minimal_bundle_dict(
+        items=[{"prompt_id": "p1", "prompt": "Hello"}]  # missing response
+    )
+    with pytest.raises(ValidationError):
+        BundleSchema.model_validate(payload)
+
+
+def test_failure_mode_5_bundle_item_missing_prompt_id_raises():
+    payload = _minimal_bundle_dict(
+        items=[{"prompt": "Hello", "response": "World"}]  # missing prompt_id
+    )
+    with pytest.raises(ValidationError):
+        BundleSchema.model_validate(payload)
+
+
+def test_failure_mode_5_result_items_not_a_list_raises():
+    """result['items'] being a dict (wrong type) must raise."""
+    payload = {**_minimal_result_dict(), "items": {"p1": {}}}
+    with pytest.raises(ValidationError):
+        ResultSchema.model_validate(payload)
+
+
+def test_failure_mode_5_result_item_axis_out_of_range_raises():
+    """An axis score of 6 (above ceiling 5) must raise on ResultItemSchema."""
+    payload = {**_minimal_result_item(), "axes": {"character": 6}}
+    with pytest.raises(ValidationError, match="out of range"):
+        ResultItemSchema(**payload)
+
+
+def test_failure_mode_5_result_item_overall_out_of_range_raises():
+    """An overall of 5.5 (above ceiling) must raise."""
+    payload = {**_minimal_result_item(), "overall": 5.5}
+    with pytest.raises(ValidationError, match="overall must be in"):
+        ResultItemSchema(**payload)
+
+
+# ---------------------------------------------------------------------------
+# SummarySchema sanity
+# ---------------------------------------------------------------------------
+
+
+def test_summary_schema_valid():
+    summary = SummarySchema(
+        slice="dialogue",
+        records=10,
+        judged=8,
+        bench_bugs=1,
+        overall=3.75,
+        character=3.5,
+        authenticity=4.0,
+        language=3.8,
+        responsiveness=3.7,
+        craft=3.9,
+    )
+    assert summary.slice == "dialogue"
+    assert summary.overall == 3.75
+
+
+def test_summary_schema_negative_count_raises():
+    with pytest.raises(ValidationError, match="non-negative"):
+        SummarySchema(slice="dialogue", records=-1)
+
+
+def test_summary_schema_none_scores_allowed():
+    """None axis scores are valid (represents 'no judged items yet')."""
+    summary = SummarySchema(slice="dialogue", records=5, judged=0, overall=None)
+    assert summary.overall is None


### PR DESCRIPTION
Promotes `validate_result` to Pydantic `BundleSchema`/`ResultSchema`/`SummarySchema` models validated at every write boundary, making the 5 known failure modes (None-in-format crash, bench_bug=true with nonzero axes, rubric_sha256 mismatch, missing required field, etc.) impossible by construction.

Part of #1206. Does NOT close the epic.

## Changes

- **`rundale-bench/schemas.py`** (new): `BundleSchema`, `ResultSchema`, `SummarySchema`, and supporting sub-models (`BundleItemSchema`, `ResultItemSchema`, `FlagsSchema`). Each model encodes the invariants previously checked procedurally in `validate_item` / `validate_result`.
- **`rundale-bench/judge_bundle.py`**: `write_pending` validates the bundle dict via `BundleSchema.model_validate` before writing to disk. `validate_result` validates the result dict via `ResultSchema.model_validate` before any per-item processing.
- **`rundale-bench/rundale_bench.py`**: All four aggregate functions (`_dialogue_aggregate`, `_reaction_aggregate`, `_simulation_aggregate`, `_gaeilge_aggregate`) validate their return value via `SummarySchema.model_validate`.
- **`requirements-dev.txt`**: Added `pydantic>=2.0`. Pydantic 2.x is already present in the system Python (`2.13.2`) — this pins it as an explicit dev dep so `.venv-dev` installs include it.
- **`rundale-bench/test_schemas.py`** (new): 22 tests asserting each of the 5 failure modes now raises `ValidationError` rather than crashing mid-format or being silently swallowed.

## Test results

```
119 passed in 0.13s  (97 pre-existing + 22 new)
```

This unit is PROOF-EXEMPT (root Python tooling, no runtime-shipping path).