### PR TITLE
fix: route bare commands as commands, not dialogue (#1351)

### DIFF
--- a/parish/crates/parish-engine/src/headless.rs
+++ b/parish/crates/parish-engine/src/headless.rs
@@ -12,7 +12,9 @@ use crate::inference::{
     self, AnyClient, InferenceClients, InferencePriority, InferenceQueue, InferenceWorkerConfig,
     QueueRequest,
 };
-use crate::input::{Command, InputResult, classify_input, extract_mention, parse_intent};
+use crate::input::{
+    Command, InputResult, classify_input, extract_mention, is_player_dialogue, parse_intent,
+};
 use crate::loading::LoadingAnimation;
 use crate::npc::manager::NpcManager;
 use crate::npc::parse_npc_stream_response;
@@ -160,7 +162,11 @@ async fn run_headless_repl_loop(
                     &mut request_id,
                 )
                 .await?;
-                emit_headless_npc_reactions(app, &text).await;
+                // #1351 — NPCs react only to genuine dialogue, not to a bare
+                // `look`/movement command routed down the GameInput path.
+                if is_player_dialogue(&text) {
+                    emit_headless_npc_reactions(app, &text).await;
+                }
             }
         }
 

--- a/parish/crates/parish-input/src/intent_local.rs
+++ b/parish/crates/parish-input/src/intent_local.rs
@@ -172,6 +172,34 @@ pub fn parse_intent_local(raw_input: &str) -> Option<PlayerIntent> {
     None
 }
 
+/// Returns `true` if `raw_input` should be surfaced as a player *dialogue*
+/// utterance — i.e. shown as a speech bubble and reacted to by co-located NPCs.
+///
+/// # Why this exists (#1351)
+///
+/// `submit-input` routes any non-`/` input that is not a bare command intercept
+/// down the `GameInput` path, which historically *unconditionally* emitted a
+/// player speech bubble and fired `emit_npc_reactions`. That made deterministic
+/// non-dialogue actions — a bare `look`, `look around`, or a movement phrase —
+/// render as player speech and provoke NPC reactions ("NPC reacts to `look`").
+///
+/// This predicate is a deterministic, no-LLM gate: an input that
+/// [`parse_intent_local`] resolves to a non-dialogue action (`Move`, `Look`,
+/// `Examine`, `Interact`) is **not** dialogue. Only a locally-recognised `Talk`
+/// (first-person narrative) or an input that falls through to the LLM (`None`,
+/// where the intent parser decides) is treated as dialogue. Mirrors the
+/// look-command set the intent path already short-circuits, so a bare `look`
+/// never reaches the small intent model that intermittently misclassifies it.
+pub fn is_player_dialogue(raw_input: &str) -> bool {
+    match parse_intent_local(raw_input) {
+        // Locally-recognised first-person narrative is genuine speech.
+        Some(intent) => matches!(intent.intent, IntentKind::Talk),
+        // Ambiguous input falls through to the LLM intent parser; treat it as
+        // dialogue (speech bubble + reactions), as the pre-#1351 path did.
+        None => true,
+    }
+}
+
 /// Shared helper: checks if `lower` starts with any prefix in `prefixes`,
 /// extracts the target from the original (cased) `trimmed` input using
 /// char-count-based byte-offset computation, and returns a `Move` intent.
@@ -659,5 +687,39 @@ mod tests {
         assert!(parse_intent_local("amble").is_none());
         assert!(parse_intent_local("run").is_none());
         assert!(parse_intent_local("dash").is_none());
+    }
+
+    // ── is_player_dialogue (#1351) ──────────────────────────────────────────
+
+    #[test]
+    fn bare_look_is_not_dialogue() {
+        // The reported bug: a bare `look` rendered as player speech and NPCs
+        // reacted to it. The deterministic gate must classify it as non-dialogue.
+        assert!(!is_player_dialogue("look"));
+        assert!(!is_player_dialogue("look around"));
+        assert!(!is_player_dialogue("l"));
+        assert!(!is_player_dialogue("LOOK"));
+        assert!(!is_player_dialogue("  look  "));
+    }
+
+    #[test]
+    fn movement_is_not_dialogue() {
+        // Movement phrases route to the look/move path, not speech — NPCs must
+        // not react to "go to the pub" as if the player said it to them.
+        assert!(!is_player_dialogue("go to the pub"));
+        assert!(!is_player_dialogue("head to Murphy's Farm"));
+        assert!(!is_player_dialogue("visit the fairy fort"));
+    }
+
+    #[test]
+    fn speech_is_dialogue() {
+        // Locally-recognised first-person narrative is genuine speech.
+        assert!(is_player_dialogue("I came from the coast"));
+        assert!(is_player_dialogue("I'm not from around here"));
+        // Input that falls through to the LLM intent parser is treated as
+        // dialogue (preserves the pre-#1351 behaviour for ambiguous text).
+        assert!(is_player_dialogue("hello there"));
+        assert!(is_player_dialogue("tell Mary the rent is too high"));
+        assert!(is_player_dialogue("good morning, Father"));
     }
 }

--- a/parish/crates/parish-input/src/lib.rs
+++ b/parish/crates/parish-input/src/lib.rs
@@ -13,7 +13,7 @@ mod parser;
 
 pub use commands::{Command, FlagSubcommand, InferenceLogSub, validate_branch_name};
 pub use intent_llm::parse_intent;
-pub use intent_local::parse_intent_local;
+pub use intent_local::{is_player_dialogue, parse_intent_local};
 pub use intent_types::{InputResult, IntentKind, PlayerIntent};
 pub use mention::{MentionExtraction, extract_mention};
 pub use parser::{classify_input, parse_system_command};

--- a/parish/crates/parish-input/src/parser.rs
+++ b/parish/crates/parish-input/src/parser.rs
@@ -118,17 +118,58 @@ fn parse_zero_arg_command(keyword: &str) -> Option<Command> {
     }
 }
 
+/// Deterministic pre-classifier for bare (no-`/` prefix) command tokens.
+///
+/// Small quantised intent models (e.g. Qwen2.5-1.5B-4bit on :8001) occasionally
+/// misclassify unambiguous bare command tokens such as `wait` and `status` as
+/// player dialogue, causing the text to appear as a player utterance and NPCs to
+/// react to it (#1351).  This function short-circuits those tokens to their
+/// canonical `SystemCommand` equivalents before the LLM intent parser is ever
+/// consulted.
+///
+/// # Scope
+///
+/// Only **exact** bare matches are intercepted (case-insensitive, trimmed).
+/// Tokens with arguments (e.g. `wait 30`) are intentionally **not** intercepted
+/// here so the LLM can still parse natural-language movement/look phrases that
+/// happen to start with one of these words.
+///
+/// # Token list rationale
+///
+/// - `wait` — maps to `Command::Wait(15)` (same default as `/wait`). A bare
+///   "wait" with no number is unambiguous: pause time for 15 minutes.
+/// - `status` — maps to `Command::Status`. A single bare word has no plausible
+///   conversational meaning distinct from the `/status` command.
+pub(crate) fn parse_bare_command_intercept(trimmed: &str) -> Option<Command> {
+    // Only intercept exact single-token inputs (no spaces after trimming).
+    if trimmed.contains(' ') {
+        return None;
+    }
+    match trimmed.to_lowercase().as_str() {
+        "wait" => Some(Command::Wait(15)),
+        "status" => Some(Command::Status),
+        _ => None,
+    }
+}
+
 /// Classifies raw input as either a system command or game input.
 ///
-/// If the input starts with `/` and matches a known command, returns
-/// `InputResult::SystemCommand`. Otherwise returns `InputResult::GameInput`.
+/// Classification order:
+/// 1. `/`-prefixed system commands via [`parse_system_command`].
+/// 2. Bare (un-prefixed) command tokens via [`parse_bare_command_intercept`]
+///    — deterministic short-circuit that prevents the LLM intent parser from
+///    seeing unambiguous command tokens and nondeterministically classifying
+///    them as player dialogue (#1351).
+/// 3. Everything else → [`InputResult::GameInput`] for LLM intent parsing.
 pub fn classify_input(raw: &str) -> InputResult {
     let trimmed = raw.trim();
     if let Some(cmd) = parse_system_command(trimmed) {
-        InputResult::SystemCommand(cmd)
-    } else {
-        InputResult::GameInput(trimmed.to_string())
+        return InputResult::SystemCommand(cmd);
     }
+    if let Some(cmd) = parse_bare_command_intercept(trimmed) {
+        return InputResult::SystemCommand(cmd);
+    }
+    InputResult::GameInput(trimmed.to_string())
 }
 
 #[cfg(test)]
@@ -383,5 +424,85 @@ mod tests {
         assert_eq!(parse_system_command("/SESSION"), Some(Command::Session));
         assert_eq!(parse_system_command("/TUNE"), Some(Command::Session));
         assert_eq!(parse_system_command("/SEISIUN"), Some(Command::Session));
+    }
+
+    // ── Bare-command intercept (#1351) ────────────────────────────────────────
+
+    /// Bare `wait` must route to `Command::Wait(15)` without reaching the LLM.
+    #[test]
+    fn bare_wait_is_intercepted_as_system_command() {
+        assert_eq!(
+            classify_input("wait"),
+            InputResult::SystemCommand(Command::Wait(15))
+        );
+        assert_eq!(
+            classify_input("WAIT"),
+            InputResult::SystemCommand(Command::Wait(15))
+        );
+        assert_eq!(
+            classify_input("  wait  "),
+            InputResult::SystemCommand(Command::Wait(15))
+        );
+    }
+
+    /// Bare `status` must route to `Command::Status` without reaching the LLM.
+    #[test]
+    fn bare_status_is_intercepted_as_system_command() {
+        assert_eq!(
+            classify_input("status"),
+            InputResult::SystemCommand(Command::Status)
+        );
+        assert_eq!(
+            classify_input("STATUS"),
+            InputResult::SystemCommand(Command::Status)
+        );
+        assert_eq!(
+            classify_input("  status  "),
+            InputResult::SystemCommand(Command::Status)
+        );
+    }
+
+    /// `wait` with an argument (e.g. "wait 30" or "wait for Mary") is NOT
+    /// intercepted — it goes to `GameInput` so natural-language phrasing is
+    /// still handled by the intent parser.
+    #[test]
+    fn wait_with_argument_is_game_input() {
+        assert_eq!(
+            classify_input("wait 30"),
+            InputResult::GameInput("wait 30".to_string())
+        );
+        assert_eq!(
+            classify_input("wait for Mary"),
+            InputResult::GameInput("wait for Mary".to_string())
+        );
+    }
+
+    /// `status` with trailing text is not intercepted — it falls through to
+    /// game input where the LLM can handle the natural-language variant.
+    #[test]
+    fn status_with_argument_is_game_input() {
+        assert_eq!(
+            classify_input("status report"),
+            InputResult::GameInput("status report".to_string())
+        );
+    }
+
+    /// All tokens in `parse_bare_command_intercept` must return `Some`.
+    /// Regression guard: whenever a new token is added, this test auto-verifies
+    /// it is covered.
+    #[test]
+    fn all_bare_intercept_tokens_return_some() {
+        let tokens = ["wait", "status"];
+        for tok in tokens {
+            assert!(
+                super::parse_bare_command_intercept(tok).is_some(),
+                "bare intercept token '{tok}' returned None — add it to parse_bare_command_intercept"
+            );
+            // Case insensitive
+            assert!(
+                super::parse_bare_command_intercept(&tok.to_uppercase()).is_some(),
+                "bare intercept token '{tok}' (uppercase) returned None"
+            );
+        }
     }
 }

--- a/parish/crates/parish-server/src/routes/input.rs
+++ b/parish/crates/parish-server/src/routes/input.rs
@@ -16,7 +16,7 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 
 use parish_core::event_bus::{EventBus as EventBusTrait, Topic};
-use parish_core::input::{InputResult, classify_input};
+use parish_core::input::{InputResult, classify_input, is_player_dialogue};
 use parish_core::ipc::{LoadingPayload, text_log};
 
 use crate::state::AppState;
@@ -69,23 +69,33 @@ pub async fn submit_input(
             handle_system_command(cmd, &state).await;
         }
         InputResult::GameInput(raw) => {
-            // Emit the player's own text as a dialogue bubble only for actual dialogue
-            let player_msg = text_log("player", format!("> {}", raw));
-            let player_msg_id = player_msg.id.clone();
-            state
-                .event_bus
-                .emit_named(Topic::TextLog, "text-log", &player_msg);
-            let raw_for_reactions = raw.clone();
+            // #1351 — only surface a player speech bubble + NPC reactions for
+            // genuine dialogue. Deterministic non-dialogue actions (a bare
+            // `look`, `look around`, movement phrases) must not render as player
+            // speech or provoke NPC reactions. `handle_game_input` still runs so
+            // the look/move action itself executes.
+            let dispatch = if is_player_dialogue(&raw) {
+                let player_msg = text_log("player", format!("> {}", raw));
+                let player_msg_id = player_msg.id.clone();
+                state
+                    .event_bus
+                    .emit_named(Topic::TextLog, "text-log", &player_msg);
+                Some((player_msg_id, raw.clone()))
+            } else {
+                None
+            };
             // Capture location before handle_game_input (which may move the player).
             let reaction_location = state.world.lock().await.player_location;
             handle_game_input(raw, body.addressed_to, &state).await;
             // Generate NPC reactions to the player's message in the background.
-            emit_npc_reactions(
-                &player_msg_id,
-                &raw_for_reactions,
-                reaction_location,
-                &state,
-            );
+            if let Some((player_msg_id, raw_for_reactions)) = dispatch {
+                emit_npc_reactions(
+                    &player_msg_id,
+                    &raw_for_reactions,
+                    reaction_location,
+                    &state,
+                );
+            }
         }
     }
 

--- a/parish/crates/parish-tauri/src/commands/input.rs
+++ b/parish/crates/parish-tauri/src/commands/input.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use parish_core::input::{InputResult, classify_input, parse_intent};
+use parish_core::input::{InputResult, classify_input, is_player_dialogue, parse_intent};
 use parish_core::ipc::text_log;
 use tauri::Emitter;
 
@@ -61,22 +61,32 @@ pub(crate) async fn do_submit_input(
         }
         InputResult::GameInput(raw) => {
             tracing::info!(input = %raw, "chat [player]");
-            // Emit the player's own text as a dialogue bubble only for actual dialogue
-            let player_msg = text_log("player", format!("> {}", raw));
-            let player_msg_id = player_msg.id.clone();
-            let _ = app.emit(EVENT_TEXT_LOG, player_msg);
-            let raw_for_reactions = raw.clone();
+            // #1351 — only surface a player speech bubble + NPC reactions for
+            // genuine dialogue. Deterministic non-dialogue actions (a bare
+            // `look`, `look around`, movement phrases) must not render as player
+            // speech or provoke NPC reactions. `handle_game_input` still runs so
+            // the look/move action itself executes.
+            let dispatch = if is_player_dialogue(&raw) {
+                let player_msg = text_log("player", format!("> {}", raw));
+                let player_msg_id = player_msg.id.clone();
+                let _ = app.emit(EVENT_TEXT_LOG, player_msg);
+                Some((player_msg_id, raw.clone()))
+            } else {
+                None
+            };
             // Capture location before handle_game_input (which may move the player).
             let reaction_location = state.world.lock().await.player_location;
             handle_game_input(raw, addressed_to, state, app.clone()).await;
             // Generate NPC reactions to the player's message in the background.
-            super::reactions::emit_npc_reactions(
-                &player_msg_id,
-                &raw_for_reactions,
-                reaction_location,
-                state,
-                app,
-            );
+            if let Some((player_msg_id, raw_for_reactions)) = dispatch {
+                super::reactions::emit_npc_reactions(
+                    &player_msg_id,
+                    &raw_for_reactions,
+                    reaction_location,
+                    state,
+                    app,
+                );
+            }
         }
     }
 

--- a/parish/testing/fixtures/play_1351-command-vs-dialogue.txt
+++ b/parish/testing/fixtures/play_1351-command-vs-dialogue.txt
@@ -1,0 +1,8 @@
+# #1351 — a bare `look` (and movement) must route as a command, never as
+# player speech, and must not provoke NPC reactions. A genuine greeting must
+# still produce dialogue + reactions.
+look
+go to the pub
+look
+good morning to ye all
+/quit


### PR DESCRIPTION
## What

A bare `look` (and movement phrases) rendered as a player speech line and made NPCs react to it. Root cause: the `GameInput` path unconditionally emitted a player speech bubble (`> {raw}`) and fired `emit_npc_reactions` for every non-`/` input. `look`/movement are game actions (not `SystemCommand`s), so they leaked down the dialogue path.

## Fix

- New shared deterministic predicate `parish_input::is_player_dialogue(raw)` — `false` for locally-recognised non-dialogue actions (Look/Move/Examine), `true` for first-person narrative and LLM-bound ambiguous input.
- Gate the speech-bubble + reaction emit on it at all three GameInput emit sites: `parish-server`, `parish-tauri`, `parish-engine` (mode parity, rule #2/#12). `handle_game_input` still runs, so the look/move action executes.
- Defensive: intercept bare `wait`/`status` to their `SystemCommand` equivalents before the intent parser.

## Tests / proof

- `parish-input`: 176 pass (added `bare_look_is_not_dialogue`, `movement_is_not_dialogue`, `speech_is_dialogue`, + wait/status intercept tests).
- clippy `-D warnings` clean, fmt clean on the four touched crates.
- Live headless transcript (`cargo run -p parish-engine -- --headless --script ...`): at Darcy's Pub with Niamh + Padraig present, `look` → `result:"looked"` and **0** reaction lines; `good morning to ye all` → `Niamh Darcy 😊`, `Padraig Darcy 😊`. Same location, same NPCs — routing fix in action.

Scope note: the simulator can't exercise the LLM reaction model, so the live transcript proves the routing/gating; the LLM-reaction-to-`look` symptom is prevented because the emit is never called for `look` (unit-tested + gated call sites).

Fixes #1351

<!-- parish-proof-bundle:1351 v=1 -->

## Proof: 1351

### Acceptance criteria

# Acceptance criteria — #1351 (command-vs-dialogue routing)

Player **commands** must never be treated as player **dialogue**. Two linked
symptoms (one root cause): a bare `look` rendered as a player speech line, and
NPCs reacting to `look` as if it were spoken to them.

## Root cause

`submit-input` routes any non-`/` input that is not a bare-command intercept
down the `GameInput` path, which **unconditionally** (a) emitted a player
speech bubble (`> {raw}`) and (b) fired `emit_npc_reactions`. `look`,
`look around`, and movement phrases are `GameInput` (they are game _actions_,
not `SystemCommand`s), so they were echoed as speech and provoked reactions.
The intent layer already classifies a bare `look` correctly (`parse_intent_local`
→ `Look`), so the leak was in the _emit gating_, not intent parsing. The
duplicated emit block lived in three entry points (server, Tauri, engine).

## Observable criteria

- **AC1** — A bare `look` classifies as a command (`result: "looked"`), not as
  dialogue, in a live run.
- **AC2** — A bare `look` at a location with NPCs present produces **no** NPC
  reaction lines.
- **AC3** — A genuine greeting at the same location with the same NPCs present
  **does** produce NPC reaction lines (the gate's positive branch still works).
- **AC4** — `is_player_dialogue` returns `false` for `look` / `look around` /
  `l` / movement phrases, and `true` for first-person narrative and
  LLM-bound (ambiguous) input. (unit)
- **AC5** — The dialogue gate is the **same** shared predicate
  (`parish_input::is_player_dialogue`) applied in all three entry points
  (server, Tauri, engine) — mode parity (rule #2).
- **AC6** — Bare `wait` / `status` are intercepted to their `SystemCommand`
  equivalents before the LLM intent parser (defensive; agent-originated). (unit)
- **AC7** — No pre-existing tests regress.

## Scope note (honest)

The headless/simulator backend cannot exercise the **LLM** reaction model, so
the live transcript demonstrates the _routing_ fix (AC1–AC3) deterministically;
the prevention of the LLM-reaction-to-`look` symptom is guaranteed by the emit
being **gated** (never invoked for `look`), covered by AC4 unit tests + the code
gate. Full real-model confirmation would require driving the Tauri app with the
bundled Qwen-1.5B reaction model.

### Evidence

# Evidence — #1351

Evidence type: live gameplay transcript

Command:

```
cargo run -p parish-engine -- --headless \
  --script parish/testing/fixtures/play_1351-command-vs-dialogue.txt
```

Transcript: [transcript.txt](transcript.txt) (full stdout, log lines filtered).

## Criterion → proof

- **AC1** (look is a command, not dialogue) — line 1 and line 3 of the
  transcript: `{"command":"look","result":"looked", ...}`. The input is routed
  to the look action; it is not echoed as a player speech line.

- **AC2** (no NPC reaction to look) — line 3 is `look` at **Darcy's Pub**, where
  `Niamh Darcy` and `Padraig Darcy` are present (they greet on arrival, line 2).
  The `look` result carries only the location description in `new_log_lines` —
  **no** `Niamh Darcy 😊` / `Padraig Darcy 😊` reaction lines.

- **AC3** (dialogue still reacts) — line 4, `good morning to ye all` at the same
  location with the same NPCs present:
  `"new_log_lines":["Niamh Darcy 😊","Padraig Darcy 😊"]`. Genuine dialogue
  drives reactions; the gate's positive branch works in a live process.

  The contrast between line 3 (look → 0 reactions) and line 4 (greeting → 2
  reactions) at one location, same NPCs, is the routing fix in action.

- **AC4 / AC6** — unit tests in `parish-input`:
  `bare_look_is_not_dialogue`, `movement_is_not_dialogue`, `speech_is_dialogue`
  (intent_local.rs) and the bare `wait`/`status` intercept tests (parser.rs).
  `cargo test -p parish-input` → 176 passed.

- **AC5** (mode parity) — `parish_input::is_player_dialogue` is applied at all
  three GameInput emit sites: `parish-server/src/routes/input.rs`,
  `parish-tauri/src/commands/input.rs`, `parish-engine/src/headless.rs`. The
  predicate is defined once in the shared leaf crate (rule #2 / #12).

- **AC7** — `cargo test -p parish-input` 176 passed (3 added, 0 regressions);
  workspace crates build clean; `cargo clippy -D warnings` clean on the four
  touched crates.

## Scope (no overclaim)

The simulator backend short-circuits the real `:8001` reaction model, so this
transcript proves the deterministic routing/gating (AC1–AC3). The
LLM-reaction-to-`look` symptom is prevented because `emit_*_npc_reactions` is
**not called** for `look` (gated by `is_player_dialogue`) — proven by the AC4
unit tests + the gated call sites, not by a real-model run.

### Transcript

```text
{"command":"look","result":"looked","description":"The small village of Kilteevan — a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The clear sky hangs over the quiet street. It is morning.","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["The small village of Kilteevan — a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The clear sky hangs over the quiet street. It is morning.","You can go to: The Crossroads (13 min on foot), The Forge (1 min on foot), The Holy Well (1 min on foot), The Mill (1 min on foot), The Weaver's Cottage (2 min on foot), Knockcroghery Village (85 min on foot), St. Brigid's Church (9 min on foot), Murphy's Farm (21 min on foot), The Lime Kiln (1 min on foot), The Letter Office (11 min on foot)","An older woman with sharp eyes and herb-stained fingers heads off down the road.","A lean, red-haired young man with hard eyes heads off down the road.","An older man heads off down the road.","A young woman heads off down the road."]}
{"command":"go to the pub","result":"moved","to":"Darcy's Pub","minutes":14,"narration":"You set off along the road north past low fields to the crossroads toward Darcy's Pub. (14 minutes on foot)","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["\"And who might you be? I'm Niamh Darcy, the Publican's Daughter,\" they say.","\"I'm Padraig Darcy, the Publican here. You're welcome,\" they say.","You set off along the road north past low fields to the crossroads toward Darcy's Pub. (14 minutes on foot)","","The warm interior of Darcy's Pub. Turf smoke hangs in the air. Old prints of hurling matches line the walls beside a faded map of the county. A fiddle sits propped in the corner. It is morning and the weather outside is clear.\nYou can go to: The Crossroads (1 min on foot)","  · You hear a man singing to himself — thin and reedy — before you see him around the bend."]}
{"command":"look","result":"looked","description":"The warm interior of Darcy's Pub. Turf smoke hangs in the air. Old prints of hurling matches line the walls beside a faded map of the county. A fiddle sits propped in the corner. It is morning and the weather outside is clear.","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["The warm interior of Darcy's Pub. Turf smoke hangs in the air. Old prints of hurling matches line the walls beside a faded map of the county. A fiddle sits propped in the corner. It is morning and the weather outside is clear.","You can go to: The Crossroads (1 min on foot)"]}
{"command":"good morning to ye all","result":"npc_not_available","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["Niamh Darcy 😊","Padraig Darcy 😊"]}
{"command":"/quit","result":"quit","location":"Darcy's Pub","time":"Morning","season":"Spring"}
```

### Judge

# Judge — #1351

Reviewed the diff, the acceptance criteria, and the live transcript.

## Findings

- The root cause is correctly identified: `GameInput` unconditionally emitted a
  player speech bubble + NPC reactions, so non-dialogue actions (`look`,
  movement) leaked as speech and provoked reactions. The fix gates both on a
  shared deterministic predicate `is_player_dialogue`, applied at all three
  entry points — mode parity holds (rule #2/#12).
- The live transcript shows the decisive contrast at one location with the same
  two NPCs present: `look` → `result:"looked"`, zero reaction lines; greeting →
  two reaction lines. AC1, AC2, AC3 met in a real process.
- Unit tests cover the predicate (look/movement → not dialogue; narrative +
  ambiguous → dialogue) and the bare `wait`/`status` intercept. 176 pass in
  parish-input, no regressions. AC4, AC6, AC7 met.
- The evidence is honest about scope: the simulator cannot exercise the LLM
  reaction model, so the LLM-reaction symptom is prevented by _gating the emit
  call_ (verified by unit tests + gated call sites) rather than by a real-model
  run. This is the correct mechanism and is not overclaimed.

## Verdict

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:1351 -->
