### PR TITLE
chore(agent-check): accept game-loop integration test in the type validator too

### DIFF
--- a/parish/scripts/agent-check.sh
+++ b/parish/scripts/agent-check.sh
@@ -195,11 +195,15 @@ validate_evidence_file() {
             # tier (rule #10) requires for proofs of changes touching
             # the Tauri/server/CLI/UI/mod seams. Plain
             # `Evidence type: gameplay transcript` remains valid for
-            # non-runtime proof-relevant changes.
-            if grep -Eiq '^Evidence type:[[:space:]]*(live[[:space:]]+)?(gameplay transcript|screenshot|gif)[[:space:]]*$' "$file"; then
+            # non-runtime proof-relevant changes. `game-loop integration
+            # test` is the real-loop tier for deterministic guards that
+            # cannot be triggered live on demand (its runtime-path
+            # acceptance below additionally requires an `execute_via_real_loop`
+            # reference, so it cannot be stamped over plain unit tests).
+            if grep -Eiq '^Evidence type:[[:space:]]*((live[[:space:]]+)?(gameplay transcript|screenshot|gif)|game-loop integration test)[[:space:]]*$' "$file"; then
                 return 0
             fi
-            echo "agent-check FAILED: $file must declare 'Evidence type: [live ](gameplay transcript|screenshot|gif)'." >&2
+            echo "agent-check FAILED: $file must declare 'Evidence type: [live ](gameplay transcript|screenshot|gif)' or 'Evidence type: game-loop integration test'." >&2
             return 1
             ;;
     esac


### PR DESCRIPTION
Follow-up to #1501. `agent-check.sh` validates evidence types in two places: the general type validator and the runtime-shipping live check. #1501 added the `game-loop integration test` tier only to the latter, so the header passed the runtime check but the validator still rejected it. This accepts it in both.

The runtime-path acceptance still requires an `execute_via_real_loop` reference in the same evidence file, so the tier cannot be stamped over plain unit tests.

Verified: regex accepts the new tier + all live forms, rejects unknown types; `bash -n` + `shfmt -i 4 -ci -bn` clean. Script-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)