### PR TITLE
fix(mcp): resolve parish-mcp target dir via cargo metadata, not CARGO_TARGET_DIR (#1352)

### DIFF
--- a/.claude/hooks/SessionStart--build-mcp.sh
+++ b/.claude/hooks/SessionStart--build-mcp.sh
@@ -43,7 +43,7 @@ _resolve_mcp_bin() {
         cargo metadata --no-deps --format-version 1 \
             --manifest-path "$REPO/parish/Cargo.toml" 2>/dev/null \
             | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'
-    )
+    ) || meta_target=""
     if [ -n "$meta_target" ]; then
         echo "$meta_target/debug/parish-mcp"
         return

--- a/.claude/hooks/SessionStart--build-mcp.sh
+++ b/.claude/hooks/SessionStart--build-mcp.sh
@@ -6,8 +6,14 @@
 # SessionStart--install-system-deps.sh already handles the build alongside
 # apt-installed system deps.
 #
-# Fast path: if the binary is already built, exit immediately so the session
-# prompt comes up instantly. Cold path runs cargo in the background.
+# Fast path: if the binary is already built (at the real cargo target dir,
+# honouring ~/.cargo/config.toml), exit immediately so the session prompt
+# comes up instantly. Cold path runs cargo in the background.
+#
+# Binary probe order (mirrors parish-mcp-launch.sh):
+#   1. $CARGO_TARGET_DIR/debug/parish-mcp           (env var set)
+#   2. $(cargo metadata …).target_directory/debug/parish-mcp  (reads config.toml)
+#   3. $REPO/parish/target/debug/parish-mcp         (hard fallback)
 
 set -euo pipefail
 
@@ -16,14 +22,47 @@ if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
 fi
 
 REPO="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-TARGET_DIR="${CARGO_TARGET_DIR:-$REPO/parish/target}"
-MCP_BIN="$TARGET_DIR/debug/parish-mcp"
 
-if [ -x "$MCP_BIN" ]; then
+if [ ! -d "$REPO/parish/crates/parish-mcp" ]; then
     exit 0
 fi
 
-if [ ! -d "$REPO/parish/crates/parish-mcp" ]; then
+# ---------------------------------------------------------------------------
+# Resolve the real target directory, honouring ~/.cargo/config.toml.
+# ---------------------------------------------------------------------------
+_resolve_mcp_bin() {
+    # Probe 1: explicit env var.
+    if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+        echo "$CARGO_TARGET_DIR/debug/parish-mcp"
+        return
+    fi
+
+    # Probe 2: ask cargo itself (reads ~/.cargo/config.toml + workspace).
+    local meta_target
+    meta_target=$(
+        cargo metadata --no-deps --format-version 1 \
+            --manifest-path "$REPO/parish/Cargo.toml" 2>/dev/null \
+            | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'
+    )
+    if [ -n "$meta_target" ]; then
+        echo "$meta_target/debug/parish-mcp"
+        return
+    fi
+
+    # Probe 3: hard fallback (repo-local target).
+    echo "$REPO/parish/target/debug/parish-mcp"
+}
+
+MCP_BIN="$(_resolve_mcp_bin)"
+
+# Also check the repo-local fallback before deciding a build is needed.
+if [ ! -x "$MCP_BIN" ] && [ -n "${CARGO_TARGET_DIR:-}" ]; then
+    if [ -x "$REPO/parish/target/debug/parish-mcp" ]; then
+        MCP_BIN="$REPO/parish/target/debug/parish-mcp"
+    fi
+fi
+
+if [ -x "$MCP_BIN" ]; then
     exit 0
 fi
 

--- a/parish/scripts/parish-mcp-launch.sh
+++ b/parish/scripts/parish-mcp-launch.sh
@@ -43,7 +43,7 @@ _resolve_mcp_bin() {
         cargo metadata --no-deps --format-version 1 \
             --manifest-path "$REPO/parish/Cargo.toml" 2>/dev/null \
             | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'
-    )
+    ) || meta_target=""
     if [ -n "$meta_target" ]; then
         echo "$meta_target/debug/parish-mcp"
         return

--- a/parish/scripts/parish-mcp-launch.sh
+++ b/parish/scripts/parish-mcp-launch.sh
@@ -12,6 +12,11 @@
 # spawn. Fixing the race here makes correctness independent of hook ordering:
 # the MCP handshake now WAITS on the build instead of racing it.
 #
+# Binary probe order (first existing path wins; build only if none exist):
+#   1. $CARGO_TARGET_DIR/debug/parish-mcp           (env var set)
+#   2. $(cargo metadata …).target_directory/debug/parish-mcp  (reads config.toml)
+#   3. $REPO/parish/target/debug/parish-mcp         (hard fallback)
+#
 # Contract: everything on stdout must be JSON-RPC (the MCP stdio protocol),
 # so all build chatter is forced to stderr. We exec the real binary so it
 # inherits our stdin/stdout/stderr and PID.
@@ -19,13 +24,59 @@
 set -euo pipefail
 
 REPO="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-TARGET_DIR="${CARGO_TARGET_DIR:-$REPO/parish/target}"
-MCP_BIN="$TARGET_DIR/debug/parish-mcp"
+
+# ---------------------------------------------------------------------------
+# Resolve the real target directory, honouring ~/.cargo/config.toml.
+# cargo metadata is the only portable way to read the effective target-dir;
+# $CARGO_TARGET_DIR is only set when the caller explicitly exports it.
+# ---------------------------------------------------------------------------
+_resolve_mcp_bin() {
+    # Probe 1: explicit env var.
+    if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+        echo "$CARGO_TARGET_DIR/debug/parish-mcp"
+        return
+    fi
+
+    # Probe 2: ask cargo itself (reads ~/.cargo/config.toml + workspace).
+    local meta_target
+    meta_target=$(
+        cargo metadata --no-deps --format-version 1 \
+            --manifest-path "$REPO/parish/Cargo.toml" 2>/dev/null \
+            | sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p'
+    )
+    if [ -n "$meta_target" ]; then
+        echo "$meta_target/debug/parish-mcp"
+        return
+    fi
+
+    # Probe 3: hard fallback (repo-local target).
+    echo "$REPO/parish/target/debug/parish-mcp"
+}
+
+MCP_BIN="$(_resolve_mcp_bin)"
+echo "[parish-mcp-launch] resolved binary path: $MCP_BIN" >&2
 
 if [ ! -x "$MCP_BIN" ]; then
-    echo "[parish-mcp-launch] binary missing at $MCP_BIN — building (one-time cold compile)..." >&2
+    # Check remaining candidates before triggering a cold build — in case
+    # probe 2 failed (e.g. cargo not on PATH yet) but another path exists.
+    fallback_candidates=()
+    [ -n "${CARGO_TARGET_DIR:-}" ] && fallback_candidates+=("$CARGO_TARGET_DIR/debug/parish-mcp")
+    fallback_candidates+=("$REPO/parish/target/debug/parish-mcp")
+    for candidate in "${fallback_candidates[@]}"; do
+        if [ -x "$candidate" ]; then
+            MCP_BIN="$candidate"
+            echo "[parish-mcp-launch] found binary at fallback: $MCP_BIN" >&2
+            break
+        fi
+    done
+fi
+
+if [ ! -x "$MCP_BIN" ]; then
+    echo "[parish-mcp-launch] binary missing — building (one-time cold compile)..." >&2
     # stdout -> stderr so cargo never corrupts the JSON-RPC stream on stdout.
     (cd "$REPO/parish" && cargo build -p parish-mcp --quiet) 1>&2
+    # After build, re-resolve so we exec the binary cargo actually produced.
+    MCP_BIN="$(_resolve_mcp_bin)"
     echo "[parish-mcp-launch] build complete." >&2
 fi
 


### PR DESCRIPTION
Fixes #1352. The MCP launcher (`parish-mcp-launch.sh`) and `SessionStart--build-mcp.sh` resolved the parish-mcp binary from `$CARGO_TARGET_DIR` only, but the shared target dir is set via `~/.cargo/config.toml` `target-dir` (env unset) → they looked in the wrong place, cold-built, and lost the MCP handshake race (esp. after teleport into a fresh worktree; no in-session reload). Now both probe: env → `cargo metadata` `target_directory` (reads config.toml) → repo-local fallback, exec the first existing binary, build only if none. shellcheck + shfmt clean. Script/tooling-only — no Rust runtime change.