### PR TITLE
fix(input): gate movement on addressed_to; narrate Interact actions (#1449, #1450)

### DIFF
--- a/parish/crates/parish-core/src/game_loop/input.rs
+++ b/parish/crates/parish-core/src/game_loop/input.rs
@@ -1092,6 +1092,78 @@ mod tests {
         );
     }
 
+    /// AC-5 / AC-6 (#1449) end-to-end via local parser: the local parser now
+    /// classifies physical-action imperative verbs as `Interact` directly
+    /// (no LLM required), so `handle_game_input` with flag enabled must
+    /// emit a narrated `text-log` and NOT route to NPC conversation.
+    #[tokio::test]
+    async fn handle_game_input_interact_narrates_via_local_parser() {
+        let emitter = Arc::new(CapturingEmitter::new());
+        let world = tokio::sync::Mutex::new(WorldState::new());
+        let npc_manager = tokio::sync::Mutex::new(NpcManager::new());
+        let config = tokio::sync::Mutex::new(GameConfig::default());
+        let conversation = tokio::sync::Mutex::new(ConversationRuntimeState::new());
+        let inference_queue = tokio::sync::Mutex::new(None);
+        let client = tokio::sync::Mutex::new(None); // no LLM — local parser only
+        let cloud_client = tokio::sync::Mutex::new(None);
+        let inference_config = crate::config::InferenceConfig::default();
+
+        let ctx = GameLoopContext {
+            world: &world,
+            npc_manager: &npc_manager,
+            config: &config,
+            conversation: &conversation,
+            inference_queue: &inference_queue,
+            emitter: Arc::clone(&emitter) as Arc<dyn EventEmitter>,
+            inference_config: &inference_config,
+            pronunciations: &[],
+            client: &client,
+            cloud_client: &cloud_client,
+            language: crate::npc::LanguageSettings::english_only(),
+            inference_failure_messages: &[],
+            idle_messages: &[],
+        };
+
+        let transport = make_transport();
+        let templates = ReactionTemplates::default();
+
+        // "tie a strip of cloth to the thorn bush" — primary #1449 repro.
+        // The local parser classifies this as Interact; with flag enabled (default)
+        // handle_game_input must emit a narrated action text-log.
+        super::handle_game_input(
+            &ctx,
+            "tie a strip of cloth to the thorn bush".to_string(),
+            vec![],
+            &transport,
+            &templates,
+            || None,
+        )
+        .await;
+
+        let logs: Vec<String> = emitter
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(n, _)| n == "text-log")
+            .filter_map(|(_, p)| {
+                p.get("content")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .collect();
+
+        assert!(
+            !logs.is_empty(),
+            "#1449: interact must emit a text-log; got none"
+        );
+        assert!(
+            logs.iter()
+                .any(|l| l.contains("tie a strip of cloth to the thorn bush")),
+            "#1449: narration must reference the original input; got: {logs:?}"
+        );
+    }
+
     /// AC-7 (#1449): with `interact-narration` flag disabled, interact falls
     /// through to NPC conversation (legacy behaviour preserved as kill-switch).
     #[tokio::test]
@@ -1127,14 +1199,11 @@ mod tests {
         let transport = make_transport();
         let templates = ReactionTemplates::default();
 
-        // Craft an intent that the dispatch code sees as Interact with flag off.
-        // We can't inject an Interact intent directly from the local parser, so
-        // we call handle_game_input with an action phrase and observe that —
-        // because the local parser returns None (not Interact) — the input routes
-        // to NPC conversation as before (no action narration emitted).
-        //
-        // This test primarily guards that disabling the flag does not panic and
-        // that the fallthrough path produces a text-log (idle message).
+        // "pick up the bellows" — the local parser now classifies this as
+        // `Interact` (#1449 fix). With the `interact-narration` flag disabled,
+        // the `is_interact` dispatch branch falls through to NPC conversation
+        // (legacy kill-switch). No action narration should be emitted; an idle
+        // text-log (no NPC present) is produced instead.
         super::handle_game_input(
             &ctx,
             "pick up the bellows".to_string(),
@@ -1145,8 +1214,8 @@ mod tests {
         )
         .await;
 
-        // With flag disabled and no LLM (local parser returns None for "pick up"),
-        // the dispatch falls through to NPC conversation → idle message text-log.
+        // With flag disabled, dispatch falls through to NPC conversation →
+        // idle message text-log (no NPC present).
         let event_names = emitter.event_names();
         assert!(
             event_names.iter().any(|n| n == "text-log"),

--- a/parish/crates/parish-core/src/game_loop/input.rs
+++ b/parish/crates/parish-core/src/game_loop/input.rs
@@ -141,7 +141,19 @@ async fn try_handle_move(
 /// Extracted so tests can drive the narration branch directly without
 /// requiring an LLM-classified `Interact` intent.
 pub(crate) async fn handle_interact(ctx: &GameLoopContext<'_>, raw: &str) {
-    let msg = format!("You {raw}.");
+    // Normalize: trim whitespace, strip trailing period, lowercase first character.
+    // This prevents awkward output like "You Tie a strip of cloth.." when the player
+    // types a capitalized sentence with trailing punctuation.
+    let mut chars = raw.trim().trim_end_matches('.').chars();
+    let normalized = match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_lowercase().collect::<String>() + chars.as_str(),
+    };
+    // Don't emit anything for blank/empty input after normalization.
+    if normalized.is_empty() {
+        return;
+    }
+    let msg = format!("You {normalized}.");
     ctx.emitter.emit_event(
         "text-log",
         serde_json::to_value(text_log("action", msg)).unwrap_or(serde_json::Value::Null),
@@ -283,7 +295,10 @@ pub async fn handle_game_input(
     // acknowledgement rather than routing to NPC conversation.  Gated by the
     // `interact-narration` flag (default-ON, kill-switch pattern: gate fires
     // unless the flag has been explicitly disabled).
-    if is_interact {
+    // Additionally, mirror the #1450 pattern: if the player explicitly addresses
+    // an NPC while performing an action, route to NPC conversation so the NPC
+    // can witness/react rather than the generic narration handler intercepting.
+    if is_interact && addressed_to.is_empty() {
         let flag_enabled = {
             let config = ctx.config.lock().await;
             !config.flags.is_disabled("interact-narration")
@@ -1220,6 +1235,149 @@ mod tests {
         assert!(
             event_names.iter().any(|n| n == "text-log"),
             "interact fallthrough must still emit a text-log; got {event_names:?}"
+        );
+    }
+
+    // ── Gemini review thread fixes ────────────────────────────────────────────
+
+    /// Thread 1: capitalized input with trailing period must be normalized to
+    /// lowercase-first, no trailing double-period.
+    ///
+    /// "Tie a strip of cloth." → "You tie a strip of cloth."
+    #[tokio::test]
+    async fn handle_interact_normalizes_capitalized_trailing_period() {
+        let emitter = Arc::new(CapturingEmitter::new());
+        let world = tokio::sync::Mutex::new(WorldState::new());
+        let npc_manager = tokio::sync::Mutex::new(NpcManager::new());
+        let config = tokio::sync::Mutex::new(GameConfig::default());
+        let conversation = tokio::sync::Mutex::new(ConversationRuntimeState::new());
+        let inference_queue = tokio::sync::Mutex::new(None);
+        let client = tokio::sync::Mutex::new(None);
+        let cloud_client = tokio::sync::Mutex::new(None);
+        let inference_config = crate::config::InferenceConfig::default();
+
+        let ctx = GameLoopContext {
+            world: &world,
+            npc_manager: &npc_manager,
+            config: &config,
+            conversation: &conversation,
+            inference_queue: &inference_queue,
+            emitter: Arc::clone(&emitter) as Arc<dyn EventEmitter>,
+            inference_config: &inference_config,
+            pronunciations: &[],
+            client: &client,
+            cloud_client: &cloud_client,
+            language: crate::npc::LanguageSettings::english_only(),
+            inference_failure_messages: &[],
+            idle_messages: &[],
+        };
+
+        // Capitalized input with trailing period — the Gemini repro case.
+        super::handle_interact(&ctx, "Tie a strip of cloth.").await;
+
+        let logs: Vec<String> = emitter
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(n, _)| n == "text-log")
+            .filter_map(|(_, p)| {
+                p.get("content")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .collect();
+
+        assert!(
+            !logs.is_empty(),
+            "handle_interact must emit a text-log for capitalized input"
+        );
+        // Must normalize to lowercase first char, single trailing period.
+        assert!(
+            logs.iter().any(|l| l == "You tie a strip of cloth."),
+            "expected 'You tie a strip of cloth.' (normalized); got: {logs:?}"
+        );
+        // Must NOT produce a double-period.
+        assert!(
+            !logs.iter().any(|l| l.contains("..")),
+            "narration must not contain '..'; got: {logs:?}"
+        );
+    }
+
+    /// Thread 2: an Interact-classified input WITH addressed_to non-empty must
+    /// route to NPC conversation, NOT emit the generic narration.
+    ///
+    /// In no-LLM mode, "tie a strip of cloth to the thorn bush" is classified as
+    /// Interact by the local parser.  With `addressed_to = ["Brigid"]`, the
+    /// `is_interact && addressed_to.is_empty()` guard must be false, so the input
+    /// falls through to handle_npc_conversation (here: idle text-log, no NPC).
+    /// We assert that NO "You tie" narration is emitted.
+    #[tokio::test]
+    async fn interact_with_addressed_to_routes_to_npc_conversation_not_narration() {
+        let emitter = Arc::new(CapturingEmitter::new());
+        let world = tokio::sync::Mutex::new(WorldState::new());
+        let npc_manager = tokio::sync::Mutex::new(NpcManager::new());
+        let config = tokio::sync::Mutex::new(GameConfig::default());
+        let conversation = tokio::sync::Mutex::new(ConversationRuntimeState::new());
+        let inference_queue = tokio::sync::Mutex::new(None);
+        let client = tokio::sync::Mutex::new(None);
+        let cloud_client = tokio::sync::Mutex::new(None);
+        let inference_config = crate::config::InferenceConfig::default();
+
+        let ctx = GameLoopContext {
+            world: &world,
+            npc_manager: &npc_manager,
+            config: &config,
+            conversation: &conversation,
+            inference_queue: &inference_queue,
+            emitter: Arc::clone(&emitter) as Arc<dyn EventEmitter>,
+            inference_config: &inference_config,
+            pronunciations: &[],
+            client: &client,
+            cloud_client: &cloud_client,
+            language: crate::npc::LanguageSettings::english_only(),
+            inference_failure_messages: &[],
+            idle_messages: &[],
+        };
+
+        let transport = make_transport();
+        let templates = ReactionTemplates::default();
+
+        // Interact-classified input but with addressed_to set — must NOT narrate.
+        super::handle_game_input(
+            &ctx,
+            "tie a strip of cloth to the thorn bush".to_string(),
+            vec!["Brigid".to_string()],
+            &transport,
+            &templates,
+            || None,
+        )
+        .await;
+
+        let logs: Vec<String> = emitter
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(n, _)| n == "text-log")
+            .filter_map(|(_, p)| {
+                p.get("content")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .collect();
+
+        // Must NOT emit the interact narration "You tie ..." — it must fall
+        // through to NPC conversation routing instead.
+        assert!(
+            !logs.iter().any(|l| l.starts_with("You tie")),
+            "interact with addressed_to must NOT produce action narration; got: {logs:?}"
+        );
+        // Must still emit something (idle message from NPC conversation path,
+        // no NPC present in test world).
+        assert!(
+            !logs.is_empty(),
+            "interact with addressed_to must still produce a text-log (NPC path); got none"
         );
     }
 }

--- a/parish/crates/parish-core/src/game_loop/input.rs
+++ b/parish/crates/parish-core/src/game_loop/input.rs
@@ -130,6 +130,24 @@ async fn try_handle_move(
     MoveDispatch::Handled
 }
 
+// ── Interact ──────────────────────────────────────────────────────────────────
+
+/// Handles an `Interact` intent by emitting a narrated action `text-log`.
+///
+/// Gated by the `interact-narration` flag (default-ON via `is_disabled`).
+/// When the flag is explicitly disabled the caller falls through to
+/// `handle_npc_conversation`, preserving pre-fix behaviour (#1449).
+///
+/// Extracted so tests can drive the narration branch directly without
+/// requiring an LLM-classified `Interact` intent.
+pub(crate) async fn handle_interact(ctx: &GameLoopContext<'_>, raw: &str) {
+    let msg = format!("You {raw}.");
+    ctx.emitter.emit_event(
+        "text-log",
+        serde_json::to_value(text_log("action", msg)).unwrap_or(serde_json::Value::Null),
+    );
+}
+
 // ── Game input dispatch ───────────────────────────────────────────────────────
 
 /// Handles free-form player input: parses intent (with LLM fallback) then
@@ -220,6 +238,10 @@ pub async fn handle_game_input(
         .as_ref()
         .map(|i| matches!(i.intent, crate::input::IntentKind::Talk))
         .unwrap_or(false);
+    let is_interact = intent
+        .as_ref()
+        .map(|i| matches!(i.intent, crate::input::IntentKind::Interact))
+        .unwrap_or(false);
     let move_target = intent
         .as_ref()
         .filter(|_i| is_move)
@@ -233,7 +255,10 @@ pub async fn handle_game_input(
         .filter(|_i| is_talk)
         .and_then(|i| i.target.clone());
 
-    if is_move {
+    // #1450: when `addressed_to` is non-empty the player is explicitly directing
+    // speech at a named NPC — movement classification must NOT win. Skip the move
+    // branch so the input routes to `handle_npc_conversation` instead.
+    if is_move && addressed_to.is_empty() {
         match try_handle_move(ctx, move_target, transport, reaction_templates).await {
             MoveDispatch::Handled => return,
             // TODO #40/#56: Move-no-target at a populated location falls through
@@ -252,6 +277,22 @@ pub async fn handle_game_input(
     if is_examine {
         handle_examine(ctx, examine_target, transport).await;
         return;
+    }
+
+    // #1449: physical player actions classified as `Interact` get a narrated
+    // acknowledgement rather than routing to NPC conversation.  Gated by the
+    // `interact-narration` flag (default-ON, kill-switch pattern: gate fires
+    // unless the flag has been explicitly disabled).
+    if is_interact {
+        let flag_enabled = {
+            let config = ctx.config.lock().await;
+            !config.flags.is_disabled("interact-narration")
+        };
+        if flag_enabled {
+            handle_interact(ctx, &raw).await;
+            return;
+        }
+        // Flag disabled: fall through to NPC conversation (legacy behaviour).
     }
 
     // Resolve ordered NPC recipients from visible local names.
@@ -848,6 +889,268 @@ mod tests {
         assert!(
             !logs.iter().any(|l| l.contains("is not here.")),
             "object mention must not emit 'X is not here.'; got {logs:?}"
+        );
+    }
+
+    // ── #1450: addressed_to pins dialogue intent over movement ────────────────
+
+    /// AC-1 / AC-2 (#1450): a move-classified input with non-empty `addressed_to`
+    /// must NOT trigger movement — it must fall through to NPC conversation routing.
+    ///
+    /// In no-LLM mode the local parser classifies "go to the pub" as `Move`.
+    /// But when `addressed_to = ["Peig Hannigan"]`, the `is_move` guard must be
+    /// skipped so the dialogue is routed to NPC conversation.  We assert that no
+    /// movement system message is emitted (movement emits "And where would ye be
+    /// off to?" or a travel log, neither of which would appear here since there
+    /// is no connected location "the pub" in the default world; what we can assert
+    /// is that the input does NOT emit a movement attempt and falls through
+    /// to NPC conversation — in the empty-NPC case this produces an idle text-log,
+    /// not a movement message).
+    #[tokio::test]
+    async fn addressed_to_non_empty_skips_move_branch() {
+        let emitter = Arc::new(CapturingEmitter::new());
+        let world = tokio::sync::Mutex::new(WorldState::new());
+        let npc_manager = tokio::sync::Mutex::new(NpcManager::new());
+        let config = tokio::sync::Mutex::new(GameConfig::default());
+        let conversation = tokio::sync::Mutex::new(ConversationRuntimeState::new());
+        let inference_queue = tokio::sync::Mutex::new(None);
+        let client = tokio::sync::Mutex::new(None);
+        let cloud_client = tokio::sync::Mutex::new(None);
+        let inference_config = crate::config::InferenceConfig::default();
+
+        let ctx = GameLoopContext {
+            world: &world,
+            npc_manager: &npc_manager,
+            config: &config,
+            conversation: &conversation,
+            inference_queue: &inference_queue,
+            emitter: Arc::clone(&emitter) as Arc<dyn EventEmitter>,
+            inference_config: &inference_config,
+            pronunciations: &[],
+            client: &client,
+            cloud_client: &cloud_client,
+            language: crate::npc::LanguageSettings::english_only(),
+            inference_failure_messages: &[],
+            idle_messages: &[],
+        };
+
+        let transport = make_transport();
+        let templates = ReactionTemplates::default();
+
+        // "go to the pub" → local parser classifies as Move.
+        // addressed_to = ["Peig Hannigan"] → must NOT route to movement.
+        super::handle_game_input(
+            &ctx,
+            "go to the pub".to_string(),
+            vec!["Peig Hannigan".to_string()],
+            &transport,
+            &templates,
+            || None,
+        )
+        .await;
+
+        let logs: Vec<String> = emitter
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(n, _)| n == "text-log")
+            .filter_map(|(_, p)| {
+                p.get("content")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .collect();
+
+        // The movement "where would ye be off to?" hint must NOT appear —
+        // that would indicate the is_move branch fired despite addressed_to.
+        assert!(
+            !logs.iter().any(|l| l.contains("where would ye be off to")),
+            "#1450: addressed_to must suppress move branch; got logs: {logs:?}"
+        );
+    }
+
+    /// AC-3 (#1450): with empty `addressed_to`, movement classification still
+    /// wins as before (regression guard).
+    #[tokio::test]
+    async fn empty_addressed_to_preserves_move_routing() {
+        let emitter = Arc::new(CapturingEmitter::new());
+        let world = tokio::sync::Mutex::new(WorldState::new());
+        let npc_manager = tokio::sync::Mutex::new(NpcManager::new());
+        let config = tokio::sync::Mutex::new(GameConfig::default());
+        let conversation = tokio::sync::Mutex::new(ConversationRuntimeState::new());
+        let inference_queue = tokio::sync::Mutex::new(None);
+        let client = tokio::sync::Mutex::new(None);
+        let cloud_client = tokio::sync::Mutex::new(None);
+        let inference_config = crate::config::InferenceConfig::default();
+
+        let ctx = GameLoopContext {
+            world: &world,
+            npc_manager: &npc_manager,
+            config: &config,
+            conversation: &conversation,
+            inference_queue: &inference_queue,
+            emitter: Arc::clone(&emitter) as Arc<dyn EventEmitter>,
+            inference_config: &inference_config,
+            pronunciations: &[],
+            client: &client,
+            cloud_client: &cloud_client,
+            language: crate::npc::LanguageSettings::english_only(),
+            inference_failure_messages: &[],
+            idle_messages: &[],
+        };
+
+        let transport = make_transport();
+        let templates = ReactionTemplates::default();
+
+        // Bare "go to the pub" with no NPC present and no addressed_to:
+        // the move branch fires, no NPC present, no matching location →
+        // the movement handler emits a "not found" system message (not the
+        // idle message). We assert something was emitted (the move path ran).
+        super::handle_game_input(
+            &ctx,
+            "go to the pub".to_string(),
+            vec![],
+            &transport,
+            &templates,
+            || None,
+        )
+        .await;
+
+        let event_names = emitter.event_names();
+        // The move path always emits at least one event (travel or error).
+        assert!(
+            !event_names.is_empty(),
+            "empty addressed_to with Move input must produce output; got none"
+        );
+    }
+
+    // ── #1449: Interact intent produces narrated action ───────────────────────
+
+    /// AC-5 / AC-6 (#1449): an `Interact`-classified input must NOT route to
+    /// `handle_npc_conversation`; it must emit a narrated `text-log`.
+    ///
+    /// The local parser does not emit `Interact`; that intent comes from the LLM.
+    /// In tests (no LLM configured), `parse_intent_local` returns `None` for
+    /// physical action phrases, and the dispatch falls through to NPC conversation
+    /// which emits an idle-message `text-log`.  To test the `is_interact` branch
+    /// directly we call `handle_interact` (the extracted helper).
+    ///
+    /// We test the branch via `handle_interact` directly to avoid LLM dependency.
+    #[tokio::test]
+    async fn interact_intent_emits_narrated_action_not_npc_dialogue() {
+        let emitter = Arc::new(CapturingEmitter::new());
+        let world = tokio::sync::Mutex::new(WorldState::new());
+        let npc_manager = tokio::sync::Mutex::new(NpcManager::new());
+        let config = tokio::sync::Mutex::new(GameConfig::default());
+        let conversation = tokio::sync::Mutex::new(ConversationRuntimeState::new());
+        let inference_queue = tokio::sync::Mutex::new(None);
+        let client = tokio::sync::Mutex::new(None);
+        let cloud_client = tokio::sync::Mutex::new(None);
+        let inference_config = crate::config::InferenceConfig::default();
+
+        let ctx = GameLoopContext {
+            world: &world,
+            npc_manager: &npc_manager,
+            config: &config,
+            conversation: &conversation,
+            inference_queue: &inference_queue,
+            emitter: Arc::clone(&emitter) as Arc<dyn EventEmitter>,
+            inference_config: &inference_config,
+            pronunciations: &[],
+            client: &client,
+            cloud_client: &cloud_client,
+            language: crate::npc::LanguageSettings::english_only(),
+            inference_failure_messages: &[],
+            idle_messages: &[],
+        };
+
+        // Call handle_interact directly (the interact-narration branch).
+        super::handle_interact(&ctx, "tie a strip of cloth to the thorn bush").await;
+
+        let logs: Vec<String> = emitter
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(n, _)| n == "text-log")
+            .filter_map(|(_, p)| {
+                p.get("content")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .collect();
+
+        assert!(
+            !logs.is_empty(),
+            "#1449: interact must emit a text-log narration; got none"
+        );
+        assert!(
+            logs.iter()
+                .any(|l| l.contains("tie a strip of cloth to the thorn bush")),
+            "#1449: narration must reference the original input; got: {logs:?}"
+        );
+    }
+
+    /// AC-7 (#1449): with `interact-narration` flag disabled, interact falls
+    /// through to NPC conversation (legacy behaviour preserved as kill-switch).
+    #[tokio::test]
+    async fn interact_with_flag_disabled_falls_through() {
+        let emitter = Arc::new(CapturingEmitter::new());
+        let world = tokio::sync::Mutex::new(WorldState::new());
+        let npc_manager = tokio::sync::Mutex::new(NpcManager::new());
+        let mut cfg = GameConfig::default();
+        cfg.flags.disable("interact-narration");
+        let config = tokio::sync::Mutex::new(cfg);
+        let conversation = tokio::sync::Mutex::new(ConversationRuntimeState::new());
+        let inference_queue = tokio::sync::Mutex::new(None);
+        let client = tokio::sync::Mutex::new(None);
+        let cloud_client = tokio::sync::Mutex::new(None);
+        let inference_config = crate::config::InferenceConfig::default();
+
+        let ctx = GameLoopContext {
+            world: &world,
+            npc_manager: &npc_manager,
+            config: &config,
+            conversation: &conversation,
+            inference_queue: &inference_queue,
+            emitter: Arc::clone(&emitter) as Arc<dyn EventEmitter>,
+            inference_config: &inference_config,
+            pronunciations: &[],
+            client: &client,
+            cloud_client: &cloud_client,
+            language: crate::npc::LanguageSettings::english_only(),
+            inference_failure_messages: &[],
+            idle_messages: &[],
+        };
+
+        let transport = make_transport();
+        let templates = ReactionTemplates::default();
+
+        // Craft an intent that the dispatch code sees as Interact with flag off.
+        // We can't inject an Interact intent directly from the local parser, so
+        // we call handle_game_input with an action phrase and observe that —
+        // because the local parser returns None (not Interact) — the input routes
+        // to NPC conversation as before (no action narration emitted).
+        //
+        // This test primarily guards that disabling the flag does not panic and
+        // that the fallthrough path produces a text-log (idle message).
+        super::handle_game_input(
+            &ctx,
+            "pick up the bellows".to_string(),
+            vec![],
+            &transport,
+            &templates,
+            || None,
+        )
+        .await;
+
+        // With flag disabled and no LLM (local parser returns None for "pick up"),
+        // the dispatch falls through to NPC conversation → idle message text-log.
+        let event_names = emitter.event_names();
+        assert!(
+            event_names.iter().any(|n| n == "text-log"),
+            "interact fallthrough must still emit a text-log; got {event_names:?}"
         );
     }
 }

--- a/parish/crates/parish-input/src/intent_llm.rs
+++ b/parish/crates/parish-input/src/intent_llm.rs
@@ -47,8 +47,16 @@ Input: \"look around\" → {\"intent\": \"look\", \"target\": null, \"dialogue\"
 Input: \"Might I look about the village a while?\" → {\"intent\": \"talk\", \"target\": null, \"dialogue\": \"Might I look about the village a while?\"}\n\
 Input: \"I'll have a look at the cattle later\" → {\"intent\": \"talk\", \"target\": null, \"dialogue\": \"I'll have a look at the cattle later\"}\n\
 Input: \"pick up the stone\" → {\"intent\": \"interact\", \"target\": \"the stone\", \"dialogue\": null}\n\
+Input: \"tie a strip of cloth to the thorn bush\" → {\"intent\": \"interact\", \"target\": \"the thorn bush\", \"dialogue\": null}\n\
+Input: \"light the candle on the altar\" → {\"intent\": \"interact\", \"target\": \"the candle\", \"dialogue\": null}\n\
+Input: \"pour water into the basin\" → {\"intent\": \"interact\", \"target\": \"the basin\", \"dialogue\": null}\n\
+Input: \"kneel before the cross\" → {\"intent\": \"interact\", \"target\": \"the cross\", \"dialogue\": null}\n\
 Input: \"I came from the coast\" → {\"intent\": \"talk\", \"target\": null, \"dialogue\": \"I came from the coast\"}\n\
 Input: \"I was at the shore yesterday\" → {\"intent\": \"talk\", \"target\": null, \"dialogue\": \"I was at the shore yesterday\"}\n\
+\n\
+IMPORTANT: \"interact\" is for any imperative physical-action command — picking up, \
+putting down, tying, lighting, pouring, filling, lifting, pumping, digging, placing, \
+or touching/using an object. Do NOT classify physical-action imperatives as \"talk\".\n\
 \n\
 Respond ONLY with valid JSON. No explanation.";
 
@@ -238,6 +246,28 @@ mod tests {
         assert!(
             INTENT_SYSTEM_PROMPT.contains("\"look around\" → {\"intent\": \"look\""),
             "intent system prompt lost the imperative-look exemplar"
+        );
+    }
+
+    /// Guard: intent system prompt must carry enough interact examples and
+    /// instructions that small quantised models classify physical-action
+    /// imperatives as "interact", not "talk" (#1449).
+    #[test]
+    fn intent_system_prompt_includes_interact_examples() {
+        // Core interact instruction.
+        assert!(
+            INTENT_SYSTEM_PROMPT.contains("\"interact\" is for any imperative physical-action"),
+            "intent system prompt lost the interact instruction (#1449)"
+        );
+        // Original example retained.
+        assert!(
+            INTENT_SYSTEM_PROMPT.contains("\"pick up the stone\""),
+            "intent system prompt lost the pick-up example"
+        );
+        // Repro examples from #1449.
+        assert!(
+            INTENT_SYSTEM_PROMPT.contains("tie a strip of cloth"),
+            "intent system prompt lost the tie-cloth example (#1449 repro)"
         );
     }
 }

--- a/parish/crates/parish-input/src/intent_local.rs
+++ b/parish/crates/parish-input/src/intent_local.rs
@@ -206,6 +206,84 @@ pub fn parse_intent_local(raw_input: &str) -> Option<PlayerIntent> {
         });
     }
 
+    // Interact guard — unambiguous imperative physical-action verb prefixes.
+    //
+    // These verb forms are never greetings, questions, movement commands, or
+    // first-person narratives.  Classifying them deterministically avoids
+    // relying on the LLM intent classifier, which small quantised models
+    // sometimes misclassify as Talk (the repro for #1449 was
+    // "tie a strip of cloth to the thorn bush" → kind:"talked").
+    //
+    // Rules:
+    //  • Prefixes must be followed by at least one non-whitespace character.
+    //  • Only verbs that are unambiguously physical-action imperatives are
+    //    listed.  Verbs with plausible movement or dialogue interpretations
+    //    (e.g. "push", "pull", "take") are intentionally omitted and left to
+    //    the LLM so they can be resolved by context.
+    //  • Multi-word prefixes are listed first for longest-match semantics.
+    let interact_prefixes: &[&str] = &[
+        // Multi-word (longest first)
+        "pick up ",
+        "put down ",
+        "set down ",
+        "tie a ",
+        "tie the ",
+        "tie your ",
+        "light the ",
+        "light a ",
+        "pour the ",
+        "pour a ",
+        "fill the ",
+        "fill a ",
+        "lift the ",
+        "lift a ",
+        "carry the ",
+        "carry a ",
+        "pump the ",
+        "pump a ",
+        "dig a ",
+        "dig the ",
+        "kneel ",
+        "kneel at ",
+        "kneel before ",
+        "wash the ",
+        "wash your ",
+        "hang the ",
+        "hang a ",
+        "place the ",
+        "place a ",
+        "drop the ",
+        "drop a ",
+        // Single-word (these do not appear in move_verbs or move_phrases)
+        "pump ",
+        "kneel",
+    ];
+    for prefix in interact_prefixes {
+        if lower.starts_with(prefix) {
+            // Ensure something follows the prefix (not a bare verb stub).
+            let byte_offset: usize = trimmed
+                .char_indices()
+                .nth(prefix.chars().count())
+                .map(|(i, _)| i)
+                .unwrap_or(trimmed.len());
+            let rest = trimmed[byte_offset..].trim();
+            // For multi-word prefixes the target is everything after;
+            // for bare imperatives like "kneel" with no args rest is empty —
+            // that is still a valid Interact (kneeling in place).
+            let target = if rest.is_empty() {
+                None
+            } else {
+                Some(rest.to_string())
+            };
+            return Some(PlayerIntent {
+                intent: IntentKind::Interact,
+                target,
+                dialogue: None,
+                raw: raw_input.to_string(),
+            });
+        }
+    }
+
     None
 }
 
@@ -333,8 +411,79 @@ mod tests {
     #[test]
     fn test_local_parse_no_match() {
         assert!(parse_intent_local("tell Mary hello").is_none());
-        assert!(parse_intent_local("pick up the stone").is_none());
         assert!(parse_intent_local("hello there").is_none());
+    }
+
+    // ── Interact patterns (#1449) ─────────────────────────────────────────────
+
+    /// Deterministic Interact classification for unambiguous physical-action verbs.
+    /// These must not route to the LLM (which small models misclassify as Talk).
+    #[test]
+    fn test_local_parse_interact_physical_actions() {
+        // "pick up" — the original repro verb from #1449.
+        let intent = parse_intent_local("pick up the stone").unwrap();
+        assert_eq!(intent.intent, IntentKind::Interact);
+        assert_eq!(intent.target, Some("the stone".to_string()));
+        assert!(intent.dialogue.is_none());
+
+        // "tie a" — the other repro from the issue ("tie a strip of cloth to the thorn bush").
+        let intent = parse_intent_local("tie a strip of cloth to the thorn bush").unwrap();
+        assert_eq!(intent.intent, IntentKind::Interact);
+        assert_eq!(
+            intent.target,
+            Some("strip of cloth to the thorn bush".to_string())
+        );
+
+        // "pump" — "pick up the bellows and pump them".
+        let intent = parse_intent_local("pick up the bellows and pump them").unwrap();
+        assert_eq!(intent.intent, IntentKind::Interact);
+
+        // Other action verbs.
+        let intent = parse_intent_local("light the candle").unwrap();
+        assert_eq!(intent.intent, IntentKind::Interact);
+        assert_eq!(intent.target, Some("candle".to_string()));
+
+        let intent = parse_intent_local("pour the water into the basin").unwrap();
+        assert_eq!(intent.intent, IntentKind::Interact);
+
+        let intent = parse_intent_local("fill the bucket at the well").unwrap();
+        assert_eq!(intent.intent, IntentKind::Interact);
+
+        let intent = parse_intent_local("kneel before the altar").unwrap();
+        assert_eq!(intent.intent, IntentKind::Interact);
+
+        let intent = parse_intent_local("wash your hands in the stream").unwrap();
+        assert_eq!(intent.intent, IntentKind::Interact);
+    }
+
+    /// Interact verbs are case-insensitive.
+    #[test]
+    fn test_local_parse_interact_case_insensitive() {
+        let intent = parse_intent_local("PICK UP THE STONE").unwrap();
+        assert_eq!(intent.intent, IntentKind::Interact);
+
+        let intent = parse_intent_local("Tie a cloth around the post").unwrap();
+        assert_eq!(intent.intent, IntentKind::Interact);
+    }
+
+    /// Regression guard: greetings, questions, and dialogue must NOT match Interact.
+    #[test]
+    fn test_local_parse_interact_does_not_trigger_on_dialogue() {
+        assert!(parse_intent_local("tell Mary hello").is_none());
+        assert!(parse_intent_local("hello there").is_none());
+        // First-person stays Talk, not Interact.
+        let intent = parse_intent_local("I picked up the stone").unwrap();
+        assert_eq!(intent.intent, IntentKind::Talk);
+    }
+
+    /// Regression guard: movement verbs still route as Move, not Interact.
+    #[test]
+    fn test_local_parse_interact_does_not_trigger_on_movement() {
+        let intent = parse_intent_local("go to the forge").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
+
+        let intent = parse_intent_local("walk to the well").unwrap();
+        assert_eq!(intent.intent, IntentKind::Move);
     }
     #[test]
     fn test_local_parse_first_person_narrative_is_talk() {
@@ -827,5 +976,18 @@ mod tests {
         assert!(is_player_dialogue("hello there"));
         assert!(is_player_dialogue("tell Mary the rent is too high"));
         assert!(is_player_dialogue("good morning, Father"));
+    }
+
+    /// Interact-classified inputs are NOT player dialogue — NPCs must not
+    /// react to "tie a strip of cloth to the thorn bush" as speech (#1449).
+    #[test]
+    fn interact_is_not_dialogue() {
+        assert!(!is_player_dialogue(
+            "tie a strip of cloth to the thorn bush"
+        ));
+        assert!(!is_player_dialogue("pick up the bellows and pump them"));
+        assert!(!is_player_dialogue("pick up the stone"));
+        assert!(!is_player_dialogue("light the candle"));
+        assert!(!is_player_dialogue("kneel before the altar"));
     }
 }

--- a/parish/testing/fixtures/play_1449-1450-intent-routing.txt
+++ b/parish/testing/fixtures/play_1449-1450-intent-routing.txt
@@ -1,0 +1,3 @@
+look
+go to the crossroads
+/status


### PR DESCRIPTION
## Summary

Fix two P1 intent-routing bugs in `handle_game_input` (`parish-core/src/game_loop/input.rs`).

**#1450** — When `addressed_to` was non-empty, the `is_move` branch fired unconditionally and returned before `addressed_to` was consulted. A directions question addressed to an NPC teleported the player and discarded the dialogue.

Fix: Added `&& addressed_to.is_empty()` guard to the `is_move` branch.

**#1449** — Physical actions classified as `Interact` had no handler. They fell through to `handle_npc_conversation` and were treated as speech, never narrated.

Fix: Added `is_interact` branch calling new `handle_interact`, which emits `text-log("action", "You <raw>.")`. Gated by `interact-narration` flag (default-ON, kill-switch pattern).

Both fixes land in `parish-core` — shared across Tauri, web server, and headless CLI.

Six new unit tests (AC-1 through AC-7). `just check` passes clean.

## Commands run

```
just check
cargo run -p parish-engine -- --headless --script testing/fixtures/play_1449-1450-intent-routing.txt
```

Fixes #1449
Fixes #1450

---

<!-- parish-proof-bundle:1449-1450 v=1 -->

## Proof: 1449-1450

### Acceptance criteria

# Acceptance Criteria — #1449 / #1450 Intent Routing Fixes

## #1450 — addressed_to dialogue overridden by movement intent

**Problem:** When `addressed_to` is non-empty, the `is_move` branch fires
unconditionally and returns before `addressed_to` is consulted. A directions
question addressed to an NPC (e.g. "Which road takes me to Darcy's Pub?"
addressed to "Peig Hannigan") teleports the player and discards the dialogue.

**Fix:** Guard the `is_move` branch with `addressed_to.is_empty()`. When
`addressed_to` is non-empty, skip the move branch and fall through to
NPC conversation routing.

### Criteria

- **AC-1:** `handle_game_input` with a move-classified input AND non-empty
  `addressed_to` must NOT call `handle_movement` / `try_handle_move`.
- **AC-2:** The same input with non-empty `addressed_to` must route to
  `handle_npc_conversation` with the addressed NPC in the targets list.
- **AC-3:** `handle_game_input` with a move-classified input AND empty
  `addressed_to` continues to behave exactly as before (movement is handled).
- **AC-4:** This fix is a bugfix / routing guard; no feature flag is required.

---

## #1449 — Interact intent falls through to NPC conversation

**Problem:** Physical player actions ("tie a strip of cloth to the thorn bush",
"pick up the bellows and pump them") are classified as `Interact` by the LLM
intent parser but have no dedicated handler. They fall through to
`handle_npc_conversation` and are treated as speech, never narrated.

**Fix:** Add an `is_interact` branch that produces a narrated action result
(player action acknowledged via `text-log`) rather than routing to dialogue.
Gate the new narrated-action path with `config.flags.is_disabled("interact-narration")`
(default-ON, kill-switch pattern — consistent with `examine-intent`).

### Criteria

- **AC-5:** Input classified as `Interact` must NOT route to `handle_npc_conversation`.
- **AC-6:** Input classified as `Interact` must emit at least one `text-log` event
  referencing the original input text (narrated acknowledgement).
- **AC-7:** The `interact-narration` flag, when explicitly disabled, causes the
  `Interact` intent to fall through to `handle_npc_conversation` (legacy
  behaviour preserved as kill-switch).
- **AC-8:** Interact routing is exercised in a headless run (live proof tier):
  a scripted input that the local parser classifies as `Interact` (or which
  the engine dispatches as Interact) produces a narrated text-log and NOT an
  NPC conversation turn.

---

## Verification plan

1. Unit tests in `parish-core/src/game_loop/input.rs` asserting AC-1 through AC-7.
2. `just check` passes (fmt + clippy + tests).
3. Headless run with `--script` carrying an action phrase confirms live routing
   in a real process.

### Evidence

# Live Gameplay Transcript — #1449 / #1450 Intent Routing

Evidence type: live gameplay transcript

## Session setup

Backend started on branch `fix/1449-1450-intent-action-routing` via:

```
bash parish/scripts/parish-mcp-backend.sh start   # spawns parish-server on 127.0.0.1:3030
curl http://127.0.0.1:3030/api/health              # HTTP 200 confirmed
```

A fresh game was started via `POST /api/new-game`. Player begins at Kilteevan Village.
NPCs present: Aoife Brennan, Mick Flanagan, Brigid Ni Fhatharta, Sean Ruadh Kelly,
Peig Hannigan (confirmed via `GET /api/npcs-here`).

---

## #1450 — addressed_to guard: live proof

### Test A — WITH addressed_to (bug-fix behavior: must NOT move)

```
POST /api/command
{"text": "which road takes me to the forge", "addressedTo": ["Peig Hannigan"], "includeState": true}
```

**Response (verbatim):**

```json
{
  "outcome": "ok",
  "kind": "talked",
  "echo": "which road takes me to the forge",
  "lines": [
    {
      "id": "stream-1",
      "role": "npc",
      "speaker": "Peig Hannigan",
      "text": "In this year and nothing has set tongues wagging in rare form today and honestly nobody can quite the planning board has."
    }
  ],
  "kind_detail": null,
  "state": {
    "world": {
      "location_name": "Kilteevan Village",
      "location_description": "The small village of Kilteevan — a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The clear sky hangs over the quiet street. It is morning.",
      "time_label": "Morning",
      "hour": 8,
      "minute": 0,
      "weather": "Clear",
      "season": "Spring",
      "festival": null,
      "paused": false,
      "inference_paused": false,
      "game_epoch_ms": -4726742395000.0,
      "speed_factor": 36.0,
      "name_hints": [
        {
          "word": "Kilteevan",
          "pronunciation": "kill-TEE-van",
          "meaning": "Cill Taobháin — Teevan's Church"
        },
        {
          "word": "Peig",
          "pronunciation": "peg",
          "meaning": "Irish form of Peg/Margaret"
        }
      ],
      "day_of_week": "Monday",
      "turn_in_flight": false
    },
    "npcs_here": [
      {
        "name": "Peig Hannigan",
        "real_name": "Peig Hannigan",
        "occupation": "Widow",
        "mood": "neutral",
        "introduced": true,
        "mood_emoji": "😐"
      },
      {
        "name": "an older man",
        "real_name": "Mick Flanagan",
        "occupation": "Retired Constable",
        "mood": "watchful",
        "introduced": false,
        "mood_emoji": "👀"
      },
      {
        "name": "a young woman",
        "real_name": "Aoife Brennan",
        "occupation": "Hedge School Teacher",
        "mood": "passionate",
        "introduced": false,
        "mood_emoji": "🔥"
      },
      {
        "name": "an older woman with sharp eyes and herb-stained fingers",
        "real_name": "Brigid Ni Fhatharta",
        "occupation": "Midwife",
        "mood": "watchful",
        "introduced": false,
        "mood_emoji": "👀"
      },
      {
        "name": "a lean, red-haired young man with hard eyes",
        "real_name": "Sean Ruadh Kelly",
        "occupation": "Labourer",
        "mood": "bitter",
        "introduced": false,
        "mood_emoji": "😒"
      }
    ]
  },
  "elapsed_ms": 1110
}
```

**What this proves:** `kind: "talked"` and `state.world.location_name: "Kilteevan Village"`.
The player was NOT moved. The direction-question reached Peig Hannigan as dialogue,
not as a movement command. This is the AC-1/AC-2 fix in action end-to-end in a live process.

### Test B — WITHOUT addressed_to (baseline: must move)

```
POST /api/command
{"text": "go to the forge", "includeState": true}
```

**Response (verbatim):**

```json
{
  "outcome": "ok",
  "kind": "moved",
  "echo": "go to the forge",
  "lines": [
    {
      "id": "msg-3",
      "role": "system",
      "speaker": "System",
      "text": "You walk along a lane toward the ring of the anvil. (1 minute on foot)"
    },
    {
      "id": "msg-4",
      "role": "system",
      "speaker": "System",
      "text": "A farmer nods to you from the far side of a gate as you pass."
    },
    {
      "id": "msg-5",
      "role": "system",
      "speaker": "System",
      "text": "A low stone building open at the front, where a bellows feeds a glowing hearth. The anvil sits dark and scarred in the centre. Horseshoes, tongs, and half-finished ironwork hang from hooks along the wall. Sparks drift in the clear air. It is morning.\nYou can go to: Kilteevan Village (1 min on foot)"
    },
    {
      "id": "msg-6",
      "role": "system",
      "speaker": "System",
      "text": "  · Closing early on account of something nobody can quite the parish newsletter has been done about the crossroads arguing with the back. God help us."
    },
    {
      "id": "stream-100000",
      "role": "npc",
      "speaker": "Colm Gallagher",
      "text": "\"I don't think we've met. Colm Gallagher, Blacksmith's Apprentice,\" they say."
    },
    {
      "id": "stream-100001",
      "role": "npc",
      "speaker": "Seamus Gallagher",
      "text": "\"I don't think we've met. Seamus Gallagher, Blacksmith,\" they say."
    }
  ],
  "kind_detail": null,
  "travel": {
    "from": "Kilteevan Village",
    "to": "The Forge",
    "duration_minutes": 1
  },
  "state": {
    "world": {
      "location_name": "The Forge",
      "location_description": "A low stone building open at the front, where a bellows feeds a glowing hearth. The anvil sits dark and scarred in the centre. Horseshoes, tongs, and half-finished ironwork hang from hooks along the wall. Sparks drift in the clear air. It is morning.",
      "time_label": "Morning",
      "hour": 8,
      "minute": 1,
      "weather": "Clear",
      "season": "Spring",
      "festival": null,
      "paused": false,
      "inference_paused": false,
      "game_epoch_ms": -4726742334000.0,
      "speed_factor": 36.0,
      "name_hints": [
        {
          "word": "Séamus",
          "pronunciation": "SHAY-mus",
          "meaning": "Irish form of James"
        }
      ],
      "day_of_week": "Monday",
      "turn_in_flight": false
    },
    "npcs_here": [
      {
        "name": "Colm Gallagher",
        "real_name": "Colm Gallagher",
        "occupation": "Blacksmith's Apprentice",
        "mood": "eager",
        "introduced": true,
        "mood_emoji": "🙂"
      },
      {
        "name": "Seamus Gallagher",
        "real_name": "Seamus Gallagher",
        "occupation": "Blacksmith",
        "mood": "cheerful",
        "introduced": true,
        "mood_emoji": "😊"
      }
    ],
    "map": {
      "locations": [
        {
          "id": "16",
          "name": "The Forge",
          "lat": 53.63318486094661,
          "lon": -8.102232997701996,
          "adjacent": true,
          "hops": 0,
          "indoor": true,
          "visited": true
        },
        {
          "id": "15",
          "name": "Kilteevan Village",
          "lat": 53.632544989054054,
          "lon": -8.102168938364912,
          "adjacent": true,
          "hops": 1,
          "indoor": false,
          "travel_minutes": 1,
          "visited": true
        }
      ],
      "player_location": "16",
      "edge_traversals": [["15", "16", 1]],
      "transport_label": "on foot",
      "transport_id": "walking"
    }
  },
  "elapsed_ms": 161
}
```

**What this proves:** `kind: "moved"`, `travel: {"from":"Kilteevan Village","to":"The Forge","duration_minutes":1}`,
`state.world.location_name: "The Forge"`. Movement routing is unaffected when `addressed_to` is empty.
This is the AC-3 baseline confirmed in a live process.

---

## #1449 — Interact narration: live run + unit-test proof

### What the live process shows

An action phrase was sent to the running engine to observe behavior:

```
POST /api/command
{"text": "tie a strip of cloth to the thorn bush", "includeState": true}
```

**Response (verbatim):**

```json
{"outcome":"ok","kind":"talked","echo":"tie a strip of cloth to the thorn bush","lines":[{"id":"stream-2","role":"npc","speaker":"Sean Ruadh Kelly","text":"Gone down about the whole parish at ballymullen has swallowed two cars already this particular point in this particular point in the."}],"kind_detail":null,"state":{"world":{"location_name":"Kilteevan Village","location_description":"The small village of Kilteevan — a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The clear sky hangs over the quiet street. It is morning.","time_label":"Morning","hour":8,"minute":0,"weather":"Clear","season":"Spring","festival":null,"paused":false,"inference_paused":false,"game_epoch_ms":-4726742395000.0,"speed_factor":36.0},"elapsed_ms":1090}
```

**What this shows honestly:** `kind: "talked"`, NPC responds. The local deterministic parser
(`parse_intent_local`) does not emit `Interact` — that intent label is assigned by the LLM
intent classifier which runs as a separate inference step. In this run the bundled LLM
classified the input as dialogue (Talk/Other), not Interact, so the `is_interact` branch
did not fire. This is correct behavior for a session without the Qwen intent model engaged
in classify-intent mode.

The live run confirms: (a) the engine starts and accepts the input without panic;
(b) the `is_interact` branch in `handle_game_input` does not break anything when LLM
classifies differently; (c) the server routes the call successfully end-to-end.

**The `handle_interact` function and the `is_interact` dispatch branch are proven by
unit tests that call them directly**, because the Interact intent label only arrives from
the LLM in production — it cannot be injected deterministically via a live headless run
without controlling the LLM's output. This is documented explicitly in the test
docstring at `parish-core/src/game_loop/input.rs:1033-1038`.

### Unit-test evidence for AC-5, AC-6, AC-7

All three tests run in `parish-core` — verified with `cargo test -p parish-core`
from the parish workspace directory: **495 passed, 4 ignored**.

- **`interact_intent_emits_narrated_action_not_npc_dialogue`** (AC-5/AC-6):
  Calls `handle_interact(&ctx, "tie a strip of cloth to the thorn bush")` directly
  and asserts (a) at least one `text-log` event is emitted and (b) the log content
  references the original input text.

- **`interact_with_flag_disabled_falls_through`** (AC-7):
  Sets `cfg.flags.disable("interact-narration")` then calls `handle_game_input` with
  an action phrase. Confirms the flag kills narration and falls through to NPC
  conversation (idle message) without panicking.

---

## Evidence mapping

| AC   | Status        | Evidence                                                                                                                                                                                                                                                                                                                 |
| ---- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| AC-1 | **Live**      | Test A above: `kind:"talked"`, player stays at Kilteevan Village when `addressed_to:["Peig Hannigan"]`                                                                                                                                                                                                                   |
| AC-2 | **Live**      | Test A above: `lines[0].speaker:"Peig Hannigan"`, input routed to NPC dialogue                                                                                                                                                                                                                                           |
| AC-3 | **Live**      | Test B above: `kind:"moved"`, `travel.to:"The Forge"`, empty `addressed_to` still moves                                                                                                                                                                                                                                  |
| AC-4 | **Code**      | Guard is a one-line routing change; no feature flag is added (correct by design)                                                                                                                                                                                                                                         |
| AC-5 | **Unit test** | `interact_intent_emits_narrated_action_not_npc_dialogue`: no NPC dialogue line emitted                                                                                                                                                                                                                                   |
| AC-6 | **Unit test** | `interact_intent_emits_narrated_action_not_npc_dialogue`: log contains "tie a strip of cloth to the thorn bush"                                                                                                                                                                                                          |
| AC-7 | **Unit test** | `interact_with_flag_disabled_falls_through`: idle message emitted, no panic                                                                                                                                                                                                                                              |
| AC-8 | **Withdrawn** | Previous version overclaimed. Live headless run does NOT demonstrate Interact routing: the local parser does not emit Interact and the LLM did not classify this input as Interact. AC-8 is replaced by the honest unit-test evidence above (AC-5/AC-6) plus the code path in `handle_game_input` at `input.rs:286-296`. |

`cargo test -p parish-core` — 495 passed, 4 ignored.

### Judge

# Judge Verdict — #1449 / #1450 Intent Routing Fixes

## Review

### #1450 — addressed_to guard over movement intent

The fix is a single `&& addressed_to.is_empty()` guard on the `is_move` branch in
`handle_game_input`. When `addressed_to` is non-empty, the move branch is skipped and
the input falls through to `handle_npc_conversation` with the addressed NPC already in
the `targets` list (built from `addressed_to` further down). No data is lost: the raw
input, the NPC chip selection, and any name mentions all flow correctly to NPC dialogue.

Unit tests added:

- `addressed_to_non_empty_skips_move_branch` — AC-1/AC-2
- `empty_addressed_to_preserves_move_routing` — AC-3

The live run confirms `"go to the crossroads"` with empty `addressed_to` still produces
`"result":"moved"`.

### #1449 — Interact narration branch

A new `handle_interact` function emits a `text-log("action", "You <raw>.")` event.
It is called from a new `is_interact` branch, guarded by `!config.flags.is_disabled("interact-narration")`.
The kill-switch is consistent with the existing `examine-intent` pattern. The branch
is extracted as `pub(crate)` so tests can drive it directly without requiring an LLM.

Unit tests added:

- `interact_intent_emits_narrated_action_not_npc_dialogue` — AC-5/AC-6
- `interact_with_flag_disabled_falls_through` — AC-7

### Mode parity

The fix is in `parish-core/src/game_loop/input.rs` (`handle_game_input`), which is the
shared dispatch used by Tauri, the web server, and the headless CLI. No entry-point
duplication was needed. Architecture fitness test will continue to pass (no new deps on
forbidden backends).

### No tech debt introduced

All code paths are complete. The interact narration message ("You <raw>.") is minimal
and consistent. Future iterations can replace it with richer world-model-driven prose.

Verdict: sufficient

Acceptance criteria: met

Technical debt: clear

<!-- /parish-proof-bundle:1449-1450 -->
