### PR TITLE
fix: add standard user-select to InputField (svelte-check compat)

### DIFF
--- a/parish/apps/ui/src/components/InputField.svelte
+++ b/parish/apps/ui/src/components/InputField.svelte
@@ -866,6 +866,7 @@ import ModelDropdown from './ModelDropdown.svelte';
 		overflow-wrap: break-word;
 		transition: border-color 0.2s;
 		-webkit-user-select: text;
+		user-select: text;
 	}
 
 	.input-field:focus {


### PR DESCRIPTION
## Summary

Clears the one pre-existing svelte-check warning on `main`: `.input-field`
in `parish/apps/ui/src/components/InputField.svelte` declared
`-webkit-user-select: text;` without the standard `user-select` companion
("Also define the standard property 'user-select' for compatibility").
Adds `user-select: text;` alongside it.

No behavior change: Chromium/WebKit (the renderers Parish ships to) already
honored the `-webkit-` prefix. This is spec/lint hygiene.

## Commands run

- `npm run check` -> `0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS` (was 1 warning)
- `npm run format:check` -> clean
- Live browser (Playwright Chromium against vite dev :5173): input renders,
  `computed user-select: "text"`, `selectedText: "go to the church"`.
- `just agent-check` -> passed

<!-- parish-proof-bundle:ui-input-user-select v=1 -->

## Proof: ui-input-user-select

### Acceptance criteria

# Acceptance criteria — ui-input-user-select

Cleanup: clear the pre-existing svelte-check warning that `.input-field`
declares `-webkit-user-select: text;` without the standard `user-select`
companion property.

1. `.input-field` in `parish/apps/ui/src/components/InputField.svelte`
   declares the standard `user-select: text;` alongside the existing
   `-webkit-user-select: text;`.
2. `npm run check` (svelte-kit sync + svelte-check) reports **0 errors,
   0 warnings**.
3. `npm run format:check` (prettier) stays clean.
4. No behavior regression: the player input field still renders in a live
   browser and its text remains selectable (the property's purpose).

### Evidence

Evidence type: live screenshot

# Evidence — ui-input-user-select

## Change

`parish/apps/ui/src/components/InputField.svelte`, rule `.input-field`:

```css
		-webkit-user-select: text;
		user-select: text;   /* added — standard companion */
	}
```

## Live run

Started the real Svelte UI dev server (`npm run dev`, vite on :5173) and
drove it in a live Chromium browser (Playwright). Set text in the player
input (`.input-field`), selected it, and screenshotted.

```
$ node /tmp/shot.cjs   # Playwright Chromium against http://localhost:5173
{"computed_user_select":"text","selectedText":"go to the church",...}
```

- `computed_user_select: "text"` — the standard `user-select` property
  resolves on the live element (criterion 1).
- `selectedText: "go to the church"` — the input text is selectable in a
  real browser (criterion 4).

Artifact: `input-field-selection.png` — the player input field rendered
live with "go to the church" highlighted (selection visible).

## Criteria mapping

- **C1 (standard property present):** source diff above + live
  `computed_user_select: "text"`.
- **C2 (svelte-check 0 warnings):**
  `npm run check` → `COMPLETED 3550 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS`.
- **C3 (prettier clean):**
  `npm run format:check` → `All matched files use Prettier code style!`.
- **C4 (no regression, text selectable):** screenshot +
  `selectedText: "go to the church"`.

### Judge

# Judge — ui-input-user-select

Independent review of the bundle against the acceptance criteria.

## Per-criterion verdict

- **C1 — standard `user-select: text;` present:** MET. Source diff adds it
  next to `-webkit-user-select: text;`; live `computed_user_select: "text"`.
- **C2 — svelte-check 0 warnings:** MET. `npm run check` →
  `0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS` (was 1 warning pre-fix).
- **C3 — prettier clean:** MET. `npm run format:check` →
  `All matched files use Prettier code style!`.
- **C4 — no regression, text selectable:** MET. Live Chromium screenshot
  shows the player input rendered with "go to the church" selected;
  `selectedText: "go to the church"`.

## Assessment

One-line CSS compatibility fix. No behavior change — Chromium/WebKit already
honored the `-webkit-` prefix; the standard property is spec/lint hygiene.
Exercised in a live browser against the real dev server, not just
type-checked. Scope is exactly the lint warning; no collateral edits.

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

### Artifacts

Drag these files into this PR comment in the GitHub UI to attach them:

- `input-field-selection.png`

<!-- /parish-proof-bundle:ui-input-user-select -->
