### PR TITLE
ci: auto-update Rust toolchain via rust-toolchain.toml + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,22 @@ updates:
       actions-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # The Rust compiler version is managed via rust-toolchain.toml (the
+      # rust-toolchain ecosystem below), NOT by bumping this action's ref.
+      # dtolnay encodes the toolchain version in the @ref and pre-publishes
+      # future-version branches (e.g. 1.100.0), so letting Dependabot bump it
+      # here installs an unreleased compiler -> rustup 404 (see closed #1312).
+      - dependency-name: "dtolnay/rust-toolchain"
+
+  # Rust toolchain: bumps rust-toolchain.toml `channel` to newly-released
+  # toolchains only (real stable releases, not dtolnay's future branches).
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    schedule:
+      { interval: "weekly", day: "monday", time: "06:17", timezone: "Etc/UTC" }
+    commit-message: { prefix: "chore(deps)" }
+    labels: ["dependencies", "infra"]
 
   - package-ecosystem: "npm"
     directories:

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,9 +35,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Pinned to match rust-quality-gate in ci.yml. Bump deliberately.
+      # Channel from rust-toolchain.toml (same as ci.yml). Caching stays in the
+      # Swatinem step below.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          cache: false
 
       # Caches ~/.cargo/bin so cargo-audit does not recompile each run.
       # cache-targets: false — there is no workspace target/ to preserve.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,13 +118,14 @@ jobs:
         with:
           clean: true
 
-      # Pinned to 1.95.0 so a new stable Rust release does not silently
-      # break PRs via newly-activated clippy lints. Bump deliberately in
-      # a dedicated PR alongside any lint fixes the new version surfaces.
+      # Toolchain channel comes from rust-toolchain.toml. Dependabot opens a
+      # dedicated PR when a new stable releases; CI runs on it here so any
+      # newly-activated clippy lints surface in that isolated PR, never on an
+      # unrelated one. rustfmt + clippy are declared in the toml.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          components: rustfmt, clippy
+          cache: false
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
@@ -218,11 +219,12 @@ jobs:
         with:
           clean: true
 
-      # Keep the coverage job on the same pinned toolchain as rust-quality-gate
-      # so coverage drift is from tests/code, not a surprise compiler update.
+      # Same toolchain as the rest of CI (rust-toolchain.toml) so coverage drift
+      # is from tests/code, not a surprise compiler update. Adds llvm-tools-preview.
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
+          cache: false
           components: llvm-tools-preview
 
       # Distinct cache prefix: coverage instrumentation bakes -Cinstrument-coverage
@@ -267,6 +269,10 @@ jobs:
     if: ${{ needs.changes.outputs.rust == 'true' || github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # rust-toolchain.toml would otherwise pin every cargo command to the repo
+    # channel; override so this job actually exercises stable/beta.
+    env:
+      RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
     strategy:
       fail-fast: false
       matrix:
@@ -444,7 +450,9 @@ jobs:
           clean: true
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          cache: false
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
@@ -495,7 +503,9 @@ jobs:
           clean: true
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          cache: false
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2
@@ -590,7 +600,9 @@ jobs:
           cache-dependency-path: parish/apps/ui/package-lock.json
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          cache: false
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/eval-inference.yml
+++ b/.github/workflows/eval-inference.yml
@@ -25,6 +25,10 @@ jobs:
     name: Build parish
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # rust-toolchain.toml would pin this to the repo channel; this job tracks
+    # @stable on purpose, so override the file.
+    env:
+      RUSTUP_TOOLCHAIN: stable
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.95.0
+        # Channel from rust-toolchain.toml; caching stays in the Swatinem step.
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          cache: false
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,11 @@
+# Single source of truth for the Rust toolchain used by CI and local dev.
+# Dependabot's `rust-toolchain` ecosystem (see .github/dependabot.yml) opens a
+# PR bumping `channel` when a newer stable releases; CI runs on it and the bump
+# only lands when green. rustup auto-installs this channel for any cargo command
+# run in the repo, so `cargo`/`clippy`/`rustfmt` all agree with CI.
+#
+# Jobs that intentionally float (the stable/beta channel matrix and the
+# eval-inference build) override this via the RUSTUP_TOOLCHAIN env var.
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## What

Makes the Rust toolchain **auto-update to new stable releases, safely** — and kills the `dtolnay/rust-toolchain → 1.100.0` breakage (#1312).

### The problem
`dtolnay/rust-toolchain@1.95.0` encodes the *compiler version* in the action ref, and dtolnay pre-publishes future-version **branches** (1.96…1.100). Dependabot's github-actions updater saw `1.100.0` as "newest" and bumped to it → CI tried `rustup install 1.100.0` → 404 (Rust is at 1.95). Same PR hit [PostHog](https://github.com/PostHog/posthog/pull/30006), [Dioxus](https://github.com/DioxusLabs/dioxus/pull/3885), [Meilisearch](https://github.com/meilisearch/meilisearch/pull/5484).

### The fix — single source of truth
- **`rust-toolchain.toml`** (new): `channel = "1.95.0"` + `rustfmt`, `clippy`. rustup honors it for every cargo command.
- **7 install steps** (`ci.yml` ×5, `release.yml`, `audit.yml`): `dtolnay/rust-toolchain@1.95.0` → `actions-rust-lang/setup-rust-toolchain@46268bd` (v1.16.1), which reads the toml. `cache: false` so the existing tuned `Swatinem/rust-cache` steps stay; coverage still adds `llvm-tools-preview`.
- **Float jobs guarded:** the `Rust channel matrix` (stable/beta) and `eval-inference` (@stable) set `RUSTUP_TOOLCHAIN` to override the toml — otherwise the directory pin would silently force them onto 1.95.0 and defeat their purpose.
- **`dependabot.yml`:** add the **`rust-toolchain` ecosystem** (bumps the channel to *real released* toolchains only) and **`ignore` `dtolnay/rust-toolchain`** in github-actions so it never chases future-version branches again.

### Result
New stable ships → Dependabot opens a `chore(deps)` PR bumping `channel` → CI runs on the new compiler → lands only when green (auto-merges once #1329 + branch protection are in place). Reproducible, isolated, never silently breaks an unrelated PR.

## Validation
- No `rust-toolchain@1.95.0` left; only intentional `@master` (matrix) + `@stable` (eval) remain.
- yamllint, prettier (YAML), taplo (TOML) clean. actionlint shows only pre-existing `run:`-step warnings (none on changed lines).
- **This PR's own `Rust quality gate` / coverage jobs are the live proof** the file-driven install works (clippy/rustfmt present, channel resolves to 1.95.0).

## Supersedes
Closes the breakage in #1312 (the poisoned actions-group PR); I'll close that once this lands.

## Proof gate
CI + build-config only (`.github/**` + `rust-toolchain.toml`), no app code → exempt per CLAUDE.md rule #10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)