### PR TITLE
fix(npc): decline indirect/pronoun affirmations of a fabricated person across the conversation (#1470)

### DIFF
--- a/parish/crates/parish-core/src/game_loop/npc_turn.rs
+++ b/parish/crates/parish-core/src/game_loop/npc_turn.rs
@@ -335,18 +335,28 @@ pub async fn run_npc_turn(
         .map(|meta| meta.language_hints.clone())
         .unwrap_or_default();
 
-    // Post-generation person-confirmation guard (#1459): detect when the NPC's
-    // reply affirmatively confirms a fabricated person from the player's input
-    // who is not in the known-roster, and replace with a stock decline.
+    // Post-generation person-confirmation guard (#1459, #1466, #1470): detect
+    // when the NPC's reply affirmatively confirms a fabricated person from the
+    // player's input (or an earlier turn) who is not in the known-roster, and
+    // replace with a stock decline.
     // Runs before the logging/quality-check block so the guarded text is what
     // gets logged and forwarded to the shared pipeline.
     if person_guard_enabled && !parsed.dialogue.trim().is_empty() {
         let guard_seed =
             speaker_id.0 as u64 ^ ctx.world.lock().await.clock.now().timestamp() as u64;
+        // Extract prior player-speaker lines from the conversation transcript so
+        // the pronoun follow-up guard (#1470 gap 2) can detect fabricated
+        // referents established in earlier turns.
+        let prior_player_inputs: Vec<&str> = transcript
+            .iter()
+            .filter(|line| line.speaker == "You")
+            .map(|line| line.text.as_str())
+            .collect();
         let guarded = crate::npc::guard_fabricated_person_confirmation(
             &parsed.dialogue,
             prompt_input,
             &setup.known_person_names,
+            &prior_player_inputs,
             None,
             guard_seed,
         );

--- a/parish/crates/parish-engine/src/headless.rs
+++ b/parish/crates/parish-engine/src/headless.rs
@@ -808,9 +808,12 @@ fn apply_npc_response(
         tracing::debug!("NPC metadata: action={}, mood={}", meta.action, meta.mood);
     }
 
-    // Post-generation person-confirmation guard (#1459): headless parity with
-    // the live-loop path in `run_npc_turn`. Both guards default-on; no
-    // runtime-flag access here so we use the NpcConfig default (true).
+    // Post-generation person-confirmation guard (#1459, #1466, #1470): headless
+    // parity with the live-loop path in `run_npc_turn`. Both guards default-on;
+    // no runtime-flag access here so we use the NpcConfig default (true).
+    // Prior player inputs are not available in this single-turn helper scope,
+    // so we pass &[] — the pronoun follow-up guard is conservative and will
+    // only fire when prior_player_inputs is non-empty.
     let cfg = parish_core::config::NpcConfig::default();
     if cfg.person_confirmation_guard_enabled && !parsed.dialogue.trim().is_empty() {
         let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
@@ -818,6 +821,7 @@ fn apply_npc_response(
             &parsed.dialogue,
             player_input,
             known_person_names,
+            &[],
             None,
             seed,
         );

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -267,6 +267,26 @@ fn non_recognition_decline(seed: u64) -> &'static str {
     DECLINES[(seed as usize) % DECLINES.len()]
 }
 
+/// Denial markers used by both the affirmation check and the pronoun-referent
+/// check. If any of these appear in the dialogue the NPC is already declining —
+/// the guard must not fire.
+const DENIAL_MARKERS: &[&str] = &[
+    "know no",
+    "no such",
+    "never heard",
+    "don't know",
+    "do not know",
+    "no one by that name",
+    "not known to me",
+    "cannot say i've",
+    "never met",
+    "no knowledge of",
+    "not familiar",
+    "not acquainted",
+    "stranger to me",
+    "wrong parish",
+];
+
 /// Returns `true` when `dialogue` contains an affirmation of the given `name`
 /// but no denial. The check is intentionally conservative — it only fires when
 /// there is a clear locating or confirming phrase near the name.
@@ -280,22 +300,6 @@ fn dialogue_affirms_name(dialogue: &str, name: &str) -> bool {
     }
 
     // Denial markers: if any are present, the NPC is already declining.
-    const DENIAL_MARKERS: &[&str] = &[
-        "know no",
-        "no such",
-        "never heard",
-        "don't know",
-        "do not know",
-        "no one by that name",
-        "not known to me",
-        "cannot say i've",
-        "never met",
-        "no knowledge of",
-        "not familiar",
-        "not acquainted",
-        "stranger to me",
-        "wrong parish",
-    ];
     for marker in DENIAL_MARKERS {
         if lower.contains(marker) {
             return false;
@@ -374,6 +378,117 @@ fn dialogue_affirms_name(dialogue: &str, name: &str) -> bool {
     }
 
     false
+}
+
+/// Returns `true` when `dialogue` contains a pronoun-based affirmation of an
+/// absent referent (e.g. "he's off to the mill", "she's at the church") but no
+/// denial. Used by the pronoun follow-up guard (#1470) to catch turns where the
+/// player's input had no name — only a pronoun or continuation — but the NPC
+/// confirms a previously-established fabricated referent via pronoun.
+///
+/// This is intentionally broader than [`dialogue_affirms_name`]: it does not
+/// require the name to appear in the dialogue at all. It fires purely on the
+/// presence of pronoun-locative / pronoun-confirmatory phrases in the absence of
+/// denial markers.
+fn dialogue_affirms_via_pronoun(dialogue: &str) -> bool {
+    let lower = dialogue.to_lowercase();
+
+    // If the NPC is already declining, don't suppress.
+    for marker in DENIAL_MARKERS {
+        if lower.contains(marker) {
+            return false;
+        }
+    }
+
+    // Pronoun affirmation markers — these indicate the NPC is confirming or
+    // locating a person referenced only by pronoun or appositive ("the lad",
+    // "the man"). Broader than [`dialogue_affirms_name`] affirmation markers.
+    const PRONOUN_AFFIRMATION_MARKERS: &[&str] = &[
+        "he's off to",
+        "she's off to",
+        "he is off to",
+        "she is off to",
+        "he's out",
+        "she's out",
+        "he is out",
+        "she is out",
+        "he's at ",
+        "she's at ",
+        "he is at ",
+        "she is at ",
+        "he's in ",
+        "she's in ",
+        "he is in ",
+        "she is in ",
+        "he's over",
+        "she's over",
+        "he is over",
+        "she is over",
+        "he'll be",
+        "she'll be",
+        "he will be",
+        "she will be",
+        "he's away",
+        "she's away",
+        "he is away",
+        "she is away",
+        "he's gone",
+        "she's gone",
+        "he is gone",
+        "she is gone",
+        "he went",
+        "she went",
+        "he headed",
+        "she headed",
+        "he's working",
+        "she's working",
+        "aye, he",
+        "aye, she",
+        "aye, he's",
+        "aye, she's",
+    ];
+    for marker in PRONOUN_AFFIRMATION_MARKERS {
+        if lower.contains(marker) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Returns `true` when the dialogue contains the given first name in combination
+/// with a pronoun-affirmation marker, with no denial marker present. Used for the
+/// indirect / appositive first-name check (#1470 gap 1): catches "he's out, the
+/// lad Cormac" where "Cormac" appears in appositive position after a pronoun
+/// affirmation ("he's out"), so the standard affirmation-marker-collocated check
+/// misses it.
+///
+/// Fires only when BOTH conditions hold:
+///   1. The first name appears anywhere in the dialogue.
+///   2. The dialogue contains a pronoun-affirmation marker (from
+///      `dialogue_affirms_via_pronoun`), confirming the referent is a person
+///      being located/confirmed rather than merely questioned.
+///
+/// Only used when the caller already established that the first name belongs to a
+/// player-named fabricated full name — do not call for arbitrary first names.
+fn dialogue_contains_name_with_pronoun_affirmation(dialogue: &str, name: &str) -> bool {
+    let lower = dialogue.to_lowercase();
+    let name_lower = name.to_lowercase();
+
+    if !lower.contains(&name_lower) {
+        return false;
+    }
+
+    for marker in DENIAL_MARKERS {
+        if lower.contains(marker) {
+            return false;
+        }
+    }
+
+    // Require a pronoun-affirmation marker to be present — this distinguishes
+    // "he's out, the lad Cormac" (pronoun affirms, name in appositive) from
+    // "Cormac Sweeney, you say? I cannot recall" (name in question, no pronoun).
+    dialogue_affirms_via_pronoun(dialogue)
 }
 
 /// Extracts candidate person-name tokens (consecutive Title-cased bigrams and
@@ -472,7 +587,7 @@ fn name_in_roster(
     false
 }
 
-/// Post-generation guard for fabricated-person confirmation (#1459, #1466).
+/// Post-generation guard for fabricated-person confirmation (#1459, #1466, #1470).
 ///
 /// After dialogue completion is produced, scans the text for affirmative
 /// confirmation of a named person extracted from `player_input` whose full
@@ -484,6 +599,11 @@ fn name_in_roster(
 ///   extracted from here as Title-cased bigrams/trigrams).
 /// - `known_person_names`: the names from the NPC's "PEOPLE YOU KNOW" roster,
 ///   as plain name strings (e.g. `["Cormac Duffy", "Brigid Connolly"]`).
+/// - `prior_player_inputs`: recent preceding player utterances from the
+///   conversation transcript, oldest-first. Used to detect fabricated referents
+///   established in earlier turns so that pronoun follow-up replies ("he's off
+///   to the mill") are also declined (#1470 gap 2). Pass `&[]` when no prior
+///   player text is available (e.g. the headless scripted path).
 /// - `player_name`: the player's own name if known, to avoid false-positives.
 /// - `seed`: deterministic seed for decline pool selection.
 ///
@@ -503,10 +623,32 @@ fn name_in_roster(
 /// fabricated full name — casual first-name queries about real roster members
 /// ("do you know Cormac?" where "Cormac Duffy" is in the roster) still pass
 /// through unchanged, because the player did not supply a fabricated full name.
+///
+/// ## Indirect / appositive first-name affirmation (#1470 gap 1)
+///
+/// The #1466 check used `dialogue_affirms_name` (which requires an affirmation
+/// marker near the name). This misses appositive forms like "he's out, the lad
+/// Cormac" where "Cormac" appears after a comma as an appositive, not near any
+/// affirmation keyword. The guard now broadens the first-name conflation check:
+/// if the fabricated first name appears ANYWHERE in the dialogue (not just near
+/// an affirmation marker) and no denial is present, it fires.
+///
+/// ## Pronoun follow-up (#1470 gap 2)
+///
+/// After the fabricated referent is established in one turn, the player may ask
+/// a follow-up with no name at all ("Out where?"). The current player input has
+/// no extractable candidate name so the guard would never fire. By scanning
+/// `prior_player_inputs` for fabricated full names, the guard accumulates a set
+/// of "established fabricated referents". When the current player input yields
+/// no fabricated candidates (pronoun-only turn), if the NPC dialogue contains
+/// pronoun-affirmation markers ("he's off to", "she's at", …) the guard fires.
+/// This is conservative: it only fires when no real-roster full name appears in
+/// the immediately preceding player inputs.
 pub fn guard_fabricated_person_confirmation(
     dialogue: &str,
     player_input: &str,
     known_person_names: &[String],
+    prior_player_inputs: &[&str],
     player_name: Option<&str>,
     seed: u64,
 ) -> String {
@@ -586,17 +728,28 @@ pub fn guard_fabricated_person_confirmation(
         }
     }
 
-    // First-name conflation check (#1466): if the player named a fabricated
-    // full name AND the NPC affirms by that first name alone, also decline.
-    // Only runs when there are fabricated full names in this exchange.
+    // First-name conflation check (#1466 + #1470 gap 1): if the player named a
+    // fabricated full name AND the NPC's reply confirms the referent by that
+    // first name, also decline.
     //
-    // Real-roster escape hatch: if the dialogue affirms the first name but the
-    // affirmation is accompanied by a real roster full name that begins with
-    // that first name (e.g. dialogue contains "Cormac Duffy" and roster has
-    // "Cormac Duffy"), the NPC is talking about a real person — do NOT decline.
+    // Two sub-cases handled:
+    //   (a) #1466 original: `dialogue_affirms_name` — strict affirmation marker
+    //       collocates with the first name (e.g. "Cormac is at the mill").
+    //   (b) #1470 gap 1: `dialogue_contains_name_with_pronoun_affirmation` —
+    //       the dialogue contains BOTH a pronoun-affirmation marker ("he's out")
+    //       AND the first name in appositive/trailing position (e.g. "he's out,
+    //       the lad Cormac"). The pronoun marker confirms a person is being
+    //       located; the appositive names the fabricated first name.
+    //
+    // Real-roster escape hatch: if the dialogue contains the first name but also
+    // contains a real roster full name that begins with that first name (e.g.
+    // "Cormac Duffy" is in the dialogue and in the roster), the NPC is talking
+    // about a real person — do NOT decline.
     let dialogue_lower = dialogue.to_lowercase();
     for first_name in &fabricated_full_name_first_names {
-        if dialogue_affirms_name(dialogue, first_name) {
+        let affirms = dialogue_affirms_name(dialogue, first_name)
+            || dialogue_contains_name_with_pronoun_affirmation(dialogue, first_name);
+        if affirms {
             // Check if the dialogue resolves the first name to a real roster entry.
             let first_lower = first_name.to_lowercase();
             let resolves_to_real = known_person_names.iter().any(|roster_name| {
@@ -617,7 +770,76 @@ pub fn guard_fabricated_person_confirmation(
             }
             tracing::warn!(
                 fabricated_first_name = %first_name,
-                "person-confirmation guard fired: NPC affirmed by first name only for player-named fabricated full name (#1466)"
+                "person-confirmation guard fired: NPC affirmed by first name (direct or appositive) for player-named fabricated full name (#1466/#1470)"
+            );
+            return non_recognition_decline(seed).to_string();
+        }
+    }
+
+    // Pronoun follow-up guard (#1470 gap 2): when the current player turn has no
+    // extractable fabricated full name (pronoun-only turn, e.g. "Out where?"),
+    // scan `prior_player_inputs` for fabricated full names established earlier in
+    // the same conversation. If any are found AND the NPC dialogue contains a
+    // pronoun-affirmation marker ("he's off to", "she's out", …) without a denial,
+    // the NPC is confirming the previously-established fabricated referent via
+    // pronoun — decline.
+    //
+    // Conservative conditions that must ALL hold:
+    //   1. The current turn has no fabricated full name candidates (pronoun turn).
+    //   2. At least one prior player turn named a fabricated full name.
+    //   3. No prior player turn also named a real roster full name with the SAME
+    //      first name in the same utterance (ambiguous referent → don't suppress).
+    //   4. The NPC reply contains a pronoun affirmation marker.
+    //   5. The NPC reply contains no denial marker.
+    let current_turn_has_fabricated_candidate = candidates.iter().any(|c| {
+        c.split_whitespace().count() >= 2 && !name_in_roster(c, known_person_names, player_name)
+    });
+
+    if !current_turn_has_fabricated_candidate && !prior_player_inputs.is_empty() {
+        // Collect fabricated full names established in prior player turns.
+        let prior_established_fabricated: Vec<String> = prior_player_inputs
+            .iter()
+            .flat_map(|prior| extract_candidate_names(prior))
+            .filter(|c| {
+                c.split_whitespace().count() >= 2
+                    && !name_in_roster(c, known_person_names, player_name)
+            })
+            // Ambiguous-but-real: exclude if the same prior input also named a real
+            // roster full name sharing the first name (too ambiguous to suppress).
+            .filter(|fabricated| {
+                let fab_first = fabricated
+                    .split_whitespace()
+                    .next()
+                    .map(|w| w.to_lowercase())
+                    .unwrap_or_default();
+                // Find which prior input(s) mentioned this fabricated name.
+                let prior_that_named_it: Vec<&&str> = prior_player_inputs
+                    .iter()
+                    .filter(|prior| {
+                        extract_candidate_names(prior)
+                            .iter()
+                            .any(|c| c.to_lowercase() == fabricated.to_lowercase())
+                    })
+                    .collect();
+                // For each such prior input, check whether it ALSO named a real
+                // roster full name that shares this first name.
+                !prior_that_named_it.iter().any(|prior| {
+                    extract_candidate_names(prior).iter().any(|c| {
+                        c.split_whitespace().count() >= 2
+                            && name_in_roster(c, known_person_names, player_name)
+                            && c.split_whitespace()
+                                .next()
+                                .map(|w| w.to_lowercase() == fab_first)
+                                .unwrap_or(false)
+                    })
+                })
+            })
+            .collect();
+
+        if !prior_established_fabricated.is_empty() && dialogue_affirms_via_pronoun(dialogue) {
+            tracing::warn!(
+                established_fabricated = ?prior_established_fabricated,
+                "person-confirmation guard fired: pronoun follow-up affirms established fabricated referent (#1470)"
             );
             return non_recognition_decline(seed).to_string();
         }
@@ -1066,7 +1288,8 @@ mod tests {
         let dialogue = "Aye, I know Cormac Sweeney well. He is a fine man who works in the mill.";
         let player_input = "Do you know Cormac Sweeney?";
         let known: Vec<String> = vec!["Brigid Connolly".into(), "Tadhg Murphy".into()];
-        let result = guard_fabricated_person_confirmation(dialogue, player_input, &known, None, 0);
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
         // Must not contain affirmation of fabricated name.
         assert!(
             !result.to_lowercase().contains("aye, i know cormac"),
@@ -1088,7 +1311,8 @@ mod tests {
         let dialogue = "Aye, I know Brigid Connolly well. She is a fine woman.";
         let player_input = "Do you know Brigid Connolly?";
         let known: Vec<String> = vec!["Brigid Connolly".into(), "Tadhg Murphy".into()];
-        let result = guard_fabricated_person_confirmation(dialogue, player_input, &known, None, 0);
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
         assert_eq!(
             result, dialogue,
             "known-roster person should not be altered: {result:?}"
@@ -1101,7 +1325,8 @@ mod tests {
         let dialogue = "I know no one by that name in these parts. You may have the wrong parish.";
         let player_input = "Do you know Cormac Sweeney?";
         let known: Vec<String> = vec![];
-        let result = guard_fabricated_person_confirmation(dialogue, player_input, &known, None, 0);
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
         assert_eq!(
             result, dialogue,
             "already-declining dialogue should pass through unchanged: {result:?}"
@@ -1114,7 +1339,8 @@ mod tests {
         let dialogue = "Cormac Sweeney, you say? I cannot recall that name.";
         let player_input = "Do you know Cormac Sweeney?";
         let known: Vec<String> = vec![];
-        let result = guard_fabricated_person_confirmation(dialogue, player_input, &known, None, 0);
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
         assert_eq!(
             result, dialogue,
             "neutral mention should not trigger guard: {result:?}"
@@ -1131,6 +1357,7 @@ mod tests {
             dialogue,
             player_input,
             &known,
+            &[],
             Some("Cormac Sweeney"),
             0,
         );
@@ -1149,7 +1376,8 @@ mod tests {
         let dialogue = "Aye, I know Cormac Sweeney well. He is a fine man.";
         let player_input = "Do you know Cormac Sweeney?";
         let known: Vec<String> = vec!["Cormac Duffy".into(), "Brigid Connolly".into()];
-        let result = guard_fabricated_person_confirmation(dialogue, player_input, &known, None, 0);
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
         assert!(
             !result.to_lowercase().contains("aye, i know cormac sweeney"),
             "guard should have fired and replaced fabricated-person confirmation: {result:?}"
@@ -1170,7 +1398,8 @@ mod tests {
         let dialogue = "Aye, Cormac is a good man indeed. I see him at the mill most days.";
         let player_input = "Do you know Cormac?";
         let known: Vec<String> = vec!["Cormac Duffy".into()];
-        let result = guard_fabricated_person_confirmation(dialogue, player_input, &known, None, 0);
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
         assert_eq!(
             result, dialogue,
             "first-name-only reference to a roster member should not trigger guard: {result:?}"
@@ -1189,7 +1418,8 @@ mod tests {
         let dialogue = "Cormac is at the mill, about his affairs. Mayhap he's there now.";
         let player_input = "find my cousin Cormac Sweeney";
         let known: Vec<String> = vec!["Cormac Duffy".into(), "Roisin Connolly".into()];
-        let result = guard_fabricated_person_confirmation(dialogue, player_input, &known, None, 0);
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
         assert!(
             !result.to_lowercase().contains("cormac is at the mill"),
             "guard should have fired and replaced first-name affirmation of fabricated full name: {result:?}"
@@ -1213,7 +1443,8 @@ mod tests {
         let dialogue = "Aye, Cormac Duffy works the mill. He's a reliable sort.";
         let player_input = "do you know Cormac?";
         let known: Vec<String> = vec!["Cormac Duffy".into(), "Brigid Connolly".into()];
-        let result = guard_fabricated_person_confirmation(dialogue, player_input, &known, None, 0);
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
         assert_eq!(
             result, dialogue,
             "casual first-name query about a real roster member should not trigger guard: {result:?}"
@@ -1230,11 +1461,94 @@ mod tests {
         let dialogue = "Aye, Cormac Duffy works the mill, right enough. A reliable man.";
         let player_input = "I'm looking for Cormac Sweeney but have you seen Cormac Duffy today?";
         let known: Vec<String> = vec!["Cormac Duffy".into(), "Brigid Connolly".into()];
-        let result = guard_fabricated_person_confirmation(dialogue, player_input, &known, None, 0);
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
         assert_eq!(
             result, dialogue,
             "NPC affirming real roster member 'Cormac Duffy' in full should not be suppressed \
              even when fabricated 'Cormac Sweeney' shares the first name: {result:?}"
+        );
+    }
+
+    // ── #1470 — indirect/appositive and pronoun follow-up bypass ────────────
+
+    #[test]
+    fn indirect_appositive_affirmation_of_fabricated_firstname_is_declined() {
+        // AC-1 (#1470 gap 1): player asks about fabricated "Cormac Sweeney" (roster
+        // has "Cormac Duffy"). NPC replies with an appositive form: "Ye've come at a
+        // time when he's out, the lad Cormac." — "Cormac" is in appositive position,
+        // NOT near a standard affirmation marker, so the old #1466 guard missed it.
+        // The broadened check (dialogue_contains_name_without_denial) must catch it.
+        let dialogue = "Ye've come at a time when he's out, the lad Cormac.";
+        let player_input = "is my cousin Cormac Sweeney about?";
+        let known: Vec<String> = vec!["Cormac Duffy".into(), "Roisin Brennan".into()];
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
+        assert!(
+            !result.to_lowercase().contains("the lad cormac"),
+            "guard should have fired on appositive first-name affirmation of fabricated full name: {result:?}"
+        );
+        assert!(
+            result.to_lowercase().contains("no")
+                || result.to_lowercase().contains("not known")
+                || result.to_lowercase().contains("never heard")
+                || result.to_lowercase().contains("no one"),
+            "result should be a decline phrase: {result:?}"
+        );
+    }
+
+    #[test]
+    fn pronoun_followup_affirmation_of_established_fabricated_referent_is_declined() {
+        // AC-2 (#1470 gap 2): prior player turn established fabricated "Cormac
+        // Sweeney". Current turn is a pronoun-only follow-up "Out where?" — no name
+        // in current player_input. NPC replies "Aye, he's off to the mill with some
+        // of the flour." The pronoun affirmation guard must fire because the
+        // previously-established referent is fabricated.
+        let dialogue = "Aye, he's off to the mill with some of the flour.";
+        let player_input = "Out where?"; // no name — pronoun-only continuation
+        let prior_inputs: Vec<&str> = vec!["is my cousin Cormac Sweeney about?"];
+        let known: Vec<String> = vec!["Cormac Duffy".into(), "Roisin Brennan".into()];
+        let result = guard_fabricated_person_confirmation(
+            dialogue,
+            player_input,
+            &known,
+            &prior_inputs,
+            None,
+            0,
+        );
+        assert!(
+            !result.to_lowercase().contains("he's off to the mill"),
+            "guard should have fired on pronoun follow-up affirming established fabricated referent: {result:?}"
+        );
+        assert!(
+            result.to_lowercase().contains("no")
+                || result.to_lowercase().contains("not known")
+                || result.to_lowercase().contains("never heard")
+                || result.to_lowercase().contains("no one"),
+            "result should be a decline phrase: {result:?}"
+        );
+    }
+
+    #[test]
+    fn pronoun_followup_about_real_person_passes_through() {
+        // AC-4 (#1470 conservative): prior player turn named a REAL roster person
+        // "Cormac Duffy". Follow-up "Where is he?" + NPC "He's at the mill." must
+        // NOT be suppressed — the established referent is real, not fabricated.
+        let dialogue = "He's at the mill, working the grain as usual.";
+        let player_input = "Where is he?"; // pronoun-only follow-up
+        let prior_inputs: Vec<&str> = vec!["Have you seen Cormac Duffy today?"];
+        let known: Vec<String> = vec!["Cormac Duffy".into(), "Roisin Brennan".into()];
+        let result = guard_fabricated_person_confirmation(
+            dialogue,
+            player_input,
+            &known,
+            &prior_inputs,
+            None,
+            0,
+        );
+        assert_eq!(
+            result, dialogue,
+            "pronoun follow-up about a real roster member should not trigger guard: {result:?}"
         );
     }
 

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -456,15 +456,35 @@ fn dialogue_affirms_via_pronoun(dialogue: &str) -> bool {
     false
 }
 
-/// Returns `true` when the dialogue contains the given first name in combination
-/// with a pronoun-affirmation marker, with no denial marker present. Used for the
-/// indirect / appositive first-name check (#1470 gap 1): catches "he's out, the
-/// lad Cormac" where "Cormac" appears in appositive position after a pronoun
-/// affirmation ("he's out"), so the standard affirmation-marker-collocated check
-/// misses it.
+/// Returns `true` when `name` appears as a standalone word (not as a substring
+/// of a larger word) in `text`. Matching is case-insensitive. Each word in
+/// `text` is stripped of surrounding non-alphabetic characters before comparison
+/// so that punctuation-attached occurrences ("Al," "Al's") are still found, but
+/// accidental substring matches ("Al" inside "shall" or "talk") are not.
+///
+/// Example: `name="Al"` matches "Aye, Al's at the mill" but NOT "Ye shall talk".
+fn text_contains_name_as_word(text: &str, name: &str) -> bool {
+    let name_lower = name.to_lowercase();
+    for token in text.split_whitespace() {
+        // Strip leading/trailing non-alphabetic chars (punctuation, quotes, etc.)
+        let stripped = token.trim_matches(|c: char| !c.is_alphabetic());
+        if stripped.to_lowercase() == name_lower {
+            return true;
+        }
+    }
+    false
+}
+
+/// Returns `true` when the dialogue contains the given first name as a whole word
+/// (not a substring of another word) in combination with a pronoun-affirmation
+/// marker, with no denial marker present. Used for the indirect / appositive
+/// first-name check (#1470 gap 1): catches "he's out, the lad Cormac" where
+/// "Cormac" appears in appositive position after a pronoun affirmation ("he's
+/// out"), so the standard affirmation-marker-collocated check misses it.
 ///
 /// Fires only when BOTH conditions hold:
-///   1. The first name appears anywhere in the dialogue.
+///   1. The first name appears as a whole word in the dialogue (word-boundary
+///      match — prevents short names like "Al" from falsely matching "shall").
 ///   2. The dialogue contains a pronoun-affirmation marker (from
 ///      `dialogue_affirms_via_pronoun`), confirming the referent is a person
 ///      being located/confirmed rather than merely questioned.
@@ -472,13 +492,13 @@ fn dialogue_affirms_via_pronoun(dialogue: &str) -> bool {
 /// Only used when the caller already established that the first name belongs to a
 /// player-named fabricated full name — do not call for arbitrary first names.
 fn dialogue_contains_name_with_pronoun_affirmation(dialogue: &str, name: &str) -> bool {
-    let lower = dialogue.to_lowercase();
-    let name_lower = name.to_lowercase();
-
-    if !lower.contains(&name_lower) {
+    // Word-boundary check: name must appear as a standalone token, not as a
+    // substring of another word (e.g. "Al" must not match "shall" or "talk").
+    if !text_contains_name_as_word(dialogue, name) {
         return false;
     }
 
+    let lower = dialogue.to_lowercase();
     for marker in DENIAL_MARKERS {
         if lower.contains(marker) {
             return false;
@@ -796,10 +816,17 @@ pub fn guard_fabricated_person_confirmation(
     });
 
     if !current_turn_has_fabricated_candidate && !prior_player_inputs.is_empty() {
-        // Collect fabricated full names established in prior player turns.
-        let prior_established_fabricated: Vec<String> = prior_player_inputs
+        // Pre-extract candidate names from each prior input exactly once to avoid
+        // O(N²) re-parsing inside the ambiguity filter below.
+        let prior_candidates_per_input: Vec<Vec<String>> = prior_player_inputs
             .iter()
-            .flat_map(|prior| extract_candidate_names(prior))
+            .map(|prior| extract_candidate_names(prior))
+            .collect();
+
+        // Collect fabricated full names established in prior player turns.
+        let prior_established_fabricated: Vec<String> = prior_candidates_per_input
+            .iter()
+            .flat_map(|names| names.iter().cloned())
             .filter(|c| {
                 c.split_whitespace().count() >= 2
                     && !name_in_roster(c, known_person_names, player_name)
@@ -812,19 +839,20 @@ pub fn guard_fabricated_person_confirmation(
                     .next()
                     .map(|w| w.to_lowercase())
                     .unwrap_or_default();
-                // Find which prior input(s) mentioned this fabricated name.
-                let prior_that_named_it: Vec<&&str> = prior_player_inputs
+                // Find which prior input(s) mentioned this fabricated name (using
+                // the pre-extracted sets — no re-parsing).
+                let prior_that_named_it: Vec<&Vec<String>> = prior_candidates_per_input
                     .iter()
-                    .filter(|prior| {
-                        extract_candidate_names(prior)
+                    .filter(|names| {
+                        names
                             .iter()
                             .any(|c| c.to_lowercase() == fabricated.to_lowercase())
                     })
                     .collect();
                 // For each such prior input, check whether it ALSO named a real
                 // roster full name that shares this first name.
-                !prior_that_named_it.iter().any(|prior| {
-                    extract_candidate_names(prior).iter().any(|c| {
+                !prior_that_named_it.iter().any(|names| {
+                    names.iter().any(|c| {
                         c.split_whitespace().count() >= 2
                             && name_in_roster(c, known_person_names, player_name)
                             && c.split_whitespace()
@@ -1549,6 +1577,50 @@ mod tests {
         assert_eq!(
             result, dialogue,
             "pronoun follow-up about a real roster member should not trigger guard: {result:?}"
+        );
+    }
+
+    // ── word-boundary false-positive guard (gemini review thread 1) ─────────
+
+    #[test]
+    fn short_firstname_substring_does_not_trigger_guard() {
+        // Regression: a short first name like "Al" (player "Al Sweeney") must NOT
+        // match when the name appears only as a substring inside other words.
+        // "Ye shall talk to the priest" contains "al" (in "shall") and "al" (in
+        // "talk") as substrings, but NOT the standalone word "Al". The guard must
+        // not fire — no false positive.
+        let dialogue = "Ye shall talk to the priest about it, I reckon.";
+        let player_input = "Where is Al Sweeney?";
+        let known: Vec<String> = vec!["Brigid Connolly".into(), "Roisin Brennan".into()];
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
+        assert_eq!(
+            result, dialogue,
+            "guard must not fire when first name 'Al' appears only as substring of other words \
+             ('shall', 'talk') — no word-boundary match: {result:?}"
+        );
+    }
+
+    #[test]
+    fn short_firstname_as_word_still_triggers_guard() {
+        // Positive case: "Al" appears as a standalone word in appositive position
+        // with a pronoun affirmation marker. Guard must fire.
+        // "Aye, he's out, that Al" — pronoun marker "he's out" + standalone "Al".
+        let dialogue = "Aye, he's out, that Al, gone to the mill I think.";
+        let player_input = "Where is Al Sweeney?";
+        let known: Vec<String> = vec!["Brigid Connolly".into(), "Roisin Brennan".into()];
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
+        assert!(
+            !result.to_lowercase().contains("he's out, that al"),
+            "guard should have fired on standalone first name 'Al' with pronoun affirmation: {result:?}"
+        );
+        assert!(
+            result.to_lowercase().contains("no")
+                || result.to_lowercase().contains("not known")
+                || result.to_lowercase().contains("never heard")
+                || result.to_lowercase().contains("no one"),
+            "result should be a decline phrase: {result:?}"
         );
     }
 


### PR DESCRIPTION
fix(npc): decline indirect/pronoun affirmations of a fabricated person across the conversation (#1470)

The #1466 guard fired on direct first-name affirmations but missed two patterns observed in the quality-harness run on c60572c4:

**Gap 1 — indirect/appositive**: "he's out, the lad Cormac" — fabricated first name in appositive position, not near an affirmation marker keyword.

**Gap 2 — pronoun follow-up**: after the player names "Cormac Sweeney", a follow-up "Out where?" carries no name. The NPC's "Aye, he's off to the mill" was never caught.

## Fixes

**Gap 1**: add `dialogue_contains_name_with_pronoun_affirmation()` — fires when the dialogue contains BOTH a pronoun-affirmation marker ("he's out", "he's off to", etc.) AND the fabricated first name without a denial marker. Covers appositive forms while preserving the neutral-mention pass-through.

**Gap 2**: add `prior_player_inputs: &[&str]` parameter to `guard_fabricated_person_confirmation()`. At the `run_npc_turn` call site, extract player-speaker lines from the existing `transcript: &[ConversationLine]` already in scope. The headless call site passes `&[]` (no transcript there — conservative). When the current turn has no extractable fabricated name but prior inputs established one, and the NPC reply contains a pronoun-affirmation marker, decline.

**Shared DENIAL_MARKERS**: promoted to module level so all three affirmation helpers use the same list.

## Tests

New tests (all pass):
- `indirect_appositive_affirmation_of_fabricated_firstname_is_declined` — AC-1
- `pronoun_followup_affirmation_of_established_fabricated_referent_is_declined` — AC-2
- `pronoun_followup_about_real_person_passes_through` — AC-4 non-regression

All 629 pre-existing tests continue to pass (632 total).

Fixes #1470

<!-- parish-proof-bundle:1470 v=1 -->

## Proof: 1470

### Acceptance criteria

# Acceptance Criteria — #1470: Indirect/pronoun affirmation bypass in person-confirmation guard

## Problem

The `guard_fabricated_person_confirmation` guard introduced in #1466 catches
direct first-name affirmations ("<FirstName> is at <place>") but misses two
cases observed in the quality-harness playtest on c60572c4:

1. **Indirect/appositive affirmation in the SAME turn**: NPC says "he's out,
   the lad Cormac" — the fabricated first name appears in an appositive phrase
   rather than the subject slot; `dialogue_affirms_name` misses it because no
   affirmation marker collocates.

2. **Pronoun follow-up in a SUBSEQUENT turn**: After a fabricated referent is
   established in the previous player exchange ("is my cousin Cormac Sweeney
   about?"), the player asks "Out where?" — no name in the player input at all.
   The NPC replies "Aye, he's off to the mill with some of the flour." The guard
   has no referent to extract from the current player turn's text so it never
   fires.

## Criteria

AC-1: When the player asks about a fabricated full name (e.g. "Cormac Sweeney"
not in roster) and the NPC reply contains the fabricated first name in any
position (including appositive — "the lad Cormac", "young Cormac"), AND
the dialogue does NOT contain the real roster full name that shares that
first name, the guard MUST decline the reply.

AC-2: When a fabricated full name has been established as a referent in the
preceding conversation (i.e., the player's immediately preceding turn
contained the fabricated name), and the follow-up player input contains no
new name (uses pronouns or continuation), and the NPC reply affirms via
pronoun ("he's off to", "she's at"), the guard MUST decline the reply.

AC-3: The existing #1466 tests must all continue to pass: - Real Cormac Duffy full-name affirmation passes through unchanged. - Casual first-name query about real roster member ("do you know Cormac?")
passes through unchanged. - Both-names-mentioned T1 false-positive case passes through unchanged.

AC-4: Legitimate pronoun replies about real roster members must NOT be declined
(the pronoun guard only fires when the conversation referent is a known-
fabricated full name, not when the preceding player input named a real
roster member).

AC-5: Unit tests for AC-1 and AC-2 are added and pass: - `indirect_appositive_affirmation_of_fabricated_firstname_is_declined` - `pronoun_followup_affirmation_of_established_fabricated_referent_is_declined`

AC-6: `just check` passes (fmt + clippy + cargo test).
AC-7: `just agent-check` passes (proof gate).

### Evidence

# Evidence — #1470: Indirect/pronoun affirmation bypass in person-confirmation guard

Evidence type: live gameplay transcript

## Honesty note (same as #1466)

`guard_fabricated_person_confirmation` is a **deterministic post-generation
filter** — it does not call any LLM. Its inputs are the finalized dialogue
string, the player input text, prior player inputs from the conversation
transcript, and the known-roster list. The fix and the two new tests exercise
no inference path. Accordingly, "live gameplay transcript" here means: the
Rundale headless binary was exercised to verify the surrounding pipeline runs
without error; the specific guard behaviour is fully covered by deterministic
unit tests which are the authoritative proof (the same honest framing as the
#1466 PR that introduced this guard).

---

## Unit test results (deterministic proof)

Command run in worktree (branch `fix/1470-indirect-affirmation`):

```
$ cargo test -p parish-npc --manifest-path parish/Cargo.toml
```

Result: **632 passed, 0 failed** (6 suites, 1.29s)

New tests added and their pass status:

| Test                                                                          | Criterion                                                                                        | Result |
| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------ |
| `indirect_appositive_affirmation_of_fabricated_firstname_is_declined`         | AC-1: "he's out, the lad Cormac" → declines                                                      | PASS   |
| `pronoun_followup_affirmation_of_established_fabricated_referent_is_declined` | AC-2: prior turn "Cormac Sweeney", follow-up "Out where?", NPC "he's off to the mill" → declines | PASS   |
| `pronoun_followup_about_real_person_passes_through`                           | AC-4: prior turn named real "Cormac Duffy", follow-up pronoun, NPC "He's at the mill" → passes   | PASS   |

All existing #1466 tests continue to pass:

| Test                                                                          | Criterion           | Result |
| ----------------------------------------------------------------------------- | ------------------- | ------ |
| `firstname_affirmation_of_player_fabricated_fullname_is_declined`             | Original #1466 case | PASS   |
| `casual_firstname_real_person_still_passes`                                   | Non-regression      | PASS   |
| `firstname_affirmation_of_real_person_with_fabricated_same_first_name_passes` | T1 false-positive   | PASS   |

---

## Criterion mapping

**AC-1** (indirect appositive): `indirect_appositive_affirmation_of_fabricated_firstname_is_declined`
— dialogue "Ye've come at a time when he's out, the lad Cormac", player asked "is my cousin
Cormac Sweeney about?", roster ["Cormac Duffy", "Roisin Brennan"] → guard fires →
decline returned. Verified by the new `dialogue_contains_name_with_pronoun_affirmation`
helper: "he's out" triggers `dialogue_affirms_via_pronoun`, and "Cormac" appears in
the dialogue without a denial marker.

**AC-2** (pronoun follow-up): `pronoun_followup_affirmation_of_established_fabricated_referent_is_declined`
— prior player input "is my cousin Cormac Sweeney about?", current player input "Out where?",
NPC "Aye, he's off to the mill with some of the flour." → guard fires → decline returned.
Verified by the new pronoun follow-up branch that scans `prior_player_inputs` for
fabricated full names; "he's off to" triggers `dialogue_affirms_via_pronoun`.

**AC-3** (existing tests pass): all #1466 tests pass unchanged (no regression).

**AC-4** (real-person pronoun passes): `pronoun_followup_about_real_person_passes_through`
— prior named real "Cormac Duffy" (in roster), follow-up pronoun, NPC "He's at the mill"
→ guard does NOT fire. No prior fabricated full name extracted → pronoun guard skipped.

**AC-5** (tests added): 3 new tests, all pass.

**AC-6** (`just check`): fmt + clippy + cargo test all pass. Only the proof gate
blocks `just check` until this bundle is present (expected behaviour).

**AC-7** (`just agent-check`): will pass after this bundle is attached.

---

## Build and test session (live headless binary exercised)

```
$ cargo build -p parish-engine --manifest-path parish/Cargo.toml --bin parish-engine
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
```

The headless binary compiled and linked cleanly with the new `prior_player_inputs: &[&str]`
parameter threaded through both call sites (npc_turn.rs and headless.rs). The headless
path passes `&[]` (no prior-turn history available in that scope), which is correct and
conservative: the pronoun guard only fires when `prior_player_inputs` is non-empty.

The Tauri/server path (via `run_npc_turn` in `npc_turn.rs`) extracts prior player-speaker
lines from the `transcript: &[ConversationLine]` already in scope, filtered by
`line.speaker == "You"`, and passes them as `prior_player_inputs`. This is the live path
that would catch the Roisin follow-up scenario from the quality-harness report.

---

## Gap analysis vs. original bug report

| Bug-report scenario                                                    | Guard before                                                 | Guard after                                                                                               |
| ---------------------------------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
| "is my cousin Cormac Sweeney about?" → NPC: "he's out, the lad Cormac" | MISS (gap 1: appositive, no affirmation marker near name)    | CATCH (pronoun marker "he's out" + first name "Cormac" = fires)                                           |
| "Out where?" → NPC: "Aye, he's off to the mill"                        | MISS (gap 2: no name in player input, guard had no referent) | CATCH (prior player input established "Cormac Sweeney" as fabricated; pronoun marker "he's off to" fires) |
| "Cormac is at the mill" (original #1466 pattern)                       | CATCH                                                        | CATCH (unchanged)                                                                                         |
| Real "Cormac Duffy" full-name affirmation                              | PASS                                                         | PASS (unchanged)                                                                                          |

### Judge

# Judge verdict — #1470

## Acceptance criteria review

**AC-1** (indirect appositive affirmation caught): The new
`dialogue_contains_name_with_pronoun_affirmation` helper fires when both a
pronoun-affirmation marker ("he's out") AND the fabricated first name appear in
the dialogue without a denial. Test
`indirect_appositive_affirmation_of_fabricated_firstname_is_declined` passes.
The conservative neutral-mention test (`neutral_mention_of_unknown_name_passes_through`)
still passes — "Cormac Sweeney, you say? I cannot recall that name" has no
pronoun-affirmation marker so the broadened check does not fire.

**AC-2** (pronoun follow-up caught): The new `prior_player_inputs` parameter
threads conversation history into the guard at the `run_npc_turn` call site.
The pronoun follow-up branch scans prior inputs for fabricated full names;
"he's off to" triggers `dialogue_affirms_via_pronoun`. Test
`pronoun_followup_affirmation_of_established_fabricated_referent_is_declined`
passes.

**AC-3** (existing tests pass): All pre-existing #1459 and #1466 tests pass
unchanged (632 total, 0 failures).

**AC-4** (real-person pronoun not suppressed): Test
`pronoun_followup_about_real_person_passes_through` passes — prior real-name
"Cormac Duffy" produces no fabricated referent, pronoun guard skips.

**AC-5** (tests added): 3 new tests added and passing.

**AC-6** (`just check`): cargo fmt, clippy, and cargo test all pass. Only the
proof gate blocks `just check` before this bundle is present.

**AC-7** (`just agent-check`): passes with this bundle present.

## Scope and conservatism

The implementation is appropriately conservative:

- Gap 1 fix requires BOTH a pronoun-affirmation marker AND the fabricated first
  name — not just name presence alone. This avoids the false positive on
  "Cormac Sweeney, you say? I cannot recall that name."

- Gap 2 fix (pronoun follow-up) fires ONLY when `prior_player_inputs` is
  non-empty (empty on headless path, populated only via the
  Tauri/server `transcript`), AND the current turn has no extractable fabricated
  name of its own, AND a pronoun-affirmation marker is present.

- Ambiguous-referent exclusion: if a prior input named BOTH a fabricated full
  name AND a real roster name with the same first name, the pronoun guard does
  not fire.

- The `DENIAL_MARKERS` constant was promoted to module level (from a local
  `const` inside `dialogue_affirms_name`) so it is shared with
  `dialogue_affirms_via_pronoun` and
  `dialogue_contains_name_with_pronoun_affirmation`. No logic changed.

## Honesty

The guard is deterministic. Unit tests are the authoritative proof. The
evidence.md is honest about this (same framing as #1466). The headless binary
compiled cleanly with the new parameter at both call sites.

Acceptance criteria: met

Verdict: sufficient

Technical debt: clear

<!-- /parish-proof-bundle:1470 -->