### PR TITLE
test(client): close TD-001/TD-002 coverage gaps in parish-client

### DIFF
--- a/parish/Cargo.lock
+++ b/parish/Cargo.lock
@@ -3963,9 +3963,11 @@ dependencies = [
  "anyhow",
  "clap",
  "dirs 5.0.1",
+ "parish-server",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/parish/crates/parish-client/Cargo.toml
+++ b/parish/crates/parish-client/Cargo.toml
@@ -19,3 +19,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 dirs = "5"
+
+[dev-dependencies]
+tempfile = { workspace = true }
+# Dev-only: the contract test round-trips a real server `CommandResponse`
+# through the client's wire types, so a server-side rename fails the build
+# instead of silently breaking the CLI (TD-002). Keeps the shipped binary
+# dependency-free while still detecting drift.
+parish-server = { path = "../parish-server" }

--- a/parish/crates/parish-client/TODO.md
+++ b/parish/crates/parish-client/TODO.md
@@ -2,11 +2,9 @@
 
 ## Open
 
-| ID     | Category       | Severity | Location                                                         | Description                                                                                                                                                                                                                                                                                                                                                                                          |
-| ------ | -------------- | -------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| TD-001 | Weak Tests     | P2       | `src/client.rs:1-148`, `src/repl.rs:1-49`, `src/session.rs:1-27` | The thin CLI client has few crate-local tests. `render.rs` gained tests for travel pluralization (commit b76ff2b6, #1156), but `client.rs`, `repl.rs`, and `session.rs` remain untested. Add tests for command body serialization (`camelCase` fields), session cookie persistence, and error rendering before expanding the public CLI surface. (note: partial — render.rs covered, 3 files remain) |
-| TD-002 | API Drift      | P2       | `src/client.rs:15-64`                                            | Wire response structs manually mirror `parish-server::sync_types::CommandResponse` and state payloads. Add a compatibility test or shared type strategy so server response changes do not silently break the CLI.                                                                                                                                                                                    |
-| TD-003 | Config Hygiene | P3       | `src/session.rs:4-10`                                            | Session cookie storage falls back to `$HOME/parish/session` when platform state/data dirs are unavailable. Document and test the fallback, or route it through the persistence path helpers if the CLI starts sharing more runtime state.                                                                                                                                                            |
+| ID     | Category       | Severity | Location              | Description                                                                                                                                                                                                                               |
+| ------ | -------------- | -------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TD-003 | Config Hygiene | P3       | `src/session.rs:4-10` | Session cookie storage falls back to `$HOME/parish/session` when platform state/data dirs are unavailable. Document and test the fallback, or route it through the persistence path helpers if the CLI starts sharing more runtime state. |
 
 ## In Progress
 
@@ -14,11 +12,15 @@ _(none)_
 
 ## Done
 
-_(none)_
+| ID     | Resolved   | Notes                                                                                                                                                                                                                                                                                                                                                          |
+| ------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TD-001 | 2026-06-06 | Added crate-local unit tests for the three untested files: `client.rs` (`CommandOpts` camelCase keys, `skip_serializing_if` omission, `CommandBody` flatten), `repl.rs` (extracted `is_skippable`/`is_quit` line classifiers + tests), `session.rs` (extracted `load_from`/`save_to` + tempfile round-trip / trim / empty / missing-file tests). 2 → 12 tests. |
+| TD-002 | 2026-06-06 | Added a drift-guard test that round-trips a fully-populated `parish_server::sync_types::CommandResponse` through the client's wire `CommandResponse`; `parish-server` added as a dev-dependency so a server-side field rename fails the build instead of silently breaking the CLI.                                                                            |
 
 ## Progress Log
 
 - **2026-05-25**: Initialized the crate debt ledger and recorded TD-001 through TD-003 from the current source scan.
+- **2026-06-06**: Closed TD-001 (weak tests) and TD-002 (API drift) — see Done table. TD-003 remains open.
 
 ## Discovery note
 

--- a/parish/crates/parish-client/src/client.rs
+++ b/parish/crates/parish-client/src/client.rs
@@ -76,6 +76,15 @@ pub struct NpcInfo {
     pub extra: serde_json::Value,
 }
 
+/// Request body for `POST /api/command`: the input text plus the flattened
+/// option fields. Mirrors `parish-server`'s `CommandRequest` wire shape.
+#[derive(Serialize)]
+pub(crate) struct CommandBody<'a> {
+    pub text: &'a str,
+    #[serde(flatten)]
+    pub opts: CommandOpts,
+}
+
 // ── Client ────────────────────────────────────────────────────────────────────
 
 pub struct ParishClient {
@@ -104,16 +113,10 @@ impl ParishClient {
     }
 
     pub async fn post_command(&self, text: &str, opts: CommandOpts) -> Result<CommandResponse> {
-        #[derive(Serialize)]
-        struct Body<'a> {
-            text: &'a str,
-            #[serde(flatten)]
-            opts: CommandOpts,
-        }
         let resp = self
             .client
             .post(format!("{}/api/command", self.base_url))
-            .json(&Body { text, opts })
+            .json(&CommandBody { text, opts })
             .send()
             .await
             .context(transport_hint(&self.base_url))?;
@@ -145,4 +148,102 @@ fn transport_hint(base_url: &str) -> String {
         "could not reach Parish server at {base_url} — \
          start it with `just run-headless --web 3001` or set PARISH_SERVER"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_opts_use_camel_case_keys() {
+        let opts = CommandOpts {
+            addressed_to: vec!["Maggie".into()],
+            timeout_ms: Some(5_000),
+            include_state: Some(true),
+            include_map: Some(false),
+        };
+        let v = serde_json::to_value(&opts).expect("serialize");
+        let obj = v.as_object().expect("object");
+        // Wire contract: server's CommandRequest is `rename_all = "camelCase"`.
+        assert!(obj.contains_key("addressedTo"));
+        assert!(obj.contains_key("timeoutMs"));
+        assert!(obj.contains_key("includeState"));
+        assert!(obj.contains_key("includeMap"));
+        // Snake-case names must never leak onto the wire.
+        assert!(!obj.contains_key("addressed_to"));
+        assert!(!obj.contains_key("timeout_ms"));
+    }
+
+    #[test]
+    fn default_opts_omit_empty_and_none_fields() {
+        let v = serde_json::to_value(CommandOpts::default()).expect("serialize");
+        // skip_serializing_if keeps the body minimal: no keys at all when unset.
+        assert_eq!(v.as_object().expect("object").len(), 0, "got: {v}");
+    }
+
+    #[test]
+    fn command_body_flattens_text_and_opts() {
+        let body = CommandBody {
+            text: "go to the church",
+            opts: CommandOpts {
+                include_map: Some(true),
+                ..Default::default()
+            },
+        };
+        let v = serde_json::to_value(&body).expect("serialize");
+        assert_eq!(v["text"], "go to the church");
+        // Flattened: opt keys sit alongside `text`, not nested under `opts`.
+        assert_eq!(v["includeMap"], true);
+        assert!(v.get("opts").is_none(), "opts must be flattened: {v}");
+    }
+
+    /// TD-002 drift guard: the client's wire `CommandResponse` is a hand
+    /// mirror of `parish_server::sync_types::CommandResponse`. Round-trip a
+    /// real, fully-populated server response through the client type so a
+    /// server-side field rename/removal fails this test instead of silently
+    /// deserializing to a wrong/missing value at runtime.
+    #[test]
+    fn deserializes_a_real_server_command_response() {
+        use parish_server::sync_types as server;
+
+        let server_resp = server::CommandResponse {
+            outcome: server::Outcome::Ok,
+            kind: server::Kind::Moved,
+            echo: "go to the church".to_string(),
+            lines: vec![server::OutputLine {
+                id: "l1".to_string(),
+                role: server::Role::Npc,
+                speaker: "Maggie".to_string(),
+                text: "Off you go, then.".to_string(),
+            }],
+            kind_detail: serde_json::json!({ "reason": "ok" }),
+            travel: Some(server::TravelDetail {
+                from: "The Crossroads".to_string(),
+                to: "St Brigid's".to_string(),
+                duration_minutes: 12,
+            }),
+            // `state` exercises the `skip_serializing_if = Option::is_none`
+            // branch; the client must tolerate its absence via `#[serde(default)]`.
+            state: None,
+            elapsed_ms: 42,
+        };
+
+        let wire = serde_json::to_value(&server_resp).expect("server serializes");
+        let client: CommandResponse =
+            serde_json::from_value(wire).expect("client deserializes server response");
+
+        assert_eq!(client.outcome, "ok");
+        assert_eq!(client.kind, "moved");
+        assert_eq!(client.echo, "go to the church");
+        assert_eq!(client.lines.len(), 1);
+        assert_eq!(client.lines[0].speaker, "Maggie");
+        assert_eq!(client.lines[0].role, "npc");
+        assert_eq!(client.kind_detail["reason"], "ok");
+        let travel = client.travel.expect("travel present for kind=moved");
+        assert_eq!(travel.from, "The Crossroads");
+        assert_eq!(travel.to, "St Brigid's");
+        assert_eq!(travel.duration_minutes, 12);
+        assert!(client.state.is_none());
+        assert_eq!(client.elapsed_ms, 42);
+    }
 }

--- a/parish/crates/parish-client/src/repl.rs
+++ b/parish/crates/parish-client/src/repl.rs
@@ -6,15 +6,25 @@ use anyhow::Result;
 use crate::client::{CommandOpts, ParishClient};
 use crate::render::render_response;
 
+/// A trimmed line that should be ignored: blank or a `#` comment.
+fn is_skippable(text: &str) -> bool {
+    text.is_empty() || text.starts_with('#')
+}
+
+/// A trimmed line that ends the session: `quit`/`exit`, bare or slash-prefixed.
+fn is_quit(text: &str) -> bool {
+    matches!(text, "quit" | "/quit" | "exit" | "/exit")
+}
+
 pub async fn run_interactive(client: &ParishClient, json: bool) -> Result<()> {
     let stdin = io::stdin();
     for line in stdin.lock().lines() {
         let line = line?;
         let text = line.trim();
-        if text.is_empty() || text.starts_with('#') {
+        if is_skippable(text) {
             continue;
         }
-        if text == "quit" || text == "/quit" || text == "exit" || text == "/exit" {
+        if is_quit(text) {
             break;
         }
         send(client, text, json).await?;
@@ -27,10 +37,10 @@ pub async fn run_script(client: &ParishClient, path: &Path, json: bool) -> Resul
         .map_err(|e| anyhow::anyhow!("cannot read script {}: {e}", path.display()))?;
     for line in content.lines() {
         let text = line.trim();
-        if text.is_empty() || text.starts_with('#') {
+        if is_skippable(text) {
             continue;
         }
-        if text == "quit" || text == "/quit" || text == "exit" || text == "/exit" {
+        if is_quit(text) {
             break;
         }
         send(client, text, json).await?;
@@ -46,4 +56,28 @@ async fn send(client: &ParishClient, text: &str, json: bool) -> Result<()> {
         print!("{}", render_response(&resp));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skips_blank_and_comment_lines() {
+        assert!(is_skippable(""));
+        assert!(is_skippable("# a comment"));
+        assert!(is_skippable("#"));
+        assert!(!is_skippable("look"));
+        assert!(!is_skippable("go to the church"));
+    }
+
+    #[test]
+    fn recognizes_quit_aliases() {
+        for q in ["quit", "/quit", "exit", "/exit"] {
+            assert!(is_quit(q), "{q} should quit");
+        }
+        for keep in ["look", "quitter", "/quitt", "exits"] {
+            assert!(!is_quit(keep), "{keep} should not quit");
+        }
+    }
 }

--- a/parish/crates/parish-client/src/session.rs
+++ b/parish/crates/parish-client/src/session.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn session_path() -> Option<PathBuf> {
     let state_dir = dirs::state_dir()
@@ -8,20 +8,65 @@ fn session_path() -> Option<PathBuf> {
     Some(state_dir.join("parish").join("session"))
 }
 
-pub fn load() -> Option<String> {
-    let path = session_path()?;
+/// Read a session id from `path`, trimming surrounding whitespace and treating
+/// an empty (or whitespace-only) file as "no session".
+fn load_from(path: &Path) -> Option<String> {
     fs::read_to_string(path)
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
 }
 
+/// Persist `sid` to `path`, creating parent directories as needed.
+fn save_to(path: &Path, sid: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, sid)
+}
+
+pub fn load() -> Option<String> {
+    load_from(&session_path()?)
+}
+
 pub fn save(sid: &str) -> std::io::Result<()> {
     if let Some(path) = session_path() {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        fs::write(path, sid)?;
+        save_to(&path, sid)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("session");
+        save_to(&path, "abc123").expect("save creates parents + writes");
+        assert_eq!(load_from(&path), Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn load_trims_surrounding_whitespace() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("session");
+        save_to(&path, "  sid-with-newline\n").expect("save");
+        assert_eq!(load_from(&path), Some("sid-with-newline".to_string()));
+    }
+
+    #[test]
+    fn load_treats_empty_file_as_no_session() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("session");
+        save_to(&path, "   \n\t").expect("save");
+        assert_eq!(load_from(&path), None);
+    }
+
+    #[test]
+    fn load_missing_file_is_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(load_from(&dir.path().join("does-not-exist")), None);
+    }
 }


### PR DESCRIPTION
## Summary

Closes the `parish-client` coverage gaps tracked under epic #1202 — TD-001 (Weak Tests, P2) and TD-002 (API Drift, P2). Test-only; no runtime behavior change.

**TD-001** — the three previously untested files now carry crate-local tests:
- `client.rs`: `CommandOpts` camelCase wire keys, `skip_serializing_if` omission, and `CommandBody` flatten (the request `Body` struct was hoisted to module scope as `pub(crate) CommandBody` so it is testable).
- `repl.rs`: extracted pure `is_skippable` / `is_quit` line classifiers, used by both loops and unit-tested (blank/`#` skip; `quit`/`/quit`/`exit`/`/exit` aliases incl. near-miss rejection).
- `session.rs`: extracted explicit-path `load_from` / `save_to`, unit-tested with `tempfile` (round-trip, whitespace trim, empty-file → `None`, missing-file → `None`).

**TD-002** — added a drift-guard test that round-trips a fully-populated `parish_server::sync_types::CommandResponse` through the client's hand-mirrored wire `CommandResponse`. `parish-server` is now a **dev-dependency** so a server-side field rename/removal fails the build instead of silently breaking the CLI; the shipped binary stays dependency-free.

## Coverage delta

`parish-client` unit tests **2 → 12**, all green.

## Commands run

- `cargo test -p parish-client` → 12 passed, 0 failed
- `cargo clippy -p parish-client --all-targets -- -D warnings` → clean
- `cargo test -p parish-core --test architecture_fitness` → 5 passed (new dev-dep touches no backend-agnostic crate)
- `just agent-check` → passed

Updates `parish/crates/parish-client/TODO.md`: TD-001 and TD-002 moved to Done; TD-003 remains open.

<!-- parish-proof-bundle:td001-td002-parish-client-tests v=1 -->

## Proof: td001-td002-parish-client-tests

### Acceptance criteria

# Acceptance criteria — parish-client TD-001 / TD-002 test coverage

Closes the coverage gaps catalogued under epic #1202 for the `parish-client` crate.
Test-only change (no runtime behavior change); the new tests ARE the proof.

## TD-001 — Weak Tests (P2): `client.rs`, `repl.rs`, `session.rs` untested

1. `client.rs`: a test asserts `CommandOpts` serializes with `camelCase` keys
   (`addressedTo`, `timeoutMs`, `includeState`, `includeMap`) and never leaks
   snake_case names — the server's `CommandRequest` wire contract.
2. `client.rs`: a test asserts a default `CommandOpts` serializes to an empty
   object (the `skip_serializing_if` branches), keeping the request body minimal.
3. `client.rs`: a test asserts the request `CommandBody` flattens `text` + opts
   into one object (no nested `opts` key).
4. `repl.rs`: tests cover blank/`#`-comment skipping and the `quit`/`/quit`/
   `exit`/`/exit` termination aliases (and reject near-misses like `quitter`).
5. `session.rs`: tests cover the cookie-file round-trip, whitespace trimming,
   empty-file → `None`, and missing-file → `None`.

## TD-002 — API Drift (P2): client wire types hand-mirror the server

6. A drift-guard test round-trips a fully-populated
   `parish_server::sync_types::CommandResponse` through the client's wire
   `CommandResponse` and asserts every field maps. A server-side rename/removal
   now fails the build instead of silently breaking the CLI.

## Verification

- `cargo test -p parish-client` goes from 2 → 12 passing tests, all green.
- `cargo clippy -p parish-client --all-targets -- -D warnings` clean.
- `cargo test -p parish-core --test architecture_fitness` still green (the new
  `parish-server` dev-dependency does not touch any backend-agnostic crate).

### Evidence

# Evidence — parish-client TD-001 / TD-002

Evidence type: gameplay transcript

Note: test-only change. `parish-client` is NOT a runtime-shipping
live-proof-tier path (`parish-client/**` is absent from the rule #10 live-proof
matrix), so the non-live transcript form is the correct tier. The transcript
below is the crate-local `cargo test` run, not a gameplay session — the new
unit tests ARE the proof for this coverage-only change.

Source: `cargo test -p parish-client` → `transcript.txt` (12 passed, 0 failed).

## Criterion → proving test

| AC                              | Test (in transcript)                                                                                                                                                               |
| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 1 (camelCase keys)              | `client::tests::command_opts_use_camel_case_keys ... ok`                                                                                                                           |
| 2 (default omits fields)        | `client::tests::default_opts_omit_empty_and_none_fields ... ok`                                                                                                                    |
| 3 (body flatten)                | `client::tests::command_body_flattens_text_and_opts ... ok`                                                                                                                        |
| 4 (repl skip/quit)              | `repl::tests::skips_blank_and_comment_lines ... ok`, `repl::tests::recognizes_quit_aliases ... ok`                                                                                 |
| 5 (session persistence)         | `session::tests::save_then_load_round_trips ... ok`, `load_trims_surrounding_whitespace ... ok`, `load_treats_empty_file_as_no_session ... ok`, `load_missing_file_is_none ... ok` |
| 6 (server contract drift guard) | `client::tests::deserializes_a_real_server_command_response ... ok`                                                                                                                |

Coverage delta: `parish-client` unit tests 2 → 12. The three previously
untested files (`client.rs`, `repl.rs`, `session.rs`) now each carry tests;
`render.rs` was already covered (#1156).

### Transcript

```text
running 12 tests
test client::tests::default_opts_omit_empty_and_none_fields ... ok
test client::tests::command_body_flattens_text_and_opts ... ok
test client::tests::command_opts_use_camel_case_keys ... ok
test repl::tests::recognizes_quit_aliases ... ok
test repl::tests::skips_blank_and_comment_lines ... ok
test client::tests::deserializes_a_real_server_command_response ... ok
test render::tests::travel_line_plural_for_many_minutes ... ok
test render::tests::travel_line_singular_for_one_minute ... ok
test session::tests::load_missing_file_is_none ... ok
test session::tests::load_treats_empty_file_as_no_session ... ok
test session::tests::load_trims_surrounding_whitespace ... ok
test session::tests::save_then_load_round_trips ... ok
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

### Judge

# Judge — parish-client TD-001 / TD-002

Reviewed `acceptance-criteria.md`, `evidence.md`, and `transcript.txt`.

- AC 1 (camelCase keys): met — `command_opts_use_camel_case_keys` passes.
- AC 2 (default omits unset fields): met — `default_opts_omit_empty_and_none_fields` passes.
- AC 3 (body flatten): met — `command_body_flattens_text_and_opts` passes.
- AC 4 (repl skip/quit classifiers): met — `skips_blank_and_comment_lines`, `recognizes_quit_aliases` pass.
- AC 5 (session persistence): met — four `session::tests::*` pass (round-trip, trim, empty, missing).
- AC 6 (server contract drift guard): met — `deserializes_a_real_server_command_response` round-trips a real `parish_server::sync_types::CommandResponse` through the client type.

Coverage genuinely increases: the three named untested files now carry tests
(2 → 12). The TD-002 guard is a real drift detector (dev-dep on the actual
server type, not a hand-copied JSON golden), so it fails on future server
renames. No runtime behavior changed; the extracted helpers
(`is_skippable`/`is_quit`, `load_from`/`save_to`, module-level `CommandBody`)
are behavior-preserving and exercised by the new tests.

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:td001-td002-parish-client-tests -->
