### PR TITLE
chore: install just in the web sandbox via SessionStart hook

### DIFF
--- a/.claude/hooks/SessionStart--install-system-deps.sh
+++ b/.claude/hooks/SessionStart--install-system-deps.sh
@@ -58,7 +58,8 @@ echo '{"async": true, "asyncTimeout": 600000}'
 # Refresh apt indices once if either apt-based step is needed — packaged
 # container lists can go stale enough to 404 individual .deb URLs.
 if $needs_gtk || $needs_just; then
-    sudo -n apt-get update -qq
+    sudo -n apt-get update -qq \
+        || echo "[session-start-hook] WARN: apt-get update failed" >&2
 fi
 
 if $needs_gtk; then
@@ -67,7 +68,8 @@ if $needs_gtk; then
         libgtk-3-dev \
         libwebkit2gtk-4.1-dev \
         libsoup-3.0-dev \
-        libjavascriptcoregtk-4.1-dev
+        libjavascriptcoregtk-4.1-dev \
+        || echo "[session-start-hook] WARN: GTK/WebKit2GTK install failed" >&2
 fi
 
 if $needs_just; then

--- a/.claude/hooks/SessionStart--install-system-deps.sh
+++ b/.claude/hooks/SessionStart--install-system-deps.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
 # SessionStart hook — prepare the Claude Code on the web sandbox for parish work.
 #
-# Two responsibilities:
+# Three responsibilities:
 # 1. Install GTK 3 + WebKit2GTK 4.1 dev packages so `cargo check -p parish-tauri`
 #    works (Tauri 2 + wry depend on `gdk-3.0`, `webkit2gtk-4.1`, `libsoup-3.0`,
 #    `javascriptcoregtk-4.1` `.pc` files that aren't preinstalled).
-# 2. Pre-build `parish-mcp` and `parish` binaries so the project-level MCP
+# 2. Install `just` (the command runner) so the project's justfile recipes
+#    (`just check`, `just run-headless`, `just web`, ...) are available — the
+#    web sandbox image ships without it.
+# 3. Pre-build `parish-mcp` and `parish` binaries so the project-level MCP
 #    server in `.mcp.json` can spawn parish-mcp at session start, and so the
 #    agent can run `parish web` as the bridge backend without a cold cargo
 #    compile.
 #
-# Both responsibilities are gated by a fast-path: if pkg-config already finds
-# the .pc files AND both binaries are executable, the hook exits before
-# emitting the async marker so the prompt comes up instantly. Cold path runs
-# both steps in the background.
+# All responsibilities are gated by a fast-path: if pkg-config already finds
+# the .pc files, `just` is on PATH, AND both binaries are executable, the hook
+# exits before emitting the async marker so the prompt comes up instantly. The
+# cold path runs the needed steps in the background.
 #
 # Locally (CLAUDE_CODE_REMOTE unset) the hook is a no-op.
 
@@ -27,10 +30,15 @@ REPO="$(git rev-parse --show-toplevel)"
 MCP_BIN="$REPO/parish/target/debug/parish-mcp"
 PARISH_BIN="$REPO/parish/target/debug/parish"
 
-needs_apt=false
+needs_gtk=false
 if ! pkg-config --exists 'gdk-3.0' 'webkit2gtk-4.1' 'libsoup-3.0' \
     'javascriptcoregtk-4.1' 2>/dev/null; then
-    needs_apt=true
+    needs_gtk=true
+fi
+
+needs_just=false
+if ! command -v just >/dev/null 2>&1; then
+    needs_just=true
 fi
 
 needs_build=false
@@ -38,7 +46,7 @@ if [ ! -x "$MCP_BIN" ] || [ ! -x "$PARISH_BIN" ]; then
     needs_build=true
 fi
 
-if ! $needs_apt && ! $needs_build; then
+if ! $needs_gtk && ! $needs_just && ! $needs_build; then
     exit 0
 fi
 
@@ -47,16 +55,25 @@ fi
 # cargo build of parish-mcp + parish is the bulk.
 echo '{"async": true, "asyncTimeout": 600000}'
 
-if $needs_apt; then
-    echo "[session-start-hook] Installing parish-tauri system deps (GTK 3 + WebKit2GTK 4.1)..." >&2
-    # Refresh apt indices first — packaged container lists can go stale
-    # enough to 404 individual .deb URLs.
+# Refresh apt indices once if either apt-based step is needed — packaged
+# container lists can go stale enough to 404 individual .deb URLs.
+if $needs_gtk || $needs_just; then
     sudo -n apt-get update -qq
+fi
+
+if $needs_gtk; then
+    echo "[session-start-hook] Installing parish-tauri system deps (GTK 3 + WebKit2GTK 4.1)..." >&2
     sudo -n apt-get install -y --no-install-recommends \
         libgtk-3-dev \
         libwebkit2gtk-4.1-dev \
         libsoup-3.0-dev \
         libjavascriptcoregtk-4.1-dev
+fi
+
+if $needs_just; then
+    echo "[session-start-hook] Installing just (command runner)..." >&2
+    sudo -n apt-get install -y --no-install-recommends just \
+        || echo "[session-start-hook] WARN: just install failed" >&2
 fi
 
 if $needs_build; then


### PR DESCRIPTION
## Problem

The Claude Code on the web sandbox image ships without `just`, so the project's justfile recipes (`just check`, `just run-headless`, `just web`, `just agent-check`, ...) were unavailable in cloud sessions — `which just` returned nothing in a fresh container.

## Fix

Extend the existing `SessionStart--install-system-deps.sh` hook to also install `just`. The hook already prepares the web sandbox (GTK/WebKit dev packages + pre-built `parish-mcp`/`parish` binaries); this adds a third responsibility:

- Detect a missing `just` with a `command -v just` fast-path so warm containers still skip all work and the prompt comes up instantly.
- `apt-get install -y --no-install-recommends just` (apt's `noble/universe` has `just` 1.21.0, which supports every feature the repo's justfiles use — only `set shell` and plain recipes, no `[group]`/`[script]`/modules).
- Run `apt-get update` once when either the GTK step or the `just` step needs it, instead of only before the GTK install.
- Remote-only (`CLAUDE_CODE_REMOTE=true`); a no-op locally where developers already have `just`.

## Verification

Ran the hook in a fresh remote container:

```
$ CLAUDE_CODE_REMOTE=true bash .claude/hooks/SessionStart--install-system-deps.sh
[session-start-hook] Installing just (command runner)...
Setting up just (1.21.0-1) ...
$ which just && just --version
/usr/bin/just
just 1.21.0
$ just --list   # drives the repo justfile, recipes listed
```

`bash -n` passes; the warm-container fast-path exits before the async marker when `just` is already on PATH.

## Notes

Agent-instruction-only change (`.claude/**`, no code) — exempt from the proof-evidence gate per AGENTS.md rule 10.

https://claude.ai/code/session_01M7ou7S1uSoz4wXeAYxMzR2

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7ou7S1uSoz4wXeAYxMzR2)_