### PR TITLE
ci: add aggregate "CI gate" so path-skipped required checks dont hang PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -664,6 +664,11 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # No checkout, so override the workflow-level `working-directory: parish`
+    # default (that dir doesn't exist here) to the always-present workspace root.
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
     steps:
       - name: Require gated jobs to succeed or be skipped
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,3 +643,46 @@ jobs:
           name: playwright-report
           path: parish/apps/ui/playwright-report/
           if-no-files-found: ignore
+
+  # ── Aggregate required-checks gate ─────────────────────────────────────────
+  # Branch protection requires THIS single job, not the individual Rust matrix
+  # leaves. The Rust jobs above are path-gated (skipped on doc / CI / script-only
+  # PRs via the `changes` filter). A *required matrix leaf* that is skipped never
+  # reports a status, so such PRs got stuck on "Expected — Waiting for status to
+  # be reported" forever. This job always runs and passes when every gated job
+  # either succeeded or was legitimately skipped — non-Rust PRs go green instead
+  # of hanging, while a real Rust failure still blocks the merge.
+  ci-gate:
+    name: CI gate
+    needs:
+      [
+        rust-quality-gate,
+        rust-coverage-ratchet,
+        rust-multi-channel,
+        game-harness,
+      ]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require gated jobs to succeed or be skipped
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "gated job results: $RESULTS"
+          read -ra results <<< "$RESULTS"
+          status=0
+          for r in "${results[@]}"; do
+            case "$r" in
+              success | skipped) ;;
+              *)
+                echo "::error::a required CI job ended with '$r'"
+                status=1
+                ;;
+            esac
+          done
+          if [ "$status" -ne 0 ]; then
+            echo "CI gate: FAIL — a required job failed or was cancelled."
+            exit 1
+          fi
+          echo "CI gate: PASS — all gated jobs succeeded or were legitimately skipped."


### PR DESCRIPTION
## Problem

Branch protection requires 4 checks: **Rust quality gate**, **Rust channel matrix (stable)**, **Full game harness fixture sweep**, **Rust coverage ratchet**. These come from jobs that are path-gated by the `changes` filter and **skip** when a PR touches no Rust.

A *required matrix leaf* (`Rust channel matrix (stable)`) that is skipped at the job level **never creates its check context** — so doc / CI / script-only PRs sit on **"Expected — Waiting for status to be reported"** indefinitely and can only be force-merged (bypassing the protection). Hit by #1358 and #1367.

## Fix

Add one always-running `ci-gate` job (`name: CI gate`):

```yaml
ci-gate:
  name: CI gate
  needs: [rust-quality-gate, rust-coverage-ratchet, rust-multi-channel, game-harness]
  if: always()
  ...  # passes when each upstream is `success` or `skipped`; fails on failure/cancelled
```

It always runs and reports, so it never hangs. A non-Rust PR → all four skip → `CI gate` passes → green. A real Rust failure → `CI gate` fails → still blocked.

## Rollout (after merge)

1. Merge this PR (it edits `ci.yml`, so `changes` sets `rust=true` → full Rust CI runs → mergeable normally, no admin needed).
2. Update branch protection: require **`CI gate`**, drop the 4 leaf contexts.
3. Re-trigger CI on #1358 / #1367 → they report `CI gate` green → merge normally.

Net: doc/CI/script-only PRs stop hanging; the Rust security posture is unchanged (a real Rust failure still blocks via the gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)