### PR TITLE
fix(bench): two rundale-bench v2 run blockers (whitespace keys, RB_SLICE)

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -33,6 +33,12 @@ bottom; don't lengthen items past 2-3 lines.
 - **Qwen3 thinking-mode leaks unless `chat_template_kwargs={"enable_thinking": False}` is injected on mlx_lm.server requests.** `parish/scripts/local-eval/eval_lib.py::THINKING_MLX_PREFIXES` lists the affected repos. Without the flag, reasoning fills `max_tokens` and the assistant content is empty → near-zero rubric scores. Cloud reasoning models (kimi-k2.5/6, deepseek-r1, claude, openai-o\*, glm-4.6/7, gemini-2.5+) are already handled centrally by `_is_reasoning_model` → `_default_reasoning_for` in `eval_lib.py::call_chat`.
 - **opencode.ai is fronted by Cloudflare which 403s the default Python-urllib UA** (firewall rule 1010). `call_chat` sets `User-Agent: rundale-bench/1.0 (+...)` so the request gets through.
 
+## rundale-bench v2 (promptfoo)
+
+- **A stray space/newline on an exported API key 401s the candidate + judge, but NOT `/v1/models`.** OpenRouter's `/v1/models` is unauthenticated so a malformed key looks fine there, while chat calls fail with "Missing Authentication header" (an extra space after the `Bearer` token is enough). `eval_lib.Target.api_key()` now `.strip()`s the value; if you read a key anywhere else, strip it too.
+- **`RB_SLICE` from a config's `env:` block is NOT applied before the dataset loader runs (promptfoo >=0.118).** `tests: file://load_dataset.py:generate_tests` resolves during config _load_, before `env:` reaches the process, so a bare `npx promptfoo eval -c promptfooconfig.<slice>.yaml` dies with "RB_SLICE env var required". The `promptfoo/justfile` `_eval` recipe now exports `RB_SLICE` itself — drive runs through `just -f promptfoo/justfile …`, or export `RB_SLICE`/`RB_TARGET`/`RB_LIMIT` yourself before a raw `npx promptfoo eval`.
+- **v2 has no multi-run results persistence yet (#1232).** `scripts/report.py` is a single-target rollup over `output/` (gitignored); a second model overwrites the first. Don't expect a v1-style cross-run leaderboard until #1232 lands.
+
 ## Agent + tooling gotchas
 
 - **`gh pr view --json baseRepository` was removed** ("Unknown JSON field: baseRepository"). `parish/scripts/attach-proof.sh` no longer uses it — it derives `<owner>/<repo>` from `gh pr view --json url --jq .url` + `sed` (see the comment at attach-proof.sh:63-70). If you hit the error elsewhere, use the same parse. Fallback for posting the proof bundle by hand: `bash parish/scripts/render-proof-comment.sh <task-id> | gh pr comment <pr> --body-file -`.

--- a/parish/scripts/local-eval/eval_lib.py
+++ b/parish/scripts/local-eval/eval_lib.py
@@ -49,7 +49,15 @@ class Target:
     def api_key(self) -> str | None:
         if not self.api_key_env:
             return None
+        # Strip surrounding whitespace: secret stores / `.env` files routinely
+        # leave a stray leading space or trailing newline on an exported key,
+        # which sails through `/v1/models` (often unauthenticated) but gets the
+        # candidate *and* judge chat calls rejected with a 401 (an extra space
+        # after `Bearer ` is enough — OpenRouter returns "Missing Authentication
+        # header"). Normalise here so both paths are immune.
         key = os.environ.get(self.api_key_env)
+        if key:
+            key = key.strip()
         if not key:
             raise RuntimeError(
                 f"target {self.model} requires API key in ${self.api_key_env} but env is empty"

--- a/promptfoo/justfile
+++ b/promptfoo/justfile
@@ -30,6 +30,15 @@ _eval slice config target limit:
     mkdir -p "{{ OUT }}"
     export RB_TARGET='{{ target }}'
     export RB_LIMIT='{{ limit }}'
+    # RB_SLICE must be exported here, not left to each config's `env:` block:
+    # promptfoo >=0.118 resolves the `tests: file://load_dataset.py` generator
+    # during config load, BEFORE a config's `env:` is applied to the process,
+    # so the loader sees no RB_SLICE and aborts with
+    # "RB_SLICE env var required for load_dataset". Exporting it from the recipe
+    # makes the documented `just … bench/<slice>` flow self-contained. (The perf
+    # slice passes "perf"; nothing on the perf path reads RB_SLICE, so it's inert
+    # there — generate_perf_tests loads dialogue records directly.)
+    export RB_SLICE='{{ slice }}'
     # Two -o flags: JSON for scripts/report.py, HTML for a standalone web report.
     npx promptfoo eval -c "{{ config }}" \
         -o "{{ OUT }}/{{ slice }}.json" \


### PR DESCRIPTION
## Summary

Two bugs found doing the **real-model + real-judge** follow-up that #1219 called out — running rundale-bench v2 (`promptfoo/`) against live OpenRouter candidates with the Sonnet judge. Both blocked the documented run path; both are small and proof-gate-exempt (the changed files are `*.md`, `parish/scripts/*`, and a `justfile` — none are proof-relevant per `agent-check.sh::is_proof_relevant`).

### 1. Whitespace on a resolved API key → 401 (candidate **and** judge)
A stray leading space / trailing newline on an exported key (common from secret stores / `.env`) passes OpenRouter's **unauthenticated** `/v1/models` probe but gets chat calls rejected with `401 "Missing Authentication header"` — a single extra space after the `Bearer` token does it. `eval_lib.Target.api_key()` now `.strip()`s the value, so every `call_chat` / `call_chat_streaming` path (v1 **and** the v2 promptfoo judge, which both go through `Target.api_key()`) is immune.

### 2. `RB_SLICE` not applied before the dataset loader runs
promptfoo ≥0.118 resolves `tests: file://load_dataset.py:generate_tests` during **config load**, *before* a config's `env:` block reaches the process — so the loader saw no `RB_SLICE` and aborted with `RB_SLICE env var required for load_dataset`. The `promptfoo/justfile` `_eval` recipe (which already receives the slice) now exports it, making the documented `just -f promptfoo/justfile bench/<slice>` flow self-contained. (The `perf` recipe passes `"perf"`; nothing on that path reads `RB_SLICE`, so it's inert there.)

Plus `LEARNINGS.md` bullets for both, and a note about the absent v2 multi-run persistence layer (filed as #1232).

## Verification

Ran the documented recipe with **both keys carrying a leading space** and `RB_SLICE` **unset** — a judged slice, so it exercises both candidate and Sonnet-judge auth:

```
$ python3 -c "import os;print(os.environ['OPENROUTER_API_KEY'][:1].isspace(), os.environ['ANTHROPIC_API_KEY'][:1].isspace())"
True True
$ echo "RB_SLICE=${RB_SLICE:-<unset>}"
RB_SLICE=<unset>
$ just -f promptfoo/justfile dialogue 'openai/gpt-oss-120b:free@https://openrouter.ai/api/v1#env:OPENROUTER_API_KEY' 3
...
Successes: 3   Failures: 0   Errors: 0   Pass Rate: 100.00%
```

Before these fixes this run dies at config-load (`RB_SLICE`) and 401s on auth.

Also: `python3 promptfoo/scripts/test_v2.py` → all 30 offline checks pass; `ruff check eval_lib.py` clean; key-strip unit-checked (`'  sk-test\n'` → `'sk-test'`); `markdownlint-cli2 LEARNINGS.md` → 0 errors.

## Commands run
- `just -f promptfoo/justfile dialogue '<spec>' 3` (live, real Sonnet judge)
- `python3 promptfoo/scripts/test_v2.py`
- `ruff check parish/scripts/local-eval/eval_lib.py`
- `npx markdownlint-cli2 LEARNINGS.md`

Related: #1219 (v2 suite), #1232 (v2 persistence/leaderboard gap).

https://claude.ai/code/session_019UKe5xTgUzARZgwr1swgyf

---
_Generated by [Claude Code](https://claude.ai/code/session_019UKe5xTgUzARZgwr1swgyf)_