### PR TITLE
fix(scripts): shfmt-format launch-tauri-screenshottable helper

### DIFF
--- a/parish/scripts/launch-tauri-screenshottable.sh
+++ b/parish/scripts/launch-tauri-screenshottable.sh
@@ -39,8 +39,8 @@ else
         curl -sf -o /dev/null "http://localhost:${VITE_PORT}" 2>/dev/null && break
         sleep 1
     done
-    curl -sf -o /dev/null "http://localhost:${VITE_PORT}" 2>/dev/null ||
-        {
+    curl -sf -o /dev/null "http://localhost:${VITE_PORT}" 2>/dev/null \
+        || {
             echo "ERROR: vite did not come up on :${VITE_PORT} (see ${VITE_LOG})"
             exit 1
         }
@@ -59,8 +59,8 @@ for _ in $(seq 1 120); do
     curl -sf "http://127.0.0.1:${PORT}/api/health" >/dev/null 2>&1 && break
     sleep 1
 done
-curl -sf "http://127.0.0.1:${PORT}/api/health" >/dev/null 2>&1 ||
-    {
+curl -sf "http://127.0.0.1:${PORT}/api/health" >/dev/null 2>&1 \
+    || {
         echo "ERROR: parish-tauri health never came up on :${PORT} (see ${TAURI_LOG})"
         exit 1
     }


### PR DESCRIPTION
## What

Run the repo's shfmt config (`-i 4 -ci -bn`) over `parish/scripts/launch-tauri-screenshottable.sh`. Pure formatting — `||` continuations moved to line-start with `\`.

## Why

That helper (added in #1474) was never shfmt-clean under `-bn`, so the **Shell quality (shellcheck + shfmt)** job has been red on `main` since #1474 merged (main CI failure @ 7302c50a). That failure trips the aggregate **CI gate**, which blocks merging every open PR. This unblocks the queue.

## Verification

- `shfmt -i 4 -ci -bn -l $(git ls-files '*.sh')` → empty (all clean)
- Script-only change; no Rust/UI/proof-relevant paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)