### PR TITLE
feat(bench): surface pending_judge + bench-bug-rate on the leaderboard (#1206)

### DIFF
--- a/rundale-bench/bench-site/src/pages/models/[slug].astro
+++ b/rundale-bench/bench-site/src/pages/models/[slug].astro
@@ -151,10 +151,16 @@ const perfRows = perf.map((r) => ({
       <table>
         <thead><tr><th>Axis</th><th class="num">Score</th></tr></thead>
         <tbody>
-          <tr><td><strong>Overall</strong></td><td class="num"><strong>{fmt(dialogueRow.overall)}</strong></td></tr>
+          <tr><td><strong>Overall</strong></td><td class="num"><strong>{dialogueRow.pending_judge ? '(pending judge)' : fmt(dialogueRow.overall)}</strong></td></tr>
           {DIALOGUE_AXES.map((ax) => (
             <tr><td>{ax}</td><td class="num">{fmt(dialogueRow[ax])}</td></tr>
           ))}
+          {(() => {
+            const records = dialogueRow.records ?? 0;
+            const bugs = dialogueRow.bench_bugs ?? 0;
+            const rate = records > 0 ? `${bugs}/${records} (${(bugs / records * 100).toFixed(0)}%)` : '—';
+            return <tr><td>bench-bug rate</td><td class="num" title="responses flagged as chain-of-thought bypass or harness bug, excluded from the score">{rate}</td></tr>;
+          })()}
         </tbody>
       </table>
       {samples.dialogue?.items?.length > 0 && (

--- a/rundale-bench/build_leaderboard_page.py
+++ b/rundale-bench/build_leaderboard_page.py
@@ -96,17 +96,19 @@ def build_data() -> dict:
         if ":free" in cand:
             continue
         # A bundled summary with no judged items publishes axes as `None`
-        # plus `pending_judge: True`. Skip — the row appears once
+        # plus `pending_judge: True`. Include the row so it appears on the
+        # leaderboard with a visible marker — it will be superseded once
         # `ingest --finalize` folds the subagent scores back in.
-        if summary.get("pending_judge"):
-            continue
-        if summary.get("overall") is None:
+        pending = bool(summary.get("pending_judge"))
+        if summary.get("overall") is None and not pending:
             continue
         judge_model = summary.get("judge_model") or "?"
         judge_id = summary.get("judge") or "?"
         base_url = target.get("base_url", "?")
         split = d.get("split", "?")
         key = (cand, judge_id, base_url, split)
+        records = summary.get("records", 0) or 0
+        bench_bugs = summary.get("bench_bugs", 0) or 0
         latest_quality[key] = {
             "candidate": cand,
             "judge": judge_model,
@@ -114,7 +116,10 @@ def build_data() -> dict:
             "base_url": base_url,
             "split": split,
             "file": path.name,
-            "n": summary.get("judged", summary.get("records", 0)),
+            "pending_judge": pending,
+            "n": summary.get("judged", records),
+            "records": records,
+            "bench_bugs": bench_bugs,
             "total": _round(summary.get("overall")),
             "character": _round(summary.get("character")),
             "authenticity": _round(summary.get("authenticity")),
@@ -292,21 +297,37 @@ def build_markdown(data: dict) -> str:
         for r in data.get("averaged", [])
     ]
 
+    def _fmt_overall(r: dict) -> str:
+        """Format the Overall cell, annotating pending-judge rows."""
+        if r.get("pending_judge"):
+            return "(pending judge)"
+        return _fmt(r["total"])
+
+    def _fmt_bench_bug_rate(r: dict) -> str:
+        records = r.get("records") or 0
+        bench_bugs = r.get("bench_bugs") or 0
+        if records == 0:
+            return "-"
+        return f"{bench_bugs}/{records} ({bench_bugs / records * 100:.0f}%)"
+
     quality_rows = [
         [
             r["candidate"],
             r["judge"],
             r["n"],
-            _fmt(r["total"]),
+            _fmt_overall(r),
             _fmt(r["character"]),
             _fmt(r["authenticity"]),
             _fmt(r["language"]),
             _fmt(r["responsiveness"]),
             _fmt(r["craft"]),
+            _fmt_bench_bug_rate(r),
             r["file"],
         ]
         for r in sorted(
-            data["quality"], key=lambda r: (r["total"] is not None, r["total"]), reverse=True
+            data["quality"],
+            key=lambda r: (not r.get("pending_judge"), r["total"] is not None, r["total"]),
+            reverse=True,
         )
     ]
 
@@ -385,6 +406,7 @@ def build_markdown(data: dict) -> str:
                     "Lang",
                     "Resp",
                     "Craft",
+                    "Bench-bug %",
                     "File",
                 ],
                 quality_rows,

--- a/rundale-bench/build_site_data.py
+++ b/rundale-bench/build_site_data.py
@@ -631,6 +631,9 @@ def build_leaderboard(artifacts_dir: Path, families: dict | None = None) -> list
             ram_value, ram_is_est = peak_ram_est_by_model[model_id], True
         else:
             ram_value, ram_is_est = None, False
+        bench_bugs = s.get("bench_bugs", 0) or 0
+        records = s.get("records") or 0
+        bench_bug_rate = round(bench_bugs / records, 4) if records > 0 else None
         row = {
             "model_id": model_id,
             "display_name": display_name,
@@ -638,9 +641,11 @@ def build_leaderboard(artifacts_dir: Path, families: dict | None = None) -> list
             "family": fam,
             "tier": out.get("tier"),
             "overall": s.get("overall"),
-            "judged": s.get("judged", s.get("records")),
-            "bench_bugs": s.get("bench_bugs", 0),
-            "records": s.get("records"),
+            "pending_judge": bool(s.get("pending_judge")),
+            "judged": s.get("judged", records),
+            "bench_bugs": bench_bugs,
+            "records": records,
+            "bench_bug_rate": bench_bug_rate,
             "non_latin_rate": s.get("non_latin_rate"),
             # Sonnet-subagent is now the only allowed judge (see
             # rundale_bench.load_judge). The legacy "qwen3-235b" fallback

--- a/rundale-bench/test_leaderboard_page.py
+++ b/rundale-bench/test_leaderboard_page.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Tests for build_leaderboard_page.py — pending-judge marker and bench-bug rate column.
+
+Run: python3 rundale-bench/test_leaderboard_page.py
+or via pytest from the repo root.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+_BENCH_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(_BENCH_DIR))
+
+import build_leaderboard_page as blp  # noqa: E402
+
+
+def _write(d: Path, name: str, obj: dict) -> None:
+    d.mkdir(parents=True, exist_ok=True)
+    (d / name).write_text(json.dumps(obj), encoding="utf-8")
+
+
+def _quality_run(
+    model: str,
+    overall: float | None,
+    *,
+    pending_judge: bool = False,
+    bench_bugs: int = 0,
+    records: int = 10,
+    judged: int = 10,
+    ts: str = "2026-06-01T00:00:00Z",
+) -> dict:
+    """Minimal run file matching the shape build_leaderboard_page.build_data expects."""
+    summary: dict = {
+        "overall": overall,
+        "judged": judged,
+        "records": records,
+        "bench_bugs": bench_bugs,
+        "character": overall,
+        "authenticity": overall,
+        "language": overall,
+        "responsiveness": overall,
+        "craft": overall,
+        "judge_model": "claude-sonnet-4-6",
+        "judge": "judge_sonnet_v1",
+    }
+    if pending_judge:
+        summary["pending_judge"] = True
+        summary["overall"] = None
+        for ax in ("character", "authenticity", "language", "responsiveness", "craft"):
+            summary[ax] = None
+    return {
+        "target": {"model": model, "base_url": "https://example.com"},
+        "split": "dev",
+        "run_started_utc": ts,
+        "slices": {"dialogue": {"summary": summary}},
+    }
+
+
+def _patch_artifacts(tmp: Path) -> tuple:
+    """Return context-manager patches to redirect build_leaderboard_page constants."""
+    return (mock.patch.object(blp, "_ARTIFACTS_DIR", tmp / "artifacts"),)
+
+
+def test_pending_judge_row_appears_in_quality():
+    """A pending-judge run must appear in quality data with pending_judge=True."""
+    with tempfile.TemporaryDirectory() as d:
+        art = Path(d) / "artifacts"
+        _write(art, "run_a_all_1.json", _quality_run("model-a", None, pending_judge=True))
+        with _patch_artifacts(Path(d))[0]:
+            data = blp.build_data()
+    assert len(data["quality"]) == 1
+    assert data["quality"][0]["pending_judge"] is True
+    assert data["quality"][0]["total"] is None
+
+
+def test_pending_judge_row_excluded_from_quality_when_no_score_and_not_pending():
+    """A run with overall=None and no pending_judge flag is still excluded."""
+    with tempfile.TemporaryDirectory() as d:
+        art = Path(d) / "artifacts"
+        _write(art, "run_b_all_1.json", _quality_run("model-b", None, pending_judge=False))
+        with _patch_artifacts(Path(d))[0]:
+            data = blp.build_data()
+    assert data["quality"] == []
+
+
+def test_pending_judge_marker_in_markdown():
+    """A pending-judge row renders '(pending judge)' in the Overall column of leaderboard.md."""
+    with tempfile.TemporaryDirectory() as d:
+        art = Path(d) / "artifacts"
+        _write(art, "run_p_all_1.json", _quality_run("pending-model", None, pending_judge=True))
+        with _patch_artifacts(Path(d))[0]:
+            data = blp.build_data()
+        md = blp.build_markdown(data)
+    assert "(pending judge)" in md
+    assert "pending-model" in md
+
+
+def test_scored_row_does_not_show_pending_marker():
+    """A fully-judged row shows a numeric Overall and no pending marker."""
+    with tempfile.TemporaryDirectory() as d:
+        art = Path(d) / "artifacts"
+        _write(art, "run_s_all_1.json", _quality_run("scored-model", 3.75))
+        with _patch_artifacts(Path(d))[0]:
+            data = blp.build_data()
+        md = blp.build_markdown(data)
+    assert "(pending judge)" not in md
+    assert "3.75" in md
+
+
+def test_bench_bug_rate_column_in_markdown():
+    """Bench-bug % column appears in the quality table with correct fraction."""
+    with tempfile.TemporaryDirectory() as d:
+        art = Path(d) / "artifacts"
+        _write(art, "run_bb_all_1.json", _quality_run("buggy-model", 2.5, bench_bugs=3, records=10))
+        with _patch_artifacts(Path(d))[0]:
+            data = blp.build_data()
+        md = blp.build_markdown(data)
+    assert "Bench-bug %" in md
+    assert "3/10" in md
+    assert "30%" in md
+
+
+def test_bench_bug_rate_zero_bugs():
+    """A model with no bench bugs shows '0/N (0%)' not a blank."""
+    with tempfile.TemporaryDirectory() as d:
+        art = Path(d) / "artifacts"
+        _write(art, "run_nb_all_1.json", _quality_run("clean-model", 4.0, bench_bugs=0, records=10))
+        with _patch_artifacts(Path(d))[0]:
+            data = blp.build_data()
+        md = blp.build_markdown(data)
+    assert "0/10 (0%)" in md
+
+
+def test_bench_bug_rate_zero_records():
+    """When records is 0, the cell shows '-' not an error."""
+    with tempfile.TemporaryDirectory() as d:
+        art = Path(d) / "artifacts"
+        _write(art, "run_nr_all_1.json", _quality_run("empty-model", 3.0, bench_bugs=0, records=0))
+        with _patch_artifacts(Path(d))[0]:
+            data = blp.build_data()
+        md = blp.build_markdown(data)
+    assert "Bench-bug %" in md
+    # The '-' placeholder appears for the zero-records row.
+    assert " - |" in md or "| - " in md
+
+
+def test_quality_row_carries_bench_bugs_and_records():
+    """build_data() stores bench_bugs and records on each quality entry."""
+    with tempfile.TemporaryDirectory() as d:
+        art = Path(d) / "artifacts"
+        _write(art, "run_r_all_1.json", _quality_run("model-r", 3.2, bench_bugs=2, records=8))
+        with _patch_artifacts(Path(d))[0]:
+            data = blp.build_data()
+    row = data["quality"][0]
+    assert row["bench_bugs"] == 2
+    assert row["records"] == 8
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+        except AssertionError as e:
+            print(f"FAIL {t.__name__}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"ERROR {t.__name__}: {type(e).__name__}: {e}")
+            failed += 1
+        else:
+            print(f"OK   {t.__name__}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/rundale-bench/test_phase4.py
+++ b/rundale-bench/test_phase4.py
@@ -241,6 +241,56 @@ def test_slugify():
     assert bsd.slugify("Qwen2.5-7B") == "qwen2-5-7b"
 
 
+# ── criterion: bench_bug_rate computed from bench_bugs / records ──────────────
+def test_leaderboard_bench_bug_rate():
+    tmp = _tmp()
+    art = tmp / "artifacts"
+    run = _dialogue_run("model-a", 3.5, "2026-06-01T00:00:00Z")
+    # Inject bench_bugs into the summary.
+    run["slices"]["dialogue"]["summary"]["bench_bugs"] = 2
+    run["slices"]["dialogue"]["summary"]["records"] = 10
+    _write(art, "run_a_all_1.json", run)
+    rows = bsd.build_leaderboard(art)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["bench_bugs"] == 2
+    assert row["records"] == 10
+    assert row["bench_bug_rate"] == round(2 / 10, 4)
+
+
+def test_leaderboard_bench_bug_rate_zero_records():
+    """bench_bug_rate is None when records is 0 (avoids ZeroDivisionError)."""
+    tmp = _tmp()
+    art = tmp / "artifacts"
+    run = _dialogue_run("model-z", 4.0, "2026-06-01T00:00:00Z")
+    run["slices"]["dialogue"]["summary"]["bench_bugs"] = 0
+    run["slices"]["dialogue"]["summary"]["records"] = 0
+    _write(art, "run_z_all_1.json", run)
+    rows = bsd.build_leaderboard(art)
+    assert rows[0]["bench_bug_rate"] is None
+
+
+# ── criterion: pending_judge flag carried on leaderboard row ─────────────────
+def test_leaderboard_pending_judge_flag():
+    tmp = _tmp()
+    art = tmp / "artifacts"
+    run = _dialogue_run("model-p", None, "2026-06-01T00:00:00Z")
+    run["slices"]["dialogue"]["summary"]["pending_judge"] = True
+    _write(art, "run_p_all_1.json", run)
+    rows = bsd.build_leaderboard(art)
+    assert len(rows) == 1
+    assert rows[0]["pending_judge"] is True
+    assert rows[0]["overall"] is None
+
+
+def test_leaderboard_pending_judge_false_when_absent():
+    tmp = _tmp()
+    art = tmp / "artifacts"
+    _write(art, "run_q_all_1.json", _dialogue_run("model-q", 4.1, "2026-06-01T00:00:00Z"))
+    rows = bsd.build_leaderboard(art)
+    assert rows[0]["pending_judge"] is False
+
+
 def main() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
     failed = 0


### PR DESCRIPTION
Make pending-judge rows visibly flagged on the leaderboard and add a bench-bug-rate column to the model-detail page. Part of #1206.