### PR TITLE
chore: ignore stray rlib compile experiments and Workflow-tool scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,15 @@ rundale-bench/artifacts/local_logs/
 # docs/proofs/rundale-bench/judgments/ is durable.
 rundale-bench/.bench-queue/
 
+# Stray rustc/clippy compile experiments left at the repo root or in a crate
+# dir (e.g. `rustc --test -o libtest_foo`). Never committed — cargo output
+# lives under target/.
+*.rlib
+
+# Workflow scripts auto-persisted by Claude Code's Workflow tool when a
+# workflow-backed skill runs. Generated per session, not source.
+.claude/workflows/
+
 # Worktree metadata files (gitdir overlapping worktree root) — never track
 COMMIT_EDITMSG
 HEAD


### PR DESCRIPTION
## What

Add two `.gitignore` rules and clear out untracked noise that had built up at the repo root:

- `*.rlib` — stray `rustc --test` compile experiments (e.g. `libtest_clippy.rlib`, `parish/libtest_module_docs.rlib`). Cargo output lives under `target/`; loose rlibs are never committed.
- `.claude/workflows/` — workflow scripts auto-persisted by Claude Code's Workflow tool when a workflow-backed skill runs (`rust-audit-all.{js,mjs}`). Generated per session, not source.

## Also cleaned (out of tree, not in this diff)

- Deleted stray Mach-O test binaries `test_assert_fmt`, `test_coercion2` and the two `*.rlib` files (untracked).
- Deleted `.opencode/worktree.jsonc` (all-default plugin template, no custom content).
- Reverted `parish/apps/ui/package-lock.json` — its only change was 54 lines of `"dev": true` npm-version churn on optional platform binaries, no dependency change.

## Proof

Non-source, config-only change (`.gitignore`). No runtime/code path touched — proof gate exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)