### PR TITLE
fix(npc): ground fabricated places, enforce mood tone, suppress cross-NPC crutch phrases (#1420, #1421, #1422)

### DIFF
--- a/parish/crates/parish-npc/src/ticks/prompt.rs
+++ b/parish/crates/parish-npc/src/ticks/prompt.rs
@@ -331,7 +331,9 @@ fn prior_phrases_block(world: &WorldState, npc: &Npc) -> Option<String> {
         } else {
             line
         };
-        block.push_str(&format!("- \"{excerpt}\"\n"));
+        block.push_str("- \"");
+        block.push_str(excerpt);
+        block.push_str("\"\n");
     }
     Some(block)
 }
@@ -365,7 +367,9 @@ fn cross_npc_phrases_block(world: &WorldState, npc: &Npc) -> Option<String> {
         } else {
             line
         };
-        block.push_str(&format!("- \"{excerpt}\"\n"));
+        block.push_str("- \"");
+        block.push_str(excerpt);
+        block.push_str("\"\n");
     }
     block.push_str(
         "In particular, never greet with \"ye've come to the right place\" or any \

--- a/parish/crates/parish-npc/src/ticks/prompt.rs
+++ b/parish/crates/parish-npc/src/ticks/prompt.rs
@@ -193,6 +193,26 @@ pub fn build_enhanced_system_prompt_with_config(
             An invented name asked of you as fact is still invented \u{2014} \
             answer with honest non-recognition, not a friendly yarn.\n",
         );
+        // #1420: the SAME presupposition trap applies to PLACES. A player asks
+        // after "the abbey in town" or "Father Pendleton's chapel" as settled
+        // fact; the small model confirms it exists and even gives directions
+        // ("right in the heart of Kilteevan"). A named building or settlement
+        // stated as fact is just as invented as a named person. Cover it
+        // explicitly and forbid confirming existence OR giving a location.
+        prompt.push_str(
+            "Watch equally for a PRESUPPOSED place: if someone speaks of a \
+            specific building or settlement by name (an abbey, a chapel, a mill, \
+            a named inn, a named townland) as though it plainly exists \u{2014} \
+            asking where it is or how to reach it \u{2014} and it is NOT in the \
+            PLACES IN THIS PARISH list above, do not go along with it. Say \
+            plainly there is no such place hereabouts (\"there's no abbey in \
+            these parts\", \"I know of no such place\"). NEVER confirm it exists, \
+            NEVER say it is in or near any real place, and NEVER give directions \
+            to it. A place named to you as fact is still invented unless it is on \
+            the list. When in doubt, declare non-recognition rather than invent a \
+            location \u{2014} a wrong yarn is worse than an honest \"I don't know \
+            it.\"\n",
+        );
     }
 
     prompt
@@ -313,6 +333,45 @@ fn prior_phrases_block(world: &WorldState, npc: &Npc) -> Option<String> {
         };
         block.push_str(&format!("- \"{excerpt}\"\n"));
     }
+    Some(block)
+}
+
+/// Cross-NPC crutch-phrase suppression block (#1422).
+///
+/// The per-NPC [`prior_phrases_block`] only catches an NPC recycling *its own*
+/// lines. Small models (Qwen 14B) instead reach for an identical opener *frame*
+/// across consecutive *different* NPCs in a session ("ye've come to the right
+/// place" from three NPCs in a row). This injects recent lines from OTHER
+/// speakers at the location so the model is told to vary the frame rather than
+/// echo a neighbour. Only renders when another NPC has spoken here recently.
+fn cross_npc_phrases_block(world: &WorldState, npc: &Npc) -> Option<String> {
+    let lines = world
+        .conversation_log
+        .other_npcs_recent_lines(world.player_location, npc.id, 4);
+    if lines.is_empty() {
+        return None;
+    }
+    let mut block = String::from(
+        "\n\nOTHER FOLK HERE JUST SAID THESE \u{2014} do NOT echo their opener \
+         or frame; reach for plainly different wording of your own:\n",
+    );
+    for line in &lines {
+        let excerpt: &str = if line.len() > 120 {
+            let mut end = 120;
+            while end > 0 && !line.is_char_boundary(end) {
+                end -= 1;
+            }
+            &line[..end]
+        } else {
+            line
+        };
+        block.push_str(&format!("- \"{excerpt}\"\n"));
+    }
+    block.push_str(
+        "In particular, never greet with \"ye've come to the right place\" or any \
+         near-copy of a frame already used above \u{2014} a parish where everyone \
+         says the same line rings false.",
+    );
     Some(block)
 }
 
@@ -455,7 +514,18 @@ fn mood_block(npc: &Npc) -> String {
         return String::new();
     }
     let tone_directive = mood_tone_directive(mood);
-    format!("\n\nYour current mood: {mood}. {tone_directive}")
+    // #1421: a bare "Your current mood: X" label was inconsistently honoured —
+    // the small model would invert it (a `sharp` widow giving "a warm welcome",
+    // an `alert` shopkeeper reading cheerful) because the cultural-warmth
+    // guideline in the system prompt out-pulls a soft label. Frame the mood as
+    // an OVERRIDE the model must obey even on a first greeting, so the
+    // formulaic-warm register cannot wash it out.
+    format!(
+        "\n\nYOUR CURRENT MOOD: {mood}. This mood OVERRIDES any default-friendly \
+         or welcoming register \u{2014} let it shape THIS reply, including your \
+         very first greeting. {tone_directive} Do not paper over this mood with a \
+         warm welcome or cheerful opener if the mood does not call for one."
+    )
 }
 
 /// Returns a tone directive sentence for the given mood word.
@@ -655,6 +725,12 @@ pub fn build_enhanced_context_with_config(params: Tier1ContextParams<'_>) -> Str
         context.push_str(&block);
     }
 
+    // Cross-NPC crutch-phrase suppression (#1422): catch a frame shared across
+    // *different* NPCs in a session, which the per-NPC guard above cannot see.
+    if quality_continuity && let Some(block) = cross_npc_phrases_block(world, npc) {
+        context.push_str(&block);
+    }
+
     if let Some(block) = reactions_block(npc, config) {
         context.push_str(&block);
     }
@@ -741,6 +817,62 @@ mod tests {
         let prompt = build_enhanced_system_prompt(&npc, false, &lang, &npc_names);
         assert!(!prompt.contains("PEOPLE IN YOUR LIFE:"));
         assert!(!prompt.contains("WHAT'S ON YOUR MIND:"));
+    }
+
+    /// AC-8 (#1422): the cross-NPC crutch block must list a recent line from a
+    /// DIFFERENT NPC at the location and tell the model not to echo the frame.
+    #[test]
+    fn cross_npc_phrases_block_suppresses_shared_frame() {
+        use parish_types::conversation::ConversationExchange;
+        let npc = make_test_npc(1, "Padraig", 1);
+        let mut world = WorldState::new();
+        let loc = world.player_location;
+        // A different NPC (id 2) already used the crutch frame here.
+        world.conversation_log.add(ConversationExchange {
+            timestamp: world.clock.now(),
+            speaker_id: NpcId(2),
+            speaker_name: "Peig".to_string(),
+            player_input: "hello".to_string(),
+            npc_dialogue: "Ye've come to the right place for a spot of gossip.".to_string(),
+            location: loc,
+        });
+
+        let block = cross_npc_phrases_block(&world, &npc)
+            .expect("block must render when another NPC spoke here");
+        assert!(
+            block.contains("OTHER FOLK HERE JUST SAID"),
+            "block must head the other-folk list:\n{block}"
+        );
+        assert!(
+            block.contains("Ye've come to the right place"),
+            "block must surface the neighbour's recent line:\n{block}"
+        );
+        assert!(
+            block.contains("ye've come to the right place") && block.contains("near-copy"),
+            "block must forbid echoing the shared frame:\n{block}"
+        );
+    }
+
+    /// AC-8 negative: the NPC's own lines (id matches) must NOT appear in the
+    /// cross-NPC block — that is the per-NPC guard's job, not this one's.
+    #[test]
+    fn cross_npc_phrases_block_excludes_self() {
+        use parish_types::conversation::ConversationExchange;
+        let npc = make_test_npc(1, "Padraig", 1);
+        let mut world = WorldState::new();
+        let loc = world.player_location;
+        world.conversation_log.add(ConversationExchange {
+            timestamp: world.clock.now(),
+            speaker_id: NpcId(1),
+            speaker_name: "Padraig".to_string(),
+            player_input: "hello".to_string(),
+            npc_dialogue: "Only my own line here.".to_string(),
+            location: loc,
+        });
+        assert!(
+            cross_npc_phrases_block(&world, &npc).is_none(),
+            "block must not render when only the NPC's own lines exist"
+        );
     }
 
     #[test]
@@ -1081,6 +1213,40 @@ mod tests {
         );
     }
 
+    /// AC-1/AC-2 (#1420): the grounding block must ALSO cover a *presupposed*
+    /// unknown place — an abbey/chapel/townland asserted as fact — and forbid
+    /// confirming it exists or giving directions to it.
+    #[test]
+    fn grounding_block_covers_presupposed_unknown_place() {
+        let npc = make_test_npc(1, "Padraig", 2);
+        let config = NpcConfig::default();
+        let names: HashMap<NpcId, String> = HashMap::new();
+        let lang = LanguageSettings::english_only();
+        let places = vec!["Darcy's Pub".to_string(), "The Mill".to_string()];
+
+        let prompt = build_enhanced_system_prompt_with_config(
+            &npc,
+            false,
+            &lang,
+            &config,
+            &names,
+            None,
+            Some(&places),
+        );
+        assert!(
+            prompt.contains("PRESUPPOSED place"),
+            "grounding block must name the presupposed-place case:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("no such place"),
+            "grounding block must instruct non-recognition of an unknown place:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("NEVER give directions"),
+            "grounding block must forbid giving directions to an invented place:\n{prompt}"
+        );
+    }
+
     /// AC-7 (#1401): kill-switch — with grounding disabled (`location_names`
     /// is `None`), neither the PLACES block nor the presupposition directive
     /// is emitted.
@@ -1101,6 +1267,10 @@ mod tests {
         assert!(
             !prompt.contains("PRESUPPOSED name"),
             "no presupposition directive when grounding disabled:\n{prompt}"
+        );
+        assert!(
+            !prompt.contains("PRESUPPOSED place"),
+            "no place-presupposition directive when grounding disabled:\n{prompt}"
         );
     }
 
@@ -1156,13 +1326,33 @@ mod tests {
         npc.mood = "calm".to_string();
         let result = mood_block(&npc);
         assert!(
-            result.starts_with("\n\nYour current mood: calm."),
+            result.starts_with("\n\nYOUR CURRENT MOOD: calm."),
             "mood block must start with label: {result}"
         );
         // Directive sentence follows the label.
         assert!(
-            result.len() > "\n\nYour current mood: calm.".len(),
+            result.len() > "\n\nYOUR CURRENT MOOD: calm.".len(),
             "mood block must include tone directive after label: {result}"
+        );
+    }
+
+    /// AC-6 (#1421): the mood block must frame the mood as an OVERRIDE of the
+    /// default-friendly register so the small model stops washing it out with a
+    /// formulaic warm greeting.
+    #[test]
+    fn mood_block_frames_mood_as_override_of_friendly_register() {
+        let mut npc = make_test_npc(1, "Padraig", 1);
+        npc.mood = "sharp".to_string();
+        let result = mood_block(&npc);
+        assert!(
+            result.contains("OVERRIDES"),
+            "mood block must declare the mood overrides the default register: {result}"
+        );
+        assert!(
+            result.to_lowercase().contains("first greeting")
+                || result.to_lowercase().contains("warm welcome")
+                || result.to_lowercase().contains("cheerful opener"),
+            "mood block must explicitly forbid papering over with a warm/cheerful opener: {result}"
         );
     }
 

--- a/parish/crates/parish-npc/src/tier1_prompt.rs
+++ b/parish/crates/parish-npc/src/tier1_prompt.rs
@@ -120,7 +120,11 @@ pub fn build_tier1_system_prompt(npc: &Npc, improv: bool, language: &LanguageSet
         pure dialogue, no narration or action descriptions.\n\
         \n\
         LENGTH: 2-3 sentences maximum. Be conversational, not a monologue. \
-        Ask AT MOST ONE question per reply — never stack multiple questions.\n\
+        Ask AT MOST ONE question per reply — never stack multiple questions. \
+        If several questions occur to you, pick the SINGLE most important one and \
+        drop the rest; a reply ending in two or more question marks is wrong. Do \
+        not chain offers either (\"shall I do X, or would ye rather Y, or...\") — \
+        one offer or one question, then stop.\n\
         \n\
         JSON fields:\n\
         - \"dialogue\": your spoken words (this is shown to the player)\n\
@@ -187,6 +191,24 @@ mod tests {
                 || prompt.contains("at most one question")
                 || prompt.contains("single question"),
             "system prompt must include single-question cap: missing in:\n{prompt}"
+        );
+    }
+
+    /// AC-10 (#1422): the single-question cap was being ignored — replies still
+    /// crammed multiple questions/offers. The directive must now explicitly tell
+    /// the model to pick ONE and drop the rest, and forbid chained offers.
+    #[test]
+    fn system_prompt_question_cap_forbids_stacking_and_chained_offers() {
+        let npc = make_named_npc(1, "Padraig", 1);
+        let lang = crate::LanguageSettings::english_only();
+        let prompt = build_tier1_system_prompt(&npc, false, &lang);
+        assert!(
+            prompt.contains("pick the SINGLE most important one and drop the rest"),
+            "question cap must instruct dropping all but one question:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("Do not chain offers"),
+            "question cap must forbid chained offers:\n{prompt}"
         );
     }
 

--- a/parish/crates/parish-types/src/conversation.rs
+++ b/parish/crates/parish-types/src/conversation.rs
@@ -135,6 +135,35 @@ impl ConversationLog {
             .collect()
     }
 
+    /// Returns the last `n` dialogue lines spoken at `location` by speakers
+    /// *other than* `npc_id`, oldest first.
+    ///
+    /// Used to build the cross-NPC crutch-phrase suppression block (#1422):
+    /// small models reach for an identical opener frame ("ye've come to the
+    /// right place") across consecutive *different* NPCs in a session. The
+    /// per-NPC anti-recycling guard ([`npc_prior_lines`](Self::npc_prior_lines))
+    /// cannot catch a frame shared *across* NPCs, so this feeds other speakers'
+    /// recent lines back as a "do not reuse these frames" list.
+    pub fn other_npcs_recent_lines(
+        &self,
+        location: LocationId,
+        npc_id: NpcId,
+        n: usize,
+    ) -> Vec<&str> {
+        self.exchanges
+            .iter()
+            .filter(|e| {
+                e.location == location && e.speaker_id != npc_id && e.speaker_id != NpcId(0)
+            })
+            .rev()
+            .take(n)
+            .map(|e| e.npc_dialogue.as_str())
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect()
+    }
+
     /// Returns the number of exchanges involving `npc_id` at `location`.
     ///
     /// Used to determine NPC–player familiarity level for address vocabulary
@@ -339,6 +368,28 @@ mod tests {
         assert_eq!(
             log.context_string(LocationId(1), NpcId(1), "the newcomer", 5),
             ""
+        );
+    }
+
+    #[test]
+    fn test_other_npcs_recent_lines_excludes_self_and_player() {
+        let mut log = ConversationLog::new();
+        // NPC 1 (self), NPC 2 (other), and player (id 0) all speak at loc 1.
+        log.add(make_exchange(8, 1, "Peig", "hi", "Ye've come to the right place.", 1));
+        log.add(make_exchange(9, 2, "Roisin", "hi", "Ye've come to the right place too.", 1));
+        log.add(make_exchange(10, 0, "Player", "hi", "player line", 1));
+        // Different location — must be excluded.
+        log.add(make_exchange(11, 3, "Maire", "hi", "elsewhere line", 2));
+
+        let lines = log.other_npcs_recent_lines(LocationId(1), NpcId(1), 6);
+        assert_eq!(lines, vec!["Ye've come to the right place too."]);
+        assert!(
+            !lines.iter().any(|l| l.contains("player line")),
+            "player (id 0) lines must be excluded: {lines:?}"
+        );
+        assert!(
+            !lines.iter().any(|l| l.contains("elsewhere")),
+            "other-location lines must be excluded: {lines:?}"
         );
     }
 

--- a/parish/crates/parish-types/src/conversation.rs
+++ b/parish/crates/parish-types/src/conversation.rs
@@ -150,7 +150,8 @@ impl ConversationLog {
         npc_id: NpcId,
         n: usize,
     ) -> Vec<&str> {
-        self.exchanges
+        let mut lines: Vec<&str> = self
+            .exchanges
             .iter()
             .filter(|e| {
                 e.location == location && e.speaker_id != npc_id && e.speaker_id != NpcId(0)
@@ -158,10 +159,9 @@ impl ConversationLog {
             .rev()
             .take(n)
             .map(|e| e.npc_dialogue.as_str())
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev()
-            .collect()
+            .collect();
+        lines.reverse();
+        lines
     }
 
     /// Returns the number of exchanges involving `npc_id` at `location`.

--- a/parish/crates/parish-types/src/conversation.rs
+++ b/parish/crates/parish-types/src/conversation.rs
@@ -375,8 +375,22 @@ mod tests {
     fn test_other_npcs_recent_lines_excludes_self_and_player() {
         let mut log = ConversationLog::new();
         // NPC 1 (self), NPC 2 (other), and player (id 0) all speak at loc 1.
-        log.add(make_exchange(8, 1, "Peig", "hi", "Ye've come to the right place.", 1));
-        log.add(make_exchange(9, 2, "Roisin", "hi", "Ye've come to the right place too.", 1));
+        log.add(make_exchange(
+            8,
+            1,
+            "Peig",
+            "hi",
+            "Ye've come to the right place.",
+            1,
+        ));
+        log.add(make_exchange(
+            9,
+            2,
+            "Roisin",
+            "hi",
+            "Ye've come to the right place too.",
+            1,
+        ));
         log.add(make_exchange(10, 0, "Player", "hi", "player line", 1));
         // Different location — must be excluded.
         log.add(make_exchange(11, 3, "Maire", "hi", "elsewhere line", 2));


### PR DESCRIPTION
WIP — cap-interrupted. Resume: finish proof bundle (.proofs/1420-1421-1422-npc-dialogue), run just check + just agent-check, then attach-proof.

Fixes #1420
Fixes #1421
Fixes #1422