### PR TITLE
refactor(server): extract router/layer builders from run_server (TD-034)

### DIFF
--- a/parish/crates/parish-server/src/lib.rs
+++ b/parish/crates/parish-server/src/lib.rs
@@ -441,9 +441,41 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
     let ip_limiter = build_ip_rate_limiter_state();
     let use_tower_sessions = should_use_tower_sessions(&global);
 
-    // ── Build router ──────────────────────────────────────────────────────────
+    // ── Build router, apply layers, serve ────────────────────────────────────
     let oauth_enabled = global.oauth_config.is_some();
+    let app = build_router(oauth_enabled, use_tower_sessions);
+    let app = attach_static_and_auth(app, &global, &static_dir);
+    let app = apply_session_layer(app, &global, use_tower_sessions);
+    let app = apply_outer_layers(app, &global, ip_limiter);
 
+    let addr = format!("0.0.0.0:{}", port);
+    tracing::info!("Parish web server listening on http://{}", addr);
+    tracing::info!("Serving static files from {}", static_dir.display());
+
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Registers all API, editor, WebSocket, tile-proxy, and auth routes.
+///
+/// Returns a bare [`Router`] without middleware or state — callers attach those
+/// via [`attach_static_and_auth`], [`apply_session_layer`], and
+/// [`apply_outer_layers`].
+///
+/// OAuth routes are conditionally added based on `oauth_enabled`.  When OAuth
+/// is enabled, the correct variant (tower-sessions or legacy) is selected via
+/// `use_tower_sessions` so the callback and logout handlers match the session
+/// machinery installed by [`apply_session_layer`].
+fn build_router(
+    oauth_enabled: bool,
+    use_tower_sessions: bool,
+) -> Router<Arc<session::GlobalState>> {
     let mut app = Router::new()
         // #373 — /api/health: exempt from auth, returns 200 for health probes.
         .route("/api/health", get(routes::get_health))
@@ -564,35 +596,60 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         }
     }
 
-    // Session middleware selection — `from_fn_with_state` is invoked
-    // differently between the legacy and tower-sessions paths because the
-    // tower-sessions variant also depends on the `SessionManagerLayer` being
-    // present further out.  Both paths terminate in the same set of route
-    // handlers; only the cookie machinery differs.
-    let app = app
-        // SvelteKit's adapter-static is configured with `fallback: 'index.html'`
-        // (see parish/apps/ui/svelte.config.js) — so client-side routes such as
-        // `/editor` rely on the server returning the SPA shell for any path
-        // ServeDir can't satisfy. Without this, `/editor` 404s and the
-        // Playwright e2e suite's Editor tests time out waiting for elements
-        // that never render.
+    app
+}
+
+/// Attaches the static-file fallback service, the CF-Access auth guard, and
+/// the shared [`GlobalState`] to `router`.
+///
+/// After this call the router is typed as `Router` (state erased) and is ready
+/// for session-layer wrapping.
+///
+/// The SvelteKit adapter-static `fallback: 'index.html'` setting means
+/// client-side routes such as `/editor` rely on the server returning the SPA
+/// shell for any path ServeDir cannot satisfy.  Without the fallback service,
+/// `/editor` 404s and the Playwright e2e suite's Editor tests time out waiting
+/// for elements that never render.
+fn attach_static_and_auth(
+    router: Router<Arc<session::GlobalState>>,
+    global: &Arc<session::GlobalState>,
+    static_dir: &Path,
+) -> Router {
+    router
         .fallback_service(
-            ServeDir::new(&static_dir)
+            ServeDir::new(static_dir)
                 .append_index_html_on_directories(true)
                 .not_found_service(ServeFile::new(static_dir.join("index.html"))),
         )
         .layer(axum_mw::from_fn_with_state(
-            Arc::clone(&global),
+            Arc::clone(global),
             cf_access_guard,
         ))
-        .with_state(Arc::clone(&global));
+        .with_state(Arc::clone(global))
+}
 
-    let app = if use_tower_sessions {
-        // tower-sessions-backed: install a MemoryStore-backed
-        // SessionManagerLayer with the existing `parish_sid` cookie name so
-        // returning visitors keep the same cookie across the migration.  The
-        // `SessionId` extension is still injected by `session_middleware_tower`
-        // so downstream route handlers don't need to change.
+/// Wraps `router` with the session-cookie middleware stack.
+///
+/// Two paths are supported:
+///
+/// - **tower-sessions** (default, `use_tower_sessions = true`): installs a
+///   [`tower_sessions::MemoryStore`]-backed [`tower_sessions::SessionManagerLayer`]
+///   using the existing `parish_sid` cookie name, then wraps that with
+///   `session_middleware_tower` and `idempotency_middleware`.
+///
+/// - **legacy** (`use_tower_sessions = false`): wraps with the hand-rolled
+///   `session_middleware` and `idempotency_middleware` only.
+///
+/// In Tower/Axum the last `.layer()` is outermost, so idempotency is applied
+/// first (inner), then the session layers wrap it.  This ordering is preserved
+/// exactly from the original inline code; altering it changes which extensions
+/// are visible to which middleware.
+fn apply_session_layer(
+    router: Router,
+    global: &Arc<session::GlobalState>,
+    use_tower_sessions: bool,
+) -> Router {
+    if use_tower_sessions {
         use tower_sessions::cookie::SameSite;
         use tower_sessions::cookie::time::Duration as CookieDuration;
         use tower_sessions::{Expiry, MemoryStore, SessionManagerLayer};
@@ -615,32 +672,53 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
             .with_path("/".to_string())
             .with_expiry(Expiry::OnInactivity(CookieDuration::days(365)));
 
-        app
+        router
             // Idempotency middleware runs after session (session injects SessionId
             // extension; idempotency reads it).  In Tower/Axum the last `.layer()`
             // is outermost — so idempotency is applied first here (inner), then
             // the session layers wrap it.
             .layer(axum_mw::from_fn_with_state(
-                Arc::clone(&global),
+                Arc::clone(global),
                 middleware::idempotency_middleware,
             ))
             .layer(axum_mw::from_fn_with_state(
-                Arc::clone(&global),
+                Arc::clone(global),
                 middleware::session_middleware_tower,
             ))
             .layer(session_layer)
     } else {
-        app.layer(axum_mw::from_fn_with_state(
-            Arc::clone(&global),
-            middleware::idempotency_middleware,
-        ))
-        .layer(axum_mw::from_fn_with_state(
-            Arc::clone(&global),
-            middleware::session_middleware,
-        ))
-    };
+        router
+            .layer(axum_mw::from_fn_with_state(
+                Arc::clone(global),
+                middleware::idempotency_middleware,
+            ))
+            .layer(axum_mw::from_fn_with_state(
+                Arc::clone(global),
+                middleware::session_middleware,
+            ))
+    }
+}
 
-    let app = app
+/// Adds the outermost layers to `router`: legal/licence routes, per-request
+/// tracing, global IP rate limiter, and security-hardening response headers.
+///
+/// Layer order is security-sensitive and must be preserved exactly:
+///
+/// 1. Legal routes (`/LICENSE`, `/NOTICE`, `/THIRD_PARTY_NOTICES.md`) —
+///    mounted *after* `cf_access_guard` and `session_middleware` so they
+///    remain publicly reachable while the rate-limit and security headers
+///    still apply.
+/// 2. `request_id_layer` — per-request tracing.  Runs *inside* the rate
+///    limiter so only admitted requests are traced.
+/// 3. `ip_rate_limit_middleware` — outside the auth guard; throttles floods
+///    before JWT validation overhead is incurred (#381).
+/// 4. `apply_security_layers` — outermost; covers every route.
+fn apply_outer_layers(
+    router: Router,
+    global: &Arc<session::GlobalState>,
+    ip_limiter: Arc<IpRateLimiterState>,
+) -> Router {
+    let router = router
         // ── GPL-3.0 redistribution: legal/licence files mounted *after*
         //    `cf_access_guard` and `session_middleware` so they remain
         //    publicly reachable (the licence must travel with the hosted
@@ -653,7 +731,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
         // Reads the `otel-tracing` flag from GlobalState and is a no-op when
         // the flag is explicitly disabled.
         .layer(axum_mw::from_fn_with_state(
-            Arc::clone(&global),
+            Arc::clone(global),
             middleware::request_id_layer,
         ))
         // ── #381: Global per-IP rate limiter (outside auth guard, throttles floods) ──
@@ -662,20 +740,7 @@ pub async fn run_server(port: u16, data_dir: PathBuf, static_dir: PathBuf) -> an
             ip_rate_limit_middleware,
         ));
     // ── Security hardening headers (outermost layer — covers all routes) ──
-    let app = apply_security_layers(app);
-
-    let addr = format!("0.0.0.0:{}", port);
-    tracing::info!("Parish web server listening on http://{}", addr);
-    tracing::info!("Serving static files from {}", static_dir.display());
-
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
-    axum::serve(
-        listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    )
-    .await?;
-
-    Ok(())
+    apply_security_layers(router)
 }
 
 // ── Extracted construction-step helpers ─────────────────────────────────────


### PR DESCRIPTION
Split the monolithic run_server() into separately-reviewable router-registration / middleware-layer / serving builders. Behavior-preserving. Part of #1204 (TD-034).

<!-- parish-proof-bundle:td034-server-runserver-extract v=1 -->

## Proof: td034-server-runserver-extract

### Acceptance criteria

# Acceptance Criteria — TD-034 server run_server extract

## Task

Extract `run_server()`'s inline router-registration, session-layer building, and
middleware-stacking into focused named builder functions, so startup config,
route registration, and serving are separately reviewable.

## Criteria

AC-1: `run_server()` delegates route registration to a `build_router()` function
that constructs the full API + editor + static-fallback Router (identical routes
to the original, same order).

AC-2: Session middleware wiring is extracted into `apply_session_layer()` (or
equivalent) so the tower-sessions vs. legacy branching lives in one named
function.

AC-3: `run_server()` body is shorter and clearly sequential — setup, build router,
apply session layer, add outer layers, serve — with no multi-screen inline Router
construction remaining.

AC-4: `cargo fmt --all -- --check` passes.

AC-5: `cargo clippy --workspace --all-targets -- -D warnings` passes (no new
warnings).

AC-6: `cargo test -p parish-server` passes — all existing tests still compile and
pass.

AC-7: Server starts, `/api/health` returns 200, security headers present in
response.

AC-8: `just check` green end-to-end.

AC-9: Externally observable behavior is identical — same routes, same layer order
(layer order is security-sensitive).

### Evidence

Evidence type: live gameplay transcript

# TD-034 — server run_server extract: Live proof

## Server start

```
$ bash parish/scripts/parish-mcp-backend.sh start
Starting parish-server --port 3030 in background...
parish-mcp backend ready (pid=61638, port=3030)
```

## Route verification

### AC-7a: /api/health returns 200

```
$ python3 -c "import urllib.request; r = urllib.request.urlopen('http://localhost:3030/api/health'); print('Status:', r.status)"
Status: 200
```

### AC-7b: /api/ui-config returns 200

```
HTTP/1.1 200 OK
content-type: application/json
x-request-id: 4abf5aa2-8215-4ea3-b69e-d958ab8b230f
...
```

### AC-7c: /LICENSE legal route returns 200 (mounted via apply_outer_layers)

```
HTTP/1.1 200 OK
content-type: text/plain; charset=utf-8
x-request-id: e4a63053-ebd4-407f-bb33-39d915379065
```

### AC-7d: /metrics returns 200

```
HTTP/1.1 200 OK
content-type: text/plain; charset=utf-8
```

### AC-7e: All six security headers present on every response

From GET /api/health:

```
Status: 200
content-security-policy: default-src 'self'; script-src 'self' 'unsafe-inline'; worker-src 'self' blob:; ...
strict-transport-security: max-age=31536000; includeSubDomains
x-frame-options: DENY
x-content-type-options: nosniff
referrer-policy: strict-origin-when-cross-origin
permissions-policy: camera=(), microphone=(), geolocation=()
```

All six headers from `apply_security_layers` are present.

## Unit tests

```
cargo test -p parish-server
...
Finished `test` profile [unoptimized + debuginfo] target(s) in 24.36s
Running unittests src/lib.rs
Running unittests src/main.rs
Running tests/account_id.rs
Running tests/admission_control.rs
Running tests/auth_guard.rs
Running tests/auth_status.rs
Running tests/isolation.rs
Running tests/legal_routes.rs
Running tests/new_game_parity.rs
Running tests/oauth_integration.rs
Running tests/security_headers.rs
Running tests/session_init.rs
Running tests/ws_integration.rs
Doc-tests parish_server
cargo test: 281 passed, 2 ignored (15 suites, 0.65s)
```

## CI

```
cargo fmt --all -- --check: clean
cargo clippy --workspace --all-targets -- -D warnings: No issues found
```

## Criteria mapping

- AC-1 (build_router function): satisfied — `build_router(oauth_enabled, use_tower_sessions)` in lib.rs extracts all route registrations from run_server
- AC-2 (apply_session_layer function): satisfied — `apply_session_layer()` encapsulates tower-sessions vs. legacy branching
- AC-3 (run_server is shorter): satisfied — run_server body is now ~20 lines of clear sequential steps
- AC-4 (cargo fmt clean): satisfied — `cargo fmt --all -- --check` passes
- AC-5 (clippy clean): satisfied — `cargo clippy --workspace --all-targets -- -D warnings` shows no issues
- AC-6 (tests pass): satisfied — 281 passed, 2 ignored
- AC-7 (server starts, routes serve, security headers): satisfied — live server probe above confirms /api/health 200, /api/ui-config 200, /LICENSE 200, all six security headers present
- AC-8 (just check green): pending agent-check (needs this bundle)
- AC-9 (same routes, same layer order): satisfied — extraction is purely structural; route list and layer ordering in build_router / apply_session_layer / apply_outer_layers match the original inline code exactly

## Server stop

```
$ bash parish/scripts/parish-mcp-backend.sh stop
parish-mcp backend stopped (pid=61638)
```

### Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

The extraction splits the monolithic run_server() body into four clearly-named
builder functions with no behavior change. Evidence demonstrates:

- Server starts and responds to /api/health, /api/ui-config, /LICENSE, /metrics
- All six security headers present on each response (apply_security_layers covers all routes)
- 281 unit tests pass unchanged across 15 test suites
- cargo fmt and clippy clean
- Layer order preserved exactly: routes -> static/auth -> session -> outer (tracing, rate-limit, security headers)
- run_server() is now a short sequential list of named steps, separately reviewable

<!-- /parish-proof-bundle:td034-server-runserver-extract -->
