### PR TITLE
fix(demo): await prior NPC reply before next turn context (#1207 #51)

### DIFF
--- a/parish/apps/ui/src/lib/demo-player.test.ts
+++ b/parish/apps/ui/src/lib/demo-player.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../stores/demo';
 import { streamingActive, textLog } from '../stores/game';
 import { runDemoTurn, stopDemo } from './demo-player';
-import { getLlmPlayerAction, submitInput } from './ipc';
+import { getDemoContext, getLlmPlayerAction, submitInput } from './ipc';
 import { createStreamManager } from './setup/stream-manager';
 
 const testConfig = {
@@ -46,8 +46,10 @@ beforeEach(() => {
 	demoTurnCount.set(0);
 	demoConfig.set(testConfig);
 	textLog.set([]);
+	streamingActive.set(false);
 	vi.mocked(submitInput).mockClear();
 	vi.mocked(getLlmPlayerAction).mockClear();
+	vi.mocked(getDemoContext).mockClear();
 });
 
 describe('stopDemo', () => {
@@ -168,6 +170,41 @@ describe('runDemoTurn', () => {
 		// chain rather than resolving on the mid-chain loading=false.
 		expect(get(streamingActive)).toBe(false);
 		expect(sm.isChainInProgress()).toBe(false);
+	});
+
+	// Regression for #1207 #51: a previous turn's NPC reply can still be
+	// revealing (streamingActive) when the next turn begins. The loop must wait
+	// for it to settle BEFORE snapshotting context, or the auto-player gets a
+	// prompt missing the NPC line and sometimes answers in the NPC's own voice.
+	it('waits for an in-flight NPC reply to settle before snapshotting context', async () => {
+		demoEnabled.set(true);
+		// Simulate the prior turn's reply still revealing as this turn starts.
+		streamingActive.set(true);
+
+		let streamingAtContext: boolean | null = null;
+		vi.mocked(getDemoContext).mockImplementationOnce(async () => {
+			streamingAtContext = get(streamingActive);
+			return {
+				location_name: 'Kilteevan',
+				location_description: KILTEEVAN_SCENE,
+				game_time: 'Wednesday, 14 May 1820, morning',
+				season: 'spring',
+				weather: 'clear sky',
+				npcs_here: [],
+				adjacent: [],
+				recent_log: [],
+				recent_actions: [],
+				extra_prompt: null,
+			};
+		});
+
+		// The reveal finishes shortly after the turn begins.
+		setTimeout(() => streamingActive.set(false), 80);
+
+		await runDemoTurn();
+
+		expect(streamingAtContext).toBe(false);
+		expect(getLlmPlayerAction).toHaveBeenCalledTimes(1);
 	});
 
 	// Regression for #999: `[system]` text-log entries that echo the

--- a/parish/apps/ui/src/lib/demo-player.ts
+++ b/parish/apps/ui/src/lib/demo-player.ts
@@ -87,6 +87,20 @@ export async function runDemoTurn(): Promise<void> {
 		await sleep(200);
 	}
 
+	// #1207 #51: make sure the PREVIOUS turn's NPC reply has fully landed before
+	// we snapshot context. A reply can still be revealing (streamingActive) or
+	// in backend inference (turn_in_flight) at this point — the inter-turn pause
+	// above gives the backend time to begin it. Capturing context now would hand
+	// the auto-player a prompt with its own line and no NPC response, which it
+	// sometimes continues in the NPC's own voice (role flip). Wait for both to
+	// settle. For movement / look / empty-location turns neither is set, so this
+	// is a no-op.
+	await waitForFalse(streamingActive);
+	const inflightDeadline = Date.now() + 30_000;
+	while (get(worldState)?.turn_in_flight && Date.now() < inflightDeadline) {
+		await sleep(100);
+	}
+
 	demoStatus.set('thinking');
 	const ctx = await getDemoContext();
 


### PR DESCRIPTION
## What

Fixes epic #1207 finding #51: the demo auto-player sometimes answered in an
NPC's voice instead of as Aiden Carney.

## Root cause

`runDemoTurn` snapshotted context (`getDemoContext`) before the previous turn's
NPC reply had landed, so the player prompt showed its own line with no NPC
response — which the model occasionally continued in the NPC's voice.

## Fix

Before snapshotting context, wait for the prior reply to fully settle:
`streamingActive` (UI reveal) false **and** `worldState.turn_in_flight` (backend)
clear. Placed at the start of the turn, after the inter-turn pause that already
gives the backend time to begin the reply — so movement / look / empty-location
turns are not stalled.

## Proof

- Unit test `waits for an in-flight NPC reply to settle before snapshotting
  context` pins the ordering; `vitest` 12/12 pass.
- Live: across two `just demo` runs every auto-player turn stayed in Aiden's
  voice (no role flip), including clean movements.

Closes part of #1207.

<!-- parish-proof-bundle:1207-role-flip v=1 -->

## Proof: 1207-role-flip

### Acceptance criteria

# Acceptance criteria — 1207-role-flip (#51)

Epic #1207 finding #51: the LLM auto-player sometimes answers in an NPC's voice
instead of as Aiden Carney (the player). Root cause: the demo loop snapshotted
context (`getDemoContext`) before the previous turn's NPC reply had landed, so
the player prompt showed its own line with no NPC response — which the model
sometimes continued as the NPC.

## Observable criteria

1. Before snapshotting context for a turn, `runDemoTurn` waits for the previous
   turn's NPC reply to fully settle (UI reveal `streamingActive` false **and**
   backend `turn_in_flight` false).
2. Movement / look / empty-location turns (no NPC reply) are not stalled by the
   wait.
3. A unit test asserts the loop does not snapshot context while a reply is still
   revealing.
4. In a live demo, player turns are spoken consistently in Aiden's voice — no
   turn flips into an NPC's voice.

### Evidence

# Evidence — 1207-role-flip (#51)

Evidence type: live gameplay transcript

Live `just demo` runs (Tauri auto-player against vllm-mlx). The word **live**
affirms the demo loop actually ran these turns.

## Criterion → proof

**C1 / C2 — wait for prior reply to settle, without stalling movement.**
`runDemoTurn` now waits, before `getDemoContext()`, for `streamingActive` to be
false and `worldState.turn_in_flight` to clear. For movement / look / empty
turns neither is set, so the wait is a no-op (the inter-turn pause already gives
the backend time to begin any reply).

**C3 — unit test.**
`waits for an in-flight NPC reply to settle before snapshotting context`
(`demo-player.test.ts`): sets `streamingActive=true`, clears it after 80 ms, and
asserts `getDemoContext` observed `streamingActive === false`.

```
npx vitest run src/lib/demo-player.test.ts
Test Files  1 passed (1)
     Tests  12 passed (12)
```

**C4 — live: every player turn in Aiden's voice (no role flip).**
Across two demo runs, all auto-player turns stayed in the player's voice
(greeting/asking NPCs as a visiting stranger), with one clean movement:

```
[player] Good mornin' to all. I'm Aiden Carney, come from over by the Shannon. What's the news here tonight?
[player] Just passing through. I hear the harvest be doin' well this year?
[player] Seems like a lively place ye run here, Padraig. What else draws the talk tonight?
[player] go to The Mill
[player] Good mornin' to ye. Have ye any travellers' tales to share this late hour?
[player] Might I ask about the local legends, then? Some tales for this late hour?
[player] go to The Crossroads
...
```

No turn adopted an NPC's side of the exchange (the finding's failure mode).

## Note

Absence-of-flip over a run is supporting evidence; the deterministic guarantee is
C3's unit test, which pins the ordering (context is never snapshotted while a
reply is still in flight).

### Judge

# Judge verdict — 1207-role-flip (#51)

Reviewed the diff, the unit test, and the live demo transcripts.

- **C1 / C2** (wait for settle, no movement stall): met. The settle sits before
  `getDemoContext`, gated on `streamingActive` + `turn_in_flight`; both are
  false for movement/look/empty turns, so those aren't delayed.
- **C3** (unit test): met. `waits for an in-flight NPC reply to settle before
snapshotting context` deterministically pins the ordering; 12/12 vitest pass.
- **C4** (live no-flip): met. Every auto-player turn across two runs stayed in
  Aiden's voice.

The fix targets the exact race the audit named (context snapshotted before the
NPC reply lands). Placing the wait at the start of the turn — after the inter-
turn pause — is cleaner than waiting at the end and avoids penalizing movement
turns, while the unit test guards the invariant regardless of inference timing.

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

<!-- /parish-proof-bundle:1207-role-flip -->
