### PR TITLE
fix(harness): append per-turn inference log to page bottom (no scrollbox)

### DIFF
--- a/parish/crates/parish-harness/dashboard-ui/index.html
+++ b/parish/crates/parish-harness/dashboard-ui/index.html
@@ -44,7 +44,8 @@
     .turn-log summary { cursor: pointer; color: #8a8a96; font-size: .78rem; }
     .tl-infer { margin: .5rem 0; }
     .tl-infer-head { font-size: .72rem; color: #666; margin-bottom: .2rem; }
-    .tl-infer pre { white-space: pre-wrap; word-break: break-word; background: #0d0d13; border: 1px solid #20202a; border-radius: 4px; padding: .4rem .5rem; margin: .15rem 0; font-size: .75rem; color: #cfcfd6; max-height: 320px; overflow: auto; }
+    .tl-infer pre { white-space: pre-wrap; word-break: break-word; background: #0d0d13; border: 1px solid #20202a; border-radius: 4px; padding: .4rem .5rem; margin: .15rem 0; font-size: .75rem; color: #cfcfd6; }
+    #turn-log:not(:empty) { margin-top: 1.5rem; }
     .error-msg { color: #c06060; padding: .5rem; background: #1a0f0f; border-radius: 4px; margin: .5rem 0; font-size: .82rem; }
     .loading { color: #888; font-style: italic; }
     .back-btn { cursor: pointer; color: #9bb3e0; border: none; background: none; font-size: .9rem; padding: .25rem 0; margin-bottom: .5rem; }
@@ -115,6 +116,9 @@
     <span id="cost-footer">Cost: loading…</span>
   </footer>
 
+  <!-- Per-turn inference log: appended at the end of the page, grows naturally. -->
+  <div id="turn-log"></div>
+
   <script>
     // Injected by the serve binary from `git remote get-url origin`; empty when
     // the repo has no GitHub origin, in which case shas render unlinked.
@@ -184,10 +188,18 @@
         currentRunId = null;
         $('detail').className = '';
         $('runs-view').style.display = '';
+        clearTurnLog();
       }
     }
 
+    // Clear the page-end inference-log block (on run switch / back to list).
+    function clearTurnLog() {
+      const tl = $('turn-log');
+      if (tl) tl.innerHTML = '';
+    }
+
     async function showDetail(runId, openTurn = null) {
+      clearTurnLog();
       currentRunId = runId;
       $('runs-view').style.display = 'none';
       $('detail').className = 'visible';
@@ -307,7 +319,7 @@
             <span class="turn-thumb-label">t${t.turn_index} ${(t.game_clock||'')}</span>
           </div>`;
         }
-        html += `</div><div id="turn-log"></div>`;
+        html += `</div>`;
       }
 
       container.innerHTML = html;

--- a/parish/crates/parish-harness/src/dashboard/routes.rs
+++ b/parish/crates/parish-harness/src/dashboard/routes.rs
@@ -585,6 +585,33 @@ mod tests {
     }
 
     #[test]
+    fn turn_log_is_appended_at_page_bottom_without_inner_scroll() {
+        let html = include_str!("../../dashboard-ui/index.html");
+        // The log container exists exactly once and sits after the footer (page
+        // bottom), not inside the per-run detail render.
+        assert_eq!(
+            html.matches("id=\"turn-log\"").count(),
+            1,
+            "turn-log container must be declared exactly once"
+        );
+        let footer = html.find("</footer>").expect("footer present");
+        let log = html.find("id=\"turn-log\"").expect("turn-log present");
+        assert!(
+            log > footer,
+            "the turn-log block must come after the footer (page bottom)"
+        );
+        // No nested scrollbox — the raw prompt/response grows the page.
+        let pre_rule = html
+            .lines()
+            .find(|l| l.contains(".tl-infer pre"))
+            .expect(".tl-infer pre rule present");
+        assert!(
+            !pre_rule.contains("max-height") && !pre_rule.contains("overflow"),
+            "raw prompt/response must not be a fixed-height scrollbox: {pre_rule}"
+        );
+    }
+
+    #[test]
     fn parse_github_base_handles_remote_forms() {
         let want = Some("https://github.com/dmooney/Rundale".to_string());
         assert_eq!(


### PR DESCRIPTION
## What

The per-turn inference log rendered in a panel wedged between the turn gallery
and the rest of the detail, and its raw prompt/response `<pre>` had a fixed
`max-height` with inner `overflow:auto` — so it read like an embedded iframe.

## How

- Move the `#turn-log` container to a single permanent block at the **end of the
  page** (after `<footer>`), removed from the per-run detail render.
- Drop the `<pre>` `max-height`/`overflow` so the raw prompt/response grows the
  page naturally (no nested scrollbar).
- `clearTurnLog()` empties it on run switch / back-to-list so no stale log lingers.

## Verification

- `cargo test -p parish-harness` — adds `turn_log_is_appended_at_page_bottom_without_inner_scroll`
  (one `#turn-log`, after the footer, no `max-height`/`overflow`).
- Live: the log block renders below the Cost footer; the page scrolls naturally to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- parish-proof-bundle:turn-log-page-bottom v=1 -->

## Proof: turn-log-page-bottom

### Acceptance criteria

# Acceptance Criteria: turn-log-page-bottom

## Task

The per-turn inference log currently renders in a panel wedged between the turn gallery and the
rest of the detail, and its raw prompt/response `<pre>` blocks have a fixed `max-height` with
inner `overflow:auto` — so it reads like an embedded/iframe scrollbox. Move the log to a single
plain block appended at the **end of the page** and let it grow the page naturally (no nested
scrollbar).

## Criteria

- C1: The `#turn-log` container is a permanent element at the end of the page (after the footer),
  not injected inside the per-run detail render. Observable via: the served HTML has a top-level
  `<div id="turn-log">` after `<footer>` and the detail render no longer emits `<div id="turn-log">`.
- C2: The raw prompt/response has no inner scrollbox — `.tl-infer pre` carries no `max-height` /
  `overflow:auto`; it expands to its content and grows the page. Observable via: the CSS rule has
  no `max-height`/`overflow`.
- C3: Clicking a turn still populates the page-end log; navigating back to the list (or to another
  run) clears it so a stale log doesn't linger. Observable via: live click-through + back.

## Verification

`cargo test -p parish-harness dashboard` (HTML-structure assertions) + a live click-through.

### Evidence

Evidence type: gameplay transcript

# Evidence: turn-log-page-bottom

Source transcript: `.proofs/turn-log-page-bottom/transcript.txt`
Captured by: `cargo test -p parish-harness` + a live serve and browser load. (Frontend-only
dashboard change; no engine behavior.)

## Criterion -> evidence mapping

- **C1 (log appended at page end, single container)** -> §1 `turn_log_is_appended_at_page_bottom_without_inner_scroll`
  asserts exactly one `#turn-log` and that it follows `</footer>`; §2 live page confirms count=1
  and after-footer=True; §3 the block renders below the Cost footer in-browser.
- **C2 (no inner scrollbox)** -> §1 the test asserts `.tl-infer pre` has no `max-height`/`overflow`;
  §2 live CSS has 0 such properties — the raw prompt/response grows the page.
- **C3 (populate on click, clear on leave)** -> `showTurnLog` targets the page-end `#turn-log`;
  `clearTurnLog()` runs in `showDetail` and on the router's back-to-list branch; §3 confirms.

### Transcript

```text
=== turn-log-page-bottom verification transcript ===
Date: 2026-06-10  Branch: claude/turn-log-page-bottom off main (c45cffdd)

### 1. Rust test (C1, C2) ###
test dashboard::routes::tests::turn_log_is_appended_at_page_bottom_without_inner_scroll ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 90 filtered out; finished in 0.00s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

### 2. Live served HTML ###
id=turn-log count (want 1): 1
turn-log AFTER footer (want True): True
tl-infer pre max-height/overflow (want 0): 0

### 3. Live browser (C1,C3) ###
Loaded …#run/4/turn/5: the 'Turn 5 — inference log' block renders at the very bottom of the
page, BELOW the footer (Cost line) — a plain appended block, not a mid-page scrollbox. The
page scrolls naturally to it (no nested scroll). Switching runs / Back to runs clears it.
```

### Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

# Judge: turn-log-page-bottom

## Per-criterion verification

- **C1**: met. The `#turn-log` container is now a single permanent element after `<footer>`; the
  per-run detail render no longer injects it. Live page shows the log block below the Cost footer.
- **C2**: met. `.tl-infer pre` lost its `max-height: 320px; overflow: auto`, so the raw
  prompt/response expands inline and grows the page instead of scrolling inside a fixed box.
- **C3**: met. Clicking a turn populates the page-end block; `clearTurnLog()` empties it when
  switching runs (`showDetail`) or returning to the list (router), so no stale log lingers.

## Implementation notes

Pure index.html move + one CSS rule removed + a `clearTurnLog` helper; one HTML-structure test
added. No backend change. Addresses the "don't put it in an iframe/scrollbox — append to the end
of the page" request.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:turn-log-page-bottom -->
