### PR TITLE
fix(npc): consecutive short-phrase repeat guard + cross-turn opener dedup (#1505, #1492)

### DIFF
--- a/parish/crates/parish-core/src/game_loop/npc_turn.rs
+++ b/parish/crates/parish-core/src/game_loop/npc_turn.rs
@@ -443,13 +443,11 @@ pub async fn run_npc_turn(
     // Run BEFORE `apply_npc_dialogue_turn` so the `DialogueOccurred` event
     // and conversation log carry the deduped text, not the raw opener.
     if anti_repetition_enabled && !parsed.dialogue.trim().is_empty() {
-        let seen_openers: Vec<String> = ctx
-            .conversation
-            .lock()
-            .await
-            .seen_openers_this_location
-            .clone();
-        let deduped = crate::npc::dedupe_cross_npc_openers(&seen_openers, &parsed.dialogue);
+        let mut conversation = ctx.conversation.lock().await;
+        let deduped = crate::npc::dedupe_cross_npc_openers(
+            &conversation.seen_openers_this_location,
+            &parsed.dialogue,
+        );
         if deduped != parsed.dialogue {
             tracing::debug!(
                 npc = %display_label,
@@ -459,7 +457,7 @@ pub async fn run_npc_turn(
         // Record the opener actually shown to the player.
         let shown_opener = crate::npc::extract_normalized_opener(&deduped);
         if !shown_opener.is_empty() {
-            ctx.conversation.lock().await.record_opener(shown_opener);
+            conversation.record_opener(shown_opener);
         }
         parsed.dialogue = deduped;
     }

--- a/parish/crates/parish-core/src/game_loop/npc_turn.rs
+++ b/parish/crates/parish-core/src/game_loop/npc_turn.rs
@@ -141,6 +141,7 @@ pub async fn run_npc_turn(
         verbosity_guard_enabled,
         wrong_speaker_guard_enabled,
         action_narration_enabled,
+        anti_repetition_enabled,
     ) = {
         let mut world = ctx.world.lock().await;
         let mut npc_manager = ctx.npc_manager.lock().await;
@@ -161,6 +162,8 @@ pub async fn run_npc_turn(
         let wrong_speaker_guard = !config.flags.is_disabled("npc-wrong-speaker-guard");
         // NPC action narration (#1490): default-on, kill-switch only.
         let action_narration = !config.flags.is_disabled(NPC_ACTION_NARRATION_FLAG);
+        // Cross-NPC opener de-duplication (#1422, #1492): default-on kill-switch.
+        let anti_rep = !config.flags.is_disabled(DIALOGUE_ANTI_REPETITION_FLAG);
         let npc_cfg = crate::config::NpcConfig {
             dialogue_quality_continuity: !config.flags.is_disabled("dialogue-quality-continuity"),
             grounding_enabled: !config.flags.is_disabled("npc-dialogue-grounding"),
@@ -184,6 +187,7 @@ pub async fn run_npc_turn(
             verbosity_guard,
             wrong_speaker_guard,
             action_narration,
+            anti_rep,
         )
     };
     let setup = setup?;
@@ -433,6 +437,33 @@ pub async fn run_npc_turn(
         }
     }
 
+    // Cross-NPC opener de-duplication (#1422, #1492): strip duplicate stock
+    // opener if the session has already seen a near-identical one from a
+    // previous NPC at this location (across any number of prior turns).
+    // Run BEFORE `apply_npc_dialogue_turn` so the `DialogueOccurred` event
+    // and conversation log carry the deduped text, not the raw opener.
+    if anti_repetition_enabled && !parsed.dialogue.trim().is_empty() {
+        let seen_openers: Vec<String> = ctx
+            .conversation
+            .lock()
+            .await
+            .seen_openers_this_location
+            .clone();
+        let deduped = crate::npc::dedupe_cross_npc_openers(&seen_openers, &parsed.dialogue);
+        if deduped != parsed.dialogue {
+            tracing::debug!(
+                npc = %display_label,
+                "stripped duplicate cross-NPC opener in run_npc_turn (#1422/#1492)"
+            );
+        }
+        // Record the opener actually shown to the player.
+        let shown_opener = crate::npc::extract_normalized_opener(&deduped);
+        if !shown_opener.is_empty() {
+            ctx.conversation.lock().await.record_opener(shown_opener);
+        }
+        parsed.dialogue = deduped;
+    }
+
     if !parsed.dialogue.trim().is_empty() {
         tracing::info!(
             npc = %display_label,
@@ -672,7 +703,6 @@ pub async fn handle_npc_conversation(
         model,
         max_follow_up_turns,
         autonomous_chain_enabled,
-        anti_repetition_enabled,
         targets,
         absent,
     ) = {
@@ -703,9 +733,6 @@ pub async fn handle_npc_conversation(
             config.model_name.clone(),
             config.max_follow_up_turns,
             config.flags.is_enabled(AUTONOMOUS_NPC_CHAIN_FLAG),
-            // Default-on kill-switch: disabled only when flag is explicitly set
-            // (#1422 cross-NPC opener de-duplication).
-            !config.flags.is_disabled(DIALOGUE_ANTI_REPETITION_FLAG),
             targets,
             absent,
         )
@@ -830,13 +857,15 @@ pub async fn handle_npc_conversation(
     let mut combined_hints: Vec<crate::npc::LanguageHint> = Vec::new();
     let mut spoken_this_chain: Vec<NpcId> = Vec::new();
     let mut last_speaker: Option<NpcId> = None;
-    // Cross-NPC opener de-duplication (#1422): collect the normalized first
-    // sentence of each NPC reply already emitted this turn so subsequent NPCs
-    // can be checked against it. Only active for multi-NPC Phase 1 turns when
-    // `anti_repetition_enabled` is true.
-    let mut openers_this_turn: Vec<String> = Vec::new();
 
     // Phase 1: each addressed NPC takes one turn in the order named.
+    // Cross-NPC opener de-duplication (#1422, #1492) is now applied inside
+    // `run_npc_turn` (before `apply_npc_dialogue_turn` publishes the
+    // `DialogueOccurred` event), so the event and conversation log carry the
+    // already-deduped text. The session-level `seen_openers_this_location` set
+    // in `ctx.conversation` accumulates across both turns within this call and
+    // across successive calls (when the callers share the same `conversation`
+    // Mutex — e.g. the real-loop test harness).
     for speaker_id in &targets {
         let Some(outcome) = run_npc_turn(
             ctx,
@@ -854,34 +883,7 @@ pub async fn handle_npc_conversation(
         };
 
         combined_hints.extend(outcome.hints);
-        if let Some(mut line) = outcome.line {
-            // Cross-NPC opener dedup: strip the duplicated stock opener from
-            // this reply if a previous NPC already used a near-identical one
-            // this turn (#1422). Applied after all other per-turn guards so
-            // `line.text` is the fully post-processed dialogue.
-            if anti_repetition_enabled && targets.len() > 1 {
-                let deduped = crate::npc::dedupe_cross_npc_openers(&openers_this_turn, &line.text);
-                if deduped != line.text {
-                    tracing::debug!(
-                        npc = %line.speaker,
-                        "stripped duplicate cross-NPC opener (#1422)"
-                    );
-                }
-                // Collect opener from whatever we actually show the player.
-                let shown_opener = crate::npc::extract_normalized_opener(&deduped);
-                if !shown_opener.is_empty() {
-                    openers_this_turn.push(shown_opener);
-                }
-                line.text = deduped;
-            } else if anti_repetition_enabled {
-                // Single-NPC turn: collect opener for any future autonomous
-                // follow-ups within the same Phase 1 context (no-op for
-                // autonomous chain, which has its own cadence).
-                let opener = crate::npc::extract_normalized_opener(&line.text);
-                if !opener.is_empty() {
-                    openers_this_turn.push(opener);
-                }
-            }
+        if let Some(line) = outcome.line {
             transcript.push(line.clone());
             let mut conversation = ctx.conversation.lock().await;
             conversation.push_line(line);

--- a/parish/crates/parish-core/src/ipc/state.rs
+++ b/parish/crates/parish-core/src/ipc/state.rs
@@ -38,6 +38,19 @@ pub struct ConversationRuntimeState {
     /// (#1331). `None` until the player submits their first input. Runtime-only
     /// — never persisted to save state.
     pub last_player_input: Option<String>,
+    /// Normalized first-sentence openers already shown to the player at the
+    /// current location, across all turns (#1492 — cross-NPC opener de-dup).
+    ///
+    /// Populated by [`handle_npc_conversation`] from every NPC reply emitted
+    /// at the current location. Cleared when the player moves (via
+    /// [`Self::sync_location`]). Used to extend the same opener dedup that
+    /// previously only worked within a single multi-NPC turn to also cover
+    /// sequential single-NPC turns — catching "What brings ye to these parts?"
+    /// repeated across 4+ separate conversations at the same location.
+    ///
+    /// Capped at 32 entries so it cannot grow unboundedly during a long stay at
+    /// one location.
+    pub seen_openers_this_location: Vec<String>,
 }
 
 impl Default for ConversationRuntimeState {
@@ -57,6 +70,7 @@ impl ConversationRuntimeState {
             last_spoken_at: now,
             conversation_in_progress: false,
             last_player_input: None,
+            seen_openers_this_location: Vec::new(),
         }
     }
 
@@ -97,12 +111,29 @@ impl ConversationRuntimeState {
         }
     }
 
-    /// Clears the transcript when the player moves to a new location.
+    /// Clears the transcript and seen-opener set when the player moves to a new
+    /// location (#1492).
     pub fn sync_location(&mut self, location: LocationId) {
         if self.location != Some(location) {
             self.location = Some(location);
             self.transcript.clear();
+            self.seen_openers_this_location.clear();
         }
+    }
+
+    /// Records a normalized NPC opener shown to the player at the current
+    /// location, for cross-turn cross-NPC opener de-duplication (#1492).
+    ///
+    /// Ignores empty strings. Caps the set at 32 entries (oldest evicted) so
+    /// long stays at one location do not grow it unboundedly.
+    pub fn record_opener(&mut self, opener: String) {
+        if opener.is_empty() {
+            return;
+        }
+        if self.seen_openers_this_location.len() >= 32 {
+            self.seen_openers_this_location.remove(0);
+        }
+        self.seen_openers_this_location.push(opener);
     }
 
     /// Appends a line to the local transcript, trimming blank lines and

--- a/parish/crates/parish-core/src/ipc/state.rs
+++ b/parish/crates/parish-core/src/ipc/state.rs
@@ -130,7 +130,15 @@ impl ConversationRuntimeState {
         if opener.is_empty() {
             return;
         }
-        if self.seen_openers_this_location.len() >= 32 {
+        if let Some(pos) = self
+            .seen_openers_this_location
+            .iter()
+            .position(|x| x == &opener)
+        {
+            // Already present — move to back (LRU refresh) so the eviction order
+            // reflects recency rather than first-seen, and no duplicate is added.
+            self.seen_openers_this_location.remove(pos);
+        } else if self.seen_openers_this_location.len() >= 32 {
             self.seen_openers_this_location.remove(0);
         }
         self.seen_openers_this_location.push(opener);

--- a/parish/crates/parish-engine/src/real_loop.rs
+++ b/parish/crates/parish-engine/src/real_loop.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use parish_core::game_loop::{GameLoopContext, handle_game_input, handle_system_command};
-use parish_core::ipc::{CapturingEmitter, ConversationRuntimeState, EventEmitter};
+use parish_core::ipc::{CapturingEmitter, EventEmitter};
 use parish_core::npc::reactions::ReactionTemplates;
 
 use crate::command_host::CliCommandHost;
@@ -195,7 +195,10 @@ impl GameTestHarness {
         let world = Mutex::new(std::mem::take(&mut self.app.world));
         let npc_manager = Mutex::new(std::mem::take(&mut self.app.npc_manager));
         let config = Mutex::new(config_snapshot);
-        let conversation = Mutex::new(ConversationRuntimeState::new());
+        // Reuse the harness-level persistent conversation state so session-level
+        // data (e.g. `seen_openers_this_location` for cross-turn opener dedup,
+        // #1492) accumulates across successive `execute_via_real_loop` calls.
+        let conversation = std::sync::Arc::clone(&self.real_loop_conversation);
         // Filled inside the runtime below with a mock-backed queue so the
         // dialogue path runs against the real worker rather than short-circuiting
         // on a missing LLM (#1172 dialogue parity).

--- a/parish/crates/parish-engine/src/testing.rs
+++ b/parish/crates/parish-engine/src/testing.rs
@@ -118,6 +118,11 @@ pub struct GameTestHarness {
     /// which feed the legacy path; the mock pins the inference seam for the
     /// real `game_loop` so the two engines can be compared (#1159).
     pub(crate) mock: Arc<crate::inference::MockClient>,
+    /// Persistent conversation runtime state shared across all
+    /// [`Self::execute_via_real_loop`] calls, so session-level state such as
+    /// `seen_openers_this_location` accumulates across turns (#1492).
+    pub(crate) real_loop_conversation:
+        std::sync::Arc<tokio::sync::Mutex<parish_core::ipc::ConversationRuntimeState>>,
     /// When true, [`Self::execute`] also runs the real `game_loop` on a
     /// rolled-back copy of the pre-state and records divergences to
     /// `shadow_ledger`. Seeded from the `PARISH_HARNESS_SHADOW` env var at
@@ -284,6 +289,9 @@ impl GameTestHarness {
             simulator: None,
             rng: StdRng::seed_from_u64(0),
             mock: Arc::new(crate::inference::MockClient::new()),
+            real_loop_conversation: std::sync::Arc::new(tokio::sync::Mutex::new(
+                parish_core::ipc::ConversationRuntimeState::new(),
+            )),
             shadow_enabled: crate::shadow::is_enabled(),
             shadow_ledger: crate::shadow::ledger_path(),
             shadow_case: crate::shadow::case_label(),
@@ -2613,6 +2621,9 @@ mod tests {
             simulator: None,
             rng: rand::rngs::StdRng::seed_from_u64(0),
             mock: Arc::new(crate::inference::MockClient::new()),
+            real_loop_conversation: std::sync::Arc::new(tokio::sync::Mutex::new(
+                parish_core::ipc::ConversationRuntimeState::new(),
+            )),
             shadow_enabled: false,
             shadow_ledger: crate::shadow::ledger_path(),
             shadow_case: "test".to_string(),

--- a/parish/crates/parish-engine/tests/npc_verbosity_multiquestion_real_loop.rs
+++ b/parish/crates/parish-engine/tests/npc_verbosity_multiquestion_real_loop.rs
@@ -1,0 +1,320 @@
+//! Game-loop integration tests for NPC verbosity / multi-question guards (#1505, #1492).
+//!
+//! These tests exercise the full `handle_npc_conversation` → `run_npc_turn`
+//! pipeline via `execute_via_real_loop` with a scripted `MockClient`. They
+//! prove that the deterministic post-generation guards wired into `npc_turn.rs`
+//! fire on degenerate model output and leave clean output untouched.
+//!
+//! ## Evidence type
+//!
+//! `Evidence type: game-loop integration test` — these tests exercise
+//! `execute_via_real_loop` which drives the real `parish_core::game_loop`
+//! (including `run_npc_turn` and `guard_verbosity_runons`) with the LLM
+//! boundary mocked by `MockClient`.
+//!
+//! ## #1505 — consecutive short-phrase near-repetition
+//!
+//! A 403-char NPC reply containing "tell me, tell me" should have the
+//! repeated phrase removed by `strip_consecutive_short_phrase_repeat` inside
+//! the `guard_verbosity_runons` pipeline.
+//!
+//! ## #1492 — cross-NPC stock opener across separate turns
+//!
+//! When two NPCs are addressed on separate turns at the same location and
+//! both open with a near-identical stock phrase ("Ye've come to the right
+//! place for X"), the second NPC's opener is stripped by
+//! `dedupe_cross_npc_openers` using the session-level
+//! `seen_openers_this_location` set on `ConversationRuntimeState`.
+
+use parish_core::npc::types::NpcState;
+use parish_core::world::events::GameEvent;
+use parish_engine::testing::GameTestHarness;
+
+/// Drains the broadcast receiver until empty, returning all events.
+fn drain_events(rx: &mut tokio::sync::broadcast::Receiver<GameEvent>) -> Vec<GameEvent> {
+    let mut out = Vec::new();
+    loop {
+        match rx.try_recv() {
+            Ok(ev) => out.push(ev),
+            Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => continue,
+            Err(_) => break,
+        }
+    }
+    out
+}
+
+// ── #1505 — consecutive short-phrase repeat ("tell me, tell me") ─────────────
+
+/// AC-1 (#1505): a scripted NPC reply containing "tell me, tell me" must have
+/// the repeated phrase stripped by the verbosity guard before the
+/// `DialogueOccurred` event is published.
+///
+/// This test mocks the LLM to return a reply containing the exact pattern
+/// observed in the quality-harness run 15 bug report and asserts that the
+/// guard fires and removes the repetition from the persisted dialogue event.
+#[test]
+fn verbosity_guard_strips_tell_me_repeat_through_real_loop() {
+    let mut h = GameTestHarness::new();
+    let player_loc = h.app.world.player_location;
+
+    // Find Nora Duffy — a Rundale NPC we can co-locate with the player.
+    let nora_id = h
+        .app
+        .npc_manager
+        .all_npcs()
+        .find(|n| n.name == "Nora Duffy")
+        .map(|n| n.id)
+        .expect("Rundale mod must contain Nora Duffy");
+
+    {
+        let nora = h.app.npc_manager.get_mut(nora_id).expect("Nora exists");
+        nora.location = player_loc;
+        nora.state = NpcState::Present;
+    }
+    h.app.npc_manager.mark_introduced(nora_id);
+
+    // Script the mock with the #1505 pattern: a run-on with "tell me, tell me".
+    let injected = "Aye, the journey is a long one from the south. \
+        Does the journey yet weigh heavy on yer heart, I wonder indeed, \
+        aye or nay, tell me, tell me?";
+    h.mock().push_for("Nora", injected);
+
+    let mut rx = h.app.world.event_bus.subscribe();
+    let _ = h.execute_via_real_loop("talk to Nora about the journey");
+
+    let events = drain_events(&mut rx);
+    let dialogue_events: Vec<Option<String>> = events
+        .iter()
+        .filter_map(|e| {
+            if let GameEvent::DialogueOccurred {
+                npc_id, npc_said, ..
+            } = e
+                && *npc_id == nora_id
+            {
+                return Some(npc_said.clone());
+            }
+            None
+        })
+        .collect();
+
+    assert!(
+        !dialogue_events.is_empty(),
+        "expected a DialogueOccurred event for Nora; got events: {events:?}"
+    );
+
+    for npc_said_opt in &dialogue_events {
+        let npc_said = npc_said_opt.as_deref().unwrap_or("");
+        let tell_me_count = npc_said.to_lowercase().matches("tell me").count();
+        assert!(
+            tell_me_count <= 1,
+            "#1505: guard must strip \"tell me, tell me\" repetition from the \
+             persisted dialogue; got {tell_me_count} occurrences in: {npc_said:?}"
+        );
+    }
+}
+
+/// AC-2 (#1505): a clean NPC reply (no repeated phrase) must pass through the
+/// verbosity guard unchanged — the guard must not alter legitimate dialogue.
+#[test]
+fn verbosity_guard_passes_clean_reply_through_real_loop() {
+    let mut h = GameTestHarness::new();
+    let player_loc = h.app.world.player_location;
+
+    let nora_id = h
+        .app
+        .npc_manager
+        .all_npcs()
+        .find(|n| n.name == "Nora Duffy")
+        .map(|n| n.id)
+        .expect("Rundale mod must contain Nora Duffy");
+
+    {
+        let nora = h.app.npc_manager.get_mut(nora_id).expect("Nora exists");
+        nora.location = player_loc;
+        nora.state = NpcState::Present;
+    }
+    h.app.npc_manager.mark_introduced(nora_id);
+
+    let clean_reply = "Aye, the journey from the south is never easy. Are ye well?";
+    h.mock().push_for("Nora", clean_reply);
+
+    let mut rx = h.app.world.event_bus.subscribe();
+    let _ = h.execute_via_real_loop("talk to Nora about the journey");
+
+    let events = drain_events(&mut rx);
+    let dialogue_texts: Vec<Option<String>> = events
+        .iter()
+        .filter_map(|e| {
+            if let GameEvent::DialogueOccurred {
+                npc_id, npc_said, ..
+            } = e
+                && *npc_id == nora_id
+            {
+                return Some(npc_said.clone());
+            }
+            None
+        })
+        .collect();
+
+    assert!(
+        !dialogue_texts.is_empty(),
+        "expected a DialogueOccurred event for Nora; got: {events:?}"
+    );
+
+    // The clean reply must pass through (allowing for length/question-cap
+    // which won't fire on this short reply).
+    let found = dialogue_texts.iter().any(|d| {
+        d.as_deref()
+            .unwrap_or("")
+            .contains("journey from the south")
+    });
+    assert!(
+        found,
+        "clean legitimate dialogue must pass through unchanged; got: {dialogue_texts:?}"
+    );
+}
+
+// ── #1492 — cross-NPC stock opener across separate turns ─────────────────────
+
+/// AC-3 (#1492): when two NPCs are addressed sequentially (separate turns) at
+/// the same location, and both would open with a near-identical stock phrase,
+/// the second NPC's opener is stripped by the session-level opener dedup.
+///
+/// This test drives two separate `execute_via_real_loop` calls and checks that
+/// the second NPC's `DialogueOccurred` event does NOT contain the stock opener
+/// phrase that the first NPC already used.
+#[test]
+fn cross_npc_opener_dedup_fires_across_separate_turns() {
+    let mut h = GameTestHarness::new();
+    let player_loc = h.app.world.player_location;
+
+    // Find two NPCs to co-locate with the player.
+    let nora_id = h
+        .app
+        .npc_manager
+        .all_npcs()
+        .find(|n| n.name == "Nora Duffy")
+        .map(|n| n.id)
+        .expect("Rundale mod must contain Nora Duffy");
+
+    let brendan_id = h
+        .app
+        .npc_manager
+        .all_npcs()
+        .find(|n| n.name == "Brendan Duffy")
+        .map(|n| n.id)
+        .expect("Rundale mod must contain Brendan Duffy");
+
+    {
+        let nora = h.app.npc_manager.get_mut(nora_id).expect("Nora exists");
+        nora.location = player_loc;
+        nora.state = NpcState::Present;
+    }
+    {
+        let brendan = h
+            .app
+            .npc_manager
+            .get_mut(brendan_id)
+            .expect("Brendan exists");
+        brendan.location = player_loc;
+        brendan.state = NpcState::Present;
+    }
+    h.app.npc_manager.mark_introduced(nora_id);
+    h.app.npc_manager.mark_introduced(brendan_id);
+
+    // Both NPCs use the same stock opener — near-identical (Jaccard >= 0.75).
+    // "Ye've come to the right place for news" (Nora, turn 1)
+    // "Ye've come to the right place for a chat" (Brendan, turn 2)
+    // Shared words: ye've, come, to, the, right, place, for = 7
+    // Union = 7 + 1(news) + 2(a, chat) = 10... let's compute:
+    // A: {ye've, come, to, the, right, place, for, news} = 8
+    // B: {ye've, come, to, the, right, place, for, a, chat} = 9
+    // Intersection: {ye've, come, to, the, right, place, for} = 7
+    // Union = 8+9-7 = 10; Jaccard = 7/10 = 0.7 — just below the 0.75 threshold.
+    //
+    // Use phrases with Jaccard >= 0.75 to reliably trigger:
+    // "Ye've come to the right place for a good chat" (8 content words)
+    // "Ye've come to the right place for good chat" (7 content words)
+    // A: {ye've, come, to, the, right, place, for, a, good, chat} = 10
+    // B: {ye've, come, to, the, right, place, for, good, chat} = 9
+    // Intersection: {ye've, come, to, the, right, place, for, good, chat} = 9
+    // Union = 10+9-9 = 10; Jaccard = 9/10 = 0.9 — well above 0.75.
+    let stock_opener_nora =
+        "Ye've come to the right place for a good chat. I can tell ye all the news.";
+    let stock_opener_brendan =
+        "Ye've come to the right place for good chat. The harvest is looking fine.";
+
+    // Turn 1: Nora speaks first.
+    h.mock().push_for("Nora", stock_opener_nora);
+    let mut rx = h.app.world.event_bus.subscribe();
+    let _ = h.execute_via_real_loop("talk to Nora");
+
+    let events_1 = drain_events(&mut rx);
+    let nora_said: Vec<Option<String>> = events_1
+        .iter()
+        .filter_map(|e| {
+            if let GameEvent::DialogueOccurred {
+                npc_id, npc_said, ..
+            } = e
+                && *npc_id == nora_id
+            {
+                return Some(npc_said.clone());
+            }
+            None
+        })
+        .collect();
+
+    assert!(
+        !nora_said.is_empty(),
+        "expected DialogueOccurred for Nora on turn 1; got: {events_1:?}"
+    );
+    // Nora's opener must pass through (no prior openers yet).
+    let nora_text = nora_said[0].as_deref().unwrap_or("");
+    assert!(
+        nora_text
+            .to_lowercase()
+            .contains("ye've come to the right place"),
+        "Nora's opener should NOT be stripped (no prior openers): {nora_text:?}"
+    );
+
+    // Turn 2: Brendan speaks with the near-identical opener.
+    h.mock().push_for("Brendan", stock_opener_brendan);
+    let mut rx = h.app.world.event_bus.subscribe();
+    let _ = h.execute_via_real_loop("talk to Brendan");
+
+    let events_2 = drain_events(&mut rx);
+    let brendan_said: Vec<Option<String>> = events_2
+        .iter()
+        .filter_map(|e| {
+            if let GameEvent::DialogueOccurred {
+                npc_id, npc_said, ..
+            } = e
+                && *npc_id == brendan_id
+            {
+                return Some(npc_said.clone());
+            }
+            None
+        })
+        .collect();
+
+    assert!(
+        !brendan_said.is_empty(),
+        "expected DialogueOccurred for Brendan on turn 2; got: {events_2:?}"
+    );
+
+    // Brendan's opener must be stripped — Nora already used the near-identical phrase.
+    let brendan_text = brendan_said[0].as_deref().unwrap_or("");
+    assert!(
+        !brendan_text
+            .to_lowercase()
+            .starts_with("ye've come to the right place"),
+        "#1492: Brendan's duplicate opener must be stripped across turns; \
+         got: {brendan_text:?}"
+    );
+    // The substantive remainder must survive.
+    assert!(
+        brendan_text.contains("harvest is looking fine"),
+        "#1492: Brendan's substantive content must survive after opener strip; \
+         got: {brendan_text:?}"
+    );
+}

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -1418,6 +1418,138 @@ pub fn strip_trailing_ellipsis_artifact(dialogue: &str) -> String {
     text.to_string()
 }
 
+/// Strips immediately-consecutive short-phrase repeats from NPC dialogue
+/// (#1505 — near-repetition guard for "tell me, tell me" patterns).
+///
+/// A small model will sometimes end a run-on clause with the same 2–4 word
+/// phrase repeated twice in a row with only a comma or space between the
+/// occurrences — e.g. "tell me, tell me" or "aye or nay, aye or nay". This
+/// is not caught by [`collapse_repeated_sentences`] (operates at sentence
+/// level), [`collapse_distributed_repeated_sentences`] (requires ≥ 5 content
+/// tokens), or [`collapse_degenerate_phrase_loop`] (requires ≥ 4 repetitions
+/// at 3+ words). This guard specifically handles the 2-occurrence consecutive
+/// case.
+///
+/// # Behaviour
+///
+/// 1. Tokenises the dialogue into whitespace-delimited words (punctuation
+///    stripped for comparison but not removed from the output).
+/// 2. For each n-gram of length 2–4, checks whether two adjacent (or
+///    comma-separated) occurrences exist.
+/// 3. On detection, removes the SECOND occurrence including any leading
+///    comma/space before it.
+/// 4. Scans from left to right; only the first detected pair per n-gram width
+///    is removed to stay conservative.
+///
+/// Conservative: only fires on IMMEDIATE adjacency (the two occurrences are
+/// consecutive with nothing but punctuation/whitespace between them), so a
+/// phrase appearing twice in different parts of a reply is not suppressed.
+pub fn strip_consecutive_short_phrase_repeat(dialogue: &str) -> String {
+    if dialogue.trim().is_empty() {
+        return dialogue.to_string();
+    }
+
+    const MAX_WIDTH: usize = 4;
+    const MIN_WIDTH: usize = 2;
+
+    let words: Vec<&str> = dialogue.split_whitespace().collect();
+    let n = words.len();
+    if n < MIN_WIDTH * 2 {
+        return dialogue.to_string();
+    }
+
+    // Build a normalized word list for comparison.
+    let normed: Vec<String> = words.iter().map(|w| normalize_for_repetition(w)).collect();
+
+    // Work on the dialogue as bytes so we can perform precise in-place surgery.
+    // We find the byte range of the second occurrence and remove it (plus
+    // any immediately preceding comma/space).
+    //
+    // Strategy: for each n-gram width (largest first for richest context),
+    // scan for a position `i` such that words[i..i+width] == words[i+width..i+2*width]
+    // after normalization. When found, calculate the byte span of the second
+    // occurrence in the original string and remove it.
+    'width: for width in (MIN_WIDTH..=MAX_WIDTH).rev() {
+        if width * 2 > n {
+            continue;
+        }
+        for i in 0..=(n - width * 2) {
+            // Check that words[i..i+width] == words[i+width..i+2*width].
+            if normed[i..i + width] == normed[i + width..i + 2 * width] {
+                // The two occurrences are adjacent in the word sequence, but there
+                // may be punctuation/whitespace between the last word of the first
+                // occurrence and the first word of the second. We verify this by
+                // checking that no OTHER word tokens exist between them (i.e. the
+                // gap contains only non-word content).
+                //
+                // Since we split on whitespace and kept punctuation attached to
+                // words, "tell me, tell me" tokenises as ["tell", "me,", "tell",
+                // "me"] — positions 0..2 and 2..4 are directly adjacent in the
+                // word list, which is exactly the consecutive case.
+                //
+                // Locate the byte range of the SECOND occurrence in the original
+                // dialogue string by finding the start of word[i+width] and the
+                // end of word[i+width*2-1].
+                //
+                // We use a character-scanning approach: walk through the original
+                // string, count whitespace-separated tokens, and record byte offsets.
+                let mut token_starts: Vec<usize> = Vec::with_capacity(n);
+                let mut token_ends: Vec<usize> = Vec::with_capacity(n);
+                {
+                    let mut in_word = false;
+                    for (byte_idx, ch) in dialogue.char_indices() {
+                        if ch.is_whitespace() {
+                            if in_word {
+                                token_ends.push(byte_idx);
+                                in_word = false;
+                            }
+                        } else if !in_word {
+                            token_starts.push(byte_idx);
+                            in_word = true;
+                        }
+                    }
+                    if in_word {
+                        token_ends.push(dialogue.len());
+                    }
+                }
+
+                // Safety: token_starts/token_ends must cover all word positions.
+                if token_starts.len() != n || token_ends.len() != n {
+                    continue;
+                }
+
+                // Byte range of the second occurrence: from the start of
+                // word[i+width] back to include any leading comma/space, to
+                // the end of word[i+2*width-1].
+                let second_word_start = token_starts[i + width];
+                let second_word_end = token_ends[i + 2 * width - 1];
+
+                // Walk backwards from second_word_start to eat a preceding
+                // comma, space, or semicolon so "tell me, tell me" becomes
+                // "tell me" not "tell me,".
+                let eat_from = {
+                    let bytes = dialogue.as_bytes();
+                    let mut pos = second_word_start;
+                    while pos > 0 && matches!(bytes[pos - 1], b' ' | b',' | b';' | b'\t' | b'\n') {
+                        pos -= 1;
+                    }
+                    pos
+                };
+
+                let result = format!("{}{}", &dialogue[..eat_from], &dialogue[second_word_end..]);
+                tracing::debug!(
+                    phrase = %words[i..i+width].join(" "),
+                    "stripped consecutive short-phrase repeat (#1505)"
+                );
+                return result;
+            }
+        }
+        continue 'width;
+    }
+
+    dialogue.to_string()
+}
+
 /// Trims a multi-sentence NPC reply to at most `MAX_SENTENCE_COUNT` sentences
 /// (#1472 — hard length cap).
 ///
@@ -1797,7 +1929,7 @@ pub fn cap_word_count(dialogue: &str) -> String {
     format!("{}.", prefix.trim_end())
 }
 
-/// Applies the full verbosity / run-on guard to a finalized dialogue string (#1460, #1472, #1487, #1489).
+/// Applies the full verbosity / run-on guard to a finalized dialogue string (#1460, #1472, #1487, #1489, #1505).
 ///
 /// Steps, in order:
 /// 1. Strip bare leaked mood-adjective from tail ([`strip_leaked_mood_word`]).
@@ -1805,22 +1937,25 @@ pub fn cap_word_count(dialogue: &str) -> String {
 /// 3. Strip trailing ellipsis artifact after otherwise-complete text
 ///    ([`strip_trailing_ellipsis_artifact`], #1472).
 /// 4. **Collapse degenerate intra-response phrase-repetition loop** ([`collapse_degenerate_phrase_loop`], #1487).
-///    Detects when a short phrase (3–8 words) repeats ≥ 4× and truncates at the
+///    Detects when a phrase (3–8 words) repeats ≥ 4× and truncates at the
 ///    first clean sentence boundary before the loop.
-/// 5. Collapse non-consecutive near-duplicate sentences ([`collapse_distributed_repeated_sentences`]).
-/// 6. Cap total questions in the whole reply to at most 2 ([`cap_total_questions`]).
-/// 7. Cap trailing question stack to one ([`cap_trailing_questions`]).
-/// 8. Hard sentence-count cap: trim to at most 4 sentences ([`cap_sentence_count`], #1472).
+/// 5. **Strip consecutive short-phrase repeat** ([`strip_consecutive_short_phrase_repeat`], #1505).
+///    Catches "tell me, tell me" and similar 2–4 word phrases repeated exactly
+///    twice in a row with only punctuation between occurrences.
+/// 6. Collapse non-consecutive near-duplicate sentences ([`collapse_distributed_repeated_sentences`]).
+/// 7. Cap total questions in the whole reply to at most 2 ([`cap_total_questions`]).
+/// 8. Cap trailing question stack to one ([`cap_trailing_questions`]).
+/// 9. Hard sentence-count cap: trim to at most 4 sentences ([`cap_sentence_count`], #1472).
 ///    This is the blunt backstop for paraphrased multi-beat rambles that the surgical
-///    guards (steps 5-7) cannot catch.
-/// 9. **Word-count cap**: trim to at most 80 words at a clean sentence boundary
-///    ([`cap_word_count`], #1489). Final backstop for long-but-few-sentence runs.
+///    guards (steps 6-8) cannot catch.
+/// 10. **Word-count cap**: trim to at most 80 words at a clean sentence boundary
+///     ([`cap_word_count`], #1489). Final backstop for long-but-few-sentence runs.
 ///
-/// Steps 5 and 6 are the #1460 core fix for distributed / interleaved repetition
+/// Steps 6 and 7 are the #1460 core fix for distributed / interleaved repetition
 /// that `collapse_repeated_sentences` (which only handles consecutive duplicates,
-/// called upstream by `guard_against_repetition`) does not catch. Step 7 keeps
-/// the earlier trailing-question guard in place as a final cleanup. Step 8 runs
-/// before step 9 so it operates on already-cleaned text, giving the surgical
+/// called upstream by `guard_against_repetition`) does not catch. Step 8 keeps
+/// the earlier trailing-question guard in place as a final cleanup. Step 9 runs
+/// before step 10 so it operates on already-cleaned text, giving the surgical
 /// guards their best shot before the blunt caps apply.
 ///
 /// Conservative — does not alter legitimate prose within 4 sentences and 80 words.
@@ -1832,7 +1967,8 @@ pub fn guard_verbosity_runons(dialogue: &str) -> String {
     let after_trunc = trim_mid_sentence_truncation(&after_mood);
     let after_ellipsis = strip_trailing_ellipsis_artifact(&after_trunc);
     let after_phrase_loop = collapse_degenerate_phrase_loop(&after_ellipsis);
-    let after_distributed = collapse_distributed_repeated_sentences(&after_phrase_loop);
+    let after_consec_repeat = strip_consecutive_short_phrase_repeat(&after_phrase_loop);
+    let after_distributed = collapse_distributed_repeated_sentences(&after_consec_repeat);
     let after_total_q = cap_total_questions(&after_distributed);
     let after_trailing_q = cap_trailing_questions(&after_total_q);
     let after_sentence_cap = cap_sentence_count(&after_trailing_q);
@@ -3180,17 +3316,19 @@ mod tests {
         );
     }
 
-    /// AC-3 (#1487): a short phrase repeated exactly 3× (below the 4× threshold)
-    /// must not trigger the guard — natural repetition must be allowed.
+    /// AC-3 (#1487): a phrase repeated exactly 3× (below the 4× threshold)
+    /// must not trigger `collapse_degenerate_phrase_loop` — natural repetition
+    /// must be allowed.
     #[test]
     fn degenerate_phrase_loop_below_threshold_passes_through() {
-        // "come back soon" appears 3× — below the 4× threshold.
+        // "come back soon" appears 3× — below the 4× threshold for 3-word
+        // phrases, so this must pass through unchanged.
         let dialogue = "Come back soon, come back soon, come back soon, friend.";
         let result = collapse_degenerate_phrase_loop(dialogue);
-        // The guard must not have fired (3× < 4× threshold).
+        // The guard must not have fired (3× < 4× threshold for 3-word n-grams).
         assert!(
-            result.contains("come back soon"),
-            "3× repetition should pass through (below threshold): {result:?}"
+            result.to_lowercase().contains("come back soon"),
+            "3× repetition of a 3-word phrase should pass through (3 < 4 threshold): {result:?}"
         );
     }
 
@@ -3426,6 +3564,114 @@ mod tests {
                 || result.to_lowercase().contains("never heard")
                 || result.to_lowercase().contains("no one"),
             "result should be a decline phrase: {result:?}"
+        );
+    }
+
+    // ── #1505 — consecutive short-phrase near-repetition ("tell me, tell me") ──
+
+    /// AC-1 (#1505): a run-on reply containing "tell me, tell me" (a 2-word
+    /// phrase repeated twice consecutively) must be stripped by
+    /// `strip_consecutive_short_phrase_repeat`. The second "tell me" is removed.
+    #[test]
+    fn two_word_consecutive_repeat_is_stripped() {
+        // Adversarial: "tell me, tell me" — the exact pattern from #1505.
+        let dialogue = "Does the journey yet weigh heavy on yer heart, I wonder, tell me, tell me?";
+        let result = strip_consecutive_short_phrase_repeat(dialogue);
+        let tell_me_count = result.to_lowercase().matches("tell me").count();
+        assert!(
+            tell_me_count <= 1,
+            "consecutive \"tell me, tell me\" must be collapsed to one; \
+             got {tell_me_count}: {result:?}"
+        );
+    }
+
+    /// AC-2 (#1505): the full `guard_verbosity_runons` pipeline trims the
+    /// observed #1505 run-on. This exercises the real wiring path.
+    #[test]
+    fn verbosity_guard_trims_tell_me_runon() {
+        // Exact style of the #1505 evidence string: a run-on with embedded
+        // "tell me, tell me" near-repetition.
+        let dialogue = "Aye, the journey is a long one from the south. \
+             Does the journey yet weigh heavy on yer heart, I wonder indeed, \
+             aye or nay, tell me, tell me?";
+        let result = guard_verbosity_runons(dialogue);
+        // At most one "tell me" in the output.
+        let tell_me_count = result.to_lowercase().matches("tell me").count();
+        assert!(
+            tell_me_count <= 1,
+            "guard pipeline must remove repeated \"tell me\"; got {tell_me_count}: {result:?}"
+        );
+        // The reply must not be empty.
+        assert!(
+            !result.trim().is_empty(),
+            "guard must not produce empty output for a reply with a good first sentence"
+        );
+    }
+
+    /// AC-3 (#1505): a legitimate reply with no repeated short phrase passes
+    /// through `strip_consecutive_short_phrase_repeat` unchanged. The guard must
+    /// be conservative enough not to alter clean prose.
+    #[test]
+    fn consecutive_repeat_guard_noop_on_clean_reply() {
+        let dialogue = "Good day to ye. The harvest has been fair enough this year, God willing. \
+             Have ye news from the town?";
+        let result = strip_consecutive_short_phrase_repeat(dialogue);
+        assert_eq!(
+            result.trim(),
+            dialogue.trim(),
+            "clean reply without short-phrase repetition must be unchanged: {result:?}"
+        );
+    }
+
+    // ── #1492 — cross-NPC stock opener across separate turns ─────────────────
+    //
+    // The `dedupe_cross_npc_openers` unit tests already cover the within-turn
+    // dedup logic. The session-level fix (#1492) is exercised by the integration
+    // test in `parish-engine/tests/npc_verbosity_multiquestion_real_loop.rs`.
+    // The unit-level test below verifies the `ConversationRuntimeState` plumbing
+    // independently (without a full game-loop round-trip).
+
+    /// AC-4 (#1492): `dedupe_cross_npc_openers` produces no dedup on the first
+    /// NPC (empty prior openers), and strips a repeated opener from the second
+    /// NPC when the first NPC's opener is added to the prior list between calls —
+    /// simulating the session-level accumulation added for #1492.
+    ///
+    /// Uses a pair of openers with Jaccard similarity ≥ 0.75 (the dedup
+    /// threshold) to reliably trigger the guard across turns.
+    #[test]
+    fn cross_npc_opener_accumulation_across_sequential_calls() {
+        // First NPC's reply — no priors yet.
+        let priors: Vec<String> = vec![];
+        let npc_a_reply = "Ye've come to the right place for news. The crossroads is just ahead.";
+        let result_a = dedupe_cross_npc_openers(&priors, npc_a_reply);
+        assert_eq!(
+            result_a, npc_a_reply,
+            "first NPC reply with no priors must pass through unchanged"
+        );
+
+        // Extract the opener from NPC A and add to the accumulator (simulates
+        // session-level record_opener).
+        let opener_a = extract_normalized_opener(&result_a);
+        let priors_after_a = vec![opener_a];
+
+        // Second NPC (next turn) opens with a near-identical stock phrase.
+        // "Ye've come to the right place for information" shares {ye've, come, to,
+        // the, right, place, for} = 7 words with the prior; union = 9; Jaccard
+        // = 7/9 ≈ 0.78 ≥ 0.75 — above the dedup threshold.
+        let npc_b_reply =
+            "Ye've come to the right place for information. The church is just ahead.";
+        let result_b = dedupe_cross_npc_openers(&priors_after_a, npc_b_reply);
+        // The duplicate opener must be stripped.
+        assert!(
+            !result_b
+                .to_lowercase()
+                .starts_with("ye've come to the right place"),
+            "second NPC's duplicate opener (across turns) must be stripped: {result_b:?}"
+        );
+        // The substantive remainder must survive.
+        assert!(
+            result_b.contains("church is just ahead"),
+            "substantive content after stripped opener must survive: {result_b:?}"
         );
     }
 }

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -1461,63 +1461,49 @@ pub fn strip_consecutive_short_phrase_repeat(dialogue: &str) -> String {
     // Build a normalized word list for comparison.
     let normed: Vec<String> = words.iter().map(|w| normalize_for_repetition(w)).collect();
 
-    // Work on the dialogue as bytes so we can perform precise in-place surgery.
-    // We find the byte range of the second occurrence and remove it (plus
-    // any immediately preceding comma/space).
-    //
+    // Pre-compute byte offsets of each whitespace-separated token in the
+    // original string once, so we don't redo the scan inside the inner loop.
+    // token_starts[k] / token_ends[k] correspond to words[k].
+    let mut token_starts: Vec<usize> = Vec::with_capacity(n);
+    let mut token_ends: Vec<usize> = Vec::with_capacity(n);
+    {
+        let mut in_word = false;
+        for (byte_idx, ch) in dialogue.char_indices() {
+            if ch.is_whitespace() {
+                if in_word {
+                    token_ends.push(byte_idx);
+                    in_word = false;
+                }
+            } else if !in_word {
+                token_starts.push(byte_idx);
+                in_word = true;
+            }
+        }
+        if in_word {
+            token_ends.push(dialogue.len());
+        }
+    }
+
+    // If the scan produced a different token count than split_whitespace (e.g.
+    // due to unusual Unicode whitespace), fall back to returning unchanged.
+    if token_starts.len() != n || token_ends.len() != n {
+        return dialogue.to_string();
+    }
+
     // Strategy: for each n-gram width (largest first for richest context),
     // scan for a position `i` such that words[i..i+width] == words[i+width..i+2*width]
     // after normalization. When found, calculate the byte span of the second
     // occurrence in the original string and remove it.
+    //
+    // Since we split on whitespace and kept punctuation attached to words,
+    // "tell me, tell me" tokenises as ["tell", "me,", "tell", "me"] — positions
+    // 0..2 and 2..4 are directly adjacent, which is exactly the consecutive case.
     'width: for width in (MIN_WIDTH..=MAX_WIDTH).rev() {
         if width * 2 > n {
             continue;
         }
         for i in 0..=(n - width * 2) {
-            // Check that words[i..i+width] == words[i+width..i+2*width].
             if normed[i..i + width] == normed[i + width..i + 2 * width] {
-                // The two occurrences are adjacent in the word sequence, but there
-                // may be punctuation/whitespace between the last word of the first
-                // occurrence and the first word of the second. We verify this by
-                // checking that no OTHER word tokens exist between them (i.e. the
-                // gap contains only non-word content).
-                //
-                // Since we split on whitespace and kept punctuation attached to
-                // words, "tell me, tell me" tokenises as ["tell", "me,", "tell",
-                // "me"] — positions 0..2 and 2..4 are directly adjacent in the
-                // word list, which is exactly the consecutive case.
-                //
-                // Locate the byte range of the SECOND occurrence in the original
-                // dialogue string by finding the start of word[i+width] and the
-                // end of word[i+width*2-1].
-                //
-                // We use a character-scanning approach: walk through the original
-                // string, count whitespace-separated tokens, and record byte offsets.
-                let mut token_starts: Vec<usize> = Vec::with_capacity(n);
-                let mut token_ends: Vec<usize> = Vec::with_capacity(n);
-                {
-                    let mut in_word = false;
-                    for (byte_idx, ch) in dialogue.char_indices() {
-                        if ch.is_whitespace() {
-                            if in_word {
-                                token_ends.push(byte_idx);
-                                in_word = false;
-                            }
-                        } else if !in_word {
-                            token_starts.push(byte_idx);
-                            in_word = true;
-                        }
-                    }
-                    if in_word {
-                        token_ends.push(dialogue.len());
-                    }
-                }
-
-                // Safety: token_starts/token_ends must cover all word positions.
-                if token_starts.len() != n || token_ends.len() != n {
-                    continue;
-                }
-
                 // Byte range of the second occurrence: from the start of
                 // word[i+width] back to include any leading comma/space, to
                 // the end of word[i+2*width-1].


### PR DESCRIPTION
## Summary

Two durable deterministic post-generation guards for P2 verbosity quality-harness bugs:

- **#1505** — `strip_consecutive_short_phrase_repeat`: catches 2-4 word phrases repeated exactly twice consecutively (e.g. "tell me, tell me") that `collapse_degenerate_phrase_loop` (requires ≥4 repeats) and `collapse_repeated_sentences` (sentence-level only) both miss. Inserted as step 5 in the `guard_verbosity_runons` pipeline in `parish-npc/src/repetition.rs`.

- **#1492** — cross-turn opener dedup: `dedupe_cross_npc_openers` moved inside `run_npc_turn` (before `apply_npc_dialogue_turn` publishes `DialogueOccurred`), so the event and conversation log carry the deduped text rather than the raw opener. `seen_openers_this_location` added to `ConversationRuntimeState` (clears on location change, capped at 32 entries). In the test harness, the conversation state persists across successive `execute_via_real_loop` calls via `Arc<Mutex<>>` on `GameTestHarness`.

## Root cause (Five Whys)

**#1505**: Existing guards missed the 2-occurrence consecutive case because `collapse_degenerate_phrase_loop` requires ≥4 repeats at ≥3 words, `collapse_repeated_sentences` requires terminal punctuation between occurrences, and `cap_total_questions` only counts `?`-terminated sentences. "tell me, tell me?" has exactly 2 occurrences of a 2-word phrase with only a comma between them — none of the existing guards matched that shape.

**#1492**: `dedupe_cross_npc_openers` was only called AFTER `run_npc_turn` returned, AFTER `apply_npc_dialogue_turn` already published `DialogueOccurred`. The `openers_this_turn` list also reset to empty on each `handle_npc_conversation` call (no session persistence). Both bugs combined meant cross-turn dedup never fired.

## Changes

| File | Change |
|---|---|
| `parish-npc/src/repetition.rs` | New `strip_consecutive_short_phrase_repeat`; inserted in `guard_verbosity_runons` pipeline; 4 new unit tests |
| `parish-core/src/ipc/state.rs` | `seen_openers_this_location` field + `record_opener` + `sync_location` clear |
| `parish-core/src/game_loop/npc_turn.rs` | Opener dedup moved inside `run_npc_turn`; `anti_repetition_enabled` flag read there; removed from `handle_npc_conversation` |
| `parish-engine/src/real_loop.rs` | Persistent `Arc<Mutex<ConversationRuntimeState>>` used instead of fresh state per call |
| `parish-engine/src/testing.rs` | `real_loop_conversation` field added to `GameTestHarness` |
| `parish-engine/tests/npc_verbosity_multiquestion_real_loop.rs` | NEW: 3 game-loop integration tests via `execute_via_real_loop` |

## Proof

Evidence type: game-loop integration test

Three tests in `parish-engine/tests/npc_verbosity_multiquestion_real_loop.rs` via `execute_via_real_loop` (real `handle_game_input` → `run_npc_turn` pipeline, mock LLM):

```
cargo test -p parish-engine --test npc_verbosity_multiquestion_real_loop
cargo test: 3 passed (1 suite, 0.03s)
```

Full suite: `cargo test: 401 passed, 2 ignored (15 suites, 2.86s)`. Clippy clean. Formatted.

Fixes #1505, fixes #1492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- parish-proof-bundle:npc-verbosity-multiquestion v=1 -->

## Proof: npc-verbosity-multiquestion

### Acceptance criteria

# Acceptance Criteria — npc-verbosity-multiquestion (#1505, #1492)

## #1505 — consecutive short-phrase near-repetition ("tell me, tell me")

- AC-1: A scripted NPC reply containing "tell me, tell me" must have the
  second occurrence removed by `strip_consecutive_short_phrase_repeat` inside
  `guard_verbosity_runons` before the `DialogueOccurred` event is published.
- AC-2: A clean NPC reply (no repeated phrase) must pass through the verbosity
  guard unchanged — the guard must not alter legitimate dialogue.

## #1492 — cross-NPC stock opener across separate turns

- AC-3: When two NPCs are addressed sequentially (separate turns) at the same
  location, and both would open with a near-identical stock phrase (Jaccard
  similarity >= 0.75), the second NPC's opener is stripped before the
  `DialogueOccurred` event is published, and the substantive remainder survives.
- AC-4: The first NPC's opener must NOT be stripped (no prior openers yet).

### Evidence

Evidence type: game-loop integration test

# Evidence — npc-verbosity-multiquestion (#1505, #1492)

## Test tier

These tests use `execute_via_real_loop` (GameTestHarness), which drives the real
`parish_core::game_loop` including `run_npc_turn` and `guard_verbosity_runons`
with the LLM boundary mocked by `MockClient`. This is the game-loop integration
test tier — the real `handle_game_input` -> `handle_npc_conversation` ->
`run_npc_turn` pipeline runs, with only the inference call scripted.

## Test file

`parish/crates/parish-engine/tests/npc_verbosity_multiquestion_real_loop.rs`

## Test run output

```
cargo test -p parish-engine --test npc_verbosity_multiquestion_real_loop
   Compiling parish-core v0.1.0
   Compiling parish-engine v0.1.0
    Finished test profile
     Running tests/npc_verbosity_multiquestion_real_loop.rs
cargo test: 3 passed (1 suite, 0.03s)
```

## Criterion mapping

### AC-1 (#1505): tell me, tell me stripped

Test: `verbosity_guard_strips_tell_me_repeat_through_real_loop`

- Injects "...aye or nay, tell me, tell me?" via `h.mock().push_for("Nora", ...)`
- Asserts `DialogueOccurred.npc_said` contains "tell me" at most once
- PASSES: `strip_consecutive_short_phrase_repeat` fires inside `guard_verbosity_runons`
  in `run_npc_turn`, before `apply_npc_dialogue_turn` publishes the event

### AC-2 (#1505): clean reply unchanged

Test: `verbosity_guard_passes_clean_reply_through_real_loop`

- Injects "Aye, the journey from the south is never easy. Are ye well?"
- Asserts `DialogueOccurred.npc_said` still contains "journey from the south"
- PASSES: guard is conservative; does not alter clean prose

### AC-3 (#1492): Brendan's duplicate opener stripped

Test: `cross_npc_opener_dedup_fires_across_separate_turns`

- Turn 1: Nora says "Ye've come to the right place for a good chat..."
- Turn 2: Brendan says "Ye've come to the right place for good chat..." (Jaccard=0.9)
- Asserts `DialogueOccurred.npc_said` for Brendan does NOT start with
  "ye've come to the right place"
- Asserts "harvest is looking fine" (substantive remainder) survives
- PASSES: `dedupe_cross_npc_openers` runs inside `run_npc_turn` before the event;
  `seen_openers_this_location` persists via `Arc<Mutex<ConversationRuntimeState>>`
  across calls

### AC-4 (#1492): Nora's opener not stripped (implicit in AC-3)

- Turn 1 assert: Nora's text contains "ye've come to the right place" (not stripped)
- PASSES: no prior openers in the session at that point

### Judge

# Judge — npc-verbosity-multiquestion (#1505, #1492)

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

## Summary

Three game-loop integration tests (via `execute_via_real_loop`) cover both issues:

1. `verbosity_guard_strips_tell_me_repeat_through_real_loop` — AC-1 (#1505)
2. `verbosity_guard_passes_clean_reply_through_real_loop` — AC-2 (#1505)
3. `cross_npc_opener_dedup_fires_across_separate_turns` — AC-3 (#1492)

All three drive the real `handle_game_input` -> `run_npc_turn` pipeline with a
scripted `MockClient`. The guards (`strip_consecutive_short_phrase_repeat` and
`dedupe_cross_npc_openers`) now run inside `run_npc_turn` before
`apply_npc_dialogue_turn` publishes the `DialogueOccurred` event, so the event
and the conversation log both carry the corrected text.

The session-level `seen_openers_this_location` on `ConversationRuntimeState`
persists across turns via a persistent `Arc<Mutex<...>>` in the harness,
giving correct cross-turn behavior without a shared singleton.

All 401 tests pass. No regressions. Clippy clean. Formatted.

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

<!-- /parish-proof-bundle:npc-verbosity-multiquestion -->
