### PR TITLE
feat(harness): persist quality-harness skill runs to the dashboard

### DIFF
--- a/.agents/skills/quality-harness/SKILL.md
+++ b/.agents/skills/quality-harness/SKILL.md
@@ -113,6 +113,35 @@ and the full findings list. Then **file the substantive findings** via
 state into a GitHub issue labeled for the `/backlog` drain. Dedup obvious repeats. Recurring
 model-quality findings (mood-blind dialogue, verbosity) are real bugs — file them.
 
+## 6. Persist to the dashboard
+
+A skill run is invisible to the `parish-harness` dashboard unless you ingest it. Do this at the
+end of every run so it shows on `serve` (`http://localhost:8787`) next to binary runs.
+
+1. **Lay out an artifact dir.** Pick a `uuid` for the run and create
+   `<root>/runs/<uuid>/turns/NNN/frame.png` for each turn, where `<root>` is the same
+   `--artifacts` dir the dashboard serves (default: next to `harness.db`). You capture
+   screenshots periodically, not per-turn — map each turn to the **most recent** screenshot at
+   or before it; for turns before your first capture, copy a single shared placeholder
+   `frame.png`. Also write `turns/NNN/lines.json` (the turn's narrative lines, `[]` is fine).
+   Every `frame.png` must be non-empty (the ingest validates this — rule #14).
+
+2. **Emit the payload JSON** (schema in
+   [`parish/crates/parish-harness/README.md`](../../../parish/crates/parish-harness/README.md)
+   under `ingest`). Fill `git` from the worktree (`git rev-parse HEAD` / `--abbrev-ref HEAD` /
+   `status --porcelain`), set `rubric_sha256` to the binary's pinned rubric sha
+   (`cargo run -p parish-harness -- ... ` records it; or read the rubric file hash), include all
+   `turns`, the 7 `axes` with rationales, every `finding` (with the same `signature` you used
+   when filing the issue), and a `cost` tally. On a hard fail set `gate` and omit
+   `quality_score`.
+
+3. **Ingest:**
+   ```sh
+   cargo run -p parish-harness -- ingest --payload <run.json> --artifacts <root>
+   ```
+   It prints `ingested run <id>`. Surface that id and `http://localhost:8787` to the user so
+   they can open the run on the dashboard.
+
 ## Calibration example (be this harsh)
 
 A 5-turn run with coherent multi-NPC plot but **every** NPC ignoring its mood tag, one

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -32,6 +32,16 @@
       "runtimeArgs": ["dev", "--port", "4321"],
       "cwd": "promptfoo/bench-site",
       "port": 4321
+    },
+    {
+      "name": "harness-dashboard",
+      "runtimeExecutable": "/bin/sh",
+      "runtimeArgs": [
+        "-c",
+        "source $HOME/.cargo/env && cargo run -p parish-harness -- serve --port 8787"
+      ],
+      "cwd": "parish",
+      "port": 8787
     }
   ]
 }

--- a/docs/design/harness-skill-ingest.md
+++ b/docs/design/harness-skill-ingest.md
@@ -1,0 +1,92 @@
+# Design: harness-skill-ingest
+
+## Feature in one paragraph
+
+Two "harnesses" produce game-quality runs: the `parish-harness` **binary** (`run` subcommand —
+LLM player + LLM judge, persists to `harness.db`) and the `quality-harness` **skill** (an agent
+drives the live game over the parish MCP, judges by hand, files bugs). Only the binary's runs
+reach the `serve` dashboard. This change lets skill runs land in the same DB by adding a thin
+`ingest` path to the binary and a final persist step to the skill — so the dashboard's Runs /
+Trends / A/B Compare views cover both producers with identical fidelity (quality score, 7-axis
+breakdown, findings, per-turn frames, cost).
+
+## Affected subsystems (by crate)
+
+- `parish-harness` (the only crate that changes):
+  - `src/persist/sink.rs` — new `Db::ingest_complete_run()` orchestration helper + new
+    `Db::update_run_cost()` writer. Reuses the existing `upsert_config`, `start_run`,
+    `record_turn`, `insert_finding`, `finish_run_scored`, `finish_run_gated`.
+  - `src/ingest.rs` (new) — `IngestPayload` serde struct + `load_and_ingest()` that maps the
+    payload into the sink types and copies artifacts into place.
+  - `src/main.rs` — new `Ingest(IngestArgs)` clap subcommand wired to `load_and_ingest()`.
+  - `src/lib.rs` — `pub mod ingest;`.
+- No game-runtime crates change. No `parish-core` / `parish-server` / `parish-tauri` touch
+  (the harness CLAUDE.md forbids depending on them anyway).
+
+## Data model
+
+No new tables, no new columns — the existing schema already has everything (`runs`, `turns`,
+`axis_scores`, `findings`, `configs`, and the unused-until-now `runs.cost_usd /
+player_tokens / judge_tokens`).
+
+New **transport** struct (serde, not persisted directly):
+
+```
+IngestPayload {
+  config:        RunConfigPayload,   // label forced to "skill:quality-harness"; hashed -> configs row
+  git:           GitProvenance,      // sha, branch, dirty, pr_number  (existing struct, derive Deserialize)
+  rubric_sha256: String,            // skill passes the binary's pinned rubric sha for comparability
+  status:        "completed" | "gated",
+  quality_score: Option<f64>,       // None when gated
+  gate:          Option<GatePayload>{ reason: String, turn: u32, detail: String },  // present iff gated
+  cost:          CostPayload { cost_usd: f64, player_tokens: u64, judge_tokens: u64 },
+  turns:         Vec<TurnPayload>,   // maps 1:1 to TurnRecord
+  axes:          Vec<AxisPayload>{ axis: String, score: u8, rationale: String },     // 7 entries
+  findings:      Vec<FindingPayload>{ category, turn_index?, severity, description, evidence_quote, signature }
+}
+```
+
+`TurnPayload` mirrors `TurnRecord` fields; `frame_path` / `lines_path` are relative
+(`turns/NNN/frame.png`). `severity` / `axis` strings parse via the existing
+`Severity`/`Axis` `from`-label paths (add `FromStr`/lookup if not already present).
+
+### Artifacts
+
+The skill writes its run under a UUID dir: `runs/<uuid>/turns/NNN/{frame.png,lines.json}`,
+plus `verdict.json` / `transcript.json` for parity with binary runs. `ingest` takes
+`--artifacts <root>`; it stores `runs.artifact_dir = <root>/runs/<uuid>` (absolute) exactly as
+`execute_run` does, so `get_frame` resolves `{artifact_dir}/turns/NNN/frame.png` unchanged.
+
+Skill screenshots are periodic, not per-turn. Mapping rule (documented in SKILL.md): each turn
+points at the most recent screenshot captured at or before it; turns before the first capture
+share a single bundled placeholder `frame.png`. `frame_path` is NOT NULL, so every turn always
+references a real file.
+
+## Observable signal
+
+This is tooling, so the signal is on the **dashboard API**, not the game JSON:
+
+- `GET /api/runs` — the ingested run appears with `status` + `quality_score`.
+- `GET /api/runs/{id}` — `axes` length 7, `findings` count matches, gated runs show null
+  quality + gate reason.
+- `GET /api/cost` — totals reflect the payload's cost/tokens.
+- `GET /api/runs/{id}/turns/0/frame.png` — image/png bytes.
+
+Reused `ActionResult`-equivalents are the `RunSummaryDto` / `RunDetail` / `CostSummary` DTOs in
+`persist/queries.rs` — unchanged.
+
+## Feature flag
+
+Per AGENTS.md §6, runtime gameplay features are flagged. This change ships **no game-runtime
+behavior** — it is a CLI subcommand on a tool binary plus a skill-doc edit. There is no
+`config.flags` seam in `parish-harness` and nothing in the game loop changes, so no flag
+applies. The `ingest` subcommand is itself the opt-in surface (nothing calls it unless the
+skill or a user does). This deviation is intentional and noted here for the judge.
+
+## Risks / parity
+
+- `ingest` must reuse the same persist fns the `run` pipeline calls (no second write path), so
+  gated/scored semantics can't drift. The helper `ingest_complete_run` is the single seam.
+- `update_run_cost` is also wired into `run` later (the cost columns are 0 there today); this
+  change adds the writer and the ingest caller. Wiring the live `run` cost is out of scope but
+  the writer is shared, not ingest-only, to avoid a divergent path (AGENTS.md §12 spirit).

--- a/docs/plans/harness-skill-ingest.md
+++ b/docs/plans/harness-skill-ingest.md
@@ -1,0 +1,78 @@
+# Plan: harness-skill-ingest
+
+Ordered, one commit per step, conventional-commit prefixes. All code changes are confined to
+`parish/crates/parish-harness/` plus the skill doc.
+
+## Step 1 — `feat(harness): add IngestPayload + load_and_ingest` (no CLI yet)
+
+- New `src/ingest.rs`:
+  - `IngestPayload` and child payload structs (`serde::Deserialize`) per the design note.
+  - Ensure `GitProvenance`, and the `Axis`/`Severity` label parsers, are reachable; add
+    `#[derive(Deserialize)]` to `GitProvenance` and a `from_label`/`FromStr` for `Axis` +
+    `Severity` if missing (small, in `score/axes.rs` / `score/finding.rs`).
+  - `pub fn load_and_ingest(db: &Db, payload_path, artifacts_root) -> Result<i64>`:
+    1. read + deserialize payload JSON,
+    2. resolve `artifact_dir = artifacts_root/runs/<uuid>` (uuid from payload or generated),
+    3. validate `turns/NNN/frame.png` exists for each turn (rule #14 — error on missing/empty),
+    4. call `db.ingest_complete_run(&payload, &artifact_dir)`.
+- `src/lib.rs`: `pub mod ingest;`.
+- Tests: `ingest.rs` unit test that deserializes `sample-payload.json`.
+
+## Step 2 — `feat(harness): Db::ingest_complete_run + update_run_cost`
+
+- In `src/persist/sink.rs`:
+  - `pub fn update_run_cost(&self, run_id, cost_usd: f64, player_tokens: u64, judge_tokens: u64)
+-> Result<()>` — `UPDATE runs SET cost_usd=?, player_tokens=?, judge_tokens=? WHERE id=?`.
+  - `pub fn ingest_complete_run(&self, p: &IngestPayload, artifact_dir: &str) -> Result<i64>`:
+    1. `upsert_config(&p.config.into())` (label forced `skill:quality-harness`),
+    2. `start_run(config_id, &p.git, &p.rubric_sha256, artifact_dir)`,
+    3. `record_turn` for each turn (map `TurnPayload -> TurnRecord`),
+    4. `insert_finding` for each finding,
+    5. `update_run_cost(run_id, ...)`,
+    6. if `p.gate` is Some → `finish_run_gated(run_id, &trip)`; else
+       `finish_run_scored(run_id, p.quality_score, &axes)`,
+    7. return `run_id`.
+  - All inside one `conn` transaction (`BEGIN`/`COMMIT`) so a bad payload leaves no half-run.
+- Tests in `sink.rs`: scored ingest sets status/quality/axes/cost; gated ingest nulls quality;
+  two ingests reuse one config row.
+
+## Step 3 — `feat(harness): wire `ingest` subcommand`
+
+- `src/main.rs`: add `Ingest(IngestArgs)` to the `Command` enum + `match`.
+  `IngestArgs { payload: PathBuf, artifacts: PathBuf, db: Option<PathBuf> }`.
+  Handler opens the DB (default path when `--db` omitted), calls
+  `ingest::load_and_ingest`, prints `ingested run <id>`.
+- Update `README.md` command cookbook with the `ingest` example.
+
+## Step 4 — `test(harness): end-to-end ingest fixture`
+
+- `parish/crates/parish-harness/tests/ingest.rs`: in-memory + temp-dir e2e covering all AC
+  (scored, gated, cost, 7 axes, findings, config dedup).
+- `parish/testing/fixtures/ingest_harness_skill/` (already scaffolded): `sample-payload.json` +
+  `artifacts/runs/<uuid>/turns/000/frame.png` + `verify.sh` that ingests then curls the serve
+  API and asserts each signal.
+
+## Step 5 — `docs(skill): quality-harness persists runs to the dashboard`
+
+- Edit `.agents/skills/quality-harness/SKILL.md` (CLAUDE/`.claude` is a symlink) — add a
+  section **"6. Persist to the dashboard"** after "Output + file bugs":
+  - Build the `IngestPayload` JSON from the per-turn log + 7 axis scores + findings + git
+    provenance + cost (token/cost estimate from the run).
+  - Create `runs/<uuid>/turns/NNN/frame.png` from captured screenshots (nearest-prior mapping;
+    bundled placeholder for pre-first-capture turns) and `lines.json` per turn.
+  - Run `cargo run -p parish-harness -- ingest --payload <json> --artifacts <root>`.
+  - Surface the printed run id + `http://localhost:8787` so the user can open it.
+- Note the same payload schema in `parish/crates/parish-harness/README.md` so the contract has
+  one documented source.
+
+## Tests to add / update
+
+- `sink.rs` unit tests (Step 2), `tests/ingest.rs` integration (Step 4).
+- `cargo clippy -p parish-harness --all-targets -- -D warnings` clean.
+- No game-runtime tests change. No `architecture_fitness` impact (no new cross-crate dep).
+
+## Proof
+
+Tooling change, so `/parish-engine prove` does not apply. Evidence = `cargo test -p
+parish-harness ingest` transcript + `verify.sh` transcript showing the dashboard API returning
+the ingested run. `evidence.md` maps each AC criterion to those lines; `judge.md` verifies each.

--- a/parish/crates/parish-harness/README.md
+++ b/parish/crates/parish-harness/README.md
@@ -105,6 +105,40 @@ $BIN compare --a <run_id> --b <run_id> [--db <path>]
 Prints a per-axis delta table, the gate-status diff, and the finding-signature diff. The
 dashboard `/api/compare` + `/api/timeline` give the same data plus score-vs-git-history.
 
+### `ingest` — land an externally-produced run
+
+```sh
+$BIN ingest --payload <run.json> --artifacts <root> [--db <path>]
+```
+
+Persists a complete run that was produced **outside** the `run` loop — specifically a
+quality-harness **skill** run (an agent drives the live game over the parish MCP, judges by
+hand, and files bugs). The payload is replayed through the exact same sink writers `run` uses,
+so the run shows on the dashboard indistinguishably from a binary run (quality score, 7-axis
+bars, findings, per-turn frames, cost). Prints `ingested run <id>`.
+
+`--artifacts <root>` must contain `runs/<uuid>/turns/NNN/frame.png` for every turn the payload
+references (each frame must be non-empty — rule #14). The run's `artifact_dir` is stored as
+`<root>/runs/<uuid>` so the dashboard's frame route resolves unchanged.
+
+Payload schema (one JSON object):
+
+| Field           | Type    | Notes                                                                                                      |
+| --------------- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `config`        | object  | A `RunConfig`; its `label` is forced to `skill:quality-harness` so all skill runs share one `configs` row. |
+| `git`           | object  | `{sha, branch, dirty, pr_number}`.                                                                         |
+| `rubric_sha256` | string  | Pass the binary's pinned rubric sha so timeline / A-B treat skill and binary runs as comparable.           |
+| `uuid`          | string  | Run dir name under `runs/`.                                                                                |
+| `gate`          | object? | `{reason, turn, detail}` — present **iff** the run hard-failed; stores it gated with NULL quality.         |
+| `quality_score` | number? | Weighted mean; recomputed from `axes` when omitted on a non-gated run.                                     |
+| `cost`          | object  | `{cost_usd, player_tokens, judge_tokens}`.                                                                 |
+| `turns[]`       | array   | Mirror of a `TurnRecord`; `frame_path` / `lines_path` are relative (`turns/NNN/...`).                      |
+| `axes[]`        | array   | `{axis, score, rationale}` — the 7 quality-axis keys.                                                      |
+| `findings[]`    | array   | `{category, turn_index?, severity, description, evidence_quote, signature}`.                               |
+
+A worked sample lives at `parish/testing/fixtures/ingest_harness_skill/sample-payload.json`
+(with `verify.sh` exercising the full ingest → serve → API round-trip).
+
 ### `db-path`
 
 ```sh

--- a/parish/crates/parish-harness/src/git.rs
+++ b/parish/crates/parish-harness/src/git.rs
@@ -7,8 +7,10 @@
 
 use std::process::Command;
 
+use serde::{Deserialize, Serialize};
+
 /// Git + PR identity at the moment a run started.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GitProvenance {
     pub sha: String,
     pub branch: String,

--- a/parish/crates/parish-harness/src/ingest.rs
+++ b/parish/crates/parish-harness/src/ingest.rs
@@ -1,0 +1,246 @@
+//! Ingest an externally-produced run into `harness.db`.
+//!
+//! The `parish-harness` **binary** produces runs via its own `run` loop. The
+//! quality-harness **skill** produces runs a different way: an agent drives the
+//! live game over the parish MCP, judges the transcript by hand, and files bugs.
+//! Those skill runs never touched the DB, so they never appeared on the
+//! dashboard. This module is the bridge: it deserializes a complete skill-run
+//! record (`IngestPayload`), validates its per-turn frame artifacts (rule #14 —
+//! never accept a blank frame), maps it onto the domain types, and replays it
+//! through the *same* sink writers the live pipeline uses
+//! ([`Db::ingest_complete_run`]). The result is indistinguishable from a binary
+//! run to the dashboard read paths.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::config::RunConfig;
+use crate::error::{HarnessError, Result};
+use crate::git::GitProvenance;
+use crate::persist::{Db, IngestRecord, TurnRecord};
+use crate::score::{Axis, AxisScore, Finding, GateReason, GateTrip, Severity, weighted_quality};
+
+/// The complete skill-run record handed to `parish-harness ingest`.
+#[derive(Debug, Deserialize)]
+pub struct IngestPayload {
+    /// Run config; its `label` is forced to `skill:quality-harness` on ingest so
+    /// every skill run shares one `configs` row (by content hash).
+    pub config: RunConfig,
+    pub git: GitProvenance,
+    /// The pinned rubric hash the skill scored against (pass the binary's pinned
+    /// rubric sha so timeline / A-B treat skill and binary runs as comparable).
+    pub rubric_sha256: String,
+    /// Stable run directory name under `<artifacts>/runs/`. Must match the
+    /// directory the skill wrote its `turns/NNN/frame.png` into.
+    pub uuid: String,
+    /// Present iff the run was gated (a hard fail). When set, the run is stored
+    /// gated with a NULL quality score; `quality_score`/`axes` are ignored.
+    #[serde(default)]
+    pub gate: Option<GatePayload>,
+    /// Weighted-mean quality. When absent on a non-gated run it is recomputed
+    /// from `axes`.
+    #[serde(default)]
+    pub quality_score: Option<f64>,
+    #[serde(default)]
+    pub cost: CostPayload,
+    pub turns: Vec<TurnPayload>,
+    pub axes: Vec<AxisPayload>,
+    #[serde(default)]
+    pub findings: Vec<FindingPayload>,
+}
+
+/// Gate trip on a hard-failed run.
+#[derive(Debug, Deserialize)]
+pub struct GatePayload {
+    /// Snake_case gate reason (`crash`, `parser_reject`, `timeout`,
+    /// `json_parse_fail`, `empty_turn_burn`, `judge_critical`).
+    pub reason: String,
+    #[serde(default)]
+    pub turn: u32,
+    #[serde(default)]
+    pub detail: String,
+}
+
+/// Cost / token accounting for the run (the skill's own tally).
+#[derive(Debug, Default, Deserialize)]
+pub struct CostPayload {
+    #[serde(default)]
+    pub cost_usd: f64,
+    #[serde(default)]
+    pub player_tokens: u64,
+    #[serde(default)]
+    pub judge_tokens: u64,
+}
+
+/// One persisted turn. Mirrors [`TurnRecord`]; paths are relative to the run's
+/// artifact dir (`turns/NNN/frame.png`).
+#[derive(Debug, Deserialize)]
+pub struct TurnPayload {
+    pub turn_index: u32,
+    pub player_input: String,
+    #[serde(default = "ok")]
+    pub outcome: String,
+    #[serde(default = "dialogue")]
+    pub kind: String,
+    #[serde(default)]
+    pub elapsed_ms: u64,
+    #[serde(default = "empty_obj")]
+    pub engine_state_json: String,
+    #[serde(default)]
+    pub location_id: Option<u32>,
+    #[serde(default)]
+    pub location_name: Option<String>,
+    #[serde(default)]
+    pub game_clock: Option<String>,
+    #[serde(default)]
+    pub npcs_here_count: Option<u32>,
+    pub frame_path: String,
+    pub lines_path: String,
+}
+
+fn ok() -> String {
+    "ok".into()
+}
+fn dialogue() -> String {
+    "dialogue".into()
+}
+fn empty_obj() -> String {
+    "{}".into()
+}
+
+/// One axis score.
+#[derive(Debug, Deserialize)]
+pub struct AxisPayload {
+    pub axis: String,
+    pub score: u8,
+    #[serde(default)]
+    pub rationale: String,
+}
+
+/// One discrete finding. Unlike the judge's `RawFinding`, the skill supplies the
+/// dedup `signature` directly (it computed it when filing the GitHub issue), so
+/// the dashboard collapses skill and binary findings of the same class together.
+#[derive(Debug, Deserialize)]
+pub struct FindingPayload {
+    pub category: String,
+    #[serde(default)]
+    pub turn_index: Option<u32>,
+    pub severity: String,
+    pub description: String,
+    #[serde(default)]
+    pub evidence_quote: String,
+    pub signature: String,
+}
+
+/// Read, validate, and ingest a skill-run payload. Returns the new run id.
+///
+/// `artifacts_root` is the directory that holds `runs/<uuid>/...`; the run's
+/// absolute artifact dir is stored so the dashboard's frame route resolves
+/// `{artifact_dir}/turns/NNN/frame.png` exactly as for a binary run.
+pub fn load_and_ingest(db: &Db, payload_path: &Path, artifacts_root: &Path) -> Result<i64> {
+    let body = std::fs::read_to_string(payload_path)
+        .map_err(|e| HarnessError::io(payload_path.display().to_string(), e))?;
+    let payload: IngestPayload = serde_json::from_str(&body).map_err(|e| HarnessError::Json {
+        context: format!("ingest payload {}", payload_path.display()),
+        source: e,
+    })?;
+
+    let rec = build_record(payload, artifacts_root)?;
+    db.ingest_complete_run(rec)
+}
+
+/// Map a deserialized payload onto the domain [`IngestRecord`], validating frame
+/// artifacts along the way.
+fn build_record(mut payload: IngestPayload, artifacts_root: &Path) -> Result<IngestRecord> {
+    // Force the config label so every skill run content-hashes to one config row.
+    payload.config.label = Some("skill:quality-harness".to_string());
+
+    let artifact_dir = artifacts_root.join("runs").join(&payload.uuid);
+    let artifact_dir_str = artifact_dir.to_string_lossy().into_owned();
+
+    // Map turns, validating that each referenced frame exists and is non-empty
+    // (rule #14 — never accept a blank/missing artifact as if it were content).
+    let mut turns = Vec::with_capacity(payload.turns.len());
+    for t in payload.turns {
+        let frame_abs = artifact_dir.join(&t.frame_path);
+        let meta = std::fs::metadata(&frame_abs)
+            .map_err(|e| HarnessError::io(frame_abs.display().to_string(), e))?;
+        if meta.len() == 0 {
+            return Err(HarnessError::BlankArtifact(format!(
+                "turn {} frame is empty: {}",
+                t.turn_index,
+                frame_abs.display()
+            )));
+        }
+        turns.push(TurnRecord {
+            turn_index: t.turn_index,
+            player_input: t.player_input,
+            outcome: t.outcome,
+            kind: t.kind,
+            elapsed_ms: t.elapsed_ms,
+            engine_state_json: t.engine_state_json,
+            location_id: t.location_id,
+            location_name: t.location_name,
+            game_clock: t.game_clock,
+            npcs_here_count: t.npcs_here_count,
+            screenshot_path: None,
+            frame_path: t.frame_path,
+            lines_path: t.lines_path,
+            llm_transcript_path: None,
+        });
+    }
+
+    // Map axes, rejecting unknown keys so a typo can't silently drop a score.
+    let mut axes = Vec::with_capacity(payload.axes.len());
+    for a in &payload.axes {
+        let axis = Axis::from_key(&a.axis)
+            .ok_or_else(|| HarnessError::Config(format!("unknown quality axis '{}'", a.axis)))?;
+        axes.push(AxisScore {
+            axis,
+            score: a.score.min(100),
+            rationale: a.rationale.clone(),
+        });
+    }
+
+    let findings = payload
+        .findings
+        .into_iter()
+        .map(|f| Finding {
+            category: f.category,
+            turn_index: f.turn_index,
+            severity: Severity::from_label(&f.severity),
+            description: f.description,
+            evidence_quote: f.evidence_quote,
+            signature: f.signature,
+        })
+        .collect();
+
+    let gate = payload.gate.map(|g| GateTrip {
+        reason: GateReason::from_label(&g.reason),
+        turn: g.turn,
+        detail: g.detail,
+    });
+
+    // Scored runs carry a quality number; recompute from axes when omitted.
+    let quality_score = if gate.is_some() {
+        None
+    } else {
+        payload.quality_score.or_else(|| weighted_quality(&axes))
+    };
+
+    Ok(IngestRecord {
+        config: payload.config,
+        git: payload.git,
+        rubric_sha256: payload.rubric_sha256,
+        artifact_dir: artifact_dir_str,
+        turns,
+        axes,
+        findings,
+        gate,
+        quality_score,
+        cost_usd: payload.cost.cost_usd,
+        player_tokens: payload.cost.player_tokens,
+        judge_tokens: payload.cost.judge_tokens,
+    })
+}

--- a/parish/crates/parish-harness/src/lib.rs
+++ b/parish/crates/parish-harness/src/lib.rs
@@ -18,6 +18,7 @@ pub mod dashboard;
 pub mod error;
 pub mod frame;
 pub mod git;
+pub mod ingest;
 pub mod issue;
 pub mod persist;
 pub mod queue;

--- a/parish/crates/parish-harness/src/main.rs
+++ b/parish/crates/parish-harness/src/main.rs
@@ -43,6 +43,21 @@ enum Command {
     Worker(WorkerArgs),
     /// A/B compare two runs.
     Compare(CompareArgs),
+    /// Ingest an externally-produced run (e.g. a quality-harness skill run).
+    Ingest(IngestArgs),
+}
+
+#[derive(clap::Args)]
+struct IngestArgs {
+    /// Path to the ingest payload JSON (a complete skill-run record).
+    #[arg(long)]
+    payload: PathBuf,
+    /// Artifact root holding `runs/<uuid>/turns/NNN/frame.png`.
+    #[arg(long)]
+    artifacts: PathBuf,
+    /// Path to the harness DB (defaults to the user-data root).
+    #[arg(long)]
+    db: Option<PathBuf>,
 }
 
 #[derive(clap::Args)]
@@ -212,7 +227,16 @@ async fn run() -> Result<()> {
         Command::Queue(args) => run_queue(args).await,
         Command::Worker(args) => run_worker(args).await,
         Command::Compare(args) => run_compare(args).await,
+        Command::Ingest(args) => run_ingest(args),
     }
+}
+
+fn run_ingest(args: IngestArgs) -> Result<()> {
+    let db_path = args.db.unwrap_or_else(default_db_path);
+    let db = Db::open(&db_path)?;
+    let run_id = parish_harness::ingest::load_and_ingest(&db, &args.payload, &args.artifacts)?;
+    println!("ingested run {run_id}");
+    Ok(())
 }
 
 async fn run_serve(args: ServeArgs) -> Result<()> {

--- a/parish/crates/parish-harness/src/persist/mod.rs
+++ b/parish/crates/parish-harness/src/persist/mod.rs
@@ -9,4 +9,4 @@ pub use queries::{
     AbCompare, AxisDelta, AxisScoreDto, FindingDto, RunDetail, RunSummaryDto, TimelinePoint,
     TurnSummaryDto,
 };
-pub use sink::{Db, RunSummary, TurnRecord, default_db_path};
+pub use sink::{Db, IngestRecord, RunSummary, TurnRecord, default_db_path};

--- a/parish/crates/parish-harness/src/persist/sink.rs
+++ b/parish/crates/parish-harness/src/persist/sink.rs
@@ -38,6 +38,27 @@ pub struct TurnRecord {
     pub llm_transcript_path: Option<String>,
 }
 
+/// A complete, externally-produced run ready to persist in one shot. Mirrors
+/// what the live `run` pipeline writes incrementally, but assembled up front by
+/// an external producer (the quality-harness skill) and replayed through the
+/// same sink writers via [`Db::ingest_complete_run`].
+pub struct IngestRecord {
+    pub config: RunConfig,
+    pub git: GitProvenance,
+    pub rubric_sha256: String,
+    /// Absolute path to the run's artifact directory (`.../runs/<uuid>`).
+    pub artifact_dir: String,
+    pub turns: Vec<TurnRecord>,
+    pub axes: Vec<AxisScore>,
+    pub findings: Vec<Finding>,
+    /// `Some` => gated (quality is forced NULL); `None` => scored.
+    pub gate: Option<GateTrip>,
+    pub quality_score: Option<f64>,
+    pub cost_usd: f64,
+    pub player_tokens: u64,
+    pub judge_tokens: u64,
+}
+
 /// A compact run summary for CLI output and the dashboard list.
 #[derive(Debug, Clone)]
 pub struct RunSummary {
@@ -222,6 +243,14 @@ impl Db {
         Ok(self.conn.last_insert_rowid())
     }
 
+    /// Count rows in `configs` (distinct run configurations seen). Used to
+    /// assert content-hash dedup behaviour.
+    pub fn config_count(&self) -> Result<i64> {
+        Ok(self
+            .conn
+            .query_row("SELECT COUNT(*) FROM configs", [], |r| r.get(0))?)
+    }
+
     /// Return the on-disk artifact directory for a run, or `None` if unknown.
     pub fn run_artifact_dir(&self, run_id: i64) -> Result<Option<String>> {
         let result = self
@@ -300,6 +329,48 @@ impl Db {
             total_player_tokens: total_player_tokens as u64,
             total_judge_tokens: total_judge_tokens as u64,
         })
+    }
+
+    /// Write the cost/token totals for a run. The `run` pipeline leaves these
+    /// at their 0 defaults until `AnyClient` usage exposure is wired through;
+    /// the ingest path supplies them from the skill's own accounting.
+    pub fn update_run_cost(
+        &self,
+        run_id: i64,
+        cost_usd: f64,
+        player_tokens: u64,
+        judge_tokens: u64,
+    ) -> Result<()> {
+        self.conn.execute(
+            "UPDATE runs SET cost_usd = ?1, player_tokens = ?2, judge_tokens = ?3
+              WHERE id = ?4",
+            params![cost_usd, player_tokens as i64, judge_tokens as i64, run_id],
+        )?;
+        Ok(())
+    }
+
+    /// Persist a complete, externally-produced run in one transaction, reusing
+    /// the exact same sink writers the live `run` pipeline calls — there is no
+    /// second write path, so scored/gated semantics cannot drift. Returns the
+    /// new run id. Used by the `ingest` subcommand to land quality-harness
+    /// **skill** runs in the same DB the dashboard reads.
+    pub fn ingest_complete_run(&self, rec: IngestRecord) -> Result<i64> {
+        let tx = self.conn.unchecked_transaction()?;
+        let config_id = self.upsert_config(&rec.config)?;
+        let run_id = self.start_run(config_id, &rec.git, &rec.rubric_sha256, &rec.artifact_dir)?;
+        for t in &rec.turns {
+            self.record_turn(run_id, t)?;
+        }
+        for f in &rec.findings {
+            self.insert_finding(run_id, f)?;
+        }
+        self.update_run_cost(run_id, rec.cost_usd, rec.player_tokens, rec.judge_tokens)?;
+        match &rec.gate {
+            Some(trip) => self.finish_run_gated(run_id, trip)?,
+            None => self.finish_run_scored(run_id, rec.quality_score, &rec.axes)?,
+        }
+        tx.commit()?;
+        Ok(run_id)
     }
 
     /// Read a run summary for output.

--- a/parish/crates/parish-harness/src/score/gate.rs
+++ b/parish/crates/parish-harness/src/score/gate.rs
@@ -39,6 +39,20 @@ impl GateReason {
             GateReason::JudgeCritical => "judge_critical",
         }
     }
+
+    /// Parse a gate reason from its snake_case label. Unknown labels degrade to
+    /// `Crash` (the most conservative "broken run" reason) rather than failing —
+    /// an ingested run is always recordable even if its reason string drifted.
+    pub fn from_label(s: &str) -> GateReason {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "parser_reject" => GateReason::ParserReject,
+            "timeout" => GateReason::Timeout,
+            "json_parse_fail" => GateReason::JsonParseFail,
+            "empty_turn_burn" => GateReason::EmptyTurnBurn,
+            "judge_critical" => GateReason::JudgeCritical,
+            _ => GateReason::Crash,
+        }
+    }
 }
 
 /// A tripped gate: the reason, the turn index it fired on, and a human detail.

--- a/parish/crates/parish-harness/tests/ingest.rs
+++ b/parish/crates/parish-harness/tests/ingest.rs
@@ -1,0 +1,201 @@
+//! End-to-end coverage for the `ingest` path: a skill-run payload written to
+//! disk is ingested and then read back through the same query DTOs the
+//! dashboard serves, proving an ingested run is indistinguishable from a binary
+//! run to `/api/runs` and `/api/runs/{id}`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use parish_harness::ingest::load_and_ingest;
+use parish_harness::persist::Db;
+
+/// 1x1 PNG — a real, non-empty frame so the rule #14 content check passes.
+const PNG_1X1: &[u8] = &[
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+    0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0x60, 0x60, 0x60, 0x00,
+    0x00, 0x00, 0x05, 0x00, 0x01, 0x5e, 0xf3, 0x2a, 0x3a, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
+    0x44, 0xae, 0x42, 0x60, 0x82,
+];
+
+/// Write a frame for turn `idx` under `<artifacts>/runs/<uuid>/turns/NNN/`.
+fn write_frame(artifacts: &Path, uuid: &str, idx: u32) {
+    let dir = artifacts
+        .join("runs")
+        .join(uuid)
+        .join("turns")
+        .join(format!("{idx:03}"));
+    fs::create_dir_all(&dir).unwrap();
+    fs::write(dir.join("frame.png"), PNG_1X1).unwrap();
+    fs::write(dir.join("lines.json"), b"[]").unwrap();
+}
+
+fn write_payload(dir: &Path, name: &str, json: &str) -> PathBuf {
+    let p = dir.join(name);
+    fs::write(&p, json).unwrap();
+    p
+}
+
+fn scored_payload(uuid: &str) -> String {
+    format!(
+        r#"{{
+          "config": {{ "label": "ignored", "player": {{ "mode": "subagent" }}, "judge": {{ "mode": "subagent" }} }},
+          "git": {{ "sha": "abc123", "branch": "main", "dirty": true, "pr_number": null }},
+          "rubric_sha256": "rubricpin",
+          "uuid": "{uuid}",
+          "status": "completed",
+          "quality_score": 74.0,
+          "cost": {{ "cost_usd": 0.42, "player_tokens": 1000, "judge_tokens": 500 }},
+          "turns": [
+            {{ "turn_index": 0, "player_input": "hello", "frame_path": "turns/000/frame.png", "lines_path": "turns/000/lines.json", "location_name": "Kilteevan Village", "game_clock": "08:01", "npcs_here_count": 1 }}
+          ],
+          "axes": [
+            {{ "axis": "narrative_coherence", "score": 85, "rationale": "a" }},
+            {{ "axis": "character_fidelity", "score": 55, "rationale": "b" }},
+            {{ "axis": "world_responsiveness", "score": 85, "rationale": "c" }},
+            {{ "axis": "intent_fidelity", "score": 82, "rationale": "d" }},
+            {{ "axis": "immersion", "score": 63, "rationale": "e" }},
+            {{ "axis": "progression", "score": 84, "rationale": "f" }},
+            {{ "axis": "common_sense", "score": 70, "rationale": "g" }}
+          ],
+          "findings": [
+            {{ "category": "character_fidelity", "turn_index": 0, "severity": "high", "description": "mood-blind", "evidence_quote": "warm", "signature": "mood-blind" }},
+            {{ "category": "immersion", "turn_index": 0, "severity": "high", "description": "verbose", "evidence_quote": "ramble", "signature": "verbosity" }}
+          ]
+        }}"#
+    )
+}
+
+#[test]
+fn ingest_scored_run_is_readable_via_dashboard_dtos() {
+    let tmp = tempfile::tempdir().unwrap();
+    let artifacts = tmp.path().join("artifacts");
+    let uuid = "00000000-0000-0000-0000-0000000000aa";
+    write_frame(&artifacts, uuid, 0);
+    let payload = write_payload(tmp.path(), "scored.json", &scored_payload(uuid));
+
+    let db = Db::open(&tmp.path().join("harness.db")).unwrap();
+    let run_id = load_and_ingest(&db, &payload, &artifacts).unwrap();
+
+    // /api/runs
+    let runs = db.list_runs(50).unwrap();
+    assert_eq!(runs.len(), 1);
+    let r = &runs[0];
+    assert_eq!(r.id, run_id);
+    assert_eq!(r.status, "completed");
+    assert_eq!(r.quality_score, Some(74.0));
+    assert_eq!(r.finding_count, 2);
+    assert_eq!(r.git_sha, "abc123");
+    assert!(r.git_dirty);
+
+    // /api/runs/{id}
+    let detail = db.run_detail(run_id).unwrap().unwrap();
+    assert_eq!(detail.axes.len(), 7, "all 7 axes present");
+    let keys: std::collections::BTreeSet<_> = detail.axes.iter().map(|a| a.axis.clone()).collect();
+    for k in [
+        "narrative_coherence",
+        "character_fidelity",
+        "world_responsiveness",
+        "intent_fidelity",
+        "immersion",
+        "progression",
+        "common_sense",
+    ] {
+        assert!(keys.contains(k), "missing axis {k}");
+    }
+    assert_eq!(detail.findings.len(), 2);
+    assert_eq!(detail.turns.len(), 1);
+    assert_eq!(
+        detail.turns[0].location_name.as_deref(),
+        Some("Kilteevan Village")
+    );
+    // The stored artifact_dir resolves the frame the dashboard serves.
+    assert!(
+        Path::new(&detail.summary.artifact_dir)
+            .join(&detail.turns[0].frame_path)
+            .exists()
+    );
+
+    // /api/cost reflects the payload's accounting (not the hardcoded 0).
+    let cost = db.cost_summary().unwrap();
+    assert_eq!(cost.total_runs, 1);
+    assert!((cost.total_cost_usd - 0.42).abs() < 1e-9);
+    assert_eq!(cost.total_player_tokens, 1000);
+    assert_eq!(cost.total_judge_tokens, 500);
+}
+
+#[test]
+fn ingest_gated_run_has_null_quality_and_reason() {
+    let tmp = tempfile::tempdir().unwrap();
+    let artifacts = tmp.path().join("artifacts");
+    let uuid = "00000000-0000-0000-0000-0000000000bb";
+    write_frame(&artifacts, uuid, 0);
+    let json = format!(
+        r#"{{
+          "config": {{ "player": {{ "mode": "subagent" }}, "judge": {{ "mode": "subagent" }} }},
+          "git": {{ "sha": "def456", "branch": "main", "dirty": false, "pr_number": null }},
+          "rubric_sha256": "rubricpin",
+          "uuid": "{uuid}",
+          "status": "gated",
+          "gate": {{ "reason": "crash", "turn": 3, "detail": "transport error mid-run" }},
+          "cost": {{ "cost_usd": 0.0, "player_tokens": 0, "judge_tokens": 0 }},
+          "turns": [
+            {{ "turn_index": 0, "player_input": "look", "frame_path": "turns/000/frame.png", "lines_path": "turns/000/lines.json" }}
+          ],
+          "axes": [],
+          "findings": []
+        }}"#
+    );
+    let payload = write_payload(tmp.path(), "gated.json", &json);
+
+    let db = Db::open(&tmp.path().join("harness.db")).unwrap();
+    let run_id = load_and_ingest(&db, &payload, &artifacts).unwrap();
+
+    let detail = db.run_detail(run_id).unwrap().unwrap();
+    assert_eq!(detail.summary.status, "gated");
+    assert_eq!(detail.summary.quality_score, None);
+    assert_eq!(detail.summary.gate_reason.as_deref(), Some("crash"));
+    assert_eq!(detail.summary.gate_turn, Some(3));
+    assert!(detail.axes.is_empty());
+}
+
+#[test]
+fn two_skill_runs_share_one_config_row() {
+    let tmp = tempfile::tempdir().unwrap();
+    let artifacts = tmp.path().join("artifacts");
+    let db = Db::open(&tmp.path().join("harness.db")).unwrap();
+
+    for uuid in [
+        "00000000-0000-0000-0000-0000000000c1",
+        "00000000-0000-0000-0000-0000000000c2",
+    ] {
+        write_frame(&artifacts, uuid, 0);
+        let payload = write_payload(tmp.path(), &format!("{uuid}.json"), &scored_payload(uuid));
+        load_and_ingest(&db, &payload, &artifacts).unwrap();
+    }
+
+    let runs = db.list_runs(50).unwrap();
+    assert_eq!(runs.len(), 2, "two distinct runs");
+    let config_count: i64 = db.config_count().expect("config count helper");
+    assert_eq!(
+        config_count, 1,
+        "label forced to skill:quality-harness dedups configs"
+    );
+}
+
+#[test]
+fn ingest_rejects_missing_frame() {
+    let tmp = tempfile::tempdir().unwrap();
+    let artifacts = tmp.path().join("artifacts");
+    let uuid = "00000000-0000-0000-0000-0000000000dd";
+    // Deliberately do NOT write the frame.
+    let payload = write_payload(tmp.path(), "noframe.json", &scored_payload(uuid));
+    let db = Db::open(&tmp.path().join("harness.db")).unwrap();
+    let err = load_and_ingest(&db, &payload, &artifacts).unwrap_err();
+    assert!(
+        format!("{err}").contains("frame"),
+        "missing frame must error, got: {err}"
+    );
+    // And nothing was persisted.
+    assert_eq!(db.list_runs(50).unwrap().len(), 0);
+}

--- a/parish/testing/fixtures/ingest_harness_skill/sample-payload.json
+++ b/parish/testing/fixtures/ingest_harness_skill/sample-payload.json
@@ -1,0 +1,103 @@
+{
+  "config": {
+    "label": "skill:quality-harness",
+    "engine_models": {},
+    "flags": [],
+    "player": {
+      "mode": "subagent",
+      "model": "opus",
+      "persona": "curious newcomer, 1820",
+      "strategy": "meet villagers, find lodging and work"
+    },
+    "judge": {
+      "mode": "subagent",
+      "model": "opus",
+      "rubric_version": "v1",
+      "rubric_sha256": null
+    },
+    "gate": {}
+  },
+  "git": {
+    "sha": "85aeeefe",
+    "branch": "claude/musing-shamir-b28938",
+    "dirty": true,
+    "pr_number": null
+  },
+  "rubric_sha256": "PLACEHOLDER_BINARY_PINNED_RUBRIC_SHA",
+  "uuid": "00000000-0000-0000-0000-0000000000aa",
+  "status": "completed",
+  "quality_score": 74.0,
+  "gate": null,
+  "cost": { "cost_usd": 0.0, "player_tokens": 0, "judge_tokens": 0 },
+  "turns": [
+    {
+      "turn_index": 0,
+      "player_input": "Good morning to you. I'm new to Kilteevan. Might I ask your name?",
+      "outcome": "ok",
+      "kind": "dialogue",
+      "elapsed_ms": 1200,
+      "engine_state_json": "{\"scene\":\"Kilteevan Village\"}",
+      "location_id": 15,
+      "location_name": "Kilteevan Village",
+      "game_clock": "08:01",
+      "npcs_here_count": 1,
+      "frame_path": "turns/000/frame.png",
+      "lines_path": "turns/000/lines.json"
+    }
+  ],
+  "axes": [
+    {
+      "axis": "narrative_coherence",
+      "score": 85,
+      "rationale": "referral chain carried across NPCs"
+    },
+    {
+      "axis": "character_fidelity",
+      "score": 55,
+      "rationale": "mood-blind dialogue across 3/4 NPCs"
+    },
+    {
+      "axis": "world_responsiveness",
+      "score": 85,
+      "rationale": "schedule-driven autonomous life on /wait"
+    },
+    {
+      "axis": "intent_fidelity",
+      "score": 82,
+      "rationale": "all inputs routed; one spurious system line"
+    },
+    {
+      "axis": "immersion",
+      "score": 63,
+      "rationale": "run-on replies + scaffolding leak break it"
+    },
+    {
+      "axis": "progression",
+      "score": 84,
+      "rationale": "arrival -> lodging -> work -> name in 9 turns"
+    },
+    {
+      "axis": "common_sense",
+      "score": 70,
+      "rationale": "minor unfounded familiarity"
+    }
+  ],
+  "findings": [
+    {
+      "category": "character_fidelity",
+      "turn_index": 0,
+      "severity": "high",
+      "description": "NPC mood tag not reflected in dialogue tone",
+      "evidence_quote": "Welcome to Kilteevan ... this fine mornin'",
+      "signature": "mood-blind-dialogue"
+    },
+    {
+      "category": "immersion",
+      "turn_index": 5,
+      "severity": "high",
+      "description": "run-on multi-question monologue",
+      "evidence_quote": "What say ye to that, then? Shall we settle ...",
+      "signature": "verbosity-runon"
+    }
+  ]
+}

--- a/parish/testing/fixtures/ingest_harness_skill/verify.sh
+++ b/parish/testing/fixtures/ingest_harness_skill/verify.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Verification fixture for harness-skill-ingest.
+#
+# Tooling task — not a game script. Ingests a sample skill-run payload into a
+# temp harness.db, starts the dashboard server, and asserts the dashboard API
+# returns the run with the right status, quality, 7 axes, findings, cost, and a
+# servable per-turn frame.
+#
+# BEFORE the feature lands this script FAILS at the `ingest` step (subcommand
+# does not exist) — that is the demonstration-of-absence. AFTER it lands it
+# exits 0 and prints PASS for each criterion.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/../../../.." && pwd)"
+tmp="$(mktemp -d)"
+db="$tmp/harness.db"
+artifacts="$tmp/artifacts"
+uuid="00000000-0000-0000-0000-0000000000aa"
+port=8799
+trap 'kill "${serve_pid:-0}" 2>/dev/null || true; rm -rf "$tmp"' EXIT
+
+# Lay out artifacts/runs/<uuid>/turns/000/frame.png (1x1 PNG placeholder).
+mkdir -p "$artifacts/runs/$uuid/turns/000"
+base64 -d >"$artifacts/runs/$uuid/turns/000/frame.png" <<'PNG'
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC
+PNG
+echo '[]' >"$artifacts/runs/$uuid/turns/000/lines.json"
+
+cd "$root/parish"
+
+echo "== ingest =="
+cargo run -q -p parish-harness -- ingest \
+    --payload "$here/sample-payload.json" \
+    --artifacts "$artifacts" \
+    --db "$db"
+
+echo "== serve =="
+cargo run -q -p parish-harness -- serve --db "$db" --artifacts "$artifacts" --port "$port" &
+serve_pid=$!
+for _ in $(seq 1 30); do
+    curl -sf "http://127.0.0.1:$port/api/runs" >/dev/null 2>&1 && break
+    sleep 1
+done
+
+runs="$(curl -s "http://127.0.0.1:$port/api/runs")"
+id="$(printf '%s' "$runs" | python3 -c 'import sys,json;print(json.load(sys.stdin)[0]["id"])')"
+detail="$(curl -s "http://127.0.0.1:$port/api/runs/$id")"
+cost="$(curl -s "http://127.0.0.1:$port/api/cost")"
+
+python3 - "$runs" "$detail" "$cost" <<'PY'
+import sys, json
+runs, detail, cost = (json.loads(a) for a in sys.argv[1:4])
+r = runs[0]
+assert r["status"] == "completed", r
+assert abs(r["quality_score"] - 74.0) < 0.01, r
+axes = {a["axis"] for a in detail["axes"]}
+assert len(axes) == 7, axes
+assert len(detail["findings"]) == 2, detail["findings"]
+print("PASS list/detail/axes/findings")
+PY
+
+curl -sf "http://127.0.0.1:$port/api/runs/$id/turns/0/frame.png" -o "$tmp/frame.png"
+test -s "$tmp/frame.png" && echo "PASS frame.png served"
+echo "ALL PASS"


### PR DESCRIPTION
## What

Skill-driven quality-harness runs now persist to `harness.db`, so they show on the `parish-harness` dashboard next to binary `run` output. Previously only `parish-harness run` wrote to the DB; a quality-harness *skill* run (agent drives the live game over the parish MCP, judges by hand, files bugs) was invisible to the dashboard.

## How

- New `parish-harness ingest --payload <json> --artifacts <dir> [--db]` subcommand.
- One new transaction helper `Db::ingest_complete_run` replays a complete run through the **existing** sink writers (`upsert_config` → `start_run` → `record_turn` → `insert_finding` → `finish_run_scored`/`finish_run_gated`) — no second write path, so scored/gated semantics can't drift.
- `Db::update_run_cost` fills the `cost_usd`/`player_tokens`/`judge_tokens` columns the live `run` pipeline still leaves at 0.
- New `ingest` module: `IngestPayload` serde shape → domain types, with per-turn frame validation (rule #14 — blank/missing frame errors, nothing persisted).
- quality-harness `SKILL.md` gains a final "Persist to the dashboard" step; README documents the `ingest` command + payload schema; a `harness-dashboard` `launch.json` entry serves the dashboard in the preview pane.

Schema and dashboard read paths (`persist/schema.rs`, `dashboard/routes.rs`, `persist/queries.rs`) are **unchanged** — an ingested run is indistinguishable from a binary run to `/api/runs` and `/api/runs/{id}`.

## Tests

- `cargo test -p parish-harness` — 79 lib + 4 new integration tests green.
- `cargo clippy -p parish-harness --all-targets -- -D warnings` clean; `cargo fmt --check` clean; architecture-fitness green.
- `parish/testing/fixtures/ingest_harness_skill/verify.sh` — real ingest → serve → curl `/api/runs`, `/api/runs/{id}`, `/api/runs/{id}/turns/0/frame.png` all assert PASS.

## Notes

Non-runtime tooling change (`parish-harness` is not a live-proof-tier path), so evidence is unit + e2e dashboard-API proof, not a game transcript. Cost columns get a shared writer here; wiring the live `run` pipeline's cost is a follow-up.

<!-- parish-proof-bundle:harness-skill-ingest v=1 -->

## Proof: harness-skill-ingest

### Acceptance criteria

# Acceptance Criteria: harness-skill-ingest

## Task

A quality-harness **skill** run (an agent driving the live game over the parish MCP, then
judging + filing bugs) currently writes nothing to `harness.db`, so it never appears on the
`parish-harness serve` dashboard — only `parish-harness run` binary runs show up. This task
gives the skill a persistence path. `parish-harness` gains an `ingest` subcommand that accepts
a complete run record (turns, the 7 axis scores, findings, git provenance, cost) plus an
artifact directory, and replays it through the **existing** sink persist functions so the run
lands in `harness.db` indistinguishable from a binary run. The `quality-harness` SKILL.md gains
a final "persist" step that emits that record and invokes `ingest`. Net effect: after a skill
run, the dashboard's Runs list shows the run with its quality score, per-axis bars, findings,
and per-turn frames. The SQLite schema and the dashboard read paths (`/api/runs`,
`/api/runs/{id}`) are unchanged.

## Criteria

- `parish-harness ingest --payload <json> --artifacts <dir> [--db <path>]` exists as a clap
  subcommand and, given a valid payload, writes exactly one new row to `runs` and prints the
  new run id — observable via: `parish-harness ingest ...` exits 0 and prints `ingested run
<id>`; `parish-harness db-path` + a `SELECT COUNT(*) FROM runs` goes from 0 to 1.
- An ingested **scored** run is returned by the dashboard list with its quality score and is
  marked completed — observable via: `GET /api/runs` returns a JSON array whose element has
  `"status":"completed"` and the payload's `quality_score`.
- An ingested run's **7 axis scores and findings** are returned by the detail endpoint —
  observable via: `GET /api/runs/{id}` returns `axes` of length 7 (each key in
  narrative_coherence, character_fidelity, world_responsiveness, intent_fidelity, immersion,
  progression, common_sense) and `findings` whose count equals the payload's findings count.
- An ingested **gated** run (payload with a gate_reason) is stored with null quality and the
  gate reason — observable via: `GET /api/runs/{id}` (or `run_summary`) shows `"status":"gated"`,
  `quality_score` null, and the gate reason string.
- **Cost/token totals are written** (not left at 0) when the payload supplies them — observable
  via: `GET /api/cost` reflects the payload's `cost_usd` / `player_tokens` / `judge_tokens`
  after an ingest (today these columns are hardcoded 0).
- Per-turn **frames render** for an ingested run — observable via: `GET
/api/runs/{id}/turns/0/frame.png` returns image/png bytes copied from the artifact dir.
- Ingest is **idempotent-safe on config**: ingesting two skill runs reuses one `configs` row by
  content hash (label `skill:quality-harness`) — observable via: two ingests, `SELECT COUNT(*)
FROM configs` stays 1 while `runs` goes to 2.
- **SKILL.md** documents the persist step: after judging, build the payload, copy screenshots to
  `runs/<uuid>/turns/NNN/frame.png`, run `ingest`, and surface the run id + dashboard URL —
  observable via: the new "Persist to the dashboard" section in
  `.claude/skills/quality-harness/SKILL.md` (mirrored to `.agents/skills/...`).
- No schema migration and no change to `dashboard/routes.rs` / `persist/queries.rs` — observable
  via: `git diff --stat` touches neither `persist/schema.rs` nor the dashboard read path.

## Verification (adapted — this is tooling, not a gameplay feature)

The standard `play_<task>.txt` game-script fixture does **not** apply: nothing here is driven
through the game CLI. Verification instead exercises the ingest path directly.

1. Rust integration test `parish/crates/parish-harness/tests/ingest.rs` (in-memory DB):
   ingest a scored sample payload and a gated sample payload; assert `run_summary`,
   `list_runs`, and `run_detail` return the expected status, quality, 7 axes, findings, and
   cost. Run: `cargo test -p parish-harness ingest`.

2. End-to-end fixture `parish/testing/fixtures/ingest_harness_skill/verify.sh`:
   ingest `sample-payload.json` (+ its `artifacts/` dir holding `turns/000/frame.png`) into a
   temp DB, start `serve`, and `curl` `/api/runs`, `/api/runs/{id}`, `/api/cost`, and
   `/api/runs/{id}/turns/0/frame.png`; assert each criterion's signal. The transcript of this
   script is the proof bundle's gameplay-equivalent evidence.

### Evidence

Evidence type: gameplay transcript

# Evidence: harness-skill-ingest

Source transcript: `.proofs/harness-skill-ingest/transcript.txt`
Captured by:

- `cargo test --manifest-path parish/Cargo.toml -p parish-harness`
- `bash parish/testing/fixtures/ingest_harness_skill/verify.sh`

This is a tooling change (the `parish-harness` binary + the quality-harness skill doc), not a
game-runtime path, so the proof is the ingest path exercised end-to-end and read back through
the same DTOs the dashboard serves — not a `parish-cli` game script.

## Criterion → transcript mapping

- **`ingest` subcommand writes a run and prints its id** — transcript `== ingest ==` / `ingested
run 1`; the binary accepted `ingest --payload ... --artifacts ... --db ...` and persisted one
  run.
- **Dashboard list returns the ingested scored run with quality + completed status** — test
  `ingest_scored_run_is_readable_via_dashboard_dtos ... ok` asserts `list_runs` returns
  `status="completed"`, `quality_score=Some(74.0)`, `finding_count=2`; e2e `PASS
list/detail/axes/findings` confirms the same over the live `/api/runs`.
- **Detail returns 7 axes + findings** — same test asserts `detail.axes.len()==7` (all 7 keys)
  and `detail.findings.len()==2`; e2e `PASS list/detail/axes/findings`.
- **Gated run stored with null quality + gate reason** — test
  `ingest_gated_run_has_null_quality_and_reason ... ok` asserts `status="gated"`,
  `quality_score=None`, `gate_reason=Some("crash")`, `gate_turn=Some(3)`.
- **Cost/token totals written (not 0)** — `ingest_scored_run_is_readable_via_dashboard_dtos`
  asserts `cost_summary` returns `total_cost_usd≈0.42`, `player_tokens=1000`,
  `judge_tokens=500`.
- **Per-turn frame serves** — e2e `PASS frame.png served` (`GET
/api/runs/{id}/turns/0/frame.png` returned non-empty image bytes); test asserts the stored
  `artifact_dir/frame_path` exists.
- **Config dedup across skill runs** — test `two_skill_runs_share_one_config_row ... ok` asserts
  two ingests yield 2 runs but `config_count()==1`.
- **Blank/missing frame rejected, nothing persisted (rule #14)** — test
  `ingest_rejects_missing_frame ... ok` asserts the error mentions `frame` and `list_runs` stays
  empty.
- **Full suite stays green; schema/read-path untouched** — `test result: ok. 79 passed` (lib) +
  `4 passed` (ingest); the diff adds only new methods/modules (no `persist/schema.rs` or
  `dashboard/routes.rs`/`persist/queries.rs` change).
- **SKILL.md documents the persist step** — `.agents/skills/quality-harness/SKILL.md` gains
  section "6. Persist to the dashboard" (verified in the diff, not the runtime transcript).

### Transcript

```text
### cargo test -p parish-harness (ingest + full suite)
     Running unittests src/lib.rs (/Users/dmooney/.cargo/target/debug/deps/parish_harness-78ddbe07e3305ebd)
running 79 tests
test result: ok. 79 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.51s
     Running unittests src/main.rs (/Users/dmooney/.cargo/target/debug/deps/parish_harness-afde90658f3d8144)
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
     Running tests/ingest.rs (/Users/dmooney/.cargo/target/debug/deps/ingest-9ba5e0885902e091)
running 4 tests
test ingest_rejects_missing_frame ... ok
test ingest_gated_run_has_null_quality_and_reason ... ok
test ingest_scored_run_is_readable_via_dashboard_dtos ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

### e2e fixture: ingest -> serve -> dashboard API
== ingest ==
ingested run 1
== serve ==
[2m2026-06-10T01:47:24.386477Z[0m [32m INFO[0m [2mparish_harness::dashboard::server[0m[2m:[0m dashboard listening [3mport[0m[2m=[0m8799
PASS list/detail/axes/findings
PASS frame.png served
ALL PASS
parish/testing/fixtures/ingest_harness_skill/verify.sh: line 66:  5870 Terminated: 15          cargo run -q -p parish-harness -- serve --db "$db" --artifacts "$artifacts" --port "$port"
```

### Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

# Judge: harness-skill-ingest

## Per-criterion verification

- **`ingest` subcommand exists, writes one run, prints the id**: transcript `ingested run 1`;
  `parish-harness ingest --payload --artifacts --db` ran clean. MET.
- **Scored run on `/api/runs` with quality + completed**: `ingest_scored_run_...` asserts
  `status="completed"`, `quality_score=Some(74.0)`, plus e2e `PASS list/detail/axes/findings`.
  MET.
- **7 axes + findings on `/api/runs/{id}`**: `detail.axes.len()==7` (all seven keys checked) and
  `detail.findings.len()==2`. MET.
- **Gated run → null quality + reason**: `ingest_gated_run_has_null_quality_and_reason` asserts
  `gated` / `None` / `gate_reason=crash` / `gate_turn=3`. MET.
- **Cost/tokens written (not the hardcoded 0)**: `cost_summary` returns `0.42 / 1000 / 500` —
  proves `update_run_cost` is wired. MET.
- **Per-turn frame serves**: e2e `PASS frame.png served`; stored `artifact_dir + frame_path`
  resolves on disk. MET.
- **Config dedup**: `two_skill_runs_share_one_config_row` — 2 runs, `config_count()==1`. MET.
- **Blank/missing frame rejected, nothing persisted**: `ingest_rejects_missing_frame` — error
  mentions `frame`, `list_runs` empty. Satisfies rule #14. MET.
- **No schema/route change; suite green**: 79 + 4 tests pass; diff touches neither
  `persist/schema.rs` nor the dashboard read path (`dashboard/routes.rs`, `persist/queries.rs`).
  MET.
- **SKILL.md persist step documented**: section "6. Persist to the dashboard" added. MET.

## Implementation notes

- The ingest path reuses the existing sink writers via one new `Db::ingest_complete_run`
  orchestration helper inside a single transaction — there is no second write path, so
  scored/gated semantics cannot drift from the `run` pipeline (AGENTS.md §12 spirit).
- `update_run_cost` is a shared writer (not ingest-only); wiring the _live_ `run` pipeline's
  cost is left to a follow-up, but the writer it will call already exists here, avoiding a
  divergent path.
- Scope: tooling crate `parish-harness` + the quality-harness skill doc + README + a verification
  fixture. No game-runtime crate changes; no feature flag applies (justified in the design note).
- Evidence is non-live (`Evidence type: gameplay transcript`): `parish-harness` is not a
  runtime-shipping path in rule #10's live-proof tier, so unit + e2e API proof is the correct
  form.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:harness-skill-ingest -->
