### PR TITLE
feat(map): surface travel estimate for unexplored adjacent locations (#1207 #33/#36)

### DIFF
--- a/parish/crates/parish-core/src/ipc/demo.rs
+++ b/parish/crates/parish-core/src/ipc/demo.rs
@@ -38,9 +38,10 @@ pub struct DemoNpcInfo {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct DemoAdjacentLocation {
     pub name: String,
-    /// Walking time in minutes. `None` for frontier entries (matches the GUI
-    /// map tooltip, which hides travel time until the location has been
-    /// visited).
+    /// Estimated walking time in minutes. Present for any reachable neighbour —
+    /// visited or unexplored — so the auto-player can judge distance before
+    /// committing to a move (#1207 #33/#36). `None` only when the map could not
+    /// estimate a travel time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub travel_minutes: Option<u16>,
     /// `true` for visited locations, `false` for frontier entries.
@@ -114,11 +115,10 @@ pub fn build_demo_context(
         .filter(|loc| loc.adjacent && loc.id != map.player_location)
         .map(|loc| DemoAdjacentLocation {
             name: loc.name.clone(),
-            travel_minutes: if loc.visited {
-                loc.travel_minutes
-            } else {
-                None
-            },
+            // Carry the travel estimate for unexplored neighbours too — the map
+            // now provides it (#1207 #33/#36), so the auto-player sees how far
+            // an unvisited adjacent location is rather than a bare "unvisited".
+            travel_minutes: loc.travel_minutes,
             visited: loc.visited,
         })
         .collect();
@@ -205,7 +205,10 @@ pub fn render_user_prompt(ctx: &DemoContextSnapshot) -> String {
             .map(|a| match (a.visited, a.travel_minutes) {
                 (true, Some(m)) => format!("  - {} — {} min away, visited", a.name, m),
                 (true, None) => format!("  - {} — visited", a.name),
-                (false, _) => format!("  - {} — unvisited", a.name),
+                (false, Some(m)) => {
+                    format!("  - {} — about {} min away, unexplored", a.name, m)
+                }
+                (false, None) => format!("  - {} — unexplored", a.name),
             })
             .collect();
         parts.push(format!("Adjacent locations:\n{}", lines.join("\n")));
@@ -260,7 +263,7 @@ mod tests {
         }
     }
 
-    fn map_data(adjacent_unvisited: Vec<&str>, adjacent_visited: Vec<(&str, u16)>) -> MapData {
+    fn map_data(adjacent_unvisited: Vec<(&str, u16)>, adjacent_visited: Vec<(&str, u16)>) -> MapData {
         let mut locations = vec![MapLocation {
             id: "0".to_string(),
             name: "Kilteevan".to_string(),
@@ -287,7 +290,7 @@ mod tests {
             });
             next_id += 1;
         }
-        for name in adjacent_unvisited {
+        for (name, mins) in adjacent_unvisited {
             locations.push(MapLocation {
                 id: next_id.to_string(),
                 name: name.to_string(),
@@ -296,7 +299,7 @@ mod tests {
                 adjacent: true,
                 hops: 1,
                 indoor: None,
-                travel_minutes: None,
+                travel_minutes: Some(mins),
                 visited: false,
             });
             next_id += 1;
@@ -415,11 +418,14 @@ mod tests {
     }
 
     #[test]
-    fn adjacent_frontier_omits_travel_minutes() {
+    fn adjacent_frontier_carries_travel_estimate() {
+        // #1207 #33/#36: unexplored adjacent locations now surface their travel
+        // estimate (was previously dropped, leaving a bare "unvisited" with no
+        // distance cue the auto-player could act on).
         let ctx = build_demo_context(
             &world_snapshot(),
             &[],
-            &map_data(vec!["The Mill"], vec![("The Crossroads", 12)]),
+            &map_data(vec![("The Mill", 8)], vec![("The Crossroads", 12)]),
             "Wednesday".to_string(),
             "spring".to_string(),
             None,
@@ -430,9 +436,10 @@ mod tests {
             .find(|a| a.name == "The Mill")
             .expect("frontier entry present");
         assert!(!mill.visited);
-        assert!(
-            mill.travel_minutes.is_none(),
-            "travel_minutes leaked on frontier"
+        assert_eq!(
+            mill.travel_minutes,
+            Some(8),
+            "frontier entry should carry its travel estimate"
         );
 
         let xroads = ctx
@@ -444,7 +451,7 @@ mod tests {
         assert_eq!(xroads.travel_minutes, Some(12));
 
         let prompt = render_user_prompt(&ctx);
-        assert!(prompt.contains("The Mill — unvisited"));
+        assert!(prompt.contains("The Mill — about 8 min away, unexplored"));
         assert!(prompt.contains("The Crossroads — 12 min away, visited"));
     }
 

--- a/parish/crates/parish-core/src/ipc/demo.rs
+++ b/parish/crates/parish-core/src/ipc/demo.rs
@@ -263,7 +263,10 @@ mod tests {
         }
     }
 
-    fn map_data(adjacent_unvisited: Vec<(&str, u16)>, adjacent_visited: Vec<(&str, u16)>) -> MapData {
+    fn map_data(
+        adjacent_unvisited: Vec<(&str, u16)>,
+        adjacent_visited: Vec<(&str, u16)>,
+    ) -> MapData {
         let mut locations = vec![MapLocation {
             id: "0".to_string(),
             name: "Kilteevan".to_string(),

--- a/parish/crates/parish-core/src/ipc/handlers.rs
+++ b/parish/crates/parish-core/src/ipc/handlers.rs
@@ -153,7 +153,12 @@ pub fn build_map_data(
         })
         .collect();
 
-    // Append frontier locations (limited info)
+    // Append frontier locations (limited info). Frontier entries are unvisited
+    // but reachable; surface the BFS travel-time estimate so the player (and the
+    // demo auto-player) can judge how far an unexplored neighbour is and choose
+    // to travel there. The estimate is already computed in `travel_time_map`;
+    // discarding it left adjacent-but-unexplored locations as bare "unvisited"
+    // with no distance cue (#1207 findings #33/#36).
     for id in &frontier {
         if let Some(data) = world.graph.get(*id) {
             locations.push(MapLocation {
@@ -164,7 +169,7 @@ pub fn build_map_data(
                 adjacent: adjacent_ids.contains(id),
                 hops: *hop_map.get(id).unwrap_or(&u32::MAX),
                 indoor: None,
-                travel_minutes: None,
+                travel_minutes: travel_time_map.get(id).copied(),
                 visited: false,
             });
         }
@@ -1101,14 +1106,17 @@ mod tests {
             assert!(start_loc.indoor.is_some());
             assert!(start_loc.travel_minutes.is_none());
 
-            // Frontier locations are not visited and have limited info
+            // Frontier locations are not visited and reveal limited info: the
+            // indoor flag stays hidden, but the travel-time estimate is surfaced
+            // so the player can judge how far an unexplored neighbour is
+            // (#1207 #33/#36).
             let frontier: Vec<_> = map.locations.iter().filter(|l| !l.visited).collect();
             assert_eq!(frontier.len(), neighbor_count);
             for f in &frontier {
                 assert!(f.indoor.is_none(), "frontier should not reveal indoor flag");
                 assert!(
-                    f.travel_minutes.is_none(),
-                    "frontier should not reveal travel time"
+                    f.travel_minutes.is_some(),
+                    "frontier should surface a travel-time estimate"
                 );
             }
 

--- a/parish/crates/parish-core/tests/demo_context_integration.rs
+++ b/parish/crates/parish-core/tests/demo_context_integration.rs
@@ -73,8 +73,9 @@ fn demo_prompt_at_fresh_save_does_not_leak_widow_or_peig() {
 }
 
 /// The map-derived adjacent list must agree with the GUI's fog-of-war
-/// (`build_map_data`) — anything beyond the frontier is absent, and
-/// travel_minutes is hidden for unvisited frontier entries.
+/// (`build_map_data`) — anything beyond the frontier is absent. Unvisited
+/// frontier entries now carry a travel-time estimate so the auto-player can
+/// judge distance before moving (#1207 #33/#36).
 #[test]
 fn demo_prompt_adjacent_block_mirrors_map_fog_of_war() {
     let mod_dir = rundale_mod_dir();
@@ -112,13 +113,13 @@ fn demo_prompt_adjacent_block_mirrors_map_fog_of_war() {
         );
     }
 
-    // Frontier entries (unvisited) must not carry travel_minutes — the GUI
-    // map tooltip hides that until the location has been visited.
+    // Frontier entries (unvisited but reachable) must carry a travel-time
+    // estimate — the auto-player needs the distance cue to choose a move.
     for adj in &ctx.adjacent {
         if !adj.visited {
             assert!(
-                adj.travel_minutes.is_none(),
-                "frontier entry {} leaked travel_minutes",
+                adj.travel_minutes.is_some(),
+                "frontier entry {} should carry a travel estimate",
                 adj.name
             );
         }


### PR DESCRIPTION
## What

Fixes epic #1207 findings #33/#36: the map/adjacency list surfaced unvisited
neighbours as a bare "unvisited" with no travel time, so the demo auto-player
could see an unexplored adjacent location but had no distance cue to act on.

## Fix

`build_map_data` already computes a BFS travel-time estimate for every reachable
location (`travel_time_map`) but threw it away for frontier entries. Carry it
through to frontier `MapLocation`s and the demo adjacency block, which now reads
`- The Mill — about 8 min away, unexplored`.

The 1-hop fog-of-war frontier is unchanged (audit #36 confirmed it is by-design):
beyond-frontier locations stay absent and `indoor` stays hidden for unvisited
entries — only the travel estimate is now surfaced.

## Tests / proof

- `adjacent_frontier_carries_travel_estimate` + updated fog-of-war unit and
  integration tests.
- Full `parish-core` suite green, clippy clean.
- Live verified on a real `parish-server`: `GET /api/map` frontier entries now
  return real `travel_minutes` (Lime Kiln 1, Crossroads 13, Knockcroghery 85 …),
  previously all null.

Closes part of #1207.

<!-- parish-proof-bundle:1207-map-frontier v=1 -->

## Proof: 1207-map-frontier

### Acceptance criteria

# Acceptance criteria — 1207-map-frontier (#33/#36)

Epic #1207 findings #33/#36: the map's adjacent list surfaced unvisited
neighbours as a bare "unvisited" with no travel time, so the auto-player could
not judge how far an unexplored adjacent location was and rarely chose to move
there. `build_map_data` already computes a travel-time estimate for every
reachable location (`travel_time_map`) but discarded it for frontier entries.

The 1-hop fog-of-war frontier is intentional (audit #36 confirmed it is
by-design); the actionable gap is the missing distance cue on directly-adjacent
unexplored locations.

## Observable criteria

1. `GET /api/map` returns a non-null `travel_minutes` for unvisited frontier
   locations that are reachable (previously `null`/omitted).
2. The demo auto-player adjacency block renders unexplored neighbours with their
   estimate, e.g. `- The Mill — about 8 min away, unexplored` (was
   `- The Mill — unvisited`).
3. The 1-hop fog-of-war boundary is unchanged: locations beyond the frontier are
   still absent, and the `indoor` flag stays hidden for unvisited entries.
4. Unit + integration tests assert the new behavior (frontier carries an
   estimate); the whole `parish-core` suite stays green.

### Evidence

# Evidence — 1207-map-frontier (#33/#36)

Evidence type: live gameplay transcript

Live run against a real headless `parish-server` (`cargo run -p parish-server --
--port 3030`) rebuilt with this change. The word **live** affirms the server
process actually served these requests.

## Criterion → proof

**C1 — `/api/map` frontier carries travel_minutes (live).**
After fix, on a fresh session at Kilteevan Village, `GET /api/map` frontier
entries (unvisited + adjacent):

```
frontier adjacent count: 10
  The Lime Kiln          | visited=False | travel_minutes=1
  The Forge              | visited=False | travel_minutes=1
  Knockcroghery Village  | visited=False | travel_minutes=85
  The Crossroads         | visited=False | travel_minutes=13
  The Letter Office      | visited=False | travel_minutes=11
  The Mill               | visited=False | travel_minutes=1
```

Before the fix every frontier entry had `travel_minutes: None` (omitted from the
JSON), matching the audit's "unvisited with no distance cue" symptom.

**C2 — demo adjacency renders the estimate.**
`build_demo_context` + `render_user_prompt` now emit, for an unexplored adjacent
location:

```
  - The Mill — about 8 min away, unexplored
```

Asserted by `adjacent_frontier_carries_travel_estimate`
(`parish-core/src/ipc/demo.rs`) and the integration test
`demo_prompt_adjacent_block_mirrors_map_fog_of_war`.

**C3 — fog-of-war boundary unchanged.**
`indoor` stays `None` for frontier; locations beyond the 1-hop frontier remain
absent. Guarded by the existing `fog_of_war_*` tests in
`parish-core/src/ipc/handlers.rs` (updated to assert travel_minutes is now
`Some` while `indoor` stays `None`), plus
`locations_beyond_frontier_are_omitted`.

**C4 — tests green.**

```
cargo test -p parish-core            → EXIT=0 (13 suites ok)
cargo test -p parish-core --test demo_context_integration → 3 passed
cargo clippy -p parish-core          → clean
```

### Judge

# Judge verdict — 1207-map-frontier (#33/#36)

Reviewed the diff, the live `/api/map` transcript, and the test changes.

## Per-criterion check

- **C1** (frontier travel_minutes live): met. Live `/api/map` shows real
  estimates (1, 11, 13, 85 min) for unvisited adjacent locations that were
  previously null.
- **C2** (demo render): met. Unexplored neighbours now render "about N min away,
  unexplored"; asserted by unit + integration tests.
- **C3** (fog-of-war preserved): met. `indoor` still hidden, beyond-frontier
  still omitted; the change reuses already-computed BFS data and does not widen
  the 1-hop frontier, so discovery/fog-of-war semantics are intact.
- **C4** (tests green): met. Full parish-core suite passes; clippy clean.

## Assessment

The fix is minimal and well-scoped: it stops discarding a value the map already
computes, rather than widening visibility (which would have broken the
intentional fog-of-war that audit #36 called out as by-design). The auto-player
now has the distance cue it lacked. Tests that asserted the old (no-estimate)
behavior were inverted with clear intent comments. Reasonable concern — the GUI
map tooltip now shows an estimate for directly-adjacent unexplored locations —
is acceptable: the frontier is exactly the set of locations visible from where
the player stands, so a rough distance is not a fog-of-war leak.

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

<!-- /parish-proof-bundle:1207-map-frontier -->
