### PR TITLE
feat(harness): redesign dashboard runs page; show full finding signature

### DIFF
--- a/parish/crates/parish-harness/dashboard-ui/index.html
+++ b/parish/crates/parish-harness/dashboard-ui/index.html
@@ -5,30 +5,94 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Parish Harness Dashboard</title>
   <style>
+    :root {
+      --bg: #0f1117;
+      --panel: #151823;
+      --panel-2: #11141d;
+      --line: #232838;
+      --line-soft: #1b2030;
+      --ink: #d8dae2;
+      --ink-dim: #8a8fa3;
+      --ink-faint: #5c6175;
+      --brass: #c9b99a;
+      --brass-dim: #9d8f74;
+      --blue: #7fa3d8;
+      --blue-deep: #5080c0;
+      --green: #6dbf6d;
+      --red: #d2706a;
+      --amber: #cfa14e;
+      --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      --sans: "Avenir Next", Avenir, Seravek, "Segoe UI", system-ui, sans-serif;
+    }
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: system-ui, sans-serif; background: #0f1117; color: #e0e0e0; padding: 1.5rem; }
-    h1 { font-size: 1.4rem; margin-bottom: 1rem; color: #c9b99a; }
-    h2 { font-size: 1.1rem; margin: 1rem 0 .5rem; color: #a89880; }
-    h3 { font-size: .95rem; margin: .75rem 0 .25rem; color: #8a7a68; }
-    a { color: #9bb3e0; text-decoration: none; }
-    a:hover { text-decoration: underline; }
-    .badge { display: inline-block; padding: .15rem .5rem; border-radius: 4px; font-size: .75rem; font-weight: 600; }
-    .badge-completed { background: #1a3a1a; color: #6dbf6d; }
-    .badge-gated { background: #3a1a1a; color: #c06060; }
-    .badge-in_progress { background: #1a2a3a; color: #60a0c0; }
-    table { width: 100%; border-collapse: collapse; font-size: .85rem; }
-    th { text-align: left; padding: .5rem .75rem; border-bottom: 1px solid #2a2a2a; color: #888; font-weight: 600; }
-    td { padding: .45rem .75rem; border-bottom: 1px solid #1a1a1a; }
-    tr:hover td { background: #181820; }
+    body {
+      font-family: var(--sans); background: var(--bg); color: var(--ink);
+      padding: 2rem clamp(1.25rem, 4vw, 3rem) 3rem; max-width: 1180px; margin: 0 auto;
+      line-height: 1.5; font-size: 15px;
+      background-image: radial-gradient(ellipse 80% 50% at 50% -10%, rgba(201,185,154,.045), transparent);
+    }
+    h1 {
+      font-size: 1.15rem; color: var(--brass); font-weight: 600;
+      letter-spacing: .14em; text-transform: uppercase;
+    }
+    h1::after { content: ""; display: block; width: 2.2rem; height: 2px; background: var(--brass-dim); margin-top: .5rem; border-radius: 1px; opacity: .6; }
+    h2 { font-size: .8rem; margin: 1.5rem 0 .75rem; color: var(--brass-dim); font-weight: 600; letter-spacing: .12em; text-transform: uppercase; }
+    h3 { font-size: .72rem; margin: 1.75rem 0 .6rem; color: var(--ink-dim); font-weight: 600; letter-spacing: .12em; text-transform: uppercase; }
+    a { color: var(--blue); text-decoration: none; }
+    a:hover { text-decoration: underline; text-underline-offset: 2px; }
+    code { font-family: var(--mono); font-size: .85em; color: var(--ink-dim); }
+    .badge {
+      display: inline-flex; align-items: center; gap: .35em;
+      padding: .12rem .55rem; border-radius: 99px;
+      font-size: .68rem; font-weight: 600; letter-spacing: .05em;
+      font-family: var(--mono); border: 1px solid transparent;
+    }
+    .badge::before { content: ""; width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+    .badge-completed { background: rgba(109,191,109,.08); color: var(--green); border-color: rgba(109,191,109,.25); }
+    .badge-gated { background: rgba(210,112,106,.08); color: var(--red); border-color: rgba(210,112,106,.25); }
+    .badge-in_progress { background: rgba(127,163,216,.08); color: var(--blue); border-color: rgba(127,163,216,.25); }
+    .badge-in_progress::before { animation: pulse 1.6s ease-in-out infinite; }
+    @keyframes pulse { 50% { opacity: .35; } }
+    table {
+      width: 100%; border-collapse: separate; border-spacing: 0; font-size: .84rem;
+      background: var(--panel-2); border: 1px solid var(--line-soft); border-radius: 10px; overflow: hidden;
+    }
+    th {
+      text-align: left; padding: .6rem .85rem; border-bottom: 1px solid var(--line);
+      color: var(--ink-faint); font-weight: 600; font-size: .68rem;
+      letter-spacing: .1em; text-transform: uppercase; background: var(--panel);
+      white-space: nowrap;
+    }
+    td { padding: .55rem .85rem; border-bottom: 1px solid var(--line-soft); color: var(--ink-dim); }
+    td:first-child { font-family: var(--mono); color: var(--ink-faint); }
+    tbody tr:last-child td { border-bottom: none; }
+    tr:hover td { background: rgba(127,163,216,.045); }
     tr.clickable { cursor: pointer; }
+    tr.clickable td { transition: background .12s ease; }
     #detail { margin-top: 1.5rem; display: none; }
-    #detail.visible { display: block; }
+    #detail.visible { display: block; animation: rise .25s ease both; }
+    @keyframes rise { from { opacity: 0; transform: translateY(6px); } }
     .axes-radar { display: block; margin: .25rem 0 .5rem; }
-    .finding { background: #181820; border-left: 3px solid #5c4020; padding: .5rem .75rem; margin: .25rem 0; border-radius: 0 4px 4px 0; font-size: .82rem; }
-    .finding.severity-critical { border-color: #c04040; }
-    .finding.severity-high { border-color: #c07040; }
-    .finding.severity-medium { border-color: #c0a040; }
-    .finding.severity-low { border-color: #5c4020; }
+    .radar-panel { background: var(--panel-2); border: 1px solid var(--line-soft); border-radius: 10px; padding: .5rem 1rem; display: inline-block; }
+    .finding {
+      background: var(--panel-2); border: 1px solid var(--line-soft);
+      border-left: 3px solid var(--sev, #5c4a30); padding: .65rem .9rem; margin: .5rem 0;
+      border-radius: 8px; font-size: .84rem; color: var(--ink-dim); line-height: 1.55;
+    }
+    .finding.severity-critical { --sev: #d2706a; }
+    .finding.severity-high { --sev: #cf8a4e; }
+    .finding.severity-medium { --sev: #cfa14e; }
+    .finding.severity-low { --sev: #5c4a30; }
+    .finding-head { display: flex; align-items: baseline; gap: .5rem; flex-wrap: wrap; margin-bottom: .25rem; }
+    .finding-cat { color: var(--ink); font-weight: 600; }
+    .finding-sev { font-family: var(--mono); font-size: .68rem; letter-spacing: .06em; text-transform: uppercase; color: var(--sev, var(--ink-faint)); }
+    .finding-turn { font-family: var(--mono); font-size: .72rem; color: var(--ink-faint); }
+    .finding-sig {
+      display: inline-block; margin-top: .4rem; font-family: var(--mono); font-size: .68rem;
+      color: var(--ink-faint); background: rgba(127,163,216,.06);
+      border: 1px solid var(--line-soft); border-radius: 5px; padding: .1rem .45rem;
+      word-break: break-all;
+    }
     .turn-gallery { display: flex; gap: .5rem; flex-wrap: wrap; margin: .5rem 0; }
     .turn-thumb { display: flex; flex-direction: column; align-items: center; gap: .2rem; }
     .turn-thumb img { width: 80px; height: 60px; object-fit: cover; border: 1px solid #2a2a2a; border-radius: 3px; background: #111; }
@@ -299,9 +363,13 @@
         for (const f of d.findings) {
           const link = f.issue_url ? ` <a href="${f.issue_url}" target="_blank">[issue]</a>` : '';
           html += `<div class="finding severity-${f.severity}">
-            <strong>${f.category}</strong> · <em>${f.severity}</em> · turn ${f.turn_index??'—'}${link}<br>
-            ${escHtml(f.description)}<br>
-            <small style="color:#666">${escHtml(f.signature.substring(0,16))}…</small>
+            <div class="finding-head">
+              <span class="finding-cat">${escHtml(f.category)}</span>
+              <span class="finding-sev">${escHtml(f.severity)}</span>
+              <span class="finding-turn">turn ${f.turn_index??'—'}</span>${link}
+            </div>
+            <div>${escHtml(f.description)}</div>
+            <span class="finding-sig">${escHtml(f.signature)}</span>
           </div>`;
         }
       }


### PR DESCRIPTION
## What

Redesign the parish-harness dashboard runs page for a polished, cohesive look,
and stop truncating the finding `signature` (show it in full).

## How

A Fable subagent restyled the single-file dashboard (`dashboard-ui/index.html`):
CSS-variable dark theme, pill status badges, a rounded runs table, a clearer
run-detail header, severity-colored finding cards, and a monospace signature
tag. The full finding `signature` is now rendered (was clipped to 16 chars + `…`).

Pure presentation/markup — no JS behavior, endpoint, or backend change. The radar
stays the only inline-SVG axis chart; run pages stay deep-linkable; commit and
issue links remain; the per-turn inference log stays a page-bottom block.

## Verification

- `cargo test -p parish-harness dashboard` — 13 tests pass (assert all render
  markers + structure: radar, no bars, commit/issue links, router, page-bottom
  turn-log with no scrollbox).
- Zero external dependency (no script/CDN/font/chart.js).
- Live: redesigned runs list + run detail; full signature `wrong-village-name-curraghboy`
  visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- parish-proof-bundle:dashboard-redesign v=1 -->

## Proof: dashboard-redesign

### Acceptance criteria

# Acceptance Criteria: dashboard-redesign

## Task

Visually redesign the parish-harness dashboard (single file
`parish/crates/parish-harness/dashboard-ui/index.html`) for a polished, cohesive look — the runs
list, run-detail header, quality radar, findings, turns gallery, per-turn inference log, nav tabs,
trends, and A/B compare. All existing behavior and API wiring is preserved; only the presentation
improves. Also: stop truncating the finding `signature` — show it in full.

## Criteria

- C1: Every existing feature still works and hits the same endpoints — runs list (`/api/runs`),
  run detail (`/api/runs/{id}`), turn frames (`/turns/{idx}/frame.png`), per-turn inference log
  (`/turns/{idx}/transcript`), trends (`/api/timeline`), A/B compare (`/api/compare`), cost
  (`/api/cost`), SSE (`/stream`). No endpoint or request shape changes.
- C2: Zero external dependency — no `<script src>`, CDN, web font, or `chart.js`. The radar stays
  pure inline SVG. (CSP blocks external origins and a test asserts this.)
- C3: The finding `signature` is shown in full (no `substring`/ellipsis truncation).
- C4: Deep-linkable run pages (`#run/<id>`, `#run/<id>/turn/<idx>`), commit-sha links
  (`window.COMMIT_BASE` → `/commit/`), issue links on findings, and the radar-only axes chart all
  remain.
- C5: The per-turn inference log remains a single `#turn-log` block at the page bottom (after
  `</footer>`) with no inner scrollbox.
- C6: `cargo test -p parish-harness dashboard` passes (the served-HTML structure tests), and
  `cargo fmt --check` + `cargo clippy` are clean. Specifically these markers must remain present:
  `buildAxesRadar`, `axes-radar`, `<polygon`, `shaCell`, `window.COMMIT_BASE`, `/commit/`, the raw
  `__COMMIT_BASE__` token, `function router`, `hashchange`, `#run/` (or `'run/'`), `showTurnLog`,
  `/turn/`, `/transcript`, exactly one `id="turn-log"` after `</footer>`; and these must remain
  ABSENT: `axes-chart`, `axis-bar`, and any `max-height`/`overflow` on `.tl-infer pre`.

## Verification

`cargo test -p parish-harness dashboard` green + a live serve and browser load of the runs list and
a run detail (`#run/4/turn/5`) showing the redesigned page with all sections functional and the
full signature visible.

### Evidence

Evidence type: gameplay transcript

# Evidence: dashboard-redesign

Source transcript: `.proofs/dashboard-redesign/transcript.txt`
Captured by: `cargo test -p parish-harness dashboard` + a live serve and browser load of the runs
list and a run detail. (Frontend-only dashboard restyle; no engine behavior.)

## Criterion -> evidence mapping

- **C1 (all features + endpoints preserved)** -> §1 all 13 dashboard tests pass (they assert the
  render markers + structure); §2 the served page keeps every marker; §4 live runs list + run
  detail + radar + findings + turns + log all function.
- **C2 (zero external dep)** -> §2 `zero external deps (script src/cdn/chart.js): 0`; radar stays
  inline SVG (`axes-radar`/`<polygon` present).
- **C3 (full signature)** -> §3 the signature is rendered via `.finding-sig` with no
  `substring(0,16)` truncation on it; live detail shows `wrong-village-name-curraghboy` in full.
- **C4 (run pages, commit/issue links, radar-only)** -> §2 `function router`, `hashchange`,
  `showTurnLog`, `shaCell`, `window.COMMIT_BASE` present; `axes-chart`/`axis-bar` absent. The raw
  `__COMMIT_BASE__` token is in the file (asserted by the passing test) and the server replaces it
  on serve (so the served page shows the real base, not the token).
- **C5 (per-turn log at page bottom, no scrollbox)** -> §2 `.tl-infer pre` has no
  `max-height`/`overflow`; one `#turn-log` after the footer (passing structure test).
- **C6 (tests + fmt/clippy clean)** -> §1 tests green; `cargo fmt --check` + clippy clean (only
  index.html changed).

## Note

The redesign was implemented by a Fable subagent (restyle of the single-file dashboard); the
parent finished the findings render (new `.finding-head`/`.finding-sig` structure + full
signature) that the subagent defined in CSS but had not yet wired into the JS before its session
dropped. Screenshots are on the user's remote Chrome; the deterministic tests + served-HTML checks
are the persisted proof.

### Transcript

```text
=== dashboard-redesign verification transcript ===
Date: 2026-06-11  Branch: claude/dashboard-redesign off main
Implementation: Fable subagent restyled index.html; parent finished the findings render + un-truncated signature.

### 1. Rust dashboard tests — markers intact (C1,C2,C4,C5,C6) ###
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 78 filtered out; finished in 0.03s

### 2. Served HTML markers ###
  present buildAxesRadar: 2
  present axes-radar: 2
  present shaCell: 3
  present window.COMMIT_BASE: 3
  present __COMMIT_BASE__: 0
  present function router: 1
  present hashchange: 1
  present showTurnLog: 3
  present /transcript: 1
  ABSENT axes-chart (want 0): 0
  ABSENT axis-bar (want 0): 0
  tl-infer pre max-height/overflow (want 0): 0
  zero external deps (script src/cdn/chart.js, want 0): 0

### 3. Full signature (C3) ###
  signature truncation substring(0,16) on signature (want 0; only the started_at date keeps it): 0
class="finding-sig">${escHtml(f.signature)}<

### 4. Live browser ###
Runs list: centered layout, rounded table, pill status badges, brass heading. Run #4 detail:
styled header + pill COMPLETED, quality 73.0, git meta; radar; finding cards with severity
color + the FULL signature 'wrong-village-name-curraghboy' (mono tag, untruncated). Per-turn
log still at page bottom. (Screenshots in session; remote Chrome.)
```

### Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

# Judge: dashboard-redesign

## Per-criterion verification

- **C1**: met. All 13 dashboard tests pass; every endpoint and JS function is preserved (restyle
  only). Live runs list, run detail, radar, findings, turns gallery, and inference log all work.
- **C2**: met. No external script/CDN/font/chart.js; the radar is pure inline SVG.
- **C3**: met. The finding signature renders in full via `.finding-sig` (no truncation); live
  detail shows `wrong-village-name-curraghboy`.
- **C4**: met. Hash routing, commit-sha links, issue links, and radar-only axes all remain;
  `axes-chart`/`axis-bar` absent; `__COMMIT_BASE__` token present in the file and injected on serve.
- **C5**: met. The per-turn inference log stays a single `#turn-log` after the footer with no
  inner scrollbox.
- **C6**: met. `cargo test -p parish-harness dashboard` green; fmt/clippy clean; only index.html
  changed.

## Implementation notes

A Fable subagent restyled the single-file dashboard (CSS-variable theme, pill status badges,
rounded run table, run-detail header, severity-colored finding cards, monospace signature tag).
Its session dropped on a socket error after defining the new finding CSS but before rewriting the
finding render JS; the parent completed that render (using the subagent's classes) and removed the
signature truncation. No backend/Rust change.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:dashboard-redesign -->
