### PR TITLE
ci: auto-merge patch/minor Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,45 @@
+name: "Dependabot auto-merge"
+
+# Auto-enables squash auto-merge for Dependabot PRs that are patch/minor
+# (incl. dev-deps). Major bumps are left open for human review - they're the
+# breaking ones. `gh pr merge --auto` queues the merge so GitHub completes it
+# only once required status checks pass; this requires repo "Allow auto-merge"
+# to be ON and branch protection on main requiring the CI checks (otherwise
+# --auto merges as soon as the PR is mergeable, without waiting for CI).
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: "dependabot-automerge-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    timeout-minutes: 5
+    steps:
+      - name: "Fetch Dependabot metadata"
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: "Enable auto-merge for patch + minor"
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Flag majors for human review"
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr comment "$PR_URL" --body "Major version bump - left for human review (auto-merge applies to patch/minor only)."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Automates the recurring Dependabot landing toil. New workflow `dependabot-auto-merge.yml`:

- Runs on `pull_request_target` **only for `dependabot[bot]`**.
- Reads the bump type via `dependabot/fetch-metadata` (pinned `25dd0e3` / v3.1.0).
- **patch + minor** (incl. dev-deps) → `gh pr merge --auto --squash` (GitHub completes it once checks pass).
- **major** → posts a comment and leaves the PR open for human review (breaking changes).

## Prerequisites (must be enabled for `--auto` to gate on CI)

`gh pr merge --auto` only *waits* for CI if there are required checks. Two repo settings needed:

1. **Allow auto-merge** — Settings → General → Pull Requests → "Allow auto-merge".
2. **Branch protection on `main`** requiring the CI checks (e.g. `Rust quality gate`, `UI quality`, `Python quality`, `Docs/data formatting`, `Agent proof gate`). Without this, `--auto` merges as soon as the PR is mergeable, *before* CI — unsafe.

I can't toggle these (repo settings / access control are yours to set). Once they're on, I'll land this PR + backfill the 20 already-open Dependabot PRs.

## Safety

- `run:` steps take the PR URL via `env:` (GitHub-controlled URL, no untrusted free-text interpolation).
- Gated on `pull_request.user.login == 'dependabot[bot]'`; `fetch-metadata` itself refuses non-Dependabot runs.
- Minimal `contents: write` + `pull-requests: write`.
- Local checks pass: Prettier, yamllint, actionlint.

## Proof gate

CI-only (`.github/**`), no code → exempt per CLAUDE.md rule #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)