### PR TITLE
ci(eval): fix invalid matrix-in-job-if + ai-inference max-tokens input

### DIFF
--- a/.github/workflows/eval-inference.yml
+++ b/.github/workflows/eval-inference.yml
@@ -58,27 +58,57 @@ jobs:
           path: parish/target/release/parish-server
           retention-days: 1
 
+  # ── Select scenarios ──────────────────────────────────────────────────────
+  # `matrix` is not a valid context in a job-level `if:`, so the per-scenario
+  # filtering for workflow_dispatch is computed here and consumed by `eval`
+  # via `needs`/`fromJson` (both legal in a job `if`).
+  setup:
+    name: Select scenarios
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+      has_jobs: ${{ steps.select.outputs.has_jobs }}
+    steps:
+      - id: select
+        shell: python3 {0}
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          SCENARIO: ${{ github.event.inputs.scenario }}
+        run: |
+          import json, os
+
+          all_scenarios = [
+              {"scenario": "smoke", "turns": 10},
+              {"scenario": "intent", "turns": 25},
+              {"scenario": "reactions", "turns": 15},
+              {"scenario": "tier2", "turns": 12},
+              {"scenario": "dialogue", "turns": 20},
+          ]
+          event = os.environ.get("EVENT_NAME", "")
+          selected = os.environ.get("SCENARIO") or "all"
+          if event == "schedule" or selected == "all":
+              include = all_scenarios
+          else:
+              include = [s for s in all_scenarios if s["scenario"] == selected]
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              out.write("matrix=" + json.dumps({"include": include}) + "\n")
+              out.write("has_jobs=" + ("true" if include else "false") + "\n")
+
   # ── Per-scenario eval matrix ──────────────────────────────────────────────
   eval:
     name: Eval / ${{ matrix.scenario }}
-    needs: build
+    needs: [build, setup]
+    # Run only when at least one scenario was selected (e.g. skipped entirely
+    # when `full_session` is dispatched — that has its own job below).
+    if: ${{ needs.setup.outputs.has_jobs == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
-      matrix:
-        include:
-          - { scenario: smoke, turns: 10 }
-          - { scenario: intent, turns: 25 }
-          - { scenario: reactions, turns: 15 }
-          - { scenario: tier2, turns: 12 }
-          - { scenario: dialogue, turns: 20 }
       fail-fast: false
-
-    # Skip scenarios not requested when running via workflow_dispatch
-    if: >
-      github.event_name == 'schedule' ||
-      github.event.inputs.scenario == 'all' ||
-      github.event.inputs.scenario == matrix.scenario
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
 
     env:
       # Provider config read at server startup via resolve_config env vars.
@@ -163,7 +193,7 @@ jobs:
 
             Session log:
             ${{ steps.read_log.outputs.log }}
-          max-completion-tokens: "600"
+          max-tokens: "600"
 
       - name: Parse verdict and write summary
         shell: python3 {0}
@@ -319,7 +349,7 @@ jobs:
 
             Session log:
             ${{ steps.read_log.outputs.log }}
-          max-completion-tokens: "800"
+          max-tokens: "800"
 
       - name: Parse verdict
         shell: python3 {0}


### PR DESCRIPTION
## What

`.github/workflows/eval-inference.yml` was an **invalid workflow file** — GitHub rejected it:

> (Line: 78) Unrecognized named-value: 'matrix' … `github.event.inputs.scenario == matrix.scenario`

The `eval` job used `matrix.scenario` in its **job-level `if:`**, but `matrix` is not a valid context there (it only exists after the matrix expands; step-level `if` can use it, job-level cannot).

## Fix

- New `setup` job computes the scenario matrix as JSON (all scenarios on `schedule`/`all`; just the dispatched one otherwise) and exposes `matrix` + `has_jobs` outputs.
- `eval` consumes it via `strategy.matrix: ${{ fromJson(needs.setup.outputs.matrix) }}` and gates on `if: needs.setup.outputs.has_jobs == 'true'` — both `needs` and `fromJson` are legal in a job `if`. `full_session` dispatch → empty matrix → `eval` cleanly skipped (its own job runs).
- Also fixed both judge steps: `actions/ai-inference@v2` has no `max-completion-tokens` input — it's `max-tokens`. The dispatch input is read via `env:` (not interpolated into a shell command) to avoid workflow injection.

Verified with `actionlint` (clean — no matrix/input errors) and a YAML parse.

## Note on merge

CI-only change (`.github/**`), so the 4 required Rust gates are path-filtered and **skip** → this PR will sit `BLOCKED` like #1358 and needs an **admin squash-merge** (or the path-filter CI shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)