### PR TITLE
fix(npc): runaway-generation guard chain — phrase loop, word cap, roster allowlist

### DIFF
--- a/parish/crates/parish-core/src/ipc/handlers.rs
+++ b/parish/crates/parish-core/src/ipc/handlers.rs
@@ -937,11 +937,27 @@ pub fn prepare_npc_conversation_turn(
          one tone, one beat.\n",
     );
 
-    // Extract plain name strings from the roster for the person-confirmation
-    // guard (#1459). The roster entries are (NpcId, name, occupation); we just
-    // need the names. Player entry (NpcId(0)) is included so the guard correctly
-    // allows the player's own name when it appears in a question.
-    let known_person_names: Vec<String> = roster.iter().map(|(_, name, _)| name.clone()).collect();
+    // Extract plain name strings for the person-confirmation guard (#1459, #1488).
+    //
+    // The guard must never emit a false denial for a REAL parish NPC — even one
+    // the speaking NPC does not personally know. `roster` only contains the NPCs
+    // this NPC has a relationship/co-residence with ("PEOPLE YOU KNOW"), so a
+    // shopkeeper recommended by one NPC but absent from another NPC's roster
+    // would wrongly trigger the guard (#1488: Roisin false-denial bug).
+    //
+    // Fix: seed the known list from ALL parish NPC names, then append the
+    // player entry from the personal roster. This makes the guard conservative:
+    // it only fires for names that do not appear anywhere in the parish registry.
+    let mut known_person_names: Vec<String> =
+        npc_manager.all_npcs().map(|n| n.name.clone()).collect();
+    // Also include the player's name if injected at the front of `roster`.
+    // The player entry has NpcId(0); include it to avoid false-positive on the
+    // player's own name appearing in a question.
+    for (id, name, _) in &roster {
+        if *id == NpcId(0) && !known_person_names.iter().any(|n| n == name) {
+            known_person_names.push(name.clone());
+        }
+    }
 
     // For the wrong-speaker-identity guard (#1475): (name, occupation) pairs
     // for all roster members. Exclude the player entry (NpcId(0)) since the
@@ -1979,5 +1995,94 @@ mod tests {
         );
         // "Father" is absent (ambiguous, treated as unresolvable).
         assert_eq!(result.absent, vec!["Father".to_string()]);
+    }
+
+    /// AC-1 (#1488): `prepare_npc_conversation_turn` must include ALL parish
+    /// NPC names in `known_person_names`, not just those in the speaking NPC's
+    /// personal relationship roster. This prevents the person-confirmation guard
+    /// from emitting a false denial when NPC-A accurately describes NPC-C, who
+    /// is a real parish NPC but not in NPC-A's personal roster.
+    ///
+    /// Repro: priest (NPC 1) has NO relationship with Roisin (NPC 2). When the
+    /// player asks the priest about Roisin, the guard must NOT fire — Roisin is
+    /// in the parish registry even if she's absent from the priest's roster.
+    #[test]
+    fn known_person_names_includes_all_parish_npcs_not_just_roster() {
+        use crate::config::NpcConfig;
+        use crate::npc::{Npc, manager::NpcManager};
+        use crate::world::WorldState;
+
+        let world = WorldState::new();
+        let mut npc_mgr = NpcManager::new();
+
+        // NPC 1: priest (the speaker — has no relationship with Roisin).
+        let mut priest = Npc::new_test_npc();
+        priest.id = NpcId(1);
+        priest.name = "Father Brennan".to_string();
+        priest.occupation = "Parish Priest".to_string();
+        priest.location = world.player_location;
+        npc_mgr.add_npc(priest);
+        npc_mgr.mark_introduced(NpcId(1));
+
+        // NPC 2: Roisin — a shopkeeper the priest does NOT have a relationship with.
+        let mut roisin = Npc::new_test_npc();
+        roisin.id = NpcId(2);
+        roisin.name = "Roisin Malone".to_string();
+        roisin.occupation = "Shopkeeper".to_string();
+        // Roisin is at a different location — not co-located with the priest.
+        // So she would NOT appear in the priest's `known_roster`.
+        roisin.location = world
+            .graph
+            .location_ids()
+            .into_iter()
+            .find(|l| *l != world.player_location)
+            .unwrap_or(world.player_location);
+        npc_mgr.add_npc(roisin);
+
+        let npc_cfg = NpcConfig::default();
+        let language = crate::npc::LanguageSettings::english_only();
+
+        let setup = prepare_npc_conversation_turn(
+            &world,
+            &mut npc_mgr,
+            "Where can I find Roisin Malone?",
+            NpcId(1), // priest speaks
+            &[],
+            false,
+            &language,
+            &npc_cfg,
+        );
+
+        let setup = setup.expect("setup must succeed for co-located NPC");
+
+        // The fix: Roisin must appear in known_person_names even though she
+        // is NOT in the priest's personal relationship roster.
+        assert!(
+            setup
+                .known_person_names
+                .iter()
+                .any(|n| n == "Roisin Malone"),
+            "Roisin Malone (a real parish NPC) must appear in known_person_names \
+             even though she has no relationship with the speaking priest (#1488); \
+             got: {:?}",
+            setup.known_person_names
+        );
+
+        // Validate that the person-confirmation guard does NOT fire on a good
+        // reply about Roisin, because she is now in the known list.
+        let good_reply = "Roisin Malone keeps a shop at the crossroads. She is a fine woman.";
+        let guarded = crate::npc::guard_fabricated_person_confirmation(
+            good_reply,
+            "Where can I find Roisin Malone?",
+            &setup.known_person_names,
+            &[],
+            None,
+            0,
+        );
+        assert_eq!(
+            guarded, good_reply,
+            "person-confirmation guard must NOT fire on a real parish NPC (Roisin Malone) \
+             after #1488 fix; got: {guarded:?}"
+        );
     }
 }

--- a/parish/crates/parish-engine/tests/runaway_generation_guards.rs
+++ b/parish/crates/parish-engine/tests/runaway_generation_guards.rs
@@ -106,8 +106,7 @@ fn real_loop_degenerate_phrase_loop_is_collapsed() {
     // Preamble is kept so the NPC isn't silent after guard fires.
     let preamble = "God's blessings upon ye.";
     let loop_phrase = "in His time and His purpose";
-    let loop_part = std::iter::repeat(loop_phrase)
-        .take(15)
+    let loop_part = std::iter::repeat_n(loop_phrase, 15)
         .collect::<Vec<_>>()
         .join(", ");
     let runaway = format!("{preamble} {loop_part}");
@@ -120,7 +119,7 @@ fn real_loop_degenerate_phrase_loop_is_collapsed() {
     let dialogue_texts: Vec<String> = dialogue_events
         .iter()
         .filter_map(|ev| match ev {
-            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.as_ref().map(|s| s.clone()),
+            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.clone(),
             _ => None,
         })
         .collect();
@@ -187,7 +186,7 @@ fn real_loop_overlong_reply_is_word_capped() {
     let dialogue_texts: Vec<String> = dialogue_events
         .iter()
         .filter_map(|ev| match ev {
-            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.as_ref().map(|s| s.clone()),
+            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.clone(),
             _ => None,
         })
         .collect();
@@ -252,7 +251,7 @@ fn real_loop_real_npc_description_not_denied() {
     let shown: Vec<String> = dialogue_events
         .iter()
         .filter_map(|ev| match ev {
-            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.as_ref().map(|s| s.clone()),
+            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.clone(),
             _ => None,
         })
         .collect();

--- a/parish/crates/parish-engine/tests/runaway_generation_guards.rs
+++ b/parish/crates/parish-engine/tests/runaway_generation_guards.rs
@@ -1,0 +1,293 @@
+//! Real-loop integration tests for the runaway-generation guard chain
+//! (#1487, #1488, #1489).
+//!
+//! These tests drive the **real** `parish_core::game_loop` (`execute_via_real_loop`)
+//! with a mock inference client that injects adversarial / degenerate model
+//! responses, then assert the post-generation guards in `run_npc_turn` produce
+//! clean player-visible output.
+//!
+//! # Why `execute_via_real_loop` and not a plain unit test
+//!
+//! The guards for #1487 (`collapse_degenerate_phrase_loop`) and #1489
+//! (`cap_word_count`) are called from `guard_verbosity_runons`, which is
+//! invoked at line 382 of `parish_core::game_loop::npc_turn::run_npc_turn`.
+//! The guard for #1488 (`known_person_names` now includes all parish NPCs) is
+//! set up in `prepare_npc_conversation_turn` (also called from `run_npc_turn`).
+//!
+//! `parish-engine --script` uses the LEGACY `execute()` path which bypasses
+//! `game_loop/npc_turn`, so a plain `--script` fixture would NOT exercise these
+//! guards. `GameTestHarness::execute_via_real_loop` routes through the real
+//! `handle_game_input` → `handle_npc_conversation` → `run_npc_turn` path, so
+//! the guards ARE exercised.
+
+use parish_core::npc::types::NpcState;
+use parish_core::world::events::GameEvent;
+use parish_engine::testing::GameTestHarness;
+
+/// Helper: drain all events from a broadcast receiver.
+fn drain(rx: &mut tokio::sync::broadcast::Receiver<GameEvent>) -> Vec<GameEvent> {
+    let mut out = Vec::new();
+    loop {
+        match rx.try_recv() {
+            Ok(ev) => out.push(ev),
+            Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => continue,
+            Err(_) => break,
+        }
+    }
+    out
+}
+
+/// Sets up a harness with exactly one NPC co-located with the player, clears
+/// other NPCs from the player location, and marks the NPC as introduced so
+/// dialogue routing resolves to them deterministically.
+///
+/// Returns `(harness, npc_name)`.
+fn harness_with_one_npc() -> (GameTestHarness, String) {
+    let mut h = GameTestHarness::new();
+    let player_loc = h.app.world.player_location;
+
+    // Pick the first NPC.
+    let speaker_id = h
+        .app
+        .npc_manager
+        .all_npcs()
+        .map(|n| n.id)
+        .next()
+        .expect("harness loads at least one NPC");
+
+    let speaker_name = {
+        let npc = h
+            .app
+            .npc_manager
+            .get_mut(speaker_id)
+            .expect("speaker exists");
+        npc.location = player_loc;
+        npc.state = NpcState::Present;
+        npc.name.clone()
+    };
+    h.app.npc_manager.mark_introduced(speaker_id);
+
+    // Move every other NPC away so routing is deterministic.
+    let other_loc = h
+        .app
+        .world
+        .graph
+        .location_ids()
+        .into_iter()
+        .find(|l| *l != player_loc)
+        .expect("graph has at least two locations");
+    let others: Vec<_> = h
+        .app
+        .npc_manager
+        .all_npcs()
+        .filter(|n| n.location == player_loc && n.id != speaker_id)
+        .map(|n| n.id)
+        .collect();
+    for id in others {
+        if let Some(n) = h.app.npc_manager.get_mut(id) {
+            n.location = other_loc;
+        }
+    }
+
+    (h, speaker_name)
+}
+
+// ── #1487 — degenerate phrase-loop guard ─────────────────────────────────────
+
+/// AC-1 (#1487, real-loop): When the mock model emits a short phrase repeated
+/// 15× (the priest runaway repro), the player-visible dialogue must NOT contain
+/// that repeated phrase more than once. The guard fires inside `run_npc_turn`
+/// via `guard_verbosity_runons`.
+#[test]
+fn real_loop_degenerate_phrase_loop_is_collapsed() {
+    let (mut h, speaker_name) = harness_with_one_npc();
+
+    // Adversarial mock response: "in His time and His purpose" repeated 15×.
+    // Preamble is kept so the NPC isn't silent after guard fires.
+    let preamble = "God's blessings upon ye.";
+    let loop_phrase = "in His time and His purpose";
+    let loop_part = std::iter::repeat(loop_phrase)
+        .take(15)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let runaway = format!("{preamble} {loop_part}");
+
+    h.mock().push_for(&speaker_name, runaway.clone());
+    let mut rx = h.app.world.event_bus.subscribe();
+    let events = h.execute_via_real_loop(&format!("talk to {speaker_name}"));
+
+    let dialogue_events = drain(&mut rx);
+    let dialogue_texts: Vec<String> = dialogue_events
+        .iter()
+        .filter_map(|ev| match ev {
+            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.as_ref().map(|s| s.clone()),
+            _ => None,
+        })
+        .collect();
+
+    // At least one DialogueOccurred event must have been published.
+    assert!(
+        !dialogue_texts.is_empty(),
+        "expected DialogueOccurred for the NPC turn; got events: {events:?}"
+    );
+
+    // The player-visible text must NOT contain the runaway phrase loop.
+    // At most one occurrence is permitted (the first, kept by the guard).
+    let joined = dialogue_texts.join(" ");
+    let phrase_count = joined
+        .to_lowercase()
+        .matches("in his time and his purpose")
+        .count();
+    assert!(
+        phrase_count <= 1,
+        "degenerate phrase loop must be collapsed to ≤1 occurrence via real game loop; \
+         got {phrase_count}: {joined:?}"
+    );
+
+    // The preamble sentence must survive in the dialogue event.
+    assert!(
+        joined.contains("God's blessings"),
+        "preamble must survive the guard: {joined:?}"
+    );
+}
+
+// ── #1489 — word-count cap guard ─────────────────────────────────────────────
+
+/// AC-1 (#1489, real-loop): When the mock model emits a reply over 80 words,
+/// the `cap_word_count` guard (called from `guard_verbosity_runons` inside
+/// `run_npc_turn`) must produce a player-visible response of ≤ 80 words.
+#[test]
+fn real_loop_overlong_reply_is_word_capped() {
+    let (mut h, speaker_name) = harness_with_one_npc();
+
+    // Build a response that is 3 sentences but ~100 words. Deliberately avoid
+    // title-cased words beyond the first position to prevent false-positive
+    // person-name extraction.
+    let s1 = "A fine morning to ye, friend.";
+    let s2 = "The roads have been fierce hard on everyone this past fortnight and the river \
+        rose three whole feet after the rains came down on tuesday and wednesday and the \
+        landlord sent his agent round to collect the rents before the harvest was even in \
+        which caused great hardship to all the families in the townland and the market at \
+        the crossroads was cancelled on account of the weather as well.";
+    let s3 = "But the sun is shining today and the prices are somewhat better than they were \
+        last year which is a true blessing for the parish and all who live here.";
+    let overlong = format!("{s1} {s2} {s3}");
+    let word_count = overlong.split_whitespace().count();
+    assert!(
+        word_count > 80,
+        "test input must be >80 words, got {word_count}"
+    );
+
+    h.mock().push_for(&speaker_name, overlong);
+    let mut rx = h.app.world.event_bus.subscribe();
+    let events = h.execute_via_real_loop(&format!("talk to {speaker_name}"));
+    let _ = events; // events captured; we inspect via event bus
+
+    let dialogue_events = drain(&mut rx);
+    let dialogue_texts: Vec<String> = dialogue_events
+        .iter()
+        .filter_map(|ev| match ev {
+            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.as_ref().map(|s| s.clone()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !dialogue_texts.is_empty(),
+        "expected DialogueOccurred for the NPC turn"
+    );
+
+    let shown = dialogue_texts.join(" ");
+    let result_words = shown.split_whitespace().count();
+    assert!(
+        result_words <= 80,
+        "player-visible dialogue must be ≤80 words after real-loop word-cap guard; \
+         got {result_words} words: {shown:?}"
+    );
+
+    // The first sentence must survive.
+    assert!(
+        shown.contains("fine morning"),
+        "first sentence must survive the cap: {shown:?}"
+    );
+}
+
+// ── #1488 — no false-denial of real roster NPC ───────────────────────────────
+
+/// AC-1 (#1488, real-loop): When an NPC gives a correct description of a REAL
+/// parish NPC (one who is not in the speaking NPC's personal relationship
+/// roster but IS in the parish registry), the `guard_fabricated_person_confirmation`
+/// guard must NOT fire and must NOT replace the response with a denial.
+///
+/// Previously the guard fired because `known_person_names` only included the
+/// speaking NPC's personal roster. The fix extends it to include all parish NPCs.
+#[test]
+fn real_loop_real_npc_description_not_denied() {
+    let (mut h, speaker_name) = harness_with_one_npc();
+
+    // Find the name of a SECOND real parish NPC (the one we moved away).
+    let other_name: String = {
+        let player_loc = h.app.world.player_location;
+        h.app
+            .npc_manager
+            .all_npcs()
+            .find(|n| n.location != player_loc)
+            .map(|n| n.name.clone())
+            .expect("there must be a second NPC in the parish")
+    };
+
+    // The model accurately describes the other NPC, who is real but NOT in
+    // the speaker's personal roster. Before the fix, this would be replaced
+    // with "I know no one by that name in these parts."
+    let good_reply = format!(
+        "{other_name} is a fine person in this parish. You'll find them at their usual spot."
+    );
+
+    h.mock().push_for(&speaker_name, good_reply.clone());
+    let mut rx = h.app.world.event_bus.subscribe();
+    let events = h.execute_via_real_loop(&format!("talk to {speaker_name} about {other_name}"));
+    let _ = events;
+
+    let dialogue_events = drain(&mut rx);
+    let shown: Vec<String> = dialogue_events
+        .iter()
+        .filter_map(|ev| match ev {
+            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.as_ref().map(|s| s.clone()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !shown.is_empty(),
+        "expected DialogueOccurred for the NPC turn"
+    );
+
+    let joined = shown.join(" ");
+
+    // The guard MUST NOT have replaced the reply with a false denial.
+    assert!(
+        !joined.to_lowercase().contains("know no one by that name"),
+        "real parish NPC description must NOT be replaced with a false denial (#1488); \
+         got: {joined:?}"
+    );
+    assert!(
+        !joined.to_lowercase().contains("not known to me"),
+        "real parish NPC description must NOT be replaced with a false denial (#1488); \
+         got: {joined:?}"
+    );
+    assert!(
+        !joined.to_lowercase().contains("never heard of"),
+        "real parish NPC description must NOT be replaced with a false denial (#1488); \
+         got: {joined:?}"
+    );
+
+    // The good reply should have reached the player (or a truncated version of it).
+    // At minimum the NPC's name must appear (the guard didn't suppress it).
+    // We allow for the cap to have trimmed the reply, so check the name appears.
+    let other_first = other_name.split_whitespace().next().unwrap_or(&other_name);
+    assert!(
+        joined.contains(other_first),
+        "the real NPC's name must survive in the player-visible output (#1488); \
+         got: {joined:?}"
+    );
+}

--- a/parish/crates/parish-engine/tests/runaway_generation_guards.rs
+++ b/parish/crates/parish-engine/tests/runaway_generation_guards.rs
@@ -281,11 +281,11 @@ fn real_loop_real_npc_description_not_denied() {
     );
 
     // The good reply should have reached the player (or a truncated version of it).
-    // At minimum the NPC's name must appear (the guard didn't suppress it).
-    // We allow for the cap to have trimmed the reply, so check the name appears.
-    let other_first = other_name.split_whitespace().next().unwrap_or(&other_name);
+    // The mock reply opens with the full name, so it survives any word-cap; assert
+    // on the FULL name (not just the first name, which could be a common word like
+    // "Father" or "Mary") to avoid a false positive (gemini review #1500).
     assert!(
-        joined.contains(other_first),
+        joined.contains(&other_name),
         "the real NPC's name must survive in the player-visible output (#1488); \
          got: {joined:?}"
     );

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -1461,28 +1461,245 @@ pub fn strip_leaked_mood_word(dialogue: &str) -> String {
     text.to_string()
 }
 
-/// Applies the full verbosity / run-on guard to a finalized dialogue string (#1460, #1472).
+// ── #1487 — degenerate intra-response phrase repetition guard ─────────────────
+//
+// A small quantized model (e.g. Qwen2.5-14B-4bit) can enter a degenerate
+// sampling loop that repeats a short phrase (3–8 words) 10–20 times in a row
+// WITHOUT sentence-terminating punctuation between each occurrence. The result
+// is a wall of near-identical commas-delimited clauses ("in His time and His
+// way, and His purpose… in His time and His way…" × 15) that fills the
+// token cap. `split_sentences` produces ONE entry for the whole wall, so
+// `collapse_repeated_sentences` and `collapse_distributed_repeated_sentences`
+// never see the repetition.
+//
+// This guard operates at the WORD level instead:
+//  1. Split into whitespace-delimited word-tokens.
+//  2. Search for the longest repeated n-gram (n ∈ [3, 8]) that appears ≥
+//     DEGENERATE_REPEAT_MIN times.
+//  3. If found, truncate the text at the END of the FIRST occurrence of that
+//     n-gram so the surviving prefix ends cleanly.
+//
+// Conservative thresholds (n ≥ 3 words, repetitions ≥ 4) prevent false
+// positives on natural repetition like "Aye, aye" or "day by day".
+
+/// Detects and collapses a degenerate intra-response phrase-repetition loop
+/// (#1487 — sub-sentence phrase loop guard).
+///
+/// When a small model repeats a short phrase (3–8 words) four or more times
+/// within a single response (regardless of intervening punctuation), this
+/// function truncates the text at the end of the FIRST occurrence of that
+/// phrase, then trims to the last complete sentence before the loop started.
+///
+/// # Behaviour
+///
+/// - Scans for n-grams of length 3–8 (longest first, to keep the most
+///   context) that appear ≥ 4 times in the word-token sequence.
+/// - On detection, keeps only the text up to (and including) the end byte
+///   position of the first n-gram occurrence, then trims back to the last
+///   sentence-ending punctuation (`.`, `!`, `?`) so the reply ends cleanly.
+/// - If no complete sentence precedes the first occurrence (e.g. the entire
+///   reply IS the loop), returns the first occurrence as-is rather than a
+///   blank.
+/// - Replies without degenerate repetition are returned unchanged.
+///
+/// Exposed as `pub` so the caller in `guard_verbosity_runons` and unit tests
+/// can invoke it directly.
+pub fn collapse_degenerate_phrase_loop(dialogue: &str) -> String {
+    /// Maximum n-gram width to consider. Longer phrases are unlikely to repeat
+    /// 4× within a single NPC reply in legitimate prose.
+    const MAX_NGRAM: usize = 8;
+    /// Minimum n-gram width to consider. Phrases shorter than 3 words are
+    /// too generic ("and the", "in a") to reliably signal degeneration.
+    const MIN_NGRAM: usize = 3;
+    /// Minimum repetition count to trigger the guard. Natural dialogue can
+    /// repeat short phrases 2–3 times ("aye, aye" or consecutive paired
+    /// clauses); 4 repetitions is the degeneration threshold.
+    const MIN_REPEATS: usize = 4;
+
+    let text = dialogue.trim();
+    if text.is_empty() {
+        return String::new();
+    }
+
+    let words: Vec<&str> = text.split_whitespace().collect();
+    let n = words.len();
+    if n < MIN_NGRAM * MIN_REPEATS {
+        // Not enough words for even the shortest degenerate loop.
+        return text.to_string();
+    }
+
+    // Try n-gram widths from largest to smallest so we truncate at the
+    // richest possible context.
+    let mut best: Option<(usize, usize, usize)> = None; // (width, first_start, repeat_count)
+    'outer: for width in (MIN_NGRAM..=MAX_NGRAM).rev() {
+        if width * MIN_REPEATS > n {
+            continue;
+        }
+        // Index every n-gram start position by its normalized token tuple.
+        let mut positions: std::collections::HashMap<Vec<String>, Vec<usize>> =
+            std::collections::HashMap::new();
+        for start in 0..=(n - width) {
+            let key: Vec<String> = words[start..start + width]
+                .iter()
+                .map(|w| normalize_for_repetition(w))
+                .collect();
+            positions.entry(key).or_default().push(start);
+        }
+        for starts in positions.values() {
+            if starts.len() >= MIN_REPEATS {
+                let first = *starts.iter().min().unwrap();
+                let rep = starts.len();
+                // Prefer the n-gram that (a) repeats most, (b) is longest on tie.
+                if best.is_none()
+                    || rep > best.unwrap().2
+                    || (rep == best.unwrap().2 && width > best.unwrap().0)
+                {
+                    best = Some((width, first, rep));
+                }
+                // Found at this width — no need to check further n-grams of
+                // the same width (we already have a candidate). Move to the
+                // next width.
+                break 'outer;
+            }
+        }
+    }
+
+    let Some((width, first_start, _)) = best else {
+        return text.to_string();
+    };
+
+    // The loop was detected. Build the prefix text from words[0..first_start+width]
+    // by re-joining (single space between tokens). This avoids fragile byte-cursor
+    // arithmetic on the original string and is correct for any whitespace variation.
+    let prefix_joined = words[..first_start + width].join(" ");
+    let prefix = prefix_joined.trim_end();
+    if prefix.is_empty() {
+        return text.to_string();
+    }
+
+    // Trim back to the last sentence boundary so the reply ends cleanly.
+    if let Some(last_end) = prefix.rfind(['.', '!', '?']) {
+        let sentence_end = last_end + 1;
+        if sentence_end < prefix.len() {
+            // There is trailing non-sentence content after the last complete
+            // sentence within the prefix — trim it off.
+            return prefix[..sentence_end].trim().to_string();
+        }
+        return prefix.to_string();
+    }
+
+    // No sentence boundary found before the loop: return the prefix as-is
+    // rather than an empty string.
+    prefix.to_string()
+}
+
+// ── #1489 — word-count cap guard ──────────────────────────────────────────────
+//
+// Some generations run 43–47 s and hit the token cap, producing a reply that
+// may be 200+ words across 4 or fewer sentences (so `cap_sentence_count` does
+// not trim it). A word-count cap is the deterministic backstop: if the reply
+// exceeds MAX_WORDS words, trim at the last sentence boundary within the first
+// MAX_WORDS words. This bounds time-to-display and forces the NPC to be concise.
+
+/// Trims a dialogue string to at most `MAX_WORDS` words, cutting back to the
+/// last complete sentence (#1489 — word-count cap guard).
+///
+/// # Behaviour
+///
+/// - Counts whitespace-delimited word tokens. If the total is ≤ `MAX_WORDS`,
+///   the string is returned unchanged (the common, fast path).
+/// - When the cap fires: finds the last sentence-ending punctuation (`.`, `!`,
+///   `?`) within the first `MAX_WORDS` words and trims to that boundary.
+/// - If no sentence boundary exists within the budget (very unusual — the reply
+///   is one long unpunctuated run), the first `MAX_WORDS` words are returned
+///   with a closing period added.
+///
+/// Conservative: `MAX_WORDS = 80`. A natural 3–4 sentence NPC reply in
+/// Hiberno-English is 40–60 words; 80 words gives generous headroom (≈ 5
+/// sentences at normal length) while preventing multi-hundred-word runaways.
+pub fn cap_word_count(dialogue: &str) -> String {
+    /// Maximum word count before the cap fires. 80 words ≈ 400 tokens at
+    /// ~5 chars/token — well within a single inference call budget while
+    /// enforcing a ceiling on runaway length.
+    const MAX_WORDS: usize = 80;
+
+    let text = dialogue.trim();
+    if text.is_empty() {
+        return String::new();
+    }
+
+    // Fast path: count words. If within budget, return immediately.
+    let word_count = text.split_whitespace().count();
+    if word_count <= MAX_WORDS {
+        return text.to_string();
+    }
+
+    // Find the byte offset of the end of the MAX_WORDS-th word token.
+    let mut remaining = MAX_WORDS;
+    let mut budget_end = text.len();
+    let mut in_word = false;
+    let mut cursor = 0usize;
+    for c in text.chars() {
+        let was_in_word = in_word;
+        in_word = !c.is_whitespace();
+        // Transition non-whitespace → whitespace: a word just ended.
+        if was_in_word && !in_word {
+            remaining -= 1;
+            if remaining == 0 {
+                budget_end = cursor;
+                break;
+            }
+        }
+        cursor += c.len_utf8();
+    }
+    // Handle the case where the string ends mid-word (no trailing whitespace).
+    if in_word && remaining == 1 {
+        budget_end = text.len();
+    }
+
+    let prefix = &text[..budget_end];
+
+    // Trim to the last sentence boundary within the prefix.
+    if let Some(last_end) = prefix.rfind(['.', '!', '?']) {
+        let sentence_end = last_end + 1;
+        // Only use the sentence boundary if it's not before the very beginning
+        // (i.e. there IS some content before it).
+        if sentence_end > 1 {
+            return text[..sentence_end].trim().to_string();
+        }
+    }
+
+    // No sentence boundary: return the first MAX_WORDS words with a period.
+    format!("{}.", prefix.trim_end())
+}
+
+/// Applies the full verbosity / run-on guard to a finalized dialogue string (#1460, #1472, #1487, #1489).
 ///
 /// Steps, in order:
 /// 1. Strip bare leaked mood-adjective from tail ([`strip_leaked_mood_word`]).
 /// 2. Trim mid-sentence truncation ellipsis ([`trim_mid_sentence_truncation`]).
 /// 3. Strip trailing ellipsis artifact after otherwise-complete text
 ///    ([`strip_trailing_ellipsis_artifact`], #1472).
-/// 4. Collapse non-consecutive near-duplicate sentences ([`collapse_distributed_repeated_sentences`]).
-/// 5. Cap total questions in the whole reply to at most 2 ([`cap_total_questions`]).
-/// 6. Cap trailing question stack to one ([`cap_trailing_questions`]).
-/// 7. Hard sentence-count cap: trim to at most 4 sentences ([`cap_sentence_count`], #1472).
+/// 4. **Collapse degenerate intra-response phrase-repetition loop** ([`collapse_degenerate_phrase_loop`], #1487).
+///    Detects when a short phrase (3–8 words) repeats ≥ 4× and truncates at the
+///    first clean sentence boundary before the loop.
+/// 5. Collapse non-consecutive near-duplicate sentences ([`collapse_distributed_repeated_sentences`]).
+/// 6. Cap total questions in the whole reply to at most 2 ([`cap_total_questions`]).
+/// 7. Cap trailing question stack to one ([`cap_trailing_questions`]).
+/// 8. Hard sentence-count cap: trim to at most 4 sentences ([`cap_sentence_count`], #1472).
 ///    This is the blunt backstop for paraphrased multi-beat rambles that the surgical
-///    guards (steps 4-6) cannot catch.
+///    guards (steps 5-7) cannot catch.
+/// 9. **Word-count cap**: trim to at most 80 words at a clean sentence boundary
+///    ([`cap_word_count`], #1489). Final backstop for long-but-few-sentence runs.
 ///
-/// Steps 4 and 5 are the #1460 core fix for distributed / interleaved repetition
+/// Steps 5 and 6 are the #1460 core fix for distributed / interleaved repetition
 /// that `collapse_repeated_sentences` (which only handles consecutive duplicates,
-/// called upstream by `guard_against_repetition`) does not catch. Step 6 keeps
-/// the earlier trailing-question guard in place as a final cleanup. Step 7 runs
-/// LAST so it operates on already-cleaned text, giving the surgical guards their
-/// best shot before the blunt cap applies.
+/// called upstream by `guard_against_repetition`) does not catch. Step 7 keeps
+/// the earlier trailing-question guard in place as a final cleanup. Step 8 runs
+/// before step 9 so it operates on already-cleaned text, giving the surgical
+/// guards their best shot before the blunt caps apply.
 ///
-/// Conservative — does not alter legitimate prose within 4 sentences.
+/// Conservative — does not alter legitimate prose within 4 sentences and 80 words.
 pub fn guard_verbosity_runons(dialogue: &str) -> String {
     if dialogue.trim().is_empty() {
         return dialogue.to_string();
@@ -1490,10 +1707,12 @@ pub fn guard_verbosity_runons(dialogue: &str) -> String {
     let after_mood = strip_leaked_mood_word(dialogue);
     let after_trunc = trim_mid_sentence_truncation(&after_mood);
     let after_ellipsis = strip_trailing_ellipsis_artifact(&after_trunc);
-    let after_distributed = collapse_distributed_repeated_sentences(&after_ellipsis);
+    let after_phrase_loop = collapse_degenerate_phrase_loop(&after_ellipsis);
+    let after_distributed = collapse_distributed_repeated_sentences(&after_phrase_loop);
     let after_total_q = cap_total_questions(&after_distributed);
     let after_trailing_q = cap_trailing_questions(&after_total_q);
-    cap_sentence_count(&after_trailing_q)
+    let after_sentence_cap = cap_sentence_count(&after_trailing_q);
+    cap_word_count(&after_sentence_cap)
 }
 
 // ── #1475 — wrong-speaker identity guard ──────────────────────────────────────
@@ -2779,6 +2998,185 @@ mod tests {
         assert_eq!(
             result, dialogue,
             "first-name self-reference must not be blocked: {result:?}"
+        );
+    }
+
+    // ── #1487 — degenerate intra-response phrase-loop guard ───────────────────
+
+    /// AC-1 (#1487): the priest repro — a short clause repeated 15× to the
+    /// token cap. The guard must detect the loop and truncate at a clean
+    /// sentence boundary before the loop begins.
+    #[test]
+    fn degenerate_phrase_loop_15x_repetition_collapsed() {
+        // The harness-observed repro pattern: "in His time and His way, and
+        // His purpose…" repeated ~15 times, no terminal punctuation between
+        // occurrences. We represent it as repeating 15×.
+        let preamble = "God's blessings upon ye, and may ye find what ye seek.";
+        let loop_clause = "in His time and His way and His purpose";
+        // Build: preamble + 15× the loop clause separated by commas
+        let loop_part = std::iter::repeat_n(loop_clause, 15)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let dialogue = format!("{preamble} {loop_part}");
+        let result = collapse_degenerate_phrase_loop(&dialogue);
+        // The preamble must survive.
+        assert!(
+            result.contains("God's blessings upon ye"),
+            "preamble sentence must survive: {result:?}"
+        );
+        // The loop must be gone.
+        let occurrences = result
+            .to_lowercase()
+            .matches("in his time and his way")
+            .count();
+        assert!(
+            occurrences <= 1,
+            "phrase loop must collapse to ≤1 occurrence, got {occurrences}: {result:?}"
+        );
+    }
+
+    /// AC-2 (#1487): a reply with varied legitimate prose must not be altered.
+    #[test]
+    fn degenerate_phrase_loop_leaves_varied_prose_unchanged() {
+        let dialogue = "A fine morning to ye. The harvest has come in well this year. \
+            Brigid Connolly was asking after the grain prices only yesterday. \
+            And the priest is expected back by Thursday, so they say.";
+        let result = collapse_degenerate_phrase_loop(dialogue);
+        assert!(
+            result.contains("fine morning"),
+            "first sentence must survive: {result:?}"
+        );
+        assert!(
+            result.contains("Brigid Connolly"),
+            "third sentence must survive: {result:?}"
+        );
+        assert!(
+            result.contains("Thursday"),
+            "last sentence must survive: {result:?}"
+        );
+    }
+
+    /// AC-3 (#1487): a short phrase repeated exactly 3× (below the 4× threshold)
+    /// must not trigger the guard — natural repetition must be allowed.
+    #[test]
+    fn degenerate_phrase_loop_below_threshold_passes_through() {
+        // "come back soon" appears 3× — below the 4× threshold.
+        let dialogue = "Come back soon, come back soon, come back soon, friend.";
+        let result = collapse_degenerate_phrase_loop(dialogue);
+        // The guard must not have fired (3× < 4× threshold).
+        assert!(
+            result.contains("come back soon"),
+            "3× repetition should pass through (below threshold): {result:?}"
+        );
+    }
+
+    /// AC-4 (#1487): the guard integrates into `guard_verbosity_runons`
+    /// end-to-end, so a runaway is fully cleaned even through the full pipeline.
+    #[test]
+    fn guard_verbosity_runons_collapses_phrase_loop_end_to_end() {
+        let preamble = "Peace be with ye, friend.";
+        let loop_clause = "in His time and His purpose";
+        let loop_part = std::iter::repeat_n(loop_clause, 12)
+            .collect::<Vec<_>>()
+            .join(", ");
+        let dialogue = format!("{preamble} {loop_part}");
+        let result = guard_verbosity_runons(&dialogue);
+        // The preamble must survive.
+        assert!(
+            result.contains("Peace be with ye"),
+            "preamble must survive guard pipeline: {result:?}"
+        );
+        // The loop must be gone.
+        let occurrences = result
+            .to_lowercase()
+            .matches("in his time and his purpose")
+            .count();
+        assert!(
+            occurrences <= 1,
+            "phrase loop must be gone after guard pipeline, got {occurrences}: {result:?}"
+        );
+    }
+
+    // ── #1489 — word-count cap guard ─────────────────────────────────────────
+
+    /// AC-1 (#1489): a reply over 80 words must be trimmed to the last sentence
+    /// boundary within the 80-word budget.
+    #[test]
+    fn word_count_cap_trims_overlong_reply() {
+        // Build a 100-word reply across 3 sentences.
+        // S1: ~10 words, S2: ~55 words, S3: ~35 words — total ~100 words.
+        let s1 = "Good day to ye, friend, and welcome to Kilteevan.";
+        let s2 = "The roads have been fierce hard on everyone this past fortnight and the river at \
+            Strokestown rose three whole feet after the terrible rains came down last Tuesday \
+            and Wednesday and the landlord sent his agent round to collect the rents early \
+            before the harvest was even in which caused great hardship to all.";
+        let s3 = "But sure the sun is shining today and the market in town is full of good cheer \
+            and the grain prices are better than they were last harvest time which is a true blessing.";
+        let dialogue = format!("{s1} {s2} {s3}");
+        let word_count = dialogue.split_whitespace().count();
+        assert!(
+            word_count > 80,
+            "test input must be >80 words, got {word_count}"
+        );
+        let result = cap_word_count(&dialogue);
+        let result_words = result.split_whitespace().count();
+        assert!(
+            result_words <= 80,
+            "output must be <=80 words, got {result_words}: {result:?}"
+        );
+        // The first sentence must always survive.
+        assert!(
+            result.contains("Good day to ye"),
+            "first sentence must survive: {result:?}"
+        );
+        // The result must end with sentence punctuation.
+        assert!(
+            result.trim_end().ends_with(['.', '!', '?']),
+            "result must end with sentence punctuation: {result:?}"
+        );
+    }
+
+    /// AC-2 (#1489): a reply of 80 words or fewer must pass through unchanged.
+    #[test]
+    fn word_count_cap_noop_on_short_reply() {
+        let dialogue = "Good day to ye. The harvest has been fine this year. \
+            Brigid Connolly was asking after the grain prices only yesterday.";
+        let word_count = dialogue.split_whitespace().count();
+        assert!(
+            word_count <= 80,
+            "test input must be <=80 words, got {word_count}"
+        );
+        let result = cap_word_count(dialogue);
+        assert_eq!(
+            result.trim(),
+            dialogue.trim(),
+            "short reply must pass through unchanged"
+        );
+    }
+
+    /// AC-3 (#1489): the cap integrates into guard_verbosity_runons, so a
+    /// very long reply (>80 words, few sentences) is trimmed by the pipeline.
+    #[test]
+    fn guard_verbosity_runons_word_cap_end_to_end() {
+        // A reply that is only 2 sentences but 100+ words (bypasses sentence cap).
+        let s1 = "Good day to ye, friend, and welcome to the parish.";
+        let s2 = "The roads have been fierce hard on everyone this past fortnight and the river at \
+            Strokestown rose three whole feet after the terrible rains came down last Tuesday \
+            and Wednesday and the landlord sent his agent round to collect the rents early \
+            before the harvest was even in which caused great hardship to all the families \
+            in the townland and the priest gave a long sermon about charity on Sunday morning \
+            but sure people are struggling all the same and the market prices are terrible.";
+        let dialogue = format!("{s1} {s2}");
+        let word_count = dialogue.split_whitespace().count();
+        assert!(
+            word_count > 80,
+            "test input must be >80 words, got {word_count}"
+        );
+        let result = guard_verbosity_runons(&dialogue);
+        let result_words = result.split_whitespace().count();
+        assert!(
+            result_words <= 80,
+            "guard pipeline must trim >80 word reply, got {result_words}: {result:?}"
         );
     }
 }


### PR DESCRIPTION
Fixes #1487, fixes #1488, fixes #1489.

## Summary

- **#1487 (critical)** — `collapse_degenerate_phrase_loop`: word-level n-gram scan (width 3-8, >=4 repetitions) truncates at first clean sentence boundary before the loop. Wired as step 4 of `guard_verbosity_runons` in `parish-npc/src/repetition.rs`.
- **#1489 (high)** — `cap_word_count(80)`: hard word ceiling as the final `guard_verbosity_runons` step; trims at the last sentence boundary within the first 80 words.
- **#1488 (high)** — `known_person_names` in `prepare_npc_conversation_turn` now seeded from `npc_manager.all_npcs()` instead of only the speaking NPC personal roster. Prevents false denial of real-registry NPCs.

Kill-switches: new verbosity guards inherit `dialogue-verbosity-guard` (default-on); roster fix inherits `dialogue-person-confirmation-guard` (default-on).

## Test plan

- `cargo test -p parish-npc -- repetition` — 62 passed (7 new unit tests)
- `cargo test -p parish-core -- known_person_names` — 1 passed
- `cargo test -p parish-engine --test runaway_generation_guards` — 3 passed (real-loop via `execute_via_real_loop`)
- `cargo test --workspace` — 3676 passed, 15 ignored
- `cargo fmt --check` + `cargo clippy --workspace -- -D warnings` — both clean

<!-- parish-proof-bundle:runaway-generation-chain v=1 -->

## Proof: runaway-generation-chain

### Acceptance criteria

# Acceptance Criteria — runaway-generation-chain

## Issues fixed

- #1487 (critical): degenerate-repetition-loop — priest output collapsed into one phrase repeated ~15× to token cap
- #1489 (high): verbosity-runaway-token-cap — 3/14 dialogue inferences ran 43–47s and hit the token cap
- #1488 (high): grounding-fallback-denies-real-npc — rejection substitution overwrote a correct Roisin description with a false denial

---

## AC-1 (#1487): Degenerate intra-response phrase loop is detected and truncated

**Given** a model output where a short phrase (3–8 words) appears 4 or more times (the degenerate sampling loop repro: "in His time and His purpose" × 15),  
**When** `guard_verbosity_runons` processes the text,  
**Then** `collapse_degenerate_phrase_loop` detects the loop and truncates at the first clean sentence boundary, so the player-visible output contains that phrase at most once.

**Measurement**: `occurrences_of_loop_phrase <= 1` in `DialogueOccurred.npc_said`.

---

## AC-2 (#1487): Legitimate varied prose is NOT altered by the phrase-loop guard

**Given** a model output with naturally varied sentences (no phrase repeated ≥ 4×),  
**When** `collapse_degenerate_phrase_loop` processes it,  
**Then** the output is returned unchanged.

---

## AC-3 (#1489): Overlong reply (> 80 words) is trimmed at a sentence boundary

**Given** a model output that exceeds 80 words (the observed runaway length from 43–47s inference calls),  
**When** `cap_word_count` runs as the final step of `guard_verbosity_runons`,  
**Then** the player-visible output is ≤ 80 words, ending at a complete sentence boundary.

---

## AC-4 (#1489): Short replies (≤ 80 words) pass through the word-count cap unchanged

**Given** a normal NPC reply of ≤ 80 words,  
**When** `cap_word_count` processes it,  
**Then** the output is identical to the input.

---

## AC-5 (#1488): A real parish NPC described by an NPC that doesn't personally know them is NOT denied

**Given** NPC-A (a priest) accurately describes NPC-B (Roisin the shopkeeper, a real parish NPC) in response to a player question,  
**And** NPC-A has NO personal relationship with NPC-B (Roisin is not in the priest's `known_roster`),  
**When** `guard_fabricated_person_confirmation` runs on NPC-A's reply,  
**Then** the guard does NOT fire — Roisin's name is in `known_person_names` because it is seeded from `npc_manager.all_npcs()` rather than just the speaker's personal roster.

**Measurement**: player-visible dialogue is NOT "I know no one by that name in these parts."

---

## AC-6 (#1488): The person-confirmation guard still fires for genuinely fabricated names

**Given** an NPC's reply affirms a person whose name does NOT appear in ANY parish NPC registry,  
**When** `guard_fabricated_person_confirmation` runs,  
**Then** the guard fires and replaces the reply with a decline phrase.

---

## AC-7 (All): All existing tests pass; no regressions

`cargo test --workspace` exits 0 with all tests green.

### Evidence

# Evidence — runaway-generation-chain

Evidence type: game-loop integration test

## Evidence tier note

The changes route through `execute_via_real_loop`, which drives a real tokio process
(`handle_game_input` → `handle_npc_conversation` → `run_npc_turn`). This is NOT a
Tauri window with a human player and a live 14B model. Whether this constitutes the
"live process" tier of rule 10 is an owner decision. The test-run.txt sibling file
contains literal program output from this real process. If the owner requires a Tauri
window, that is an honest impasse: deterministic post-generation guards cannot be
verified against a live 14B model without injecting adversarial output.

## Honesty note

These changes touch `parish-core/src/game_loop/npc_turn.rs` (verbosity guard
call) and `parish-core/src/ipc/handlers.rs` (`known_person_names` expansion) —
both runtime-shipping paths. The AGENTS.md §10 live-proof requirement asks for a
`live gameplay transcript` or image from a real Tauri / server / CLI process.

What was actually run: `GameTestHarness::execute_via_real_loop`, which spins a
real `tokio` runtime, a real mock-backed inference worker, and drives
`handle_game_input` → `handle_npc_conversation` → `run_npc_turn` — the same
shared code path that ships in the Tauri app and the headless server. This is NOT
the legacy `execute()` path that bypasses `game_loop/npc_turn`. It IS a real
process exercising the real game loop.

It is NOT a live Tauri app with a human player. A live Tauri transcript was not
produced because:

1. The Tauri app drives a real 14B model; injecting a deterministic degenerate
   response for guard testing requires the mock client.
2. Running `execute_via_real_loop` with injected adversarial responses is the
   correct tier for testing deterministic post-generation guards, identical to
   how `mode_parity.rs` tests the same `run_npc_turn` path.

The evidence label below is `real-loop integration test` (not `live gameplay
transcript`) because the test does not go through a deployed Tauri window. If
`agent-check` requires a live-process tier for this, that would be an honest
impasse — the deterministic guard tests cannot be reproduced against a live 14B
model without injecting adversarial output.

---

## What was built

### Fix #1487 — `collapse_degenerate_phrase_loop`

**File**: `parish/crates/parish-npc/src/repetition.rs`  
**Function**: `pub fn collapse_degenerate_phrase_loop(dialogue: &str) -> String`

Scans word-level n-grams (width 3–8) for any that appear ≥ 4 times. On
detection, truncates at the first clean sentence boundary before the loop.
Wired into `guard_verbosity_runons` as step 4 (before `collapse_distributed_repeated_sentences`).

**Kill-switch**: Inherited from `dialogue-verbosity-guard` (default-on). Setting
`dialogue-verbosity-guard: false` disables the full verbosity guard pipeline
including this step.

Before (adversarial repro):

```
God's blessings upon ye. in His time and His purpose, in His time and His
purpose, in His time and His purpose, [×12 more]
```

After (guard fires, truncates at preamble sentence boundary):

```
God's blessings upon ye.
```

### Fix #1489 — `cap_word_count`

**File**: `parish/crates/parish-npc/src/repetition.rs`  
**Function**: `pub fn cap_word_count(dialogue: &str) -> String`

If word count > 80, finds the last sentence boundary within the first 80 words
and trims to it. Wired into `guard_verbosity_runons` as the final step (step 9).

**Kill-switch**: Inherited from `dialogue-verbosity-guard` (default-on).

Before (100-word reply):

```
A fine morning to ye, friend. The roads have been fierce hard on everyone this
past fortnight and the river rose three whole feet ... [100 words]
```

After (cap fires, trims to ≤80 words at sentence boundary):

```
A fine morning to ye, friend. The roads have been fierce hard on everyone this
past fortnight and the river rose three whole feet after the rains came down on
tuesday and wednesday and the landlord sent his agent round to collect the
rents before the harvest was even in which caused great hardship to all the
families in the townland and the market at the crossroads was cancelled on
account of the weather as well.
```

### Fix #1488 — `known_person_names` expansion

**File**: `parish/crates/parish-core/src/ipc/handlers.rs`  
**Function**: `prepare_npc_conversation_turn`

Changed `known_person_names` from being seeded only from the speaking NPC's
personal `known_roster` to being seeded from `npc_manager.all_npcs()` (all
parish NPCs). The personal roster (for the "PEOPLE YOU KNOW" prompt block) is
unchanged. Only the guard's allowlist is expanded.

**Kill-switch**: Inherited from `dialogue-person-confirmation-guard` (default-on).

Root cause of #1488: The priest's `known_roster` only contains NPCs he has a
relationship with. Roisin (a shopkeeper) had no relationship with the priest. So
when another NPC recommended Roisin and the player asked the priest about her, the
guard saw "Roisin" as "not in my roster → fabricated → deny". The fix: the guard
now uses the full parish NPC list as the allowlist.

---

## Test runs

### Unit tests — `parish-npc` repetition module

```
cargo test -p parish-npc -- repetition
```

New tests added (all pass):

- `degenerate_phrase_loop_15x_repetition_collapsed` (AC-1 #1487)
- `degenerate_phrase_loop_leaves_varied_prose_unchanged` (AC-2 #1487)
- `degenerate_phrase_loop_below_threshold_passes_through` (AC-3 #1487)
- `guard_verbosity_runons_collapses_phrase_loop_end_to_end` (AC-4 #1487)
- `word_count_cap_trims_overlong_reply` (AC-1 #1489)
- `word_count_cap_noop_on_short_reply` (AC-2 #1489)
- `guard_verbosity_runons_word_cap_end_to_end` (AC-3 #1489)

Result: `62 passed, 598 filtered out`

### Unit tests — `parish-core` ipc handlers

```
cargo test -p parish-core -- known_person_names
```

New test: `known_person_names_includes_all_parish_npcs_not_just_roster` (AC-5/6 #1488)

Result: `1 passed, 514 filtered out`

### Real-loop integration tests — `parish-engine`

```
cargo test -p parish-engine --test runaway_generation_guards
```

Tests (all pass, routed through `execute_via_real_loop` → `run_npc_turn`):

- `real_loop_degenerate_phrase_loop_is_collapsed` (#1487)
- `real_loop_overlong_reply_is_word_capped` (#1489)
- `real_loop_real_npc_description_not_denied` (#1488)

Result: `3 passed`

### Full workspace

```
cargo test --workspace
```

Result: `3676 passed, 15 ignored (99 suites, 24.15s)`

### Format + clippy

```
cargo fmt --check  → OK (exit 0)
cargo clippy --workspace -- -D warnings  → 0 errors (exit 0)
```

---

## Criterion-to-evidence mapping

| AC                                        | Met by                                                                                                      |
| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| AC-1 (#1487 phrase loop fires)            | `degenerate_phrase_loop_15x_repetition_collapsed` + `real_loop_degenerate_phrase_loop_is_collapsed`         |
| AC-2 (#1487 varied prose unchanged)       | `degenerate_phrase_loop_leaves_varied_prose_unchanged`                                                      |
| AC-3 (#1489 overlong trimmed)             | `word_count_cap_trims_overlong_reply` + `real_loop_overlong_reply_is_word_capped`                           |
| AC-4 (#1489 short unchanged)              | `word_count_cap_noop_on_short_reply`                                                                        |
| AC-5 (#1488 real NPC not denied)          | `known_person_names_includes_all_parish_npcs_not_just_roster` + `real_loop_real_npc_description_not_denied` |
| AC-6 (#1488 fabricated name still denied) | `fabricated_person_confirmed_is_declined` (pre-existing test, still passes)                                 |
| AC-7 (no regressions)                     | `cargo test --workspace`: 3676 passed                                                                       |

### Judge

# Judge Verdict — runaway-generation-chain

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

## Rationale

All 7 acceptance criteria are satisfied:

- **AC-1 (#1487)**: `collapse_degenerate_phrase_loop` correctly detects a 3–8-word phrase
  repeated ≥4× and truncates at the first clean sentence boundary before the loop. Verified by
  `degenerate_phrase_loop_15x_repetition_collapsed` (unit) and
  `real_loop_degenerate_phrase_loop_is_collapsed` (real-loop integration).

- **AC-2 (#1487)**: Varied prose (no phrase repeated ≥4×) passes through unchanged. Verified by
  `degenerate_phrase_loop_leaves_varied_prose_unchanged`.

- **AC-3 (#1489)**: `cap_word_count(80)` as the final step of `guard_verbosity_runons` trims
  overlong replies at the last sentence boundary within 80 words. Verified by
  `word_count_cap_trims_overlong_reply` (unit) and `real_loop_overlong_reply_is_word_capped`
  (real-loop integration, ~100-word adversarial input trimmed to ≤80 words).

- **AC-4 (#1489)**: Short replies (≤80 words) pass through unchanged. Verified by
  `word_count_cap_noop_on_short_reply`.

- **AC-5 (#1488)**: A real parish NPC (not in the speaking NPC's personal roster) is no longer
  denied by `guard_fabricated_person_confirmation`. Verified by
  `known_person_names_includes_all_parish_npcs_not_just_roster` (unit) and
  `real_loop_real_npc_description_not_denied` (real-loop integration).

- **AC-6 (#1488)**: A genuinely fabricated name (not in any parish NPC registry) is still denied.
  Verified by pre-existing `fabricated_person_confirmed_is_declined` (still passes).

- **AC-7 (regressions)**: `cargo test --workspace` → 3676 passed, 15 ignored.

## Evidence tier

Evidence type is `real-loop integration test` (see evidence.md). The tests route through
`execute_via_real_loop` → `run_npc_turn`, which is the same shared code path shipping in the
Tauri app and headless server. A `.txt` transcript of the test run is included as the live
process artifact (see test-run.txt).

## Format check

- `cargo fmt --check` → OK (exit 0)
- `cargo clippy --workspace -- -D warnings` → 0 errors (exit 0)
- `cargo test --workspace` → 3676 passed, 15 ignored

<!-- /parish-proof-bundle:runaway-generation-chain -->
