### PR TITLE
fix(server): reuse auto-created main branch in init_session_save (#1207 #9)

### DIFF
--- a/parish/crates/parish-server/src/session/inference_setup.rs
+++ b/parish/crates/parish-server/src/session/inference_setup.rs
@@ -106,10 +106,18 @@ pub(super) async fn init_session_save(
 
     let branch_id = tokio::task::spawn_blocking(move || -> Result<i64, String> {
         let db = Database::open(&save_path_clone).map_err(|e| e.to_string())?;
-        let branch_id = db.create_branch("main", None).map_err(|e| e.to_string())?;
-        db.save_snapshot(branch_id, &snapshot)
+        // `Database::open` already auto-creates the "main" branch, so reuse it
+        // rather than calling `create_branch("main", ...)` again — the latter
+        // trips a `UNIQUE constraint failed: branches.name` error, which left
+        // the save fields unset and `/api/save-state` returning all-null on a
+        // freshly-created session (#9). Mirrors `new_save_file`.
+        let branch = db
+            .find_branch("main")
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| "main branch missing after Database::open".to_string())?;
+        db.save_snapshot(branch.id, &snapshot)
             .map_err(|e| e.to_string())?;
-        Ok(branch_id)
+        Ok(branch.id)
     })
     .await
     .map_err(|e| e.to_string())??;
@@ -131,4 +139,40 @@ pub(super) async fn init_session_save(
     *app_state.current_branch_name.lock().await = Some("main".to_string());
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #9 regression: `Database::open` auto-creates the "main" branch, so
+    /// `init_session_save` must *reuse* it. The earlier `create_branch("main")`
+    /// tripped `UNIQUE constraint failed: branches.name`, returned `Err`, and
+    /// left `save_path` / `current_branch_id` / `current_branch_name` unset —
+    /// which surfaced as an all-null `GET /api/save-state` on every freshly
+    /// created server session.
+    #[tokio::test]
+    async fn init_session_save_populates_branch_fields() {
+        let state = crate::routes::tests::test_app_state();
+        let tmp = tempfile::tempdir().unwrap();
+
+        init_session_save(&state, tmp.path())
+            .await
+            .expect("init_session_save must succeed on a fresh save (no UNIQUE-branch panic)");
+
+        assert!(
+            state.save_path.lock().await.is_some(),
+            "save_path must be set after init_session_save"
+        );
+        assert_eq!(
+            *state.current_branch_id.lock().await,
+            Some(1),
+            "the auto-created main branch has id 1"
+        );
+        assert_eq!(
+            state.current_branch_name.lock().await.as_deref(),
+            Some("main"),
+            "branch name must be main"
+        );
+    }
 }


### PR DESCRIPTION
## What

Fixes epic #1207 finding #9: a standalone headless `parish-server` returned
`{"filename":null,"branch_id":null,"branch_name":null}` from `GET /api/save-state`
on every freshly-created session.

## Root cause

`Database::open` auto-creates the `main` branch. `init_session_save` then called
`create_branch("main", None)` a second time, which fails with
`UNIQUE constraint failed: branches.name`. The function returned `Err` before
setting the save fields, and the error was swallowed by a `tracing::warn` (the
headless binary has no subscriber) — so save-state stayed all-null.

Localised live by instrumenting the session path (see proof bundle); the audit's
original framing ("auto-load most-recent branch") was a misdiagnosis.

## Fix

`init_session_save` reuses the existing `main` branch via `find_branch("main")`,
mirroring the already-correct `new_save_file`. One file changed.

## Tests / proof

- New regression test `init_session_save_populates_branch_fields`.
- Full `parish-server` suite green (203 unit + integration), clippy clean.
- Live verified on a real `parish-server` over HTTP and `mcp__parish__parish_save_state`
  (null → `{filename:"parish_001.db", branch_id:1, branch_name:"main"}`).

Closes part of #1207.

<!-- parish-proof-bundle:1207-server-autoload v=1 -->

## Proof: 1207-server-autoload

### Acceptance criteria

# Acceptance criteria — 1207-server-autoload (#9)

Epic #1207 finding #9: a standalone headless `parish-server` returns
`{"filename":null,"branch_id":null,"branch_name":null}` from `GET /api/save-state`
even after a session is created and a command runs, whereas the desktop app shows
the active branch.

## Root cause (five-whys, confirmed live)

`Database::open` auto-creates the `main` branch. `init_session_save`
(`parish-server/src/session/inference_setup.rs`) then called
`create_branch("main", None)` a second time, which fails with
`UNIQUE constraint failed: branches.name`. The function returned `Err` before
setting `save_path` / `current_branch_id` / `current_branch_name`, and the error
was swallowed by a `tracing::warn` (no subscriber on the headless binary). So
every freshly-created server session had null save metadata.

## Observable criteria

1. On a fresh `parish-server` session (no prior save loaded), `GET /api/save-state`
   returns a non-null `filename`, `branch_id`, and `branch_name`.
2. The same is true through the canonical MCP channel: `mcp__parish__parish_save_state`
   returns the active branch (`main`) rather than nulls.
3. `init_session_save` reuses the auto-created `main` branch instead of creating a
   duplicate — no `UNIQUE constraint failed: branches.name` error path.
4. A unit regression test asserts `init_session_save` succeeds and populates all
   three save fields on a fresh save file.
5. No behavior change for the already-working paths (`new_game`, `new_save_file`,
   session restore) — full `parish-server` test suite stays green.

### Evidence

# Evidence — 1207-server-autoload (#9)

Evidence type: live gameplay transcript

Live run against a real headless `parish-server` (`cargo run -p parish-server --
--port 3030`), exercised over HTTP and the `mcp__parish__*` bridge. The word
**live** affirms the server process actually ran and served these requests.

## Diagnosis (root cause localised live)

Instrumented `init_session_save` / `create_session` / `get_save_state` with
stderr probes, ran a fresh session, and captured:

```
[DBG9] init_session_save FAILED: database error: UNIQUE constraint failed: branches.name
[DBG9] create_session sid=7a61834b-... appstate=0x10762ffb0 save_path=None
[DBG9] get_save_state appstate=0xa096d8010 save_path=None
```

→ `Database::open` already creates `main`; the second `create_branch("main")`
violates the UNIQUE index, so the save fields were never set. Probes removed
after diagnosis; final diff is the one-line branch-reuse fix + a regression test.

## Criterion → proof

**C1 — fresh session `/api/save-state` non-null (HTTP).**
Before fix (original code), fresh `parish-server`:

```
$ curl -s http://127.0.0.1:3030/api/save-state
{"filename":null,"branch_id":null,"branch_name":null}
```

After fix, fresh `parish-server` (cookieless and cookied both):

```
$ curl -s http://127.0.0.1:3030/api/save-state
{"filename":"parish_001.db","branch_id":1,"branch_name":"main"}
```

**C2 — canonical MCP channel non-null.**
After fix, `mcp__parish__parish_save_state`:

```json
{ "branch_id": 1, "branch_name": "main", "filename": "parish_001.db" }
```

(Before fix the same tool returned all-null — the audit's original symptom.)

**C3 — no duplicate-branch error path.**
`init_session_save` now calls `find_branch("main")` (mirroring `new_save_file`)
instead of `create_branch("main", None)`. The `UNIQUE constraint failed:
branches.name` error no longer occurs (the `[DBG9] ... FAILED` line is gone on a
post-fix run; save-state is populated).

**C4 — unit regression test.**
`init_session_save_populates_branch_fields` (in `session/inference_setup.rs`):

```
cargo test -p parish-server init_session_save_populates
... test result: ok. 1 passed; 285 filtered out
```

**C5 — no regression.**

```
cargo test -p parish-server   → EXIT=0
test result: ok. 203 passed; 0 failed ...
(+ all integration suites: account_id, admission_control, isolation,
 new_game_parity, session_init, ws_integration, ... all ok)
cargo clippy -p parish-server → 0 errors, 0 warnings
```

### Judge

# Judge verdict — 1207-server-autoload (#9)

Reviewed the diff, the live transcript, and the regression test independently of
the author's narrative.

## Per-criterion check

- **C1** (HTTP save-state non-null on fresh session): met. Live before/after curl
  shows null → `{filename:"parish_001.db", branch_id:1, branch_name:"main"}`.
- **C2** (MCP `parish_save_state` non-null): met. Post-fix tool output returns the
  `main` branch; this is the exact channel the audit used to observe the bug.
- **C3** (no duplicate-branch error): met. Code now uses `find_branch("main")`,
  mirroring the already-correct `new_save_file`; the live `UNIQUE constraint`
  error line is gone post-fix.
- **C4** (regression test): met. `init_session_save_populates_branch_fields`
  passes and asserts all three save fields are set.
- **C5** (no regression): met. 203 unit tests + all integration suites pass, exit
  0; clippy clean.

## Assessment

Root cause was localised live (UNIQUE-branch violation swallowed by a warn), not
guessed. The fix is minimal (one function), consistent with existing correct code
(`new_save_file`), and guarded by a focused regression test. The audit's framing
("auto-load most-recent branch") was a misdiagnosis; the real defect was a
duplicate branch creation — the fix addresses the actual observed symptom
(all-null save-state) without breaking per-visitor session isolation.

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

<!-- /parish-proof-bundle:1207-server-autoload -->
