### PR TITLE
test(npc): fail loud when arrival-greeting fixture lacks a guaranteed greeter

### DIFF
--- a/parish/crates/parish-core/src/game_session.rs
+++ b/parish/crates/parish-core/src/game_session.rs
@@ -1340,10 +1340,8 @@ mod tests {
         let Some((mut world, mut mgr, templates, transport)) = setup() else {
             return;
         };
-        let Some((origin, _dest, dest_name)) = find_one_hop_to_guaranteed_greeter(&world, &mgr)
-        else {
-            return;
-        };
+        let (origin, _dest, dest_name) = find_one_hop_to_guaranteed_greeter(&world, &mgr)
+            .expect("default mod must provide a one-hop arrival with a guaranteed greeter");
         world.player_location = origin;
 
         let effects = apply_movement(
@@ -1374,10 +1372,8 @@ mod tests {
         let Some((mut world, mut mgr, templates, transport)) = setup() else {
             return;
         };
-        let Some((origin, _dest, dest_name)) = find_one_hop_to_guaranteed_greeter(&world, &mgr)
-        else {
-            return;
-        };
+        let (origin, _dest, dest_name) = find_one_hop_to_guaranteed_greeter(&world, &mgr)
+            .expect("default mod must provide a one-hop arrival with a guaranteed greeter");
         world.player_location = origin;
 
         let mut flags = FeatureFlags::default();


### PR DESCRIPTION
## What

Replaces the two silent `else { return }` bypasses in the `npc-arrival-greetings` gate tests with `.expect(...)`, so the tests fail loudly if the default mod ever stops providing a one-hop arrival with a guaranteed greeter.

## Why

Follow-up to gemini's review on #1483 (merged): a silent return on `find_one_hop_to_guaranteed_greeter() == None` can mask a regression as a passing-but-skipped test. Since `setup()` already loaded the default mod, a guaranteed greeter is an invariant — its absence is a real failure, not a skip. The `setup()`-absent skip is preserved (the mod can legitimately be missing in some CI environments).

## Verification

- `cargo test -p parish-core --lib game_session` → 30 passed (incl. both gate tests)
- `cargo fmt --check` clean, `cargo clippy -p parish-core -- -D warnings` clean

Test-only change; no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- parish-proof-bundle:npc-arrival-greetings-test-expect v=1 -->

## Proof: npc-arrival-greetings-test-expect

### Acceptance criteria

# Acceptance Criteria: npc-arrival-greetings-test-expect

## Task

Follow-up to gemini's review on #1483. The two `npc-arrival-greetings` gate
tests in `parish-core/src/game_session.rs` silently `return`ed when
`find_one_hop_to_guaranteed_greeter` yielded `None` — a silent test bypass that
could mask a regression as a passing-but-skipped test. Since `setup()` already
loaded the default mod, a guaranteed greeter is an invariant, so replace the
`else { return }` with `.expect(...)` (fail loud). Test-only change; no runtime
behavior change. The `setup()`-absent skip is preserved (the mod can
legitimately be missing in some CI environments).

## Criteria

- **AC1 — tests still pass with a real greeter** — both
  `apply_movement_suppresses_arrival_greetings_when_flag_off` and
  `apply_movement_emits_arrival_greetings_when_flag_enabled` resolve a guaranteed
  greeter from the default mod and pass. Observable via: `cargo test -p
parish-core --lib game_session`.
- **AC2 — fails loud on a missing greeter** — the greeter lookup is now
  `.expect("default mod must provide a one-hop arrival with a guaranteed
greeter")`; absence panics instead of silently skipping. Verified by code +
  the fact the tests execute their asserts (a skip would show no greeter).
- **AC3 — no runtime behavior change** — only `#[cfg(test)]` code changed; the
  `npc-arrival-greetings` feature behaves exactly as in #1483. Observable via the
  headless fixture transcript (arrivals silent at default, greetings on enable).

## Verification script

Run: `cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_npc-arrival-greetings.txt`
and `cargo test -p parish-core --lib game_session`.

### Evidence

Evidence type: gameplay transcript

# Evidence: npc-arrival-greetings-test-expect

Non-live form: this is a **test-only** change (only `#[cfg(test)]` code in
`game_session.rs`), so it ships no runtime behavior. The transcript below is the
unchanged `npc-arrival-greetings` feature behavior (proving AC3), and the unit
test run proves AC1/AC2.

Source transcript: `.proofs/npc-arrival-greetings-test-expect/transcript.txt`
Captured by: `cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_npc-arrival-greetings.txt`

## Criterion → evidence mapping

- **AC1 — tests pass with a real greeter** — `cargo test -p parish-core --lib
game_session` → `test result: ok. 30 passed`, including
  `apply_movement_suppresses_arrival_greetings_when_flag_off ... ok` and
  `apply_movement_emits_arrival_greetings_when_flag_enabled ... ok`. The enabled
  test asserting a non-empty reaction proves a guaranteed greeter was resolved
  (so `.expect` did not panic).
- **AC2 — fails loud on missing greeter** — the source now reads
  `find_one_hop_to_guaranteed_greeter(&world, &mgr).expect("default mod must
provide a one-hop arrival with a guaranteed greeter")`; a `None` would panic.
  The tests reaching their assertions confirms the greeter resolved rather than
  the old silent `return`.
- **AC3 — no runtime behavior change** — transcript turn 3 (`go to the pub`,
  flag off) is silent; turn 8 (flag on) emits `"...I'm Padraig Darcy, the
Publican," they say.`; turn 13 (flag off) silent again — identical to #1483.
  Confirms only test code changed.

### Transcript

```text
{"command":"/status","result":"system_command","response":"Location: Kilteevan Village | Morning | Spring","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["Location: Kilteevan Village | Morning | Spring","A young woman heads off down the road.","An older man heads off down the road.","An older woman with sharp eyes and herb-stained fingers heads off down the road.","A lean, red-haired young man with hard eyes heads off down the road."]}
{"command":"/flags","result":"system_command","response":"No feature flags have been set. Use /flag enable <name> to enable one.","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["No feature flags have been set. Use /flag enable <name> to enable one."]}
{"command":"/npcs","result":"system_command","response":"NPCs here:\n  a small, sharp-eyed old woman wrapped in a shawl — Widow (sharp)","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["NPCs here:\n  a small, sharp-eyed old woman wrapped in a shawl — Widow (sharp)"]}
{"command":"go to the pub","result":"moved","to":"Darcy's Pub","minutes":14,"narration":"You set off along the road north past low fields to the crossroads toward Darcy's Pub. (14 minutes on foot)","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["You set off along the road north past low fields to the crossroads toward Darcy's Pub. (14 minutes on foot)","","A farmer nods to you from the far side of a gate as you pass.","The warm interior of Darcy's Pub. Turf smoke hangs in the air. Old prints of hurling matches line the walls beside a faded map of the county. A fiddle sits propped in the corner. It is morning and the weather outside is clear.\nYou can go to: The Crossroads (1 min on foot)","  · You hear a man singing to himself — thin and reedy — before you see him around the bend."]}
{"command":"/npcs","result":"system_command","response":"NPCs here:\n  a young woman — Publican's Daughter (restless)\n  an older man behind the bar — Publican (content)","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["NPCs here:\n  a young woman — Publican's Daughter (restless)\n  an older man behind the bar — Publican (content)"]}
{"command":"/flag enable npc-arrival-greetings","result":"system_command","response":"Feature 'npc-arrival-greetings' enabled.","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["Feature 'npc-arrival-greetings' enabled."]}
{"command":"/flags","result":"system_command","response":"Feature flags:\n  [on ] npc-arrival-greetings","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["Feature flags:\n  [on ] npc-arrival-greetings"]}
{"command":"go to the crossroads","result":"moved","to":"The Crossroads","minutes":1,"narration":"You walk along the lane back to the crossroads. (1 minute on foot)","location":"The Crossroads","time":"Morning","season":"Spring","new_log_lines":["You walk along the lane back to the crossroads. (1 minute on foot)","","A quiet crossroads where four narrow roads meet. A weathered stone wall lines the eastern side, half-hidden by brambles. The clear sky stretches over the flat midlands. It is morning.\nYou can go to: Darcy's Pub (1 min on foot), St. Brigid's Church (11 min on foot), The Letter Office (4 min on foot), The Hedge School (2 min on foot), Connolly's Shop (1 min on foot), Kilteevan Village (13 min on foot), The Hurling Green (4 min on foot)","  · A boy and his dog come up the road behind you, pass you at a run, and are gone."]}
{"command":"go to the pub","result":"moved","to":"Darcy's Pub","minutes":1,"narration":"You walk along a short lane past a row of cottages. (1 minute on foot)","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["\"Niamh,\" they say with a nod. \"I'm the Publican's Daughter here.\"","\"I'm Padraig Darcy, the Publican here. You're welcome,\" they say.","You walk along a short lane past a row of cottages. (1 minute on foot)","","The warm interior of Darcy's Pub. Turf smoke hangs in the air. Old prints of hurling matches line the walls beside a faded map of the county. A fiddle sits propped in the corner. It is morning and the weather outside is clear.\nYou can go to: The Crossroads (1 min on foot)","  · An older woman sitting on a wall watches you approach, watches you pass, says nothing."]}
{"command":"/npcs","result":"system_command","response":"NPCs here:\n  Niamh Darcy — Publican's Daughter (restless) [introduced]\n  Padraig Darcy — Publican (content) [introduced]","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["NPCs here:\n  Niamh Darcy — Publican's Daughter (restless) [introduced]\n  Padraig Darcy — Publican (content) [introduced]"]}
{"command":"/flag disable npc-arrival-greetings","result":"system_command","response":"Feature 'npc-arrival-greetings' disabled.","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["Feature 'npc-arrival-greetings' disabled."]}
{"command":"/flags","result":"system_command","response":"Feature flags:\n  [off] npc-arrival-greetings","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["Feature flags:\n  [off] npc-arrival-greetings"]}
{"command":"go to the crossroads","result":"moved","to":"The Crossroads","minutes":1,"narration":"You walk along the lane back to the crossroads. (1 minute on foot)","location":"The Crossroads","time":"Morning","season":"Spring","new_log_lines":["You walk along the lane back to the crossroads. (1 minute on foot)","","A quiet crossroads where four narrow roads meet. A weathered stone wall lines the eastern side, half-hidden by brambles. The clear sky stretches over the flat midlands. It is morning.\nYou can go to: Darcy's Pub (1 min on foot), St. Brigid's Church (11 min on foot), The Letter Office (4 min on foot), The Hedge School (2 min on foot), Connolly's Shop (1 min on foot), Kilteevan Village (13 min on foot), The Hurling Green (4 min on foot)","  · You hear a man singing to himself — thin and reedy — before you see him around the bend."]}
{"command":"go to the pub","result":"moved","to":"Darcy's Pub","minutes":1,"narration":"You walk along a short lane past a row of cottages. (1 minute on foot)","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["You walk along a short lane past a row of cottages. (1 minute on foot)","","The warm interior of Darcy's Pub. Turf smoke hangs in the air. Old prints of hurling matches line the walls beside a faded map of the county. A fiddle sits propped in the corner. It is morning and the weather outside is clear.\nYou can go to: The Crossroads (1 min on foot)"]}
{"command":"/npcs","result":"system_command","response":"NPCs here:\n  Niamh Darcy — Publican's Daughter (restless) [introduced]\n  Padraig Darcy — Publican (content) [introduced]","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["NPCs here:\n  Niamh Darcy — Publican's Daughter (restless) [introduced]\n  Padraig Darcy — Publican (content) [introduced]"]}
{"command":"Good day to you. I have just arrived in the parish.","result":"npc_not_available","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["Niamh Darcy 😊","Padraig Darcy 😊"]}
{"command":"/npcs","result":"system_command","response":"NPCs here:\n  Niamh Darcy — Publican's Daughter (restless) [introduced]\n  Padraig Darcy — Publican (content) [introduced]","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["NPCs here:\n  Niamh Darcy — Publican's Daughter (restless) [introduced]\n  Padraig Darcy — Publican (content) [introduced]"]}
{"command":"/speed fast","result":"system_command","response":"The parish quickens its step.","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["The parish quickens its step."]}
{"command":"/wait 240","result":"system_command","response":"You wait for 240 minutes...\nIt is now 12:18 Midday.","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["You wait for 240 minutes...\nIt is now 12:18 Midday."]}
{"command":"/time","result":"system_command","response":"12:18 Midday — Spring\nWeather: Clear\nSpeed: 72x\nFestival: none","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["12:18 Midday — Spring\nWeather: Clear\nSpeed: 72x\nFestival: none"]}
{"command":"/debug npcs","result":"system_command","response":"[DEBUG NPCS]\n  Padraig Darcy (58y, Publican)\n    Loc: Darcy's Pub | Tier1 | Mood: 🙂 content | Present\n  Siobhan Murphy (45y, Farmer)\n    Loc: Murphy's Farm | Tier3 | Mood: 💪 determined | Present\n  Fr. Declan Tierney (62y, Parish Priest)\n    Loc: St. Brigid's Church | Tier2 | Mood: 🤔 contemplative | Present\n  Roisin Connolly (38y, Shopkeeper)\n    Loc: Connolly's Shop | Tier2 | Mood: 👀 alert | Present\n  Tommy O'Brien (70y, Retired Farmer)\n    Loc: O'Brien's Farm | Tier1 | Mood: 🤔 reflective | -> Darcy's Pub (13:16)\n  Aoife Brennan (29y, Hedge School Teacher)\n    Loc: The Hedge School | Tier2 | Mood: 🔥 passionate | Present\n  Mick Flanagan (65y, Retired Constable)\n    Loc: The Bog Road | Tier3 | Mood: 👀 watchful | -> The Lime Kiln (12:54)\n  Niamh Darcy (22y, Publican's Daughter)\n    Loc: Darcy's Pub | Tier1 | Mood: 😟 restless | Present\n  Seamus Gallagher (42y, Blacksmith)\n    Loc: The Forge | Tier3 | Mood: 😊 cheerful | Present\n  Maire Gallagher (39y, Blacksmith's Wife)\n    Loc: Connolly's Shop | Tier2 | Mood: ⏳ busy | -> The Forge (12:33)\n  Colm Gallagher (15y, Blacksmith's Apprentice)\n    Loc: The Forge | Tier3 | Mood: 🤩 eager | Present\n  Cormac Duffy (50y, Miller)\n    Loc: The Mill | Tier3 | Mood: 🧐 calculating | Present\n  Nora Duffy (46y, Miller's Wife)\n    Loc: The Holy Well | Tier3 | Mood: 😰 anxious | -> The Mill (12:20)\n  Brendan Duffy (19y, Miller's Son)\n    Loc: The Mill | Tier3 | Mood: 😟 restless | Present\n  Eamon Walsh (35y, Boatman)\n    Loc: Hodson Bay | Tier3 | Mood: 🤨 wary | -> The Boatman's Cottage (12:20)\n  Kathleen Walsh (30y, Fisherman's Wife)\n    Loc: The Boatman's Cottage | Tier3 | Mood: 🤗 warm | -> Hodson Bay (12:20)\n  Ciaran Walsh (8y, Child)\n    Loc: The Boatman's Cottage | Tier3 | Mood: 🧐 curious | Present\n  Liam Murphy (16y, Farm Boy)\n    Loc: The Hedge School | Tier2 | Mood: 😐 quiet | -> Murphy's Farm (12:54)\n  Brigid Ni Fhatharta (56y, Midwife)\n    Loc: The Holy Well | Tier2 | Mood: 👀 watchful | -> Kilteevan Village (12:19)\n  Una Malone (48y, Weaver)\n    Loc: The Weaver's Cottage | Tier3 | Mood: 🙂 content | Present\n  Sean Ruadh Kelly (26y, Labourer)\n    Loc: Murphy's Farm | Tier3 | Mood: 😒 bitter | Present\n  Peig Hannigan (67y, Widow)\n    Loc: Kilteevan Village | Tier2 | Mood: 😤 sharp | -> The Crossroads (12:31)\n  Martin Concannon (33y, Land Agent's Clerk)\n    Loc: The Letter Office | Tier2 | Mood: 😐 guarded | Present","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["[DEBUG NPCS]","  Padraig Darcy (58y, Publican)","    Loc: Darcy's Pub | Tier1 | Mood: 🙂 content | Present","  Siobhan Murphy (45y, Farmer)","    Loc: Murphy's Farm | Tier3 | Mood: 💪 determined | Present","  Fr. Declan Tierney (62y, Parish Priest)","    Loc: St. Brigid's Church | Tier2 | Mood: 🤔 contemplative | Present","  Roisin Connolly (38y, Shopkeeper)","    Loc: Connolly's Shop | Tier2 | Mood: 👀 alert | Present","  Tommy O'Brien (70y, Retired Farmer)","    Loc: O'Brien's Farm | Tier1 | Mood: 🤔 reflective | -> Darcy's Pub (13:16)","  Aoife Brennan (29y, Hedge School Teacher)","    Loc: The Hedge School | Tier2 | Mood: 🔥 passionate | Present","  Mick Flanagan (65y, Retired Constable)","    Loc: The Bog Road | Tier3 | Mood: 👀 watchful | -> The Lime Kiln (12:54)","  Niamh Darcy (22y, Publican's Daughter)","    Loc: Darcy's Pub | Tier1 | Mood: 😟 restless | Present","  Seamus Gallagher (42y, Blacksmith)","    Loc: The Forge | Tier3 | Mood: 😊 cheerful | Present","  Maire Gallagher (39y, Blacksmith's Wife)","    Loc: Connolly's Shop | Tier2 | Mood: ⏳ busy | -> The Forge (12:33)","  Colm Gallagher (15y, Blacksmith's Apprentice)","    Loc: The Forge | Tier3 | Mood: 🤩 eager | Present","  Cormac Duffy (50y, Miller)","    Loc: The Mill | Tier3 | Mood: 🧐 calculating | Present","  Nora Duffy (46y, Miller's Wife)","    Loc: The Holy Well | Tier3 | Mood: 😰 anxious | -> The Mill (12:20)","  Brendan Duffy (19y, Miller's Son)","    Loc: The Mill | Tier3 | Mood: 😟 restless | Present","  Eamon Walsh (35y, Boatman)","    Loc: Hodson Bay | Tier3 | Mood: 🤨 wary | -> The Boatman's Cottage (12:20)","  Kathleen Walsh (30y, Fisherman's Wife)","    Loc: The Boatman's Cottage | Tier3 | Mood: 🤗 warm | -> Hodson Bay (12:20)","  Ciaran Walsh (8y, Child)","    Loc: The Boatman's Cottage | Tier3 | Mood: 🧐 curious | Present","  Liam Murphy (16y, Farm Boy)","    Loc: The Hedge School | Tier2 | Mood: 😐 quiet | -> Murphy's Farm (12:54)","  Brigid Ni Fhatharta (56y, Midwife)","    Loc: The Holy Well | Tier2 | Mood: 👀 watchful | -> Kilteevan Village (12:19)","  Una Malone (48y, Weaver)","    Loc: The Weaver's Cottage | Tier3 | Mood: 🙂 content | Present","  Sean Ruadh Kelly (26y, Labourer)","    Loc: Murphy's Farm | Tier3 | Mood: 😒 bitter | Present","  Peig Hannigan (67y, Widow)","    Loc: Kilteevan Village | Tier2 | Mood: 😤 sharp | -> The Crossroads (12:31)","  Martin Concannon (33y, Land Agent's Clerk)","    Loc: The Letter Office | Tier2 | Mood: 😐 guarded | Present"]}
{"command":"/status","result":"system_command","response":"Location: Darcy's Pub | Midday | Spring","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["Location: Darcy's Pub | Midday | Spring"]}
```

### Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

# Judge: npc-arrival-greetings-test-expect

## Per-criterion verification

- **AC1 — tests pass with a real greeter**: MET. `cargo test -p parish-core --lib
game_session` → 30 passed, including both gate tests.
- **AC2 — fails loud on missing greeter**: MET. Source uses `.expect(...)` on the
  greeter lookup; the tests reach their asserts, confirming the greeter resolved
  rather than silently skipping.
- **AC3 — no runtime behavior change**: MET. Diff is confined to `#[cfg(test)]`
  code; the transcript shows identical feature behavior to #1483 (silent at
  default, greetings on enable).

## Implementation notes

- Test-only change addressing a gemini review note on the merged #1483. The
  `setup()`-absent skip is intentionally preserved (mod can be missing in some CI
  environments); only the post-`setup()` greeter invariant is now asserted with
  `.expect`.
- `cargo fmt --check` clean, `cargo clippy -p parish-core -- -D warnings` clean.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:npc-arrival-greetings-test-expect -->
