### PR TITLE
test: close grounding presupposition-guard coverage gap (#1420)

### DIFF
--- a/parish/crates/parish-core/tests/dialogue_prompt_anchor.rs
+++ b/parish/crates/parish-core/tests/dialogue_prompt_anchor.rs
@@ -447,6 +447,97 @@ fn dialogue_system_prompt_contains_grounding_deflection_instruction() {
     );
 }
 
+/// AC-1/AC-2/AC-3 (#1420): when grounding is enabled, the system prompt must
+/// contain the presupposition-guard block that names the presupposition case
+/// and instructs the NPC to express honest non-recognition for any fabricated
+/// person, not just open-mention unknowns. The repro from #1420 was an NPC
+/// confirming "Father Pendleton" who does not exist in the parish.
+#[test]
+fn dialogue_system_prompt_contains_presupposition_guard() {
+    use parish_core::npc::LanguageSettings;
+
+    let (mut world, mut npc_manager) = fresh_rundale_world_and_npcs();
+    let speaker_id: NpcId = npc_manager
+        .npcs_at(world.player_location)
+        .first()
+        .map(|n| n.id)
+        .expect("Rundale fresh save should co-locate at least one NPC");
+    world.player_name = Some("Aiden Carney".to_string());
+
+    // Mirror the #1420 repro: player names a fabricated person as a presupposition.
+    let setup = prepare_npc_conversation_turn(
+        &world,
+        &mut npc_manager,
+        "Is Father Pendleton still hearing confessions at the abbey?",
+        speaker_id,
+        &[],
+        false,
+        &LanguageSettings::english_only(),
+        &parish_core::config::NpcConfig {
+            grounding_enabled: true,
+            ..parish_core::config::NpcConfig::default()
+        },
+    )
+    .expect("setup must succeed");
+
+    // AC-1: the presupposition case must be named explicitly
+    assert!(
+        setup.system_prompt.contains("PRESUPPOSED name"),
+        "system prompt must name the presupposition case:\n{}",
+        setup.system_prompt
+    );
+    // AC-2a: honest non-recognition instruction must be present
+    assert!(
+        setup.system_prompt.contains("know no such person")
+            || setup.system_prompt.contains("never heard of him"),
+        "system prompt must instruct honest non-recognition for presupposed names:\n{}",
+        setup.system_prompt
+    );
+    // AC-2b: forbid confirming an invented person's existence or trade
+    assert!(
+        setup
+            .system_prompt
+            .contains("Never confirm they are still about"),
+        "system prompt must forbid confirming an invented person:\n{}",
+        setup.system_prompt
+    );
+}
+
+/// AC-4 (#1420): inverse — when grounding is disabled, the presupposition guard
+/// must be absent from the system prompt along with the PLACES block.
+#[test]
+fn dialogue_system_prompt_omits_presupposition_guard_when_grounding_disabled() {
+    use parish_core::npc::LanguageSettings;
+
+    let (world, mut npc_manager) = fresh_rundale_world_and_npcs();
+    let speaker_id: NpcId = npc_manager
+        .npcs_at(world.player_location)
+        .first()
+        .map(|n| n.id)
+        .expect("Rundale fresh save should co-locate at least one NPC");
+
+    let setup = prepare_npc_conversation_turn(
+        &world,
+        &mut npc_manager,
+        "Is Father Pendleton still hearing confessions at the abbey?",
+        speaker_id,
+        &[],
+        false,
+        &LanguageSettings::english_only(),
+        &parish_core::config::NpcConfig {
+            grounding_enabled: false,
+            ..parish_core::config::NpcConfig::default()
+        },
+    )
+    .expect("setup must succeed");
+
+    assert!(
+        !setup.system_prompt.contains("PRESUPPOSED name"),
+        "presupposition guard must be absent when grounding disabled:\n{}",
+        setup.system_prompt
+    );
+}
+
 /// Inverse: when grounding is disabled, the PLACES block must be absent.
 #[test]
 fn dialogue_system_prompt_omits_location_block_when_grounding_disabled() {


### PR DESCRIPTION
Close the test-coverage gap for GitHub issue #1420 (NPC confirms fabricated person "Father Pendleton" and place "the abbey").

## Changes

Two new integration tests in `parish/crates/parish-core/tests/dialogue_prompt_anchor.rs`:

- `dialogue_system_prompt_contains_presupposition_guard` - drives `prepare_npc_conversation_turn` with `grounding_enabled: true` and a player turn naming fabricated "Father Pendleton" as a presupposed known person. Asserts the assembled `system_prompt` contains `PRESUPPOSED name`, `know no such person`/`never heard of him`, and `Never confirm they are still about`.
- `dialogue_system_prompt_omits_presupposition_guard_when_grounding_disabled` - same setup with `grounding_enabled: false`; asserts guard is absent.

No production code changed. Unit tests in `parish-npc/src/ticks/prompt.rs` already covered `build_enhanced_system_prompt_with_config` directly (lines 1048-1105); these tests close the integration-path gap by confirming the guard survives the full call chain through `prepare_npc_conversation_turn`.

## Commands run

```
cargo fmt -p parish-core
cargo test -p parish-core --test dialogue_prompt_anchor   # 14 passed
cargo clippy -p parish-core --tests -- -D warnings         # clean
```

Fixes #1420

<!-- parish-proof-bundle:fix-1420-grounding-test v=1 -->

## Proof: fix-1420-grounding-test

### Acceptance criteria

## Acceptance criteria

**Task:** Close the test-coverage gap for GitHub issue #1420 — NPC grounding presupposition guard must be asserted in the production system-prompt path.

**Scope:** Test-only, non-runtime change. No production code is modified.

### AC-1

A new test in `parish/crates/parish-core/tests/dialogue_prompt_anchor.rs` named `dialogue_system_prompt_contains_presupposition_guard` drives `prepare_npc_conversation_turn` via the production path with `grounding_enabled: true` and asserts that the assembled `system_prompt` contains the text `PRESUPPOSED name`.

### AC-2

The same test also asserts the presupposition-guard contains the honest non-recognition instruction (`know no such person` or `never heard of him`) and the `Never confirm they are still about` directive, so the full guard clause is verified end-to-end.

### AC-3

The test exercises a player input naming a fabricated person (`Father Pendleton`) to mirror the issue-#1420 repro scenario.

### AC-4

A companion test named `dialogue_system_prompt_omits_presupposition_guard_when_grounding_disabled` asserts that when `grounding_enabled: false` the `PRESUPPOSED name` text does NOT appear in the system prompt.

### AC-5

`cargo test -p parish-core --test dialogue_prompt_anchor` passes with all tests green.

### AC-6

`cargo clippy -p parish-core --tests -- -D warnings` is clean (no new warnings from the added tests).

### Evidence

Evidence type: gameplay transcript

## Summary

Test-only change adding integration tests to `parish/crates/parish-core/tests/dialogue_prompt_anchor.rs` that assert the presupposition-guard block (`PRESUPPOSED name`) reaches the production system prompt when `grounding_enabled: true`. No runtime/production code modified.

## cargo test output

```
$ cd parish && cargo test -p parish-core --test dialogue_prompt_anchor

   Compiling parish-palette v0.1.0 (...)
   Compiling parish-providers v0.1.0 (...)
   Compiling parish-setup v0.1.0 (...)
   Compiling parish-inference v0.1.0 (...)
   Compiling parish-npc v0.1.0 (...)
   Compiling parish-input v0.1.0 (...)
   Compiling parish-persistence v0.1.0 (...)
   Compiling parish-diagnostics v0.1.0 (...)
   Compiling parish-mod v0.1.0 (...)
   Compiling parish-chronicle v0.1.0 (...)
   Compiling parish-editor v0.1.0 (...)
   Compiling parish-core v0.1.0 (...)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 6.25s
     Running tests/dialogue_prompt_anchor.rs (...)
cargo test: 14 passed (1 suite, 0.01s)
```

## Criterion mapping

**AC-1** — `dialogue_system_prompt_contains_presupposition_guard` asserts `setup.system_prompt.contains("PRESUPPOSED name")`. Test 13 of 14 in the suite; all pass: `14 passed (1 suite, 0.01s)`.

**AC-2** — same test asserts `"know no such person" || "never heard of him"` and `"Never confirm they are still about"`. Covered in the same passing test.

**AC-3** — player input `"Is Father Pendleton still hearing confessions at the abbey?"` mirrors the #1420 repro scenario with a fabricated person presupposed as known.

**AC-4** — `dialogue_system_prompt_omits_presupposition_guard_when_grounding_disabled` asserts `!system_prompt.contains("PRESUPPOSED name")` when `grounding_enabled: false`. Test 14 of 14; passes.

**AC-5** — `cargo test -p parish-core --test dialogue_prompt_anchor`: `14 passed (1 suite, 0.01s)`.

**AC-6** — `cargo clippy -p parish-core --tests -- -D warnings`: no issues found.

### Judge

## Judge verdict — fix-1420-grounding-test

### Review

The change adds two integration tests to the existing `dialogue_prompt_anchor.rs` file, driving `prepare_npc_conversation_turn` through the production path with `grounding_enabled: true/false`. The tests assert the presupposition-guard block (`PRESUPPOSED name`, `know no such person`/`never heard of him`, `Never confirm they are still about`) appears in the assembled `system_prompt` when grounding is on and is absent when grounding is off. No production code is modified.

The guard text being asserted is verified against the actual source in `parish-npc/src/ticks/prompt.rs` lines 185-195. The unit tests covering `build_enhanced_system_prompt_with_config` directly already exist in `prompt.rs` (AC-6/AC-7 at lines 1048-1105); these new integration tests close the gap by confirming the guard survives the full call chain through `prepare_npc_conversation_turn`.

All 14 tests pass. Clippy is clean.

## Acceptance criteria

All six acceptance criteria from `acceptance-criteria.md` are met:

- AC-1: `dialogue_system_prompt_contains_presupposition_guard` asserts `PRESUPPOSED name` in production system_prompt. Met.
- AC-2: same test asserts honest non-recognition and forbid-confirmation directives. Met.
- AC-3: player input names fabricated "Father Pendleton". Met.
- AC-4: `dialogue_system_prompt_omits_presupposition_guard_when_grounding_disabled` asserts absence. Met.
- AC-5: `cargo test -p parish-core --test dialogue_prompt_anchor` — 14 passed. Met.
- AC-6: clippy clean. Met.

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

<!-- /parish-proof-bundle:fix-1420-grounding-test -->