### PR TITLE
fix(npc): paraphrase-frame history, label own-activity, harden season grounding (#1447, #1448, #1451)

### DIFF
--- a/parish/crates/parish-npc/src/context.rs
+++ b/parish/crates/parish-npc/src/context.rs
@@ -48,12 +48,11 @@ pub fn build_tier1_context(world: &WorldState) -> String {
     // #1451: season is present in the date string but underweighted, so NPCs
     // reference wrong seasons. Inject a dedicated directive so models cannot
     // treat season as an inert label.
-    let season_str = season.to_string();
     format!(
         "Your Location: {loc_name} — {loc_desc}{loc_details}\n\
         Date and time: {date_time}\n\
         Time of day: {tod} ({hour:02}:{minute:02}) — greet and refer to the time of day accordingly.{forbidden}\n\
-        CURRENT SEASON: {season_str}. Do not reference any other season as if it were now.",
+        CURRENT SEASON: {season}. Do not reference any other season as if it were now.",
         loc_name = world.current_location().name,
         loc_desc = rendered_desc,
         loc_details = loc_details,
@@ -62,7 +61,7 @@ pub fn build_tier1_context(world: &WorldState) -> String {
         hour = now.hour(),
         minute = now.minute(),
         forbidden = forbidden,
-        season_str = season_str,
+        season = season,
     )
 }
 

--- a/parish/crates/parish-npc/src/context.rs
+++ b/parish/crates/parish-npc/src/context.rs
@@ -45,10 +45,15 @@ pub fn build_tier1_context(world: &WorldState) -> String {
     let forbidden = forbidden_greeting_directive(time_of_day)
         .map(|d| format!(" {d}"))
         .unwrap_or_default();
+    // #1451: season is present in the date string but underweighted, so NPCs
+    // reference wrong seasons. Inject a dedicated directive so models cannot
+    // treat season as an inert label.
+    let season_str = season.to_string();
     format!(
         "Your Location: {loc_name} — {loc_desc}{loc_details}\n\
         Date and time: {date_time}\n\
-        Time of day: {tod} ({hour:02}:{minute:02}) — greet and refer to the time of day accordingly.{forbidden}",
+        Time of day: {tod} ({hour:02}:{minute:02}) — greet and refer to the time of day accordingly.{forbidden}\n\
+        CURRENT SEASON: {season_str}. Do not reference any other season as if it were now.",
         loc_name = world.current_location().name,
         loc_desc = rendered_desc,
         loc_details = loc_details,
@@ -57,6 +62,7 @@ pub fn build_tier1_context(world: &WorldState) -> String {
         hour = now.hour(),
         minute = now.minute(),
         forbidden = forbidden,
+        season_str = season_str,
     )
 }
 

--- a/parish/crates/parish-npc/src/tests.rs
+++ b/parish/crates/parish-npc/src/tests.rs
@@ -1129,6 +1129,32 @@ fn build_tier1_context_includes_forbidden_morning_greeting_at_dusk() {
     );
 }
 
+// ── #1451: season grounding directive ────────────────────────────────────
+
+/// AC (#1451): build_tier1_context must emit a CURRENT SEASON directive with
+/// an explicit prohibition on referencing other seasons, so small models cannot
+/// substitute summer in spring (or any other season mismatch).
+#[test]
+fn build_tier1_context_carries_season_directive() {
+    // WorldState::new() defaults to a fixed date — check what season it produces.
+    let world = WorldState::new();
+    let season_str = world.clock.season().to_string();
+    let context = build_tier1_context(&world);
+
+    assert!(
+        context.contains("CURRENT SEASON:"),
+        "context must carry a CURRENT SEASON directive (#1451):\n{context}"
+    );
+    assert!(
+        context.contains(&season_str),
+        "CURRENT SEASON directive must name the actual season ({season_str}) (#1451):\n{context}"
+    );
+    assert!(
+        context.contains("Do not reference any other season"),
+        "CURRENT SEASON directive must prohibit referencing other seasons (#1451):\n{context}"
+    );
+}
+
 /// Corollary to AC-3: at Morning the forbidden-greeting directive must NOT
 /// appear (a morning greeting is appropriate and the directive would confuse
 /// the model into avoiding a correct response).

--- a/parish/crates/parish-npc/src/ticks/prompt.rs
+++ b/parish/crates/parish-npc/src/ticks/prompt.rs
@@ -418,6 +418,10 @@ fn other_npcs_block(npc: &Npc, other_npcs: &[&Npc], config: &NpcConfig) -> Optio
 }
 
 /// Recent conversation history at this location.
+///
+/// Frames the history as BACKGROUND AWARENESS rather than a script to quote —
+/// small models otherwise recite another NPC's exact prior line or narrate
+/// the previous exchange (#1447).
 fn conversation_block(
     world: &WorldState,
     npc: &Npc,
@@ -430,7 +434,11 @@ fn conversation_block(
     if ctx.is_empty() {
         return None;
     }
-    Some(format!("\n\nWhat's been said here:\n{ctx}"))
+    Some(format!(
+        "\n\nBACKGROUND AWARENESS — what has recently been said nearby \
+         (use only as context; do NOT quote it word-for-word, do NOT narrate \
+         who said what, and do NOT repeat any line verbatim in your reply):\n{ctx}"
+    ))
 }
 
 /// Continuity cue when the NPC is already in conversation.
@@ -474,6 +482,19 @@ fn reactions_block(npc: &Npc, config: &NpcConfig) -> Option<String> {
         return None;
     }
     Some(format!("\n\n{ctx}"))
+}
+
+/// NPC's own current activity — injected with an explicit ownership label
+/// so models cannot attribute the NPC's errand or task to the player (#1448).
+fn last_activity_block(npc: &Npc) -> Option<String> {
+    let activity = npc.last_activity.as_deref()?;
+    if activity.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "\n\nYOUR current activity (this is what YOU have been doing — \
+         it is NOT something the player did or asked you about): {activity}"
+    ))
 }
 
 /// Recent short-term memories.
@@ -736,6 +757,12 @@ pub fn build_enhanced_context_with_config(params: Tier1ContextParams<'_>) -> Str
     }
 
     if let Some(block) = reactions_block(npc, config) {
+        context.push_str(&block);
+    }
+
+    // NPC's own current activity — labeled explicitly to prevent models from
+    // attributing the NPC's errand to the player (#1448).
+    if let Some(block) = last_activity_block(npc) {
         context.push_str(&block);
     }
 
@@ -1873,6 +1900,106 @@ mod tests {
         assert!(
             cfg.dialogue_quality_continuity,
             "dialogue_quality_continuity must default to true"
+        );
+    }
+
+    // ── #1447: conversation-history paraphrase framing ───────────────────────
+
+    /// AC (#1447): conversation_block must carry the paraphrase directive —
+    /// "BACKGROUND AWARENESS" header plus explicit no-verbatim-quote instruction.
+    #[test]
+    fn conversation_block_carries_paraphrase_directive() {
+        use parish_types::conversation::ConversationExchange;
+
+        let npc = make_test_npc(1, "Padraig", 1);
+        let mut world = WorldState::new();
+        let loc = world.player_location;
+        world.conversation_log.add(ConversationExchange {
+            timestamp: world.clock.now(),
+            speaker_id: NpcId(1),
+            speaker_name: "Padraig".to_string(),
+            player_input: "hello".to_string(),
+            npc_dialogue: "Fine day, so it is.".to_string(),
+            location: loc,
+        });
+
+        let block = conversation_block(&world, &npc, None)
+            .expect("block must render when an exchange exists");
+        assert!(
+            block.contains("BACKGROUND AWARENESS"),
+            "conversation block must use BACKGROUND AWARENESS framing (#1447):\n{block}"
+        );
+        assert!(
+            block.contains("do NOT quote it word-for-word") || block.contains("do not quote"),
+            "conversation block must forbid verbatim quoting (#1447):\n{block}"
+        );
+        assert!(
+            block.contains("do NOT narrate") || block.contains("do not narrate"),
+            "conversation block must forbid narrating who said what (#1447):\n{block}"
+        );
+    }
+
+    // ── #1448: NPC own-activity label ───────────────────────────────────────
+
+    /// AC (#1448): last_activity_block must label the activity as the NPC's OWN
+    /// and must NOT suggest the player did or asked about it.
+    #[test]
+    fn last_activity_block_labels_activity_as_npcs_own() {
+        let mut npc = make_test_npc(1, "Peig", 1);
+        npc.last_activity = Some("Walked to Connolly's shop for thread.".to_string());
+
+        let block = last_activity_block(&npc).expect("block must render when last_activity is set");
+        assert!(
+            block.contains("YOUR current activity") || block.contains("YOUR own"),
+            "block must label the activity as the NPC's own (#1448):\n{block}"
+        );
+        assert!(
+            block.contains("NOT something the player did") || block.contains("this is what YOU"),
+            "block must clarify the activity is not the player's (#1448):\n{block}"
+        );
+        assert!(
+            block.contains("Connolly's shop"),
+            "block must include the actual activity text:\n{block}"
+        );
+    }
+
+    /// AC (#1448): last_activity_block must return None when last_activity is not set.
+    #[test]
+    fn last_activity_block_absent_when_no_activity() {
+        let npc = make_test_npc(1, "Peig", 1);
+        assert!(
+            last_activity_block(&npc).is_none(),
+            "last_activity_block must be None when last_activity is not set"
+        );
+    }
+
+    /// AC (#1448): the labeled activity block must appear in the assembled context.
+    #[test]
+    fn context_includes_own_activity_label_when_last_activity_set() {
+        let mut npc = make_test_npc(1, "Peig", 1);
+        npc.last_activity = Some("Tending the cow in the byre.".to_string());
+        let world = WorldState::new();
+        let config = NpcConfig::default();
+        let names: HashMap<NpcId, String> = HashMap::new();
+
+        let context = build_enhanced_context_with_config(Tier1ContextParams {
+            npc: &npc,
+            world: &world,
+            player_input: "hello",
+            other_npcs: &[],
+            language: &LanguageSettings::english_only(),
+            config: &config,
+            npc_names: &names,
+            player_name_for_npc: None,
+            was_introduced: false,
+        });
+        assert!(
+            context.contains("YOUR current activity"),
+            "assembled context must label the NPC's own activity (#1448):\n{context}"
+        );
+        assert!(
+            context.contains("Tending the cow"),
+            "assembled context must include the activity text (#1448):\n{context}"
         );
     }
 }

--- a/parish/crates/parish-npc/src/ticks/tier3.rs
+++ b/parish/crates/parish-npc/src/ticks/tier3.rs
@@ -174,10 +174,13 @@ pub fn build_tier3_prompt(
         })
         .collect();
 
+    // #1451: "the season is X" was underweighted — LLM generated summer activities
+    // in Spring. Make it a named directive with an explicit prohibition.
     let mut prompt = format!(
         "You are simulating background NPC activity in a rural Irish parish in 1820. \
         Simulate {hours} hours of activity for the people below. \
-        The weather is {weather}, the season is {season}, the time is {time}.\n\n\
+        The weather is {weather}. CURRENT SEASON: {season} — do not reference any \
+        other season in the activity summaries. The time is {time}.\n\n\
         NPCs (id in brackets — reuse these in your JSON):\n\
         {npcs}\n\n\
         For each NPC, return one update describing their mood, what they did, \
@@ -718,6 +721,43 @@ mod tests {
 
         assert!(!snap.intelligence_adjectives.contains("INT["));
         assert_eq!(snap.intelligence_adjectives, "eloquent, wise");
+    }
+
+    // ── #1451: season directive in tier3 prompt ──────────────────────────────
+
+    /// AC (#1451): the Tier 3 batch prompt must carry a "CURRENT SEASON" directive
+    /// with an explicit no-other-season prohibition so activity summaries stay
+    /// season-correct even for distant NPCs.
+    #[test]
+    fn tier3_prompt_carries_season_directive() {
+        let snapshots: Vec<Tier3Snapshot> = vec![Tier3Snapshot {
+            id: NpcId(1),
+            name: "Padraig".to_string(),
+            occupation: "Publican".to_string(),
+            age: 58,
+            location: LocationId(2),
+            location_name: "Darcy's Pub".to_string(),
+            mood: "content".to_string(),
+            context: String::new(),
+            intelligence_adjectives: String::new(),
+            relationship_summary: String::new(),
+        }];
+        let lang = LanguageSettings::english_only();
+        let prompt = build_tier3_prompt(&snapshots, "Morning", "Clear", "Spring", 4, &lang);
+
+        assert!(
+            prompt.contains("CURRENT SEASON:") || prompt.contains("CURRENT SEASON"),
+            "tier3 prompt must carry a CURRENT SEASON directive (#1451):\n{prompt}"
+        );
+        assert!(
+            prompt.contains("Spring"),
+            "tier3 prompt must name the actual season (#1451):\n{prompt}"
+        );
+        assert!(
+            prompt.contains("do not reference any other season")
+                || prompt.contains("Do not reference any other season"),
+            "tier3 prompt must prohibit referencing other seasons (#1451):\n{prompt}"
+        );
     }
 
     /// AC-1 (#1397): when grounding_enabled is true, temperature and

--- a/parish/testing/fixtures/play_1447-1448-1451.txt
+++ b/parish/testing/fixtures/play_1447-1448-1451.txt
@@ -1,0 +1,19 @@
+# play_1447-1448-1451 — live proof: NPC dialogue prompt directives
+# ==================================================================
+# Exercises three prompt-assembly fixes in a REAL headless run backed
+# by vllm-mlx (Qwen2.5-14B). The assembled system prompt is logged to
+# the inference_logs/ JSONL and inspected for the directive text.
+#
+# Run (new game, headless):
+#   PARISH_PROVIDER=vllm-mlx \
+#   PARISH_BASE_URL=http://localhost:8000 \
+#   PARISH_MODEL=mlx-community/Qwen2.5-14B-Instruct-4bit \
+#   PARISH_INTENT_PROVIDER=vllm-mlx \
+#   PARISH_INTENT_BASE_URL=http://localhost:8001 \
+#   PARISH_INTENT_MODEL=mlx-community/Qwen2.5-1.5B-Instruct-4bit \
+#   printf 'N\nlook\nGood morning to you.\n/quit\n' | \
+#   parish-engine
+#
+# Evidence check: inspect newest inference_logs/*.jsonl for gen_ai.prompt
+# and grep for: BACKGROUND AWARENESS, do NOT quote it word-for-word,
+# do NOT narrate, CURRENT SEASON, Do not reference any other season.


### PR DESCRIPTION
Fixes three related P1 NPC dialogue-prompt bugs that cause small models to misattribute speech, regurgitate prior lines, and reference the wrong season.

## What changed

**#1447 — conversation-history regurgitation**
`conversation_block` in `ticks/prompt.rs` previously used a bare `What's been said here:` header with no directive, causing models to quote another NPC's line verbatim or narrate the prior exchange. Fixed by reframing the block as `BACKGROUND AWARENESS` with explicit instructions not to quote word-for-word and not to narrate who said what.

**#1448 — speaker/role misattribution (own-activity label)**
The NPC's `last_activity` (set by Tier 3 simulation) was not labeled as the NPC's own, so models attributed Peig's errand to the player. Fixed by a new `last_activity_block` function that injects the activity under `YOUR current activity (this is what YOU have been doing — it is NOT something the player did)`.

**#1451 — wrong-season references**
Season appeared in the date string but was underweighted. Fixed in two places: (a) `build_tier1_context` (context.rs) appends `CURRENT SEASON: {season}. Do not reference any other season as if it were now.`; (b) `build_tier3_prompt` (tier3.rs) replaces `the season is {season}` with `CURRENT SEASON: {season} — do not reference any other season in the activity summaries`.

## Tests

Five new deterministic unit tests (no live model needed — all assertions are on static prompt strings):
- `conversation_block_carries_paraphrase_directive` (#1447)
- `last_activity_block_labels_activity_as_npcs_own` (#1448)
- `last_activity_block_absent_when_no_activity` (#1448 negative)
- `context_includes_own_activity_label_when_last_activity_set` (#1448 integrated)
- `build_tier1_context_carries_season_directive` (#1451 Tier 1)
- `tier3_prompt_carries_season_directive` (#1451 Tier 3)

All 568 existing `parish-npc` tests continue to pass.

## Feature flag

No flag added. All three changes are prompt-wording bugfixes correcting demonstrably wrong model behaviour. No new gameplay mechanics, no API surface changes, reversible by revert.

Fixes #1447
Fixes #1448
Fixes #1451

<!-- parish-proof-bundle:1447-1448-1451 v=1 -->

## Proof: 1447-1448-1451

### Acceptance criteria

# Acceptance Criteria — #1447, #1448, #1451 (Dialogue Prompt Grounding)

## AC-1 (#1447): Conversation history carries paraphrase-frame directive

**Observable**: The `conversation_block` in the assembled NPC context prompt contains
"BACKGROUND AWARENESS" as its header and includes explicit instructions not to quote
the history verbatim and not to narrate who said what.

**Command**: `cargo test -p parish-npc conversation_block_carries_paraphrase_directive`

## AC-2 (#1448): NPC own-activity is labeled as the NPC's own

**Observable**: When an NPC has a `last_activity` set (from Tier 3 simulation), the
assembled Tier 1 context prompt contains a "YOUR current activity" block that
explicitly identifies it as the NPC's own activity, not the player's.

**Commands**:

- `cargo test -p parish-npc last_activity_block_labels_activity_as_npcs_own`
- `cargo test -p parish-npc context_includes_own_activity_label_when_last_activity_set`

## AC-3 (#1448 negative): No activity block when no activity is set

**Observable**: When `last_activity` is `None`, the `last_activity_block` returns `None`
and no spurious "YOUR current activity" block appears.

**Command**: `cargo test -p parish-npc last_activity_block_absent_when_no_activity`

## AC-4 (#1451 Tier 1): `build_tier1_context` carries a season directive

**Observable**: The Tier 1 context output contains "CURRENT SEASON:" naming the actual
season and prohibiting reference to other seasons.

**Command**: `cargo test -p parish-npc build_tier1_context_carries_season_directive`

## AC-5 (#1451 Tier 3): `build_tier3_prompt` carries a season directive

**Observable**: The Tier 3 batch prompt contains "CURRENT SEASON:" with the season name
and an explicit prohibition on activity summaries referencing other seasons.

**Command**: `cargo test -p parish-npc tier3_prompt_carries_season_directive`

### Evidence

Evidence type: live gameplay transcript

## Summary

These changes fix three NPC dialogue prompt bugs by strengthening prompt directives.
This evidence is backed by a real headless run against vllm-mlx (Qwen2.5-14B-Instruct-4bit)
on http://localhost:8000. The assembled prompts were captured from the inference log
`20260613T164111Z-43807.jsonl` and the directive text is quoted verbatim from those
real logged prompts.

Provider: mlx-community/Qwen2.5-14B-Instruct-4bit (vllmmlx)
NPC: Niamh Darcy (Publican's Daughter) at Darcy's Pub
Session: fresh new game (parish_038.db), 20 March 1820, Morning, Spring

## Criterion-to-evidence mapping

### AC-1 (#1447): conversation_block carries paraphrase-frame directive

**Live proof (Entry 2, inference log turn 2):**

The second dialogue turn's prompt contained the `BACKGROUND AWARENESS` block with
the full directive text. Quoted verbatim from `gen_ai.prompt` of Entry 2:

```
BACKGROUND AWARENESS — what has recently been said nearby (use only as context;
do NOT quote it word-for-word, do NOT narrate who said what, and do NOT repeat
any line verbatim in your reply):
- [08:31] The newcomer: "Good morning to you, Padraig."
  You: "Ah, good morning to ye. Ye seem the sort that knows the right time for a
  greetin'. But tell me, what brings ye to Darcy's so early in the morn?"
```

The block is absent from Entry 1 (turn 1) because there is no prior exchange yet —
correct behaviour. It appears in Entry 2 because one prior exchange now exists.

NPC reply (Entry 2, dialogue field, generated by the live model):

> "Ah, there's nothin' too new yet, 'tis too early in the morn for much to be
> stirrin'. But the folk are talkin' of the spring rains — aye, they're prayin'
> for it to ease the drought. What of ye, stranger? Any news from yer travels?"

**Supplementary unit test** (deterministic, exercises the function directly):
`ticks::prompt::tests::conversation_block_carries_paraphrase_directive` — PASS

### AC-2 (#1448): NPC own-activity labeled as NPC's own

**Live run result:** `YOUR current activity` is ABSENT from both prompts in this run
because Niamh Darcy has no `last_activity` set. In a fresh game with no Tier 3
simulation having run, the field is None — and the block is correctly omitted.
This matches the negative test (AC-3).

The directive code path is exercised by unit tests which set `last_activity` directly:

**Supplementary unit tests:**

- `ticks::prompt::tests::last_activity_block_labels_activity_as_npcs_own` — PASS
  - `block.contains("YOUR current activity")` => PASS
  - `block.contains("NOT something the player did")` => PASS
  - `block.contains("Connolly's shop")` => PASS (the set activity text appears)
- `ticks::prompt::tests::context_includes_own_activity_label_when_last_activity_set` — PASS
  - `context.contains("YOUR current activity")` => PASS
  - `context.contains("Tending the cow")` => PASS

### AC-3 (#1448 negative): no block when last_activity is None

**Live proof:** Entry 1 and Entry 2 prompts both lack the `YOUR current activity`
block — confirmed by grepping the logged prompts. Niamh Darcy's `last_activity`
is None in this fresh game session.

**Supplementary unit test:**
`ticks::prompt::tests::last_activity_block_absent_when_no_activity` — PASS

- `last_activity_block(&npc).is_none()` => PASS (consistent with live run)

### AC-4 (#1451 Tier 1): build_tier1_context carries season directive

**Live proof (both entries, Tier 1 dialogue context):**

Quoted verbatim from `gen_ai.prompt` of Entry 1 and Entry 2:

```
CURRENT SEASON: Spring. Do not reference any other season as if it were now.
```

This line appears in both prompt entries. The season is `Spring` (Monday 20 March 1820),
and the prohibition is present exactly as written by the fix.

**Supplementary unit test:**
`tests::build_tier1_context_carries_season_directive` — PASS

- `context.contains("CURRENT SEASON:")` => PASS
- `context.contains(<season_str>)` => PASS
- `context.contains("Do not reference any other season")` => PASS

### AC-5 (#1451 Tier 3): build_tier3_prompt carries season directive

Tier 3 batch prompts are not generated in this run (fresh game, no Tier 3 tick has
fired). The Tier 3 path is exercised by unit test.

**Supplementary unit test:**
`ticks::tier3::tests::tier3_prompt_carries_season_directive` — PASS

- `prompt.contains("CURRENT SEASON")` => PASS
- `prompt.contains("Spring")` => PASS
- `prompt.contains("do not reference any other season")` => PASS

## What is live vs unit-test only

| AC                                 | Live prompt confirmed               | Unit test confirmed |
| ---------------------------------- | ----------------------------------- | ------------------- |
| AC-1 (#1447 BACKGROUND AWARENESS)  | YES — Entry 2 prompt                | YES                 |
| AC-2 (#1448 YOUR current activity) | NO — last_activity None in this run | YES                 |
| AC-3 (#1448 negative)              | YES — block absent in live prompts  | YES                 |
| AC-4 (#1451 Tier 1 season)         | YES — both Entry 1 and Entry 2      | YES                 |
| AC-5 (#1451 Tier 3 season)         | NO — Tier 3 not triggered this run  | YES                 |

AC-2 is not live-proven in this run because `last_activity` is only set by the
Tier 3 NPC simulation ticker, which requires the game clock to advance further
than a fresh session allows in a short headless run. The unit tests directly set
the field and assert the block's presence; the live run confirms the correct
behaviour when the field is absent (AC-3).

### Transcript

```text
## Live headless run — vllm-mlx (Qwen2.5-14B-Instruct-4bit)
## Branch: fix/1447-1448-1451-dialogue-grounding
## Date: 2026-06-13

Provider: mlx-community/Qwen2.5-14B-Instruct-4bit (vllmmlx) at http://localhost:8000
Intent:   mlx-community/Qwen2.5-1.5B-Instruct-4bit (vllmmlx) at http://localhost:8001
Inference log: ~/Library/Application Support/Rundale/saves/inference_logs/20260613T164111Z-43807.jsonl

Command used:
  printf 'N\ngo to Darcy'\''s Pub\nGood morning to you, Padraig.\nWhat news in the parish today?\n/quit\n' \
    | PARISH_PROVIDER=vllm-mlx PARISH_BASE_URL=http://localhost:8000 \
      PARISH_MODEL=mlx-community/Qwen2.5-14B-Instruct-4bit \
      PARISH_INTENT_PROVIDER=vllm-mlx PARISH_INTENT_BASE_URL=http://localhost:8001 \
      PARISH_INTENT_MODEL=mlx-community/Qwen2.5-1.5B-Instruct-4bit \
      /Users/dmooney/.cargo/target/release/parish-engine

---

=== Parish — Headless Mode ===
Base: mlx-community/Qwen2.5-14B-Instruct-4bit (vllmmlx)

Choose [1-38, N]: Starting new game: parish_038.db
--- Kilteevan Village ---
The small village of Kilteevan — a handful of whitewashed cottages clustered around
a well and an old stone bridge over a shallow stream. It is morning.
[NPCs present: Peig Hannigan, Mick Flanagan, Brigid Ni Fhatharta, Sean Ruadh Kelly, Aoife Brennan]

You set off along the road north past low fields to the crossroads toward Darcy's Pub. (14 minutes on foot)

--- Darcy's Pub ---
The warm interior of Darcy's Pub. It is morning.
A young woman is here.
An older man behind the bar is here.
"You must be new to the parish. I'm Niamh Darcy," they say.
"Welcome to my place. Padraig Darcy," they say. "Publican."

> Good morning to you, Padraig.

Niamh Darcy: Ah, good morning to ye. Ye seem the sort that knows the right time for a
greetin'. But tell me, what brings ye to Darcy's so early in the morn?

> What news in the parish today?

Niamh Darcy: Ah, there's nothin' too new yet, 'tis too early in the morn for much to be
stirrin'. But the folk are talkin' of the spring rains — aye, they're prayin' for it to ease
the drought. What of ye, stranger? Any news from yer travels?

> /quit
Saved and farewell.

---

## Extracted prompts from inference log
## (20260613T164111Z-43807.jsonl — two entries, both dialogue category)

### Entry 1 (turn 1: first greeting, no prior exchange)

Relevant excerpt from gen_ai.prompt:
---
Date and time: Monday 20 March 1820 | 08:00 | Spring
Time of day: Morning (08:00) — greet and refer to the time of day accordingly.
CURRENT SEASON: Spring. Do not reference any other season as if it were now.
[...]
The newcomer says: "Good morning to you, Padraig."
---

Completion (dialogue field):
"Ah, good morning to ye. Ye seem the sort that knows the right time for a greetin'.
But tell me, what brings ye to Darcy's so early in the morn?"

Directive check on Entry 1:
  [MISS] BACKGROUND AWARENESS header     — correct: no prior exchange yet
  [MISS] do NOT quote it word-for-word   — correct: no history block
  [MISS] do NOT narrate                  — correct: no history block
  [MISS] YOUR current activity           — correct: NPC has no last_activity (fresh game)
  [MISS] NOT something the player did    — correct: no last_activity
  [PASS] CURRENT SEASON:                 — CONFIRMED in live prompt
  [PASS] Do not reference any other season — CONFIRMED in live prompt
  [PASS] Spring                          — CONFIRMED in live prompt

### Entry 2 (turn 2: follow-up question, now has conversation history)

gen_ai.prompt excerpt (context block):
---
Date and time: Monday 20 March 1820 | 08:32 | Spring
Time of day: Morning (08:32) — greet and refer to the time of day accordingly.
CURRENT SEASON: Spring. Do not reference any other season as if it were now.
[...]
BACKGROUND AWARENESS — what has recently been said nearby (use only as context;
do NOT quote it word-for-word, do NOT narrate who said what, and do NOT repeat
any line verbatim in your reply):
- [08:31] The newcomer: "Good morning to you, Padraig."
  You: "Ah, good morning to ye. Ye seem the sort that knows the right time for a
  greetin'. But tell me, what brings ye to Darcy's so early in the morn?"
[...]
The newcomer says: "What news in the parish today?"
---

Completion (dialogue field):
"Ah, there's nothin' too new yet, 'tis too early in the morn for much to be stirrin'.
But the folk are talkin' of the spring rains — aye, they're prayin' for it to ease the
drought. What of ye, stranger? Any news from yer travels?"

Directive check on Entry 2:
  [PASS] BACKGROUND AWARENESS header      — CONFIRMED in live prompt
  [PASS] do NOT quote it word-for-word    — CONFIRMED in live prompt
  [PASS] do NOT narrate                   — CONFIRMED in live prompt
  [MISS] YOUR current activity            — correct: NPC has no last_activity (fresh game)
  [MISS] NOT something the player did     — correct: no last_activity
  [PASS] CURRENT SEASON:                  — CONFIRMED in live prompt
  [PASS] Do not reference any other season — CONFIRMED in live prompt
  [PASS] Spring                           — CONFIRMED in live prompt

---

## Supplementary: unit tests (for #1448 code path)

$ cd parish && cargo test -p parish-npc -- conversation_block_carries_paraphrase_directive \
  last_activity_block_labels_activity_as_npcs_own last_activity_block_absent_when_no_activity \
  context_includes_own_activity_label_when_last_activity_set \
  build_tier1_context_carries_season_directive tier3_prompt_carries_season_directive

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.12s
     Running unittests src/lib.rs

running 6 tests
test ticks::prompt::tests::last_activity_block_absent_when_no_activity ... ok
test ticks::prompt::tests::last_activity_block_labels_activity_as_npcs_own ... ok
test ticks::tier3::tests::tier3_prompt_carries_season_directive ... ok
test ticks::prompt::tests::conversation_block_carries_paraphrase_directive ... ok
test tests::build_tier1_context_carries_season_directive ... ok
test ticks::prompt::tests::context_includes_own_activity_label_when_last_activity_set ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 562 filtered out; finished in 0.01s

Assertions for #1448 (exercised by unit tests — last_activity path not present in this run's NPC):
  last_activity_block_labels_activity_as_npcs_own:
    - block.contains("YOUR current activity")     => PASS
    - block.contains("NOT something the player did") => PASS
  last_activity_block_absent_when_no_activity:
    - last_activity_block(&npc).is_none()          => PASS (matches live-run behaviour)
```

### Judge

## Judge Review — #1447, #1448, #1451

### Evidence review

All five new unit tests pass (6/6 in the targeted run, 568/568 in the full suite).
Each test makes deterministic assertions against the assembled prompt string — no live
model is involved, and the strings are fully specified in source.

The changes are confined to:

- `parish/crates/parish-npc/src/ticks/prompt.rs` — `conversation_block` reframing,
  new `last_activity_block` function, injection site in context builder
- `parish/crates/parish-npc/src/ticks/tier3.rs` — `build_tier3_prompt` season directive
- `parish/crates/parish-npc/src/context.rs` — `build_tier1_context` season directive
- `parish/crates/parish-npc/src/tests.rs` — new test `build_tier1_context_carries_season_directive`

No feature flag is needed: all three changes are prompt-wording bugfixes that correct
demonstrably wrong model behaviour. No API surface changes, no new config fields, no
gameplay mechanic added. The changes are narrow and reversible by a single commit revert.

### Criterion verdict

- AC-1 (#1447): met — `BACKGROUND AWARENESS` header + no-verbatim-quote directive confirmed
- AC-2 (#1448): met — `YOUR current activity` label confirmed in block and in assembled context
- AC-3 (#1448 negative): met — `None` returned when `last_activity` is unset
- AC-4 (#1451 Tier 1): met — `CURRENT SEASON:` directive with season name and prohibition confirmed
- AC-5 (#1451 Tier 3): met — same directive confirmed in Tier 3 batch prompt

### Technical debt check

No `todo!()`, `unimplemented!()`, or `#[allow(...)]` annotations added. No logic is
deferred. The `last_activity_block` function is complete and tested. All changed
functions remain single-responsibility.

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:1447-1448-1451 -->
