### PR TITLE
fix(skills): drop invalid `paths` frontmatter that blocked skill loading

### DIFF
--- a/.agents/skills/check/SKILL.md
+++ b/.agents/skills/check/SKILL.md
@@ -2,10 +2,6 @@
 name: check
 description: Run the Rundale quality gates — `just check` (pre-commit) and `just verify` (pre-push, adds the game-harness walkthrough) — and diagnose failures, including the known CI false positives. Use before committing, before pushing, or when debugging a CI failure.
 disable-model-invocation: true
-paths:
-  - .github/**
-  - parish/scripts/**
-  - justfile
 ---
 
 Run the Rundale quality gates. There are two levels — run the one that matches where you are.

--- a/.agents/skills/parish-engine/SKILL.md
+++ b/.agents/skills/parish-engine/SKILL.md
@@ -3,12 +3,6 @@ name: parish-engine
 description: Drive the Rundale engine to see gameplay actually working — the script harness, feature proofs, autonomous play-tests, eval rubrics/baselines, the live LLM auto-player, browser UI sessions, and GUI screenshots. Use after changing world, movement, NPC, input, inference, UI, or mod code, and whenever you need to prove a gameplay change is live rather than that tests pass.
 disable-model-invocation: false
 argument-hint: '[harness|prove|play|rubric|demo|browser|screenshot] [scenario or feature]'
-paths:
-  - parish/crates/**
-  - parish/testing/**
-  - mods/rundale/**
-  - parish/apps/ui/**
-  - parish/crates/parish-server/**
 ---
 
 One skill for every way of running the engine to observe behaviour. Pick the section that matches the

--- a/.agents/skills/quality-harness/SKILL.md
+++ b/.agents/skills/quality-harness/SKILL.md
@@ -2,10 +2,6 @@
 name: quality-harness
 description: Run a game quality-control playtest — YOU drive the LIVE Rundale game via the parish MCP against real models, play in-character for N turns, observe the world, then judge it CRITICALLY (anchored rubric, discrete findings) and file bugs. Trigger when the user says "run the quality harness", "do a harness run", "playtest the game", "QA the game", "drive a playtest", or similar. NOT for model benchmarking (that is /rundale-bench) and NOT for scripted bug-probing (that is /demo-audit-mcp).
 argument-hint: '[turns N] [persona "..."] [goal "..."]'
-paths:
-  - parish/crates/parish-tauri/**
-  - parish/crates/parish-mcp/**
-  - docs/agent/driving-the-game-via-mcp.md
 ---
 
 # quality-harness — agent-driven critical playtest

--- a/.agents/skills/rundale-geo-tool/SKILL.md
+++ b/.agents/skills/rundale-geo-tool/SKILL.md
@@ -12,10 +12,6 @@ description: >-
   involving lat/lon in Rundale, the Parish Designer editor's geographic fields,
   "pin X to coord Y", "move the Kilteevan cluster", "the fictional
   establishments didn't follow the village", or similar.
-paths:
-  - mods/rundale/**
-  - parish/crates/parish-world/**
-  - parish/crates/parish-geo-tool/**
 ---
 
 How to work with Rundale's geographic coordinate system.

--- a/.agents/skills/techdebt/SKILL.md
+++ b/.agents/skills/techdebt/SKILL.md
@@ -3,9 +3,6 @@ name: techdebt
 description: 'Technical-debt reduction in two modes: (1) a continuous TODO.md sweeper that consumes/discovers debt and dispatches focused fix agents until none remains, and (2) a crate-layout audit that produces a behaviour-preserving refactor PR (renames → manifests → splits → extractions → README) for the Rust workspace. Use for ongoing debt cleanup or when auditing crate structure.'
 disable-model-invocation: false
 argument-hint: '[path] | crate-audit [phase]'
-paths:
-  - parish/crates/**
-  - parish/Cargo.toml
 ---
 
 Two modes. The default **debt-sweeper loop** (below) consumes a `TODO.md` list for any scope. For a


### PR DESCRIPTION
## What

Removes the `paths:` frontmatter block from 5 SKILL.md files: `check`, `parish-engine`, `quality-harness`, `rundale-geo-tool`, `techdebt`. 21 deletions, paths-only, skill bodies untouched.

## Why

`paths:` is **not a recognized Claude Code SKILL.md frontmatter field**. The skill loader silently drops any SKILL.md that carries an unrecognized key, so all 5 skills failed to register as available — `/quality-harness`, `/parish-engine`, `/check`, `/rundale-geo-tool`, and `/techdebt` were invisible.

Diagnosis was a clean correlation: every skill carrying `paths:` failed to load; every skill without it loaded. Not description length (`rundale-bench` at 871 chars loads), not `disable-model-invocation` (`five-whys` has it and loads), not git tracking (all untracked via the `.claude/skills -> .agents/skills` symlink).

## Origin

- `400538a2` (#971, "align repo with Anthropic large-codebase best practices") invented `paths:` on `rundale-geo-tool` — likely confused with Cursor's `globs` rule-scoping.
- `fb87ffdf` (#1069, skill consolidation) copy-propagated it to `check`, `parish-engine`, `techdebt`.
- `7698497c` (#1350, quality-harness) copied it again.

A homegrown convention that was never a real feature, spread by copy-paste across 4 PRs.

## Safety

No code reads the `paths:` key (verified: only a stray README mention, no Rust/script/doc consumer). Removal is behavior-preserving and confirmed live — the 5 skills loaded mid-session immediately after the strip.

Valid SKILL.md frontmatter keys: `name`, `description`, `argument-hint`, `disable-model-invocation`, `allowed-tools`, `model`.

## Proof

Agent-instruction-only change (SKILL.md files) — exempt from the proof-bundle and live-proof gates per CLAUDE.md rule 10. No runtime/UI/gameplay paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)