### PR TITLE
fix(harness): responsive dashboard for mobile viewports

### DIFF
--- a/parish/crates/parish-harness/dashboard-ui/index.html
+++ b/parish/crates/parish-harness/dashboard-ui/index.html
@@ -72,7 +72,7 @@
     #detail { margin-top: 1.5rem; display: none; }
     #detail.visible { display: block; animation: rise .25s ease both; }
     @keyframes rise { from { opacity: 0; transform: translateY(6px); } }
-    .axes-radar { display: block; margin: .25rem 0 .5rem; }
+    .axes-radar { display: block; margin: .25rem 0 .5rem; max-width: 100%; height: auto; }
     .radar-panel { background: var(--panel-2); border: 1px solid var(--line-soft); border-radius: 10px; padding: .5rem 1rem; display: inline-block; }
     .finding {
       background: var(--panel-2); border: 1px solid var(--line-soft);
@@ -118,7 +118,7 @@
     .run-meta { font-size: .8rem; color: #666; margin: .25rem 0; }
     .sse-status { font-size: .75rem; color: #668; margin-left: .5rem; }
     /* trends view */
-    .trends-svg { display: block; overflow: visible; margin: .5rem 0; }
+    .trends-svg { display: block; overflow: visible; margin: .5rem 0; max-width: 100%; height: auto; }
     .trends-no-data { color: #666; font-style: italic; font-size: .85rem; }
     .trend-point { cursor: pointer; }
     .trend-point:hover circle { r: 6; }
@@ -137,6 +137,19 @@
     .nav-tabs { display: flex; gap: .25rem; margin-bottom: 1rem; }
     .nav-tab { background: #1a1a2a; border: 1px solid #2a2a3a; border-radius: 4px 4px 0 0; padding: .3rem .75rem; cursor: pointer; font-size: .85rem; color: #888; }
     .nav-tab.active { background: #1a2a3a; color: #9bb3e0; border-bottom-color: #1a2a3a; }
+    /* Wide table scrolls within its own container instead of overflowing the page. */
+    #runs-container { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    #runs-container table { min-width: 560px; }
+    #runs-container td { white-space: nowrap; }
+    /* Mobile: tighten padding, let the A/B form and nav tabs wrap. */
+    @media (max-width: 640px) {
+      body { padding: 1.25rem 1rem 2.5rem; font-size: 14px; }
+      h1 { font-size: 1rem; }
+      .nav-tabs { flex-wrap: wrap; }
+      .ab-form { flex-wrap: wrap; }
+      .ab-form input { width: 100%; }
+      .run-meta { word-break: break-word; }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## What

The redesigned dashboard overflowed narrow (phone) viewports — fixed-width radar/trends SVGs and the 9-column runs table forced horizontal page scroll.

## How

- Fluid chart SVGs (`max-width:100%; height:auto`) — the `viewBox` scales them down.
- Runs table wrapped in `overflow-x:auto` (min-width + `nowrap` cells) so it scrolls on its own instead of overflowing the page.
- `@media (max-width:640px)`: tighter padding, smaller base font, wrapping nav tabs + full-width A/B inputs.

CSS-only — no behavior/markup/backend change.

## Verification

- `cargo test -p parish-harness dashboard` — 13 pass (CSS-only, no marker touched).
- Live at a 414px viewport: radar scales to fit, runs table scrolls within its container, no horizontal page overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- parish-proof-bundle:dashboard-mobile v=1 -->

## Proof: dashboard-mobile

### Acceptance criteria

# Acceptance Criteria: dashboard-mobile

## Task

The redesigned harness dashboard does not size well on a phone (~380px): the fixed-width radar
(380px) and trends (600px) SVGs overflow the viewport, and the 9-column runs table forces
horizontal page overflow. Make the page responsive so it reads cleanly on mobile without breaking
desktop.

## Criteria

- C1: The radar and trends SVGs scale to the viewport — `.axes-radar` and `.trends-svg` are fluid
  (`max-width: 100%; height: auto`), so neither overflows a narrow screen (their `viewBox` makes
  them scale). Observable via: the CSS rules + a mobile-width render with no horizontal page scroll
  from the charts.
- C2: The wide runs table no longer forces page overflow — its container scrolls horizontally on
  its own (`#runs-container { overflow-x: auto }`) and the table keeps a sane min-width so columns
  stay legible. Observable via: CSS + a ~380px render where the page body does not overflow
  horizontally (only the table scrolls).
- C3: A small-screen media query tightens body padding and any fixed-width form inputs
  (`.ab-form` wraps). Observable via: a `@media (max-width: …)` block in the stylesheet.
- C4: No behavior/markup/JS change beyond CSS; all dashboard tests still pass and no marker is
  removed. Observable via: `cargo test -p parish-harness dashboard` green.

## Verification

`cargo test -p parish-harness dashboard` + a live serve, loading the runs list and a run detail at
a phone viewport (~390px) and confirming no horizontal page overflow and legible content.

### Evidence

Evidence type: gameplay transcript

# Evidence: dashboard-mobile

Source transcript: `.proofs/dashboard-mobile/transcript.txt`
Captured by: `cargo test -p parish-harness dashboard` + a live serve and a 414px-viewport browser
load. (CSS-only dashboard change; no engine behavior.)

## Criterion -> evidence mapping

- **C1 (fluid SVGs)** -> §2 `.axes-radar` and `.trends-svg` carry `max-width: 100%; height: auto`;
  §3 the radar scales to the phone viewport with no overflow.
- **C2 (table scrolls, page doesn't overflow)** -> §2 `#runs-container { overflow-x: auto }` (+
  `td { white-space: nowrap }` and a min-width so columns stay legible); §3 at 414px the table
  scrolls within its container while the page body stays put.
- **C3 (mobile media query)** -> §2 a `@media (max-width: 640px)` block tightens body padding and
  wraps the nav tabs / A-B form inputs.
- **C4 (no behavior change, tests pass)** -> §1 all 13 dashboard tests pass; CSS-only edit, no
  marker removed.

### Transcript

```text
=== dashboard-mobile verification transcript ===
Date: 2026-06-11  Branch: claude/dashboard-mobile off main

### 1. Dashboard tests still green (C4) ###
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 78 filtered out; finished in 0.04s

### 2. Responsive CSS on served page (C1,C2,C3) ###
axes-radar fluid (max-width:100%): 1
trends-svg fluid: 1
runs-container overflow-x auto: 1
@media max-width 640px: 1
(note: served page is pre-nowrap rebuild; nowrap added in commit)

### 3. Live mobile render (C1,C2) ###
At a 414px viewport: run-detail radar scales to fit (no overflow), meta wraps; runs list
table scrolls horizontally WITHIN #runs-container while the page body (heading, footer) stays
put — no horizontal page overflow. Verified in-browser at 414x820. (Screenshots in session.)
```

### Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

# Judge: dashboard-mobile

## Per-criterion verification

- **C1**: met. The radar and trends SVGs are now `max-width: 100%; height: auto` and have a
  `viewBox`, so they scale down on narrow screens; live 414px render shows the radar fitting.
- **C2**: met. The wide runs table is wrapped by `#runs-container { overflow-x: auto }` with a
  table min-width + nowrap cells, so it scrolls horizontally on its own and the page body no longer
  overflows. Verified live.
- **C3**: met. A `@media (max-width: 640px)` block reduces body padding, drops the base font a
  notch, and wraps the nav tabs and A/B form (full-width inputs).
- **C4**: met. CSS-only; `cargo test -p parish-harness dashboard` stays green (13) and no render
  marker was touched.

## Implementation notes

Pure CSS responsiveness on the single-file dashboard — fluid chart SVGs, a horizontally-scrolling
table container, and a small-screen media query. No JS/markup/backend change.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:dashboard-mobile -->
