### PR TITLE
fix: only show pause message on idle-pause, not focus switch (#1277)

### DIFF
--- a/parish/apps/ui/src/routes/+page.svelte
+++ b/parish/apps/ui/src/routes/+page.svelte
@@ -251,16 +251,22 @@
 		// Pause immediately when the tab is hidden; resume when it returns.
 		// Only pauses if the game wasn't already paused, and only resumes if
 		// this handler was the one that paused it.
+		//
+		// Uses /pause-silent and /resume-silent so the clock freezes but
+		// "The clocks of the parish stand still." / "Time stirs again in the
+		// parish." are NOT printed.  Switching windows is not an idle pause —
+		// the user-visible message should only appear when the player
+		// explicitly types /pause or when the auto-idle timer fires (#1277).
 		let visibilityPaused = false;
 		const handleVisibilityChange = () => {
 			if (document.hidden) {
 				const alreadyPaused = get(worldState)?.paused ?? false;
 				if (!alreadyPaused) {
-					void submitInput('/pause');
+					void submitInput('/pause-silent');
 					visibilityPaused = true;
 				}
 			} else if (visibilityPaused) {
-				void submitInput('/resume');
+				void submitInput('/resume-silent');
 				visibilityPaused = false;
 			}
 		};

--- a/parish/crates/parish-core/src/ipc/commands/dispatch.rs
+++ b/parish/crates/parish-core/src/ipc/commands/dispatch.rs
@@ -34,6 +34,8 @@ pub fn handle_command(
     match cmd {
         Command::Pause
         | Command::Resume
+        | Command::PauseSilent
+        | Command::ResumeSilent
         | Command::Status
         | Command::ShowSpeed
         | Command::SetSpeed(_)

--- a/parish/crates/parish-core/src/ipc/commands/tests.rs
+++ b/parish/crates/parish-core/src/ipc/commands/tests.rs
@@ -199,6 +199,90 @@ fn render_look_text_basic() {
     assert!(!text.is_empty());
 }
 
+// ── Silent pause / resume (focus-switch) — fix #1277 ───────────────────
+
+#[test]
+fn pause_silent_pauses_clock_with_no_message() {
+    // AC1 + AC3: /pause-silent freezes the clock but emits no text.
+    let (mut world, mut npc, mut config) = default_state();
+    assert!(!world.clock.is_paused());
+    let result = handle_command(Command::PauseSilent, &mut world, &mut npc, &mut config);
+    assert!(
+        result.response.is_empty(),
+        "PauseSilent must not emit any text; got {:?}",
+        result.response
+    );
+    assert!(
+        world.clock.is_paused(),
+        "clock must be paused after PauseSilent"
+    );
+    assert!(
+        result.effects.is_empty(),
+        "PauseSilent must not produce side effects"
+    );
+}
+
+#[test]
+fn resume_silent_resumes_clock_with_no_message() {
+    // AC2 + AC3: /resume-silent restarts the clock but emits no text.
+    let (mut world, mut npc, mut config) = default_state();
+    world.clock.pause();
+    let result = handle_command(Command::ResumeSilent, &mut world, &mut npc, &mut config);
+    assert!(
+        result.response.is_empty(),
+        "ResumeSilent must not emit any text; got {:?}",
+        result.response
+    );
+    assert!(
+        !world.clock.is_paused(),
+        "clock must be running after ResumeSilent"
+    );
+    assert!(result.effects.is_empty());
+}
+
+#[test]
+fn pause_command_still_emits_message() {
+    // AC4: user-typed /pause still shows the full message.
+    let (mut world, mut npc, mut config) = default_state();
+    let result = handle_command(Command::Pause, &mut world, &mut npc, &mut config);
+    assert!(
+        result.response.contains("stand still"),
+        "explicit /pause must still emit the user-visible message"
+    );
+}
+
+#[test]
+fn resume_command_still_emits_message() {
+    // AC4: user-typed /resume still shows the full message.
+    let (mut world, mut npc, mut config) = default_state();
+    world.clock.pause();
+    let result = handle_command(Command::Resume, &mut world, &mut npc, &mut config);
+    assert!(
+        result.response.contains("stirs again"),
+        "explicit /resume must still emit the user-visible message"
+    );
+}
+
+#[test]
+fn redundant_pause_silent_is_noop() {
+    // AC6: PauseSilent while already paused is empty-response, no state change.
+    let (mut world, mut npc, mut config) = default_state();
+    world.clock.pause();
+    let result = handle_command(Command::PauseSilent, &mut world, &mut npc, &mut config);
+    assert!(result.response.is_empty());
+    assert!(world.clock.is_paused());
+}
+
+#[test]
+fn redundant_resume_silent_is_noop() {
+    // AC6: ResumeSilent while already running is empty-response, no state change.
+    let (mut world, mut npc, mut config) = default_state();
+    assert!(!world.clock.is_paused());
+    let result = handle_command(Command::ResumeSilent, &mut world, &mut npc, &mut config);
+    assert!(result.response.is_empty());
+    assert!(!world.clock.is_paused());
+}
+
 // ── Additional coverage for previously untested Command variants ─────────
 
 #[test]

--- a/parish/crates/parish-core/src/ipc/commands/time.rs
+++ b/parish/crates/parish-core/src/ipc/commands/time.rs
@@ -38,6 +38,23 @@ pub(super) fn handle_time_control_command(
                 CommandResult::text("")
             }
         }
+        Command::PauseSilent => {
+            // Focus/visibility-driven pause: clock freezes but no message is
+            // emitted.  The edge-gate still applies — a redundant silent pause
+            // while already paused is a no-op with empty response.
+            if !world.clock.is_paused() {
+                world.clock.pause();
+            }
+            CommandResult::text("")
+        }
+        Command::ResumeSilent => {
+            // Focus/visibility-driven resume: clock restarts but no message is
+            // emitted.  The edge-gate still applies.
+            if world.clock.is_paused() {
+                world.clock.resume();
+            }
+            CommandResult::text("")
+        }
         Command::Status => {
             let tod = world.clock.time_of_day();
             let season = world.clock.season();

--- a/parish/crates/parish-input/src/commands.rs
+++ b/parish/crates/parish-input/src/commands.rs
@@ -44,6 +44,19 @@ pub enum Command {
     Pause,
     /// Unfreeze simulation.
     Resume,
+    /// Freeze simulation without emitting a user-visible message.
+    ///
+    /// Used by the frontend's `visibilitychange` / focus-loss handler so that
+    /// switching away from the window pauses the clock (NPC ticks stop) but
+    /// does **not** print "The clocks of the parish stand still." in the chat
+    /// log.  User-typed `/pause` still goes through [`Command::Pause`] and
+    /// emits the full message.
+    PauseSilent,
+    /// Unfreeze simulation without emitting a user-visible message.
+    ///
+    /// Symmetric counterpart to [`Command::PauseSilent`].  Used when the
+    /// window regains focus so the clock resumes silently.
+    ResumeSilent,
     /// Persist state and exit.
     Quit,
     /// Manual snapshot to current branch.

--- a/parish/crates/parish-input/src/parser.rs
+++ b/parish/crates/parish-input/src/parser.rs
@@ -95,6 +95,8 @@ fn parse_zero_arg_command(keyword: &str) -> Option<Command> {
     match keyword {
         "/pause" => Some(Command::Pause),
         "/resume" => Some(Command::Resume),
+        "/pause-silent" => Some(Command::PauseSilent),
+        "/resume-silent" => Some(Command::ResumeSilent),
         "/quit" | "/exit" => Some(Command::Quit),
         "/save" => Some(Command::Save),
         "/branches" => Some(Command::Branches),
@@ -144,6 +146,31 @@ mod tests {
         assert_eq!(parse_system_command("/EXIT"), Some(Command::Quit));
         assert_eq!(parse_system_command("  /exit  "), Some(Command::Quit));
     }
+    /// AC5 — /pause-silent and /resume-silent parse to the silent variants.
+    #[test]
+    fn test_parse_silent_pause_resume() {
+        assert_eq!(
+            parse_system_command("/pause-silent"),
+            Some(Command::PauseSilent)
+        );
+        assert_eq!(
+            parse_system_command("/resume-silent"),
+            Some(Command::ResumeSilent)
+        );
+        // Case-insensitive.
+        assert_eq!(
+            parse_system_command("/PAUSE-SILENT"),
+            Some(Command::PauseSilent)
+        );
+        assert_eq!(
+            parse_system_command("/RESUME-SILENT"),
+            Some(Command::ResumeSilent)
+        );
+        // Trailing text must not match (zero-arg policy).
+        assert_eq!(parse_system_command("/pause-silent now"), None);
+        assert_eq!(parse_system_command("/resume-silent please"), None);
+    }
+
     #[test]
     fn test_parse_all_commands() {
         assert_eq!(parse_system_command("/pause"), Some(Command::Pause));

--- a/parish/testing/fixtures/play_fix-1277.txt
+++ b/parish/testing/fixtures/play_fix-1277.txt
@@ -1,0 +1,21 @@
+# Fixture: fix-1277 — silent pause / resume for focus switch
+#
+# Demonstrates:
+# AC1/AC2: /pause-silent and /resume-silent emit no user-visible message
+# AC3:     the clock state changes (verified via /status)
+# AC4:     explicit /pause and /resume still emit their messages
+# AC5:     commands parse and execute in the headless harness
+# AC6:     redundant silent pause/resume is a no-op
+/status
+/pause
+/status
+/resume
+/status
+/pause-silent
+/status
+/resume-silent
+/status
+/pause-silent
+/pause-silent
+/resume-silent
+/resume-silent


### PR DESCRIPTION
Fixes #1277.

## Problem

Switching away from the game window and returning printed 'The clocks of the parish stand still.' and 'Time stirs again in the parish.' every single time. The `visibilitychange` handler in `+page.svelte` was calling `/pause` and `/resume` directly, which go through the backend edge-gating path and emit user-visible messages on every genuine running→paused and paused→running transition.

## Fix

Add `Command::PauseSilent` and `Command::ResumeSilent` to the shared `parish-input` crate. These are identical to `Pause`/`Resume` in clock semantics but return an empty response. The `visibilitychange` handler now calls `/pause-silent` / `/resume-silent` instead. User-typed `/pause` and `/resume` are unchanged and still emit their messages.

Mode parity is preserved: the new variants live in the shared `parish-input` Command enum and are dispatched through the same backend dispatch table used by Tauri, the web server, and the headless CLI.

## Commands run

```
cd parish && cargo build -p parish-engine
cd parish && cargo run -p parish-engine -- --headless --script testing/fixtures/play_fix-1277.txt
cd parish && just check  # exit 0
```

## Tests added (parish-core + parish-input)

- `pause_silent_pauses_clock_with_no_message`
- `resume_silent_resumes_clock_with_no_message`
- `pause_command_still_emits_message`
- `resume_command_still_emits_message`
- `redundant_pause_silent_is_noop`
- `redundant_resume_silent_is_noop`
- `test_parse_silent_pause_resume`

<!-- parish-proof-bundle:fix-1277 v=1 -->

## Proof: fix-1277

### Acceptance criteria

# Acceptance Criteria — fix-1277

## Problem

Game pause/unpause messages ("The clocks of the parish stand still." / "Time stirs again in the parish.")
appear in the chat log every time the user switches away from and back to the game window, because the
`visibilitychange` handler in `+page.svelte` issues `/pause` and `/resume` commands that go through the
same backend path that produces user-visible messages.

## Root cause (Five Whys)

1. Visibility-change-driven `/pause` and `/resume` hit the same backend handler as user-typed commands.
2. The backend emits a message on every genuine running→paused or paused→running edge.
3. Focus-switch (tab hidden/shown) produces exactly one such genuine edge each way.
4. Therefore, switching away and returning always prints both messages.
5. Root fix: use a _silent_ pause/resume variant for focus/visibility-driven pauses so the clock is
   frozen (NPC ticks stop) but no user-visible message is emitted.

## Acceptance criteria

### AC1 — Silent pause: no message on focus/visibility switch

When the tab becomes hidden (or the OS window loses focus), the game clock pauses **but no
"The clocks of the parish stand still." message appears** in the chat log.

### AC2 — Silent resume: no message on focus/visibility return

When the tab becomes visible again (or the OS window regains focus), the game clock resumes **but no
"Time stirs again in the parish." message appears** in the chat log.

### AC3 — Clock still pauses on visibility change

Despite the silent treatment, `world.clock.is_paused()` must become `true` while the tab is hidden.
(Verified via unit test asserting the clock state without a message.)

### AC4 — Explicit /pause and /resume still show messages

When the **user** types `/pause` or `/resume`, the full messages must still appear. The silent variant
is only used by the automatic focus/visibility handler.

### AC5 — New /pause-silent and /resume-silent commands parse correctly

The parser must map `/pause-silent` → `Command::PauseSilent` and `/resume-silent` → `Command::ResumeSilent`.
These are internal harness commands; they work in all entry points (Tauri, server, CLI) to preserve
mode parity.

### AC6 — Redundant silent pause/resume is still silent

A `/pause-silent` while already paused emits no text (same edge-gate as `/pause`).
A `/resume-silent` while already running emits no text.

### AC7 — Tests pass

`cd parish && just check` passes with new unit tests covering AC1–AC6.

### Evidence

# Evidence — fix-1277

Evidence type: live gameplay transcript

Run command:

```
cd parish && cargo run -p parish-engine -- --headless --script testing/fixtures/play_fix-1277.txt
```

## Live transcript

```json
{"command":"/status","result":"system_command","response":"Location: Kilteevan Village | Morning | Spring","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["Location: Kilteevan Village | Morning | Spring","A lean, red-haired young man with hard eyes heads off down the road.","An older man heads off down the road.","An older woman with sharp eyes and herb-stained fingers heads off down the road.","A young woman heads off down the road."]}
{"command":"/pause","result":"system_command","response":"The clocks of the parish stand still.","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["The clocks of the parish stand still."]}
{"command":"/status","result":"system_command","response":"Location: Kilteevan Village | Morning | Spring (paused)","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["Location: Kilteevan Village | Morning | Spring (paused)"]}
{"command":"/resume","result":"system_command","response":"Time stirs again in the parish.","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["Time stirs again in the parish."]}
{"command":"/status","result":"system_command","response":"Location: Kilteevan Village | Morning | Spring","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["Location: Kilteevan Village | Morning | Spring"]}
{"command":"/pause-silent","result":"system_command","response":"","location":"Kilteevan Village","time":"Morning","season":"Spring"}
{"command":"/status","result":"system_command","response":"Location: Kilteevan Village | Morning | Spring (paused)","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["Location: Kilteevan Village | Morning | Spring (paused)"]}
{"command":"/resume-silent","result":"system_command","response":"","location":"Kilteevan Village","time":"Morning","season":"Spring"}
{"command":"/status","result":"system_command","response":"Location: Kilteevan Village | Morning | Spring","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["Location: Kilteevan Village | Morning | Spring"]}
{"command":"/pause-silent","result":"system_command","response":"","location":"Kilteevan Village","time":"Morning","season":"Spring"}
{"command":"/pause-silent","result":"system_command","response":"","location":"Kilteevan Village","time":"Morning","season":"Spring"}
{"command":"/resume-silent","result":"system_command","response":"","location":"Kilteevan Village","time":"Morning","season":"Spring"}
{"command":"/resume-silent","result":"system_command","response":"","location":"Kilteevan Village","time":"Morning","season":"Spring"}
```

## Criterion mapping

**AC1 — Silent pause: no message on focus/visibility switch**
Line: `/pause-silent` → `"response":""` — no text emitted. Clock is paused (next /status confirms `(paused)`).

**AC2 — Silent resume: no message on focus/visibility return**
Line: `/resume-silent` → `"response":""` — no text emitted. Clock resumes (next /status drops the `(paused)` suffix).

**AC3 — Clock still pauses on visibility change**
After `/pause-silent`: `/status` returns `"Location: Kilteevan Village | Morning | Spring (paused)"` — confirming the clock is paused.
After `/resume-silent`: `/status` returns `"Location: Kilteevan Village | Morning | Spring"` — no `(paused)` suffix, confirming the clock is running.

**AC4 — Explicit /pause and /resume still show messages**
`/pause` → `"response":"The clocks of the parish stand still."` ✓
`/resume` → `"response":"Time stirs again in the parish."` ✓

**AC5 — New commands parse correctly**
`/pause-silent` and `/resume-silent` both appear as `"result":"system_command"` in the transcript, confirming the parser maps them to `Command::PauseSilent` / `Command::ResumeSilent`.

**AC6 — Redundant silent pause/resume is still silent**
Second `/pause-silent` (while already paused) → `"response":""` ✓
Second `/resume-silent` (while already running) → `"response":""` ✓

**AC7 — Tests pass**
`cargo test -p parish-input -p parish-core`: 744 tests passed, 0 failed. New tests:

- `pause_silent_pauses_clock_with_no_message`
- `resume_silent_resumes_clock_with_no_message`
- `pause_command_still_emits_message`
- `resume_command_still_emits_message`
- `redundant_pause_silent_is_noop`
- `redundant_resume_silent_is_noop`
- `test_parse_silent_pause_resume`

### Judge

# Judge — fix-1277

## Verdict review

### AC1 — Silent pause: no message on focus/visibility switch

Evidence: `/pause-silent` produces `"response":""` in the live transcript. No "stand still" text.
Result: met

### AC2 — Silent resume: no message on focus/visibility return

Evidence: `/resume-silent` produces `"response":""` in the live transcript. No "stirs again" text.
Result: met

### AC3 — Clock still pauses on visibility change

Evidence: `/status` immediately after `/pause-silent` returns `"... (paused)"`. After `/resume-silent`, `/status` returns the response without the `(paused)` suffix. Clock state changes correctly.
Result: met

### AC4 — Explicit /pause and /resume still show messages

Evidence: `/pause` → `"The clocks of the parish stand still."`, `/resume` → `"Time stirs again in the parish."`. Both messages present in transcript.
Result: met

### AC5 — New commands parse correctly

Evidence: Both `/pause-silent` and `/resume-silent` appear as `"result":"system_command"` — not as game input. Parser test `test_parse_silent_pause_resume` also passes, covering case-insensitivity and trailing-text rejection.
Result: met

### AC6 — Redundant silent pause/resume is still silent

Evidence: Second `/pause-silent` while paused → `"response":""`. Second `/resume-silent` while running → `"response":""`.
Result: met

### AC7 — Tests pass

Evidence: 744 tests pass. 7 new tests added covering all AC items.
Result: met

## Summary

The root cause was the `visibilitychange` handler in `+page.svelte` calling `/pause` and `/resume` directly, which go through the backend edge-gating path and emit user-visible messages on every genuine running→paused and paused→running transition. The fix adds `Command::PauseSilent` and `Command::ResumeSilent` to the shared `parish-input` crate (mode parity preserved — all entry points pick them up through the same dispatch table), with backend handlers that mutate the clock state identically but return an empty response. The `visibilitychange` handler now calls `/pause-silent` and `/resume-silent` instead. User-typed `/pause`/`/resume` remain unchanged.

Acceptance criteria: met

Verdict: sufficient

Technical debt: clear

<!-- /parish-proof-bundle:fix-1277 -->
