### PR TITLE
feat(tauri): expose /api/debug-snapshot on the MCP bridge (#1207 #16)

### DIFF
--- a/parish/crates/parish-mcp/README.md
+++ b/parish/crates/parish-mcp/README.md
@@ -139,13 +139,13 @@ in summary:
 
 | Category           | Exposed by bridge                                                                                                                                                             | Reads / writes |
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| Health & snapshots | `/api/health`, `/api/world-snapshot`, `/api/map`, `/api/npcs-here`, `/api/save-state`, `/api/transcript`, `/api/setup-snapshot`                                               | reads          |
+| Health & snapshots | `/api/health`, `/api/world-snapshot`, `/api/map`, `/api/npcs-here`, `/api/save-state`, `/api/transcript`, `/api/setup-snapshot`, `/api/debug-snapshot`                        | reads          |
 | Player commands    | `/api/submit-input`, `/api/new-game`, `/api/save-game`, `/api/load-branch`                                                                                                    | writes         |
 | Screenshots        | `/api/latest-screenshot`, `/api/take-screenshot`                                                                                                                              | read / write   |
 | BYOK + onboarding  | `/api/setup-status`, `/api/submit-byok`, `/api/byok-env-keys`, `/api/preset-models`, `/api/list-available-providers`, `/api/onboarding-options`, `/api/start-local-inference` | read / write   |
 
 Routes that `parish-server` ships but the bridge intentionally **does
-NOT** expose include `/api/debug-snapshot`, `/api/theme`,
+NOT** expose include `/api/theme`,
 `/api/ui-config`, `/api/app-icon.png`, `/api/favicon.png`,
 `/api/react-to-message`, `/api/discover-save-files`,
 `/api/create-branch`, `/api/new-save-file`, `/api/mods`,
@@ -154,7 +154,7 @@ NOT** expose include `/api/debug-snapshot`, `/api/theme`,
 `/api/editor-*` family, `/api/session-init`, and `/api/auth/*`. A
 request to one of these against the bridge returns
 `HTTP/1.1 404 Not Found` — use Setup B (a separate `parish-server`)
-when an agent needs the wider surface (TODO #16). The bridge layer's
+when an agent needs the wider surface. The bridge layer's
 goal is to drive the live desktop session for gameplay-shaped MCP
 tools; deeper introspection and editor-mode mutation are out of scope
 by design.

--- a/parish/crates/parish-tauri/src/mcp_bridge.rs
+++ b/parish/crates/parish-tauri/src/mcp_bridge.rs
@@ -82,6 +82,10 @@ fn build_router(bridge: BridgeState) -> Router {
         .route("/api/save-state", get(save_state))
         .route("/api/transcript", get(transcript))
         .route("/api/setup-snapshot", get(setup_snapshot))
+        // `/api/debug-snapshot` — same introspection blob `parish-server`
+        // exposes. The bridge previously omitted it, so a desktop-launched
+        // MCP session got a 404 where the web server returned data (#1207 #16).
+        .route("/api/debug-snapshot", get(debug_snapshot))
         // ── writes ───────────────────────────────────────────────────────────
         .route("/api/submit-input", post(submit_input))
         .route("/api/new-game", post(new_game))
@@ -127,6 +131,12 @@ fn build_router(bridge: BridgeState) -> Router {
 #[allow(clippy::unused_async)]
 async fn health() -> &'static str {
     "ok"
+}
+
+async fn debug_snapshot(
+    State(b): State<BridgeState>,
+) -> Json<parish_core::debug_snapshot::DebugSnapshot> {
+    Json(crate::commands::admin::build_app_debug_snapshot(&b.state).await)
 }
 
 async fn world_snapshot(State(b): State<BridgeState>) -> Json<WorldSnapshot> {
@@ -746,6 +756,7 @@ mod tests {
             "/api/npcs-here",
             "/api/save-state",
             "/api/setup-snapshot",
+            "/api/debug-snapshot",
             "/api/submit-input",
             "/api/new-game",
             "/api/save-game",
@@ -780,6 +791,7 @@ mod tests {
             "get_npcs_here",
             "get_save_state",
             "get_setup_snapshot",
+            "get_debug_snapshot",
             "submit_input",
             "new_game",
             "save_game",


### PR DESCRIPTION
## What

Fixes epic #1207 finding #16: `GET /api/debug-snapshot` returned 404 from the
Tauri MCP bridge (`parish-tauri --mcp-port`), even though `parish-server`
exposes it — so an MCP session driving the live desktop window couldn't read the
introspection blob.

## Fix

Add the `/api/debug-snapshot` route to the bridge router, delegating to the
existing `commands::admin::build_app_debug_snapshot(&state)` (the same builder
the desktop `get_debug_snapshot` IPC command uses). Route-table test updated.

## Proof

- Live: with the bridge up during a demo, `curl /api/debug-snapshot` → HTTP 200,
  379 KB (`clock`, `weather`, `world`, `npcs`, …); was 404 before.
- `route_table_matches_parish_mcp_expectations` updated; full parish-tauri suite
  green (101 + integration).

Closes part of #1207.

<!-- parish-proof-bundle:1207-bridge-route v=1 -->

## Proof: 1207-bridge-route

### Acceptance criteria

# Acceptance criteria — 1207-bridge-route (#16)

Epic #1207 finding #16: `/api/debug-snapshot` returns 404 from the Tauri MCP
bridge (port 3030) even though `parish-server` exposes it, so a desktop-launched
MCP session (`parish-tauri --mcp-port`) can't read the introspection blob.

## Observable criteria

1. `GET /api/debug-snapshot` on the Tauri MCP bridge returns HTTP 200 with the
   same `DebugSnapshot` shape `parish-server` returns (clock, weather, world,
   npcs, tier_summary, …), not 404.
2. The bridge route-table test lists `/api/debug-snapshot` so a future drift is
   caught at build time.
3. No regression: the full `parish-tauri` test suite stays green.

### Evidence

# Evidence — 1207-bridge-route (#16)

Evidence type: live gameplay transcript

Live run of the desktop app (`just demo`, which launches `parish-tauri` with
`--mcp-port 3030`, opening the MCP bridge). The word **live** affirms the Tauri
process actually ran and served these requests.

## Criterion → proof

**C1 — `/api/debug-snapshot` returns 200 (live).**
With the Tauri MCP bridge listening on 3030 during a demo:

```
$ curl -s -o /tmp/bridge-dbg.json -w '%{http_code}' http://127.0.0.1:3030/api/debug-snapshot
200
bytes: 379181
top keys: ['clock', 'weather', 'world', 'npcs', 'tier_summary', 'event_bus', 'gossip', 'conversations']
```

Before the fix the bridge router had no such route, so this returned
`404 Not Found` with an empty body (the audit's symptom).

**C2 — route-table test.**
`/api/debug-snapshot` (and the `get_debug_snapshot` command translation) added to
`route_table_matches_parish_mcp_expectations`:

```
cargo test -p parish-tauri route_table
... test mcp_bridge::tests::route_table_matches_parish_mcp_expectations ... ok
```

**C3 — no regression.**

```
cargo test -p parish-tauri   → EXIT=0
test result: ok. 101 passed; 0 failed   (+ 13 + 3 + 17 integration, all ok)
```

The handler reuses `commands::admin::build_app_debug_snapshot(&state)` — the same
builder the Tauri `get_debug_snapshot` IPC command uses — so the bridge and the
desktop command return identical data.

### Judge

# Judge verdict — 1207-bridge-route (#16)

Reviewed the diff, the live curl, and the route-table test.

- **C1** (200, not 404): met. Live curl on the running Tauri bridge returns HTTP
  200 with a 379 KB `DebugSnapshot` (clock/weather/world/npcs/…). Confirmed it
  was a 404 before.
- **C2** (route-table test): met. The expected-paths list and the command-
  translation loop both include `/api/debug-snapshot`.
- **C3** (no regression): met. Full parish-tauri suite green.

The handler delegates to the existing `build_app_debug_snapshot`, so there is no
duplicated introspection logic and the bridge cannot drift from the desktop IPC
command. Low-risk, P3-scope route addition.

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

<!-- /parish-proof-bundle:1207-bridge-route -->
