### PR TITLE
ci: Dependabot config + PR-title conventional-commit lint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,65 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/parish"
+    schedule:
+      { interval: "weekly", day: "monday", time: "06:17", timezone: "Etc/UTC" }
+    open-pull-requests-limit: 5
+    commit-message:
+      { prefix: "chore(deps)", prefix-development: "chore(deps-dev)" }
+    labels: ["dependencies", "infra"]
+    groups:
+      cargo-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      { interval: "weekly", day: "monday", time: "06:17", timezone: "Etc/UTC" }
+    open-pull-requests-limit: 5
+    commit-message: { prefix: "chore(deps)" }
+    labels: ["dependencies", "infra"]
+    groups:
+      actions-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "npm"
+    directories:
+      ["/", "/parish/apps/ui", "/promptfoo", "/rundale-bench/bench-site"]
+    schedule:
+      { interval: "weekly", day: "monday", time: "06:17", timezone: "Etc/UTC" }
+    open-pull-requests-limit: 5
+    commit-message:
+      { prefix: "chore(deps)", prefix-development: "chore(deps-dev)" }
+    labels: ["dependencies", "infra"]
+    groups:
+      npm-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "pip"
+    directories: ["/", "/rundale-bench"]
+    schedule:
+      { interval: "weekly", day: "monday", time: "06:17", timezone: "Etc/UTC" }
+    open-pull-requests-limit: 3
+    commit-message:
+      { prefix: "chore(deps)", prefix-development: "chore(deps-dev)" }
+    labels: ["dependencies", "infra"]
+    groups:
+      pip-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "docker"
+    directories: ["/.devcontainer", "/deploy"]
+    schedule:
+      { interval: "weekly", day: "monday", time: "06:17", timezone: "Etc/UTC" }
+    open-pull-requests-limit: 3
+    commit-message: { prefix: "chore(deps)" }
+    labels: ["dependencies", "infra"]
+    groups:
+      docker-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,41 @@
+name: "PR title lint"
+
+# Validates the PR title against the repo's conventional-commit prefix list.
+# Reads only the title from the event payload - never checks out or runs PR
+# head code - so pull_request_target is safe with minimal read perms. Advisory
+# until main has branch protection requiring this check.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: "pr-title-lint-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            docs
+            test
+            chore
+            security
+            perf
+            ci
+            build
+            revert
+            bug
+          requireScope: false


### PR DESCRIPTION
## What

Closes the two governance gaps flagged after #1303:

**`.github/dependabot.yml`** — proactive version updates across **every** ecosystem in the repo:

| Ecosystem | Dirs |
|---|---|
| cargo | `/parish` (workspace, 16 crates) |
| github-actions | `/` |
| npm | `/`, `/parish/apps/ui`, `/promptfoo`, `/rundale-bench/bench-site` (pnpm — auto-detected) |
| pip | `/`, `/rundale-bench` |
| docker | `/.devcontainer`, `/deploy` |

Until now only GitHub's *config-less security-update* path ran (npm-only, reactive), so Rust crates, pinned action SHAs, Python deps, and Docker base images only moved on a CVE. Minor+patch are grouped per ecosystem, weekly off-peak (`06:17 UTC Mon`), with `open-pull-requests-limit` caps, `chore(deps)`/`chore(deps-dev)` prefixes, and `dependencies`/`infra` labels.

**`.github/workflows/pr-title-lint.yml`** — `amannn/action-semantic-pull-request` (pinned to `48f2562` / v6.1.1) validates PR titles against the conventional-commit prefix list the `land`/`backlog` skills already require (`feat`/`fix`/`refactor`/`docs`/`test`/`chore`/`security`/`perf`/`ci`/`build`/`revert`/`bug`).

## Safety / notes

- **`pull_request_target` is safe here:** the job reads only the PR title from the event payload, never checks out or runs PR head code. Minimal `pull-requests: read`. No `run:` steps; only `${{ }}` uses are `pull_request.number` and `secrets.GITHUB_TOKEN`.
- **Advisory, not blocking:** `main` is unprotected, so the title check surfaces violations but won't gate merges until added to branch protection (optional follow-up).
- The `PR title lint` check will **not** run on *this* PR — `pull_request_target` uses the base branch's copy of the workflow, which doesn't exist until merge. Expected.
- Local checks pass: Prettier, yamllint, actionlint, YAML parse.

## Proof gate

CI-only (`.github/**`), no code → exempt per CLAUDE.md rule #10.

## Operational caveat

First Dependabot PRs may need the documented CI-retrigger (empty commit + `gh workflow run`, or `--admin` merge) per the `backlog` skill — pre-existing GitHub behavior, unchanged by this config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)