### PR TITLE
test: assert mood tag reaches assembled NPC context (#1421)

### DIFF
--- a/parish/crates/parish-npc/src/ticks/prompt.rs
+++ b/parish/crates/parish-npc/src/ticks/prompt.rs
@@ -1208,6 +1208,77 @@ mod tests {
         );
     }
 
+    /// AC-1 (#1421): the assembled context returned by the integrated builder
+    /// must contain both the mood label and the curt tone directive for a
+    /// "sharp" NPC — proving `mood_block()` output reaches the final context.
+    #[test]
+    fn assembled_context_sharp_mood_contains_curt_directive() {
+        let mut npc = make_test_npc(1, "Padraig", 1);
+        npc.mood = "sharp".to_string();
+        let world = WorldState::new();
+        let npc_names: HashMap<NpcId, String> = HashMap::new();
+        let config = NpcConfig::default();
+
+        let context = build_enhanced_context_with_config(Tier1ContextParams {
+            npc: &npc,
+            world: &world,
+            player_input: "good morning",
+            other_npcs: &[],
+            language: &LanguageSettings::english_only(),
+            config: &config,
+            npc_names: &npc_names,
+            player_name_for_npc: None,
+            was_introduced: false,
+        });
+
+        assert!(
+            context.contains("Your current mood: sharp"),
+            "assembled context must contain mood label for sharp NPC:\n{context}"
+        );
+        assert!(
+            context.to_lowercase().contains("curt")
+                || context.to_lowercase().contains("pleasantries")
+                || context.to_lowercase().contains("direct"),
+            "assembled context must contain curt/direct directive for sharp NPC:\n{context}"
+        );
+    }
+
+    /// AC-2 (#1421): the assembled context returned by the integrated builder
+    /// must contain both the mood label and the watchful tone directive for an
+    /// "alert" NPC — proving `mood_block()` output reaches the final context.
+    #[test]
+    fn assembled_context_alert_mood_contains_watchful_directive() {
+        let mut npc = make_test_npc(1, "Padraig", 1);
+        npc.mood = "alert".to_string();
+        let world = WorldState::new();
+        let npc_names: HashMap<NpcId, String> = HashMap::new();
+        let config = NpcConfig::default();
+
+        let context = build_enhanced_context_with_config(Tier1ContextParams {
+            npc: &npc,
+            world: &world,
+            player_input: "good morning",
+            other_npcs: &[],
+            language: &LanguageSettings::english_only(),
+            config: &config,
+            npc_names: &npc_names,
+            player_name_for_npc: None,
+            was_introduced: false,
+        });
+
+        assert!(
+            context.contains("Your current mood: alert"),
+            "assembled context must contain mood label for alert NPC:\n{context}"
+        );
+        assert!(
+            context.to_lowercase().contains("on edge")
+                || context.to_lowercase().contains("attentive")
+                || context.to_lowercase().contains("scanning")
+                || context.to_lowercase().contains("careful"),
+            "assembled context must contain watchful directive for alert NPC:\n{context}"
+        );
+    }
+
     /// Regression guard: the system prompt must be byte-stable when only the
     /// NPC mood changes (mood lives in the dynamic context, not the system
     /// prompt, so a mood change must not alter the system block).


### PR DESCRIPTION
Add two unit tests to `ticks/prompt.rs` that call the integrated `build_enhanced_context_with_config` builder and assert the mood label plus tone directive appear in the assembled context string for `sharp` and `alert` moods.

## Problem

GitHub issue #1421: the `mood_block()` helper and `mood_tone_directive()` were unit-tested in isolation, but no test asserted that the assembled context returned by the integrated builder actually contained the mood label and its tone directive. A "sharp" NPC could silently give a warm welcome if the wiring from `mood_block()` to `build_enhanced_context_with_config` were ever broken.

## Solution

Two new tests in the `#[cfg(test)]` block of `parish/crates/parish-npc/src/ticks/prompt.rs`:

- `assembled_context_sharp_mood_contains_curt_directive`: calls `build_enhanced_context_with_config` with `npc.mood = "sharp"`, asserts `"Your current mood: sharp"` and a curt/direct directive substring appear in the assembled string.
- `assembled_context_alert_mood_contains_watchful_directive`: same for `mood = "alert"`, asserting the watchful/on-edge directive.

Both use existing test fixtures (`make_test_npc`, `WorldState::new()`, `NpcConfig::default()`).

## Commands run

```
cargo fmt -p parish-npc
cargo test -p parish-npc ticks::prompt   # 48 passed
cargo test -p parish-npc assembled_context  # 2 passed
cargo clippy -p parish-npc --tests -- -D warnings  # no issues
```

Fixes #1421

<!-- parish-proof-bundle:fix-1421-mood-context-test v=1 -->

## Proof: fix-1421-mood-context-test

### Acceptance criteria

## Acceptance criteria

AC-1: A new test `assembled_context_sharp_mood_contains_curt_directive` calls
`build_enhanced_context_with_config` with an NPC whose `mood` is `"sharp"` and
asserts the returned string contains the mood label `"Your current mood: sharp"`
AND contains the curt-directive substring `"curtly"` (or `"pleasantries"` or
`"direct"`).

AC-2: A new test `assembled_context_alert_mood_contains_watchful_directive` calls
`build_enhanced_context_with_config` with an NPC whose `mood` is `"alert"` and
asserts the returned string contains the mood label `"Your current mood: alert"`
AND contains the watchful-directive substring `"on edge"` (or `"attentive"` or
`"scanning"` or `"careful"`).

AC-3: Both tests pass under `cargo test -p parish-npc`.

AC-4: `cargo clippy -p parish-npc --tests -- -D warnings` produces zero warnings.

### Evidence

Evidence type: gameplay transcript

## Summary

Test-only change: two new unit tests added to `parish/crates/parish-npc/src/ticks/prompt.rs` that call the integrated `build_enhanced_context_with_config` builder and assert mood label + tone directive appear in the assembled context for `sharp` and `alert` moods.

## Cargo test output

```
$ cd parish && cargo test -p parish-npc ticks::prompt
   Compiling parish-npc v0.1.0 (...)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 6.14s
     Running unittests src/lib.rs
     Running tests/gossip_integration.rs
     Running tests/rundale_data_consistency.rs
     Running tests/tier1_context_real_world.rs
     Running tests/tier2_llm_integration.rs
cargo test: 48 passed, 530 filtered out (5 suites, 0.00s)
```

Focused run of only the two new tests:

```
$ cargo test -p parish-npc assembled_context
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running unittests src/lib.rs
     ...
cargo test: 2 passed, 576 filtered out (5 suites, 0.00s)
```

## Clippy

```
$ cargo clippy -p parish-npc --tests -- -D warnings
cargo clippy: No issues found
```

## Criterion-to-proof mapping

AC-1 (sharp mood): test `assembled_context_sharp_mood_contains_curt_directive` — in the "2 passed" run above.

- Asserts `context.contains("Your current mood: sharp")` — the exact format from `mood_block()` line 458.
- Asserts `context.to_lowercase().contains("curt")` matching the directive `"Speak curtly and directly..."`.

AC-2 (alert mood): test `assembled_context_alert_mood_contains_watchful_directive` — in the "2 passed" run above.

- Asserts `context.contains("Your current mood: alert")`.
- Asserts `context.to_lowercase().contains("on edge")` matching `"You are on edge — attentive..."`.

AC-3: `cargo test: 2 passed` — both tests pass.

AC-4: `cargo clippy: No issues found` — zero warnings.

### Judge

## Acceptance criteria

AC-1: `assembled_context_sharp_mood_contains_curt_directive` calls the integrated
builder with `mood = "sharp"` and asserts both `"Your current mood: sharp"` and a
curt/direct directive substring appear in the assembled context string. Test passes.

AC-2: `assembled_context_alert_mood_contains_watchful_directive` calls the integrated
builder with `mood = "alert"` and asserts both `"Your current mood: alert"` and a
watchful/on-edge directive substring appear in the assembled context string. Test passes.

AC-3: `cargo test -p parish-npc` — 48 tests pass (including both new tests).

AC-4: `cargo clippy -p parish-npc --tests -- -D warnings` — no issues.

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

<!-- /parish-proof-bundle:fix-1421-mood-context-test -->
