### PR TITLE
fix(tauri): fail screenshot capture fast when screen locked / logged out (#1402)

### DIFF
--- a/parish/crates/parish-tauri/src/commands/screenshot.rs
+++ b/parish/crates/parish-tauri/src/commands/screenshot.rs
@@ -299,6 +299,134 @@ fn resolve_late_screenshot(
     }
 }
 
+/// Classification of the host display session, used to fail a capture fast when
+/// the OS cannot composite the app window at all (#1402).
+///
+/// `Active` — an on-console, unlocked session (capture can work). `Locked` — the
+/// screen is locked, so the window server isn't compositing app windows and both
+/// the native xcap path and the html-to-image fallback would hang. `LoggedOut` —
+/// no active console session (login window / fast-user-switched away).
+/// `Unknown` — the platform could not be queried; never block on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DisplaySession {
+    Active,
+    Locked,
+    LoggedOut,
+    Unknown,
+}
+
+/// Maps the two macOS session-dictionary signals to a [`DisplaySession`].
+///
+/// `on_console` is `kCGSSessionOnConsoleKey` (this session owns the console);
+/// `screen_locked` is `CGSSessionScreenIsLocked` (present + true when locked). A
+/// locked screen takes precedence; an off-console session is logged-out; an
+/// on-console unlocked session is active; absent signals are `Unknown` so an
+/// indeterminate probe never blocks a capture. Pure for unit testing.
+#[cfg(any(target_os = "macos", test))]
+fn classify_session(on_console: Option<bool>, screen_locked: Option<bool>) -> DisplaySession {
+    if screen_locked == Some(true) {
+        return DisplaySession::Locked;
+    }
+    match on_console {
+        Some(true) => DisplaySession::Active,
+        Some(false) => DisplaySession::LoggedOut,
+        None => DisplaySession::Unknown,
+    }
+}
+
+/// Returns `Err` with a clear, condition-specific message when a capture cannot
+/// possibly succeed because the display is not being composited; `Ok(())`
+/// otherwise. `Unknown` is treated as "proceed". Pure for unit testing.
+fn precheck_session(session: DisplaySession) -> Result<(), String> {
+    match session {
+        DisplaySession::Locked => Err("screen is locked — macOS is not compositing the app \
+             window, so it cannot be captured; unlock the screen and retry"
+            .into()),
+        DisplaySession::LoggedOut => Err("no active desktop session — the user is logged out or \
+             switched away (login window / fast user switching), so there is no compositor to \
+             capture; log back in and retry"
+            .into()),
+        DisplaySession::Active | DisplaySession::Unknown => Ok(()),
+    }
+}
+
+/// The caller-facing message for "the app window could not be enumerated for
+/// native capture". Named so it is unit-testable and consistent across paths.
+#[cfg(any(target_os = "macos", target_os = "windows", test))]
+fn no_window_error() -> String {
+    "no Parish/Rundale window found to capture — the window may be minimized, on another Space \
+     or display, or the screen is asleep/locked"
+        .to_string()
+}
+
+/// Queries the current macOS login-session state via
+/// `CGSessionCopyCurrentDictionary`, mapping it through [`classify_session`].
+///
+/// Non-macOS hosts return `Unknown` so the precheck proceeds, preserving prior
+/// behavior (the capture timeout still bounds a stuck attempt there).
+#[cfg(target_os = "macos")]
+fn current_display_session() -> DisplaySession {
+    use std::ffi::{CString, c_void};
+    use std::os::raw::c_char;
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    unsafe extern "C" {
+        fn CGSessionCopyCurrentDictionary() -> *const c_void;
+    }
+    #[link(name = "CoreFoundation", kind = "framework")]
+    unsafe extern "C" {
+        fn CFDictionaryGetValue(dict: *const c_void, key: *const c_void) -> *const c_void;
+        fn CFBooleanGetValue(boolean: *const c_void) -> u8;
+        fn CFStringCreateWithCString(
+            alloc: *const c_void,
+            c_str: *const c_char,
+            encoding: u32,
+        ) -> *const c_void;
+        fn CFRelease(cf: *const c_void);
+    }
+    const K_CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
+
+    // SAFETY: every returned pointer is null-checked before use. The session
+    // dictionary (create-rule) and each key string (create-rule) are released
+    // exactly once; dictionary values are get-rule (borrowed) and never released.
+    unsafe {
+        let dict = CGSessionCopyCurrentDictionary();
+        if dict.is_null() {
+            // No session dictionary at all => no console session is attached.
+            return DisplaySession::LoggedOut;
+        }
+        let read_bool = |key: &str| -> Option<bool> {
+            let c_key = CString::new(key).ok()?;
+            let cf_key = CFStringCreateWithCString(
+                std::ptr::null(),
+                c_key.as_ptr(),
+                K_CF_STRING_ENCODING_UTF8,
+            );
+            if cf_key.is_null() {
+                return None;
+            }
+            let value = CFDictionaryGetValue(dict, cf_key);
+            CFRelease(cf_key);
+            if value.is_null() {
+                None
+            } else {
+                Some(CFBooleanGetValue(value) != 0)
+            }
+        };
+        let on_console = read_bool("kCGSSessionOnConsoleKey");
+        let screen_locked = read_bool("CGSSessionScreenIsLocked");
+        CFRelease(dict);
+        classify_session(on_console, screen_locked)
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn current_display_session() -> DisplaySession {
+    // Lock / login-session detection is macOS-specific for now; other platforms
+    // proceed as before (the existing capture timeout still bounds a stuck call).
+    DisplaySession::Unknown
+}
+
 /// True when a captured OS window belongs to the Parish/Rundale desktop app.
 ///
 /// Matched on the owning application name: the dev binary reports
@@ -431,7 +559,7 @@ fn capture_app_window_png() -> Result<Vec<u8>, String> {
             best = Some((area, w));
         }
     }
-    let (_, win) = best.ok_or("no Parish/Rundale window found to capture")?;
+    let (_, win) = best.ok_or_else(no_window_error)?;
     let img = win
         .capture_image()
         .map_err(|e| format!("capture window: {e}"))?;
@@ -536,6 +664,12 @@ pub(crate) async fn do_take_screenshot(
     state: &Arc<AppState>,
     app: &tauri::AppHandle,
 ) -> Result<ScreenshotInfo, String> {
+    // Fail fast when the OS cannot composite the window at all (screen locked /
+    // logged out). Otherwise the native path errors quickly but the html-to-image
+    // fallback waits on a webview that can't render while locked, hanging for the
+    // full capture deadline before a vague timeout (#1402).
+    precheck_session(current_display_session())?;
+
     #[cfg(any(target_os = "macos", target_os = "windows"))]
     match do_take_screenshot_native(state, app).await {
         Ok(info) => return Ok(info),
@@ -597,7 +731,8 @@ async fn do_take_screenshot_frontend(
             match resolve_late_screenshot(started_at, latest) {
                 Some(info) => Ok(info),
                 None => Err(format!(
-                    "screenshot capture timed out after {} s",
+                    "screenshot capture timed out after {} s — the app window may be occluded, \
+                     off-screen, or on an inactive display; bring it to the foreground and retry",
                     timeout.as_secs()
                 )),
             }
@@ -1053,5 +1188,70 @@ mod tests {
             world.clock.is_inference_paused(),
             "inference-pause must not be disturbed by player-pause restore"
         );
+    }
+
+    // ── #1402 display-session precheck (fail fast on locked / logged-out) ─────
+
+    #[test]
+    fn classify_session_maps_all_signal_combinations() {
+        // Locked takes precedence regardless of console state.
+        assert_eq!(
+            classify_session(Some(true), Some(true)),
+            DisplaySession::Locked,
+        );
+        assert_eq!(
+            classify_session(Some(false), Some(true)),
+            DisplaySession::Locked,
+        );
+        // On-console + unlocked => active.
+        assert_eq!(
+            classify_session(Some(true), Some(false)),
+            DisplaySession::Active,
+        );
+        assert_eq!(classify_session(Some(true), None), DisplaySession::Active);
+        // Off-console (and not locked) => logged out.
+        assert_eq!(
+            classify_session(Some(false), Some(false)),
+            DisplaySession::LoggedOut,
+        );
+        assert_eq!(
+            classify_session(Some(false), None),
+            DisplaySession::LoggedOut
+        );
+        // No signals at all => unknown (must not block a capture).
+        assert_eq!(classify_session(None, None), DisplaySession::Unknown);
+    }
+
+    #[test]
+    fn precheck_session_fails_fast_on_locked_and_logged_out() {
+        let locked = precheck_session(DisplaySession::Locked).unwrap_err();
+        assert!(
+            locked.contains("locked"),
+            "locked message should name the cause: {locked}"
+        );
+        let out = precheck_session(DisplaySession::LoggedOut).unwrap_err();
+        assert!(
+            out.contains("logged out") || out.contains("no active desktop session"),
+            "logged-out message should name the cause: {out}"
+        );
+    }
+
+    #[test]
+    fn precheck_session_proceeds_on_active_and_unknown() {
+        // An active session and an indeterminate probe both proceed — the latter
+        // so a query failure never blocks a legitimate capture.
+        precheck_session(DisplaySession::Active).expect("active session must proceed");
+        precheck_session(DisplaySession::Unknown).expect("unknown session must proceed");
+    }
+
+    #[test]
+    fn no_window_error_names_likely_causes() {
+        let msg = no_window_error();
+        assert!(msg.contains("minimized"), "got: {msg}");
+        assert!(
+            msg.contains("Space") || msg.contains("display"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("locked"), "got: {msg}");
     }
 }


### PR DESCRIPTION
## What

Fixes #1402: `parish_take_screenshot` (and `/api/take-screenshot`) hung for the
full 45 s capture deadline when the macOS screen was locked or the user was
logged out. The native `xcap` path fails fast (nothing composited), but the
`html-to-image` fallback then waits on a webview that can't render while locked,
ending in a vague "screenshot capture timed out after 45 s".

## How

- macOS session precheck via `CGSessionCopyCurrentDictionary` (`kCGSSessionOnConsoleKey`
  + `CGSSessionScreenIsLocked`), mapped by a pure `classify_session` into
  `Active` / `Locked` / `LoggedOut` / `Unknown`.
- A pure `precheck_session` fails fast with a clear, condition-specific message
  for `Locked` / `LoggedOut`; `Active` and `Unknown` proceed (`Unknown` so a
  query failure never blocks a real capture). Wired as the first step of
  `do_take_screenshot`, so a locked session errors immediately instead of after 45 s.
- Non-macOS returns `Unknown` and keeps the prior behavior (the capture timeout
  remains the backstop there).
- Sharper failure messages: `no_window_error` names minimized / other Space-or-display
  / asleep-or-locked; the timeout message gains an occluded/off-screen/inactive-display hint.
- No new dependency — CoreGraphics/CoreFoundation are already linked transitively.

## Verification

- `cargo test -p parish-tauri screenshot` — 30 pass incl. 4 new (classifier,
  precheck fail-fast, precheck proceed, no-window message).
- fmt + clippy clean.
- Live happy path on the rebuilt binary: active unlocked session → precheck
  passes → `parish_take_screenshot` returns a real 6.2 MB native capture of The
  Crossroads (minimap included). The locked/logged-out fast-fail is covered by
  the precheck unit tests (a locked screen can't be scripted in CI).

Closes #1402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- parish-proof-bundle:screenshot-session-precheck v=1 -->

## Proof: screenshot-session-precheck

### Acceptance criteria

# Acceptance Criteria: screenshot-session-precheck

## Task

`parish_take_screenshot` (and the `/api/take-screenshot` bridge) hangs for the full 45 s
capture deadline when the macOS session is locked or logged out: the native `xcap` path fails
because nothing is composited, then the `html-to-image` frontend fallback waits on a webview
that can't render while the screen is locked, finally erroring with a vague
"screenshot capture timed out after 45 s". Add a macOS session precheck that detects a
locked screen or no-active-console state and returns a clear, immediate error instead of the
45 s hang, and sharpen the other capture error messages so each failure condition is
self-explanatory.

## Criteria

- C1: A pure `classify_session(on_console, screen_locked)` maps the macOS session-dictionary
  signals to a `DisplaySession` (`Active` / `Locked` / `LoggedOut` / `Unknown`) — observable via:
  unit tests covering locked, logged-out (on_console=false), active (on_console=true, unlocked),
  and unknown (both absent) cases.
- C2: A pure `precheck_session(DisplaySession)` returns `Err` with a clear, condition-specific
  message for `Locked` and `LoggedOut`, and `Ok(())` for `Active` and `Unknown` (so an
  indeterminate signal never blocks a legitimate capture) — observable via: unit tests asserting
  the Err messages name "locked" / "logged out" and that Active/Unknown pass.
- C3: `do_take_screenshot` runs the precheck before the native/frontend capture on macOS, so a
  locked/logged-out session fails fast (well under the 45 s deadline) with the precheck message
  instead of timing out — observable via: code path + the precheck unit tests; on non-macOS the
  behavior is unchanged (session = Unknown → proceed).
- C4: The remaining capture failure messages are actionable — `capture_app_window_png`'s
  "no window found" names the likely causes (minimized / other Space / asleep / locked), and the
  frontend timeout message adds a "window may be occluded/off-screen/locked" hint — observable
  via: the updated `Err` strings and a unit test asserting the no-window message names a cause.
- C5: The happy path is intact — with an active, unlocked session `parish_take_screenshot`
  still captures real content — observable via: a live capture from the running Tauri app
  returning a non-blank PNG (screenshot artifact in the bundle).

## Verification

Runtime change in `parish-tauri`. Verification:

1. Rust unit tests: `cargo test -p parish-tauri screenshot` (classify_session, precheck_session,
   improved no-window message) all pass.
2. Live: rebuild + run the Tauri app, call `parish_take_screenshot` with the screen unlocked →
   returns a real non-blank PNG (Evidence type: screenshot). The locked-session fast-fail is
   covered by the precheck unit tests (a locked screen can't be scripted in CI).

Expected signals:

- New unit tests pass; existing screenshot tests still pass.
- Live `parish_take_screenshot` returns a valid non-blank PNG (happy path unbroken).

### Evidence

Evidence type: live screenshot

# Evidence: screenshot-session-precheck

Source transcript: `.proofs/screenshot-session-precheck/transcript.txt`
Live artifact: `.proofs/screenshot-session-precheck/happy-path-capture.png` (a real 6.2 MB native
capture from the running Tauri app on the new binary).
Captured by: `cargo test -p parish-tauri screenshot` + a live `parish_take_screenshot` call.

## Criterion → evidence mapping

- **C1 (classify_session maps all signals)** — transcript §1:
  `classify_session_maps_all_signal_combinations ... ok` covers locked, logged-out, active,
  and unknown cases.
- **C2 (precheck_session condition-specific Err / Ok)** — transcript §1:
  `precheck_session_fails_fast_on_locked_and_logged_out ... ok` (messages name "locked" /
  "logged out") and `precheck_session_proceeds_on_active_and_unknown ... ok`.
- **C3 (precheck runs first → fail fast)** — `do_take_screenshot` now calls
  `precheck_session(current_display_session())` before any native/frontend capture (transcript
  §4); on macOS a locked/logged-out session returns the precheck Err immediately instead of the
  45 s html-to-image timeout. Non-macOS returns `Unknown` → proceeds (behavior unchanged).
- **C4 (actionable messages)** — transcript §1 `no_window_error_names_likely_causes ... ok`
  asserts the no-window message names minimized / Space-or-display / locked; the frontend
  timeout message now adds an "occluded / off-screen / inactive display" hint.
- **C5 (happy path intact)** — transcript §3 + `happy-path-capture.png`: with an active, unlocked
  session the precheck passes and `parish_take_screenshot` returns a real 6.2 MB native PNG of
  The Crossroads (non-blank, minimap included).

## Note on the fail-fast path

A locked screen / logged-out session cannot be scripted in CI, so the fast-fail behavior is
proven by the pure `precheck_session` unit tests plus the wiring (the precheck is the first thing
`do_take_screenshot` does). The original 45 s hang was the `html-to-image` fallback awaiting a
webview that can't render while locked; short-circuiting before that wait removes it.

### Transcript

```text
=== screenshot-session-precheck verification transcript ===
Date: 2026-06-10  Branch: claude/screenshot-session-precheck off origin/main (4faa0893)

### 1. Unit tests: session classifier + precheck + message (C1,C2,C3,C4) ###
$ cargo test -p parish-tauri screenshot
test commands::screenshot::tests::precheck_session_proceeds_on_active_and_unknown ... ok
test commands::screenshot::tests::classify_session_maps_all_signal_combinations ... ok
test commands::screenshot::tests::no_window_error_names_likely_causes ... ok
test commands::screenshot::tests::precheck_session_fails_fast_on_locked_and_logged_out ... ok
test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 95 filtered out; finished in 0.06s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s

### 2. fmt + clippy clean ###
fmt: clean
clippy: clean

### 3. Live happy path on the new binary (C5) ###
Logged-in/unlocked session: current_display_session() -> Active, precheck passes, native
xcap capture runs. parish_take_screenshot returned:
  path:  .../parish-2026-06-10T20-29-45Z.png
  size:  6214465 bytes (native capture incl. WebGL minimap)
  content: The Crossroads scene, non-blank (validated; see happy-path-capture.png)

### 4. Fail-fast path (locked / logged out) ###
Covered by the precheck unit tests (a locked screen cannot be scripted in CI):
  precheck_session(Locked)    -> Err containing 'locked'
  precheck_session(LoggedOut) -> Err containing 'logged out'
do_take_screenshot now calls precheck_session(current_display_session()) FIRST, so these
return immediately instead of the prior 45 s html-to-image timeout (#1402).
```

### Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

# Judge: screenshot-session-precheck

## Per-criterion verification

- **C1 (classify_session)**: met. `classify_session_maps_all_signal_combinations` passes,
  asserting locked-takes-precedence, on-console→Active, off-console→LoggedOut, and
  both-absent→Unknown.
- **C2 (precheck_session)**: met. `precheck_session_fails_fast_on_locked_and_logged_out` asserts
  the Err messages name the cause; `precheck_session_proceeds_on_active_and_unknown` asserts
  Active and Unknown both return Ok (an indeterminate probe never blocks a capture).
- **C3 (fail fast)**: met. `do_take_screenshot` calls `precheck_session(current_display_session())`
  as its first step, so a locked/logged-out macOS session returns the precheck Err immediately
  rather than after the 45 s frontend timeout. macOS detection uses
  `CGSessionCopyCurrentDictionary` (on-console + screen-locked keys); non-macOS returns Unknown
  and proceeds, preserving prior behavior.
- **C4 (actionable messages)**: met. `no_window_error_names_likely_causes` passes; the no-window
  message now names minimized / other Space-or-display / asleep-or-locked, and the frontend
  timeout message gained an occluded/off-screen/inactive-display hint.
- **C5 (happy path intact)**: met. On the rebuilt binary with an active unlocked session,
  `parish_take_screenshot` returned a real 6.2 MB native PNG of The Crossroads (non-blank,
  minimap rendered) — `happy-path-capture.png`. The precheck does not regress normal capture.

## Implementation notes

Scope: one file (`commands/screenshot.rs`) — a `DisplaySession` enum, pure `classify_session` /
`precheck_session`, a small macOS-only FFI `current_display_session` (two single-`#[link]` extern
blocks to satisfy `clippy::duplicated_attributes`), the precheck wired into `do_take_screenshot`,
plus sharper `no_window_error` and timeout messages. macOS/test-only helpers are `#[cfg]`-gated so
Linux builds don't warn. The FFI carefully null-checks and releases create-rule CF objects once;
dictionary values are borrowed (get-rule) and not released. No new crate dependency — CoreGraphics
and CoreFoundation are already linked transitively. Lock/logout detection is macOS-only for now
(documented); Windows/Linux keep the existing timeout as the backstop — a reasonable follow-up,
not debt that blocks this fix.

### Artifacts

Drag these files into this PR comment in the GitHub UI to attach them:

- `happy-path-capture.png`
- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:screenshot-session-precheck -->
