### PR TITLE
fix(npc): guard "Do you know X?" being treated as "Are you X?" (#1504)

### DIFF
--- a/parish/crates/parish-core/src/game_loop/npc_turn.rs
+++ b/parish/crates/parish-core/src/game_loop/npc_turn.rs
@@ -68,6 +68,13 @@ pub const SERIALIZE_TURN_STREAM_FLAG: &str = "serialize-turn-stream";
 /// (`flags.is_disabled(DIALOGUE_ANTI_REPETITION_FLAG)` → true).
 pub const DIALOGUE_ANTI_REPETITION_FLAG: &str = "dialogue-anti-repetition";
 
+/// Feature-flag name (default **on**) that enables the acquaintance-question /
+/// identity-drift guard (#1504). When the player asks "do you know X?" and the
+/// NPC responds with a pure self-identification ("I'm but Seamus Gallagher")
+/// instead of answering whether they know the named person, this guard replaces
+/// the response with the correct acquaintance answer. Kill-switch only.
+pub const ACQUAINTANCE_INTENT_GUARD_FLAG: &str = "npc-acquaintance-intent-guard";
+
 /// Token cap for Tier 1 dialogue generation.
 ///
 /// Sized so a 2-4 sentence reply plus the JSON envelope (`dialogue`, `action`,
@@ -122,7 +129,13 @@ pub async fn run_npc_turn(
     player_initiated: bool,
     spawn_loading: impl FnOnce() -> Option<CancellationToken>,
 ) -> Option<TurnOutcome> {
-    let (setup, person_guard_enabled, verbosity_guard_enabled, wrong_speaker_guard_enabled) = {
+    let (
+        setup,
+        person_guard_enabled,
+        verbosity_guard_enabled,
+        wrong_speaker_guard_enabled,
+        acquaintance_guard_enabled,
+    ) = {
         let mut world = ctx.world.lock().await;
         let mut npc_manager = ctx.npc_manager.lock().await;
         let config = ctx.config.lock().await;
@@ -140,6 +153,8 @@ pub async fn run_npc_turn(
         let verbosity_guard = !config.flags.is_disabled("dialogue-verbosity-guard");
         // Wrong-speaker-identity guard (#1475): default-on, kill-switch only.
         let wrong_speaker_guard = !config.flags.is_disabled("npc-wrong-speaker-guard");
+        // Acquaintance-question intent-drift guard (#1504): default-on, kill-switch only.
+        let acquaintance_guard = !config.flags.is_disabled(ACQUAINTANCE_INTENT_GUARD_FLAG);
         let npc_cfg = crate::config::NpcConfig {
             dialogue_quality_continuity: !config.flags.is_disabled("dialogue-quality-continuity"),
             grounding_enabled: !config.flags.is_disabled("npc-dialogue-grounding"),
@@ -157,7 +172,13 @@ pub async fn run_npc_turn(
             &ctx.language,
             &npc_cfg,
         );
-        (setup, person_guard, verbosity_guard, wrong_speaker_guard)
+        (
+            setup,
+            person_guard,
+            verbosity_guard,
+            wrong_speaker_guard,
+            acquaintance_guard,
+        )
     };
     let setup = setup?;
 
@@ -399,6 +420,27 @@ pub async fn run_npc_turn(
             &parsed.dialogue,
             &setup.npc_name,
             &setup.roster_names_occupations,
+            guard_seed,
+        );
+        if guarded != parsed.dialogue {
+            parsed.dialogue = guarded;
+        }
+    }
+
+    // Post-generation acquaintance-question intent-drift guard (#1504): detect
+    // when the player asked "do you know X?" and the NPC responded only with a
+    // self-identification ("I'm but Seamus Gallagher") instead of answering
+    // whether they know the named person. Replaces with the correct acquaintance
+    // answer (affirmation if known, non-recognition decline if not).
+    // Default-on; kill-switch via `npc-acquaintance-intent-guard` flag.
+    if acquaintance_guard_enabled && !parsed.dialogue.trim().is_empty() {
+        let guard_seed =
+            speaker_id.0 as u64 ^ ctx.world.lock().await.clock.now().timestamp() as u64;
+        let guarded = crate::npc::guard_acquaintance_question_intent_drift(
+            &parsed.dialogue,
+            prompt_input,
+            &setup.npc_name,
+            &setup.known_person_names,
             guard_seed,
         );
         if guarded != parsed.dialogue {

--- a/parish/crates/parish-engine/tests/do_you_know_intent.rs
+++ b/parish/crates/parish-engine/tests/do_you_know_intent.rs
@@ -1,0 +1,285 @@
+//! End-to-end proof for the acquaintance-intent guard (#1504).
+//!
+//! The guard lives in `parish-npc/src/repetition.rs`
+//! (`guard_acquaintance_question_intent_drift`) and is wired into
+//! `parish-core/src/game_loop/npc_turn.rs` under the flag
+//! `npc-acquaintance-intent-guard`.  Unit tests already cover the guard's
+//! logic in isolation.  This integration test exercises the full wiring: a
+//! mock reply that conflates "Do you know X?" with "Are you X?" is fed
+//! through `execute_via_real_loop` and must emerge from the event bus with
+//! the guard's replacement text in place of the self-identity drift.
+//!
+//! ## Why `execute_via_real_loop`?
+//!
+//! The legacy `execute()` path is a test-only shim that reimplements dialogue
+//! routing independently of `parish_core::game_loop`, so guard changes made in
+//! `npc_turn.rs` would be invisible to it.  `execute_via_real_loop` drives the
+//! actual `handle_game_input` → `run_npc_turn` path with the LLM boundary
+//! mocked by `MockClient`, making it the closest integration-level equivalent
+//! of the live Tauri/server runtime.
+//!
+//! ## Scenario (reproduces run-16 turn-14)
+//!
+//! Seamus Gallagher (Blacksmith) is placed at the player's location and
+//! marked as introduced.  The player asks "Do you know Father Declan Tierney?"
+//! — an acquaintance question.  The mock returns the exact buggy response from
+//! the original bug report: "Ye must be mistaken... I'm but Seamus Gallagher."
+//! The guard must intercept it and replace it with an acquaintance affirmation
+//! (because Fr. Declan Tierney IS in the parish roster) before
+//! `DialogueOccurred` is published.
+
+use parish_core::npc::types::NpcState;
+use parish_core::world::events::GameEvent;
+use parish_engine::testing::GameTestHarness;
+use parish_types::LocationId;
+
+/// Drains the broadcast receiver until empty, returning all events.
+fn drain_events(rx: &mut tokio::sync::broadcast::Receiver<GameEvent>) -> Vec<GameEvent> {
+    let mut out = Vec::new();
+    loop {
+        match rx.try_recv() {
+            Ok(ev) => out.push(ev),
+            Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => continue,
+            Err(_) => break,
+        }
+    }
+    out
+}
+
+/// The acquaintance affirmation pool from `repetition.rs` — any of these lines
+/// is an acceptable replacement when the named person is in the roster.
+const ACQUAINTANCE_AFFIRM_POOL: &[&str] = &[
+    "Aye, I know them well enough.",
+    "Aye, I've met them in the parish.",
+    "I do know who ye mean.",
+    "Aye, the name is known to me.",
+    "Sure, I know them from hereabouts.",
+];
+
+/// The exact buggy self-identity reply from run-16 turn-14.
+const SELF_IDENTITY_DRIFT: &str = "Ye must be mistaken... I'm but Seamus Gallagher.";
+
+/// The player's acquaintance question that triggered the bug.
+const PLAYER_QUESTION: &str = "Do you know Father Declan Tierney?";
+
+#[test]
+fn acquaintance_intent_guard_fires_through_real_game_loop() {
+    // ── 1. Build the harness (loads the Rundale mod). ─────────────────────────
+    let mut h = GameTestHarness::new();
+    let player_loc = h.app.world.player_location;
+
+    // ── 2. Find Seamus Gallagher by name. ────────────────────────────────────
+    //
+    // The harness loads Rundale's npcs.json which contains Seamus Gallagher
+    // (id 9, Blacksmith).  We look him up by name so the test is stable
+    // across any future re-ordering of the JSON file.
+    let seamus_id = h
+        .app
+        .npc_manager
+        .all_npcs()
+        .find(|n| n.name == "Seamus Gallagher")
+        .map(|n| n.id)
+        .expect("Rundale mod must contain Seamus Gallagher");
+
+    // ── 3. Clear all NPCs from the player location then place only Seamus. ────
+    //
+    // Several NPCs start at the player's default start location, and their
+    // system prompts may mention "Seamus" (he is a well-known blacksmith).
+    // If any are present, another NPC might consume the mock before Seamus.
+    // Clearing the location first means only Seamus receives the inference turn.
+    //
+    // Fr. Declan Tierney does NOT need to be at the player location for the
+    // guard to recognise him: `known_person_names` in NpcConversationSetup is
+    // built from ALL NPCs in the manager (the full roster), not just those
+    // currently co-located.  Seamus knows Fr. Declan through the roster.
+
+    // Move every NPC away from player_loc except Seamus.
+    let all_ids: Vec<_> = h.app.npc_manager.all_npcs().map(|n| n.id).collect();
+    for id in &all_ids {
+        if *id != seamus_id
+            && let Some(npc) = h.app.npc_manager.get_mut(*id)
+            && npc.location == player_loc
+        {
+            // Move to a sentinel location (0) that is not the player's.
+            npc.location = LocationId(0);
+        }
+    }
+
+    // Place Seamus at the player's location and mark him as introduced.
+    {
+        let seamus = h.app.npc_manager.get_mut(seamus_id).expect("Seamus exists");
+        seamus.location = player_loc;
+        seamus.state = NpcState::Present;
+    }
+    h.app.npc_manager.mark_introduced(seamus_id);
+
+    // ── 4. Script the mock to return the self-identity drift. ─────────────────
+    //
+    // With only Seamus at the player location, `push_any` ensures the next
+    // inference request (his turn) gets the buggy self-identity response.
+    h.mock().push_any(SELF_IDENTITY_DRIFT);
+
+    // ── 5. Subscribe to the event bus and run the dialogue turn. ─────────────
+    let mut rx = h.app.world.event_bus.subscribe();
+    // Send the acquaintance question directly — no "talk to" prefix needed
+    // because Seamus is co-located and introduced.  The mock matches by
+    // system-prompt content (his name), so the question reaches him.
+    let _ = h.execute_via_real_loop(PLAYER_QUESTION);
+
+    // ── 6. Drain events and find any DialogueOccurred for Seamus. ─────────────
+    //
+    // Seamus is the only addressed NPC at the player location, so the single
+    // DialogueOccurred event that arrives must be his turn.
+    let events = drain_events(&mut rx);
+    let dialogue_events: Vec<_> = events
+        .iter()
+        .filter_map(|e| {
+            if let GameEvent::DialogueOccurred {
+                npc_id, npc_said, ..
+            } = e
+                && *npc_id == seamus_id
+            {
+                return Some(npc_said.clone());
+            }
+            None
+        })
+        .collect();
+
+    // If no event for Seamus, check if ANY dialogue occurred (diagnostic).
+    let any_dialogue: Vec<_> = events
+        .iter()
+        .filter_map(|e| {
+            if let GameEvent::DialogueOccurred {
+                npc_id, npc_said, ..
+            } = e
+            {
+                Some((*npc_id, npc_said.clone()))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    assert!(
+        !dialogue_events.is_empty(),
+        "expected a DialogueOccurred event for Seamus Gallagher (id {seamus_id:?}); \
+         any_dialogue = {any_dialogue:?}; \
+         got events: {events:?}"
+    );
+
+    // ── 7. Assert the guard intercepted the self-identity drift. ─────────────
+    //
+    // `npc_said` must NOT contain "I'm but Seamus Gallagher" — the phrase
+    // that incorrectly answers an identity challenge nobody asked.
+    // The guard should have replaced it with an acquaintance affirmation
+    // (Fr. Declan Tierney IS in the parish roster as "Fr. Declan Tierney").
+    for npc_said_opt in &dialogue_events {
+        let npc_said = npc_said_opt.as_deref().unwrap_or("");
+        let lower = npc_said.to_lowercase();
+
+        // The self-identity drift must be gone.
+        assert!(
+            !lower.contains("i'm but seamus") && !lower.contains("i am but seamus"),
+            "acquaintance-intent guard did NOT fire: Seamus's reply still contains \
+             the self-identity drift instead of addressing the acquaintance question.\n  \
+             npc_said = {npc_said:?}"
+        );
+
+        // The guard must have replaced it with an acquaintance affirmation.
+        let is_affirm = ACQUAINTANCE_AFFIRM_POOL
+            .iter()
+            .any(|r| npc_said.contains(r));
+        let is_fallback = npc_said.contains("Mock: (no scripted response)");
+        assert!(
+            is_affirm || is_fallback || npc_said.is_empty(),
+            "guard fired (drift absent) but replacement is not a known \
+             acquaintance affirmation or empty.\n  npc_said = {npc_said:?}\n  \
+             affirmation pool = {ACQUAINTANCE_AFFIRM_POOL:?}"
+        );
+
+        if is_affirm {
+            let matched = ACQUAINTANCE_AFFIRM_POOL
+                .iter()
+                .find(|r| npc_said.contains(*r))
+                .unwrap();
+            eprintln!(
+                "[proof] acquaintance-intent guard fired: \
+                 self-identity drift suppressed, replacement = {matched:?}"
+            );
+        }
+    }
+}
+
+/// Sanity check: when the mock returns a correct acquaintance answer, the
+/// guard does NOT alter it.  Rules out a false-pass caused by the mock
+/// failing silently and returning empty dialogue.
+#[test]
+fn acquaintance_intent_guard_passes_correct_acquaintance_answer_through_real_loop() {
+    let mut h = GameTestHarness::new();
+    let player_loc = h.app.world.player_location;
+
+    let seamus_id = h
+        .app
+        .npc_manager
+        .all_npcs()
+        .find(|n| n.name == "Seamus Gallagher")
+        .map(|n| n.id)
+        .expect("Rundale mod must contain Seamus Gallagher");
+
+    // Clear other NPCs from the player location so only Seamus speaks.
+    let all_ids: Vec<_> = h.app.npc_manager.all_npcs().map(|n| n.id).collect();
+    for id in &all_ids {
+        if *id != seamus_id
+            && let Some(npc) = h.app.npc_manager.get_mut(*id)
+            && npc.location == player_loc
+        {
+            npc.location = LocationId(0);
+        }
+    }
+
+    {
+        let seamus = h.app.npc_manager.get_mut(seamus_id).expect("Seamus exists");
+        seamus.location = player_loc;
+        seamus.state = NpcState::Present;
+    }
+    h.app.npc_manager.mark_introduced(seamus_id);
+
+    // A correct response — Seamus knows Fr. Declan and says so.
+    // Contains "know" so the guard's content-word check must pass it through.
+    let good_reply = "Aye, I know Fr. Tierney well enough — a kind man, the priest.";
+    h.mock().push_any(good_reply);
+
+    let mut rx = h.app.world.event_bus.subscribe();
+    let _ = h.execute_via_real_loop(PLAYER_QUESTION);
+
+    let events = drain_events(&mut rx);
+    let dialogue_texts: Vec<Option<String>> = events
+        .iter()
+        .filter_map(|e| {
+            if let GameEvent::DialogueOccurred {
+                npc_id, npc_said, ..
+            } = e
+                && *npc_id == seamus_id
+            {
+                return Some(npc_said.clone());
+            }
+            None
+        })
+        .collect();
+
+    assert!(
+        !dialogue_texts.is_empty(),
+        "expected a DialogueOccurred event for Seamus; got: {events:?}"
+    );
+
+    // The good reply contains "know" — guard's content-word check must pass
+    // it through unchanged.
+    let found = dialogue_texts
+        .iter()
+        .any(|d| d.as_deref().unwrap_or("").contains("know Fr. Tierney"));
+    assert!(
+        found,
+        "correct acquaintance answer was unexpectedly suppressed by the guard; \
+         got: {dialogue_texts:?}"
+    );
+}

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -2020,6 +2020,232 @@ pub fn guard_wrong_speaker_identity(
     dialogue.to_string()
 }
 
+// ── #1504 — acquaintance-question / identity-drift guard ──────────────────────
+//
+// Quality-harness run 16, turn 14: the player asked Seamus Gallagher
+// "Do you know Father Declan Tierney?" and the NPC replied
+// "Ye must be mistaken... I'm but Seamus Gallagher" — answering as if
+// asked "Are you Father Declan Tierney?" (identity challenge) rather than
+// "Do you know him?" (acquaintance question).
+//
+// Root cause: the grounding block's "do not go along with a presupposed name"
+// instruction is broad enough that the 14B model reads "do you know X?" as
+// an identity challenge and produces a self-identification response ("I'm but
+// Seamus") that never addresses whether the NPC knows the person.
+//
+// Detection strategy (conservative):
+//   1. Detect whether the player's input is an ACQUAINTANCE question:
+//      patterns like "do you know …", "have you met …", "do you know of …",
+//      "are you acquainted with …", "have you heard of …".
+//   2. Detect whether the NPC's dialogue is purely a SELF-IDENTITY assertion:
+//      contains an identity-claim prefix ("i'm but", "i am but", "i'm only",
+//      etc.) with the SPEAKER'S OWN name and NO acquaintance content.
+//   3. If both fire: the NPC answered the wrong question. Replace with
+//      - "Yes, I know them" stock text if the named person IS in the roster.
+//      - "I know no one by that name" stock text if NOT in the roster.
+//
+// Gated by default-on flag `npc-acquaintance-intent-guard` (kill-switch only).
+
+/// Returns `true` when `player_input` reads as an acquaintance question —
+/// a question about whether the NPC knows or has met someone.
+///
+/// Patterns matched (case-insensitive):
+/// - "do you know …"
+/// - "do ye know …"
+/// - "do you know of …"
+/// - "do ye know of …"
+/// - "have you met …"
+/// - "have ye met …"
+/// - "have you heard of …"
+/// - "have ye heard of …"
+/// - "are you acquainted with …"
+/// - "are ye acquainted with …"
+/// - "do you know who …"
+fn is_acquaintance_question(player_input: &str) -> bool {
+    let lower = player_input.trim().to_lowercase();
+    const ACQUAINTANCE_PREFIXES: &[&str] = &[
+        "do you know of ",
+        "do ye know of ",
+        "do you know who ",
+        "do ye know who ",
+        "do you know ",
+        "do ye know ",
+        "have you met ",
+        "have ye met ",
+        "have you heard of ",
+        "have ye heard of ",
+        "are you acquainted with ",
+        "are ye acquainted with ",
+    ];
+    for prefix in ACQUAINTANCE_PREFIXES {
+        if lower.starts_with(prefix) {
+            return true;
+        }
+    }
+    // Also catch "do you know" / "do ye know" when trailing — the question
+    // ends with "?" and the prefix appears anywhere (for inverted word order
+    // e.g. "Seamus, do you know Father Declan?").
+    if lower.ends_with('?') {
+        for prefix in ACQUAINTANCE_PREFIXES {
+            if lower.contains(prefix) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Returns `true` when `dialogue` is purely a self-identity assertion with no
+/// acquaintance content — the NPC only said who THEY are, never addressed
+/// whether they know the person the player asked about.
+///
+/// Detects dismissive / clarifying self-identity patterns:
+/// - "i'm but <name>", "i am but <name>" (Hiberno-English dismissive)
+/// - "i'm only <name>", "i am only <name>"
+/// - "i'm just <name>", "i am just <name>"
+/// - "my name is <name>", "the name's <name>" — without any acquaintance info
+///
+/// Only fires when the dialogue ALSO does NOT contain acquaintance content
+/// words ("know", "met", "heard", "acquainted", "familiar").
+fn dialogue_is_only_self_identity(dialogue: &str, speaker_name: &str) -> bool {
+    if dialogue.trim().is_empty() {
+        return false;
+    }
+    let lower = dialogue.to_lowercase().replace('\u{2019}', "'");
+    let speaker_lower = speaker_name.to_lowercase();
+
+    // Guard: if the dialogue contains acquaintance-response words, the NPC
+    // DID address the question — don't fire.
+    const ACQUAINTANCE_CONTENT_WORDS: &[&str] = &[
+        "know",
+        "met",
+        "heard",
+        "acquainted",
+        "familiar",
+        "never seen",
+        "no one by",
+        "no such",
+    ];
+    for word in ACQUAINTANCE_CONTENT_WORDS {
+        if lower.contains(word) {
+            return false;
+        }
+    }
+
+    // Guard: the speaker's own name must appear (it's about self-identification).
+    if !lower.contains(&speaker_lower) {
+        // Also check first-name only.
+        let speaker_first = speaker_lower
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .to_lowercase();
+        if speaker_first.len() < 2 || !text_contains_name_as_word(dialogue, &speaker_first) {
+            return false;
+        }
+    }
+
+    // Identity-claim patterns that indicate the NPC answered with self-identification.
+    const SELF_IDENTITY_MARKERS: &[&str] = &[
+        "i'm but ",
+        "i am but ",
+        "i'm only ",
+        "i am only ",
+        "i'm just ",
+        "i am just ",
+        "i'm merely ",
+        "i am merely ",
+        "'tis only ",
+        "'tis but ",
+        "ye must be mistaken",
+        "you must be mistaken",
+        "ye have the wrong",
+        "you have the wrong",
+    ];
+    for marker in SELF_IDENTITY_MARKERS {
+        if lower.contains(marker) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Stock acquaintance-affirmation responses — used when the NPC DOES know the
+/// named person (name is in their roster) but answered the wrong question.
+fn acquaintance_affirm(seed: u64) -> &'static str {
+    const POOL: &[&str] = &[
+        "Aye, I know them well enough.",
+        "Aye, I've met them in the parish.",
+        "I do know who ye mean.",
+        "Aye, the name is known to me.",
+        "Sure, I know them from hereabouts.",
+    ];
+    POOL[(seed as usize) % POOL.len()]
+}
+
+/// Post-generation guard for acquaintance-question / identity-drift (#1504).
+///
+/// Fires when the player asked an acquaintance question ("do you know X?")
+/// and the NPC responded with a pure self-identity assertion ("I'm but Seamus
+/// Gallagher") — answering the wrong question entirely.
+///
+/// # Parameters
+///
+/// - `dialogue`: the finalized NPC reply.
+/// - `player_input`: the triggering player utterance.
+/// - `speaker_name`: the actual NPC's real name (e.g. "Seamus Gallagher").
+/// - `known_person_names`: all parish NPC names the guard may affirm about.
+///   If the name from the player's question is in this list, the replacement
+///   is an acquaintance-affirmation; otherwise it is a non-recognition decline.
+/// - `seed`: deterministic seed for response pool selection.
+///
+/// Conservative: only fires when BOTH the acquaintance-question signal AND the
+/// self-identity signal are present. Never fires on normal dialogue.
+pub fn guard_acquaintance_question_intent_drift(
+    dialogue: &str,
+    player_input: &str,
+    speaker_name: &str,
+    known_person_names: &[String],
+    seed: u64,
+) -> String {
+    if dialogue.trim().is_empty() {
+        return dialogue.to_string();
+    }
+
+    // Only fire when the player asked an acquaintance question.
+    if !is_acquaintance_question(player_input) {
+        return dialogue.to_string();
+    }
+
+    // Only fire when the NPC's reply is purely a self-identity assertion.
+    if !dialogue_is_only_self_identity(dialogue, speaker_name) {
+        return dialogue.to_string();
+    }
+
+    // Determine whether the named person is in the roster to choose the
+    // right replacement. We extract candidate names from the player input
+    // and check each against the roster.
+    let candidates = extract_candidate_names(player_input);
+    let named_person_is_known = candidates
+        .iter()
+        .any(|c| name_in_roster(c, known_person_names, None));
+
+    tracing::warn!(
+        speaker = %speaker_name,
+        player_input = %player_input,
+        named_person_is_known,
+        "acquaintance-question intent-drift guard fired: NPC answered identity \
+         question instead of acquaintance question (#1504)"
+    );
+
+    if named_person_is_known {
+        acquaintance_affirm(seed).to_string()
+    } else {
+        non_recognition_decline(seed).to_string()
+    }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -3426,6 +3652,151 @@ mod tests {
                 || result.to_lowercase().contains("never heard")
                 || result.to_lowercase().contains("no one"),
             "result should be a decline phrase: {result:?}"
+        );
+    }
+
+    // ── #1504 — acquaintance-question / identity-drift guard ──────────────────
+
+    /// AC-1 (#1504): the exact run-16 repro — Seamus asked "Do you know Father
+    /// Declan Tierney?" responds with a pure self-identity denial. The guard
+    /// must detect the question-type mismatch and replace.
+    ///
+    /// "Fr. Declan Tierney" IS in the roster, so the replacement must be an
+    /// acquaintance-affirmation response, not a non-recognition decline.
+    #[test]
+    fn acquaintance_intent_drift_guard_fires_on_run16_repro() {
+        let dialogue = "Ye must be mistaken... I'm but Seamus Gallagher.";
+        let player_input = "Do you know Father Declan Tierney?";
+        let speaker = "Seamus Gallagher";
+        let known: Vec<String> = vec![
+            "Fr. Declan Tierney".into(),
+            "Brigid Connolly".into(),
+            "Seamus Gallagher".into(),
+        ];
+        let result =
+            guard_acquaintance_question_intent_drift(dialogue, player_input, speaker, &known, 0);
+        // The self-identity drift must not survive.
+        assert!(
+            !result.to_lowercase().contains("i'm but seamus"),
+            "guard must have fired: original drift still present in: {result:?}"
+        );
+        // Replacement must be an acquaintance-affirmation (person IS in roster).
+        let affirm_pool = [
+            "know them",
+            "know who ye mean",
+            "known to me",
+            "know them well",
+            "know them from",
+        ];
+        assert!(
+            affirm_pool
+                .iter()
+                .any(|p| result.to_lowercase().contains(p)),
+            "replacement must be an acquaintance-affirmation when named person is in roster; \
+             got: {result:?}"
+        );
+    }
+
+    /// AC-2 (#1504): when the named person is NOT in the roster, the replacement
+    /// must be a non-recognition decline, not an affirmation.
+    #[test]
+    fn acquaintance_intent_drift_guard_declines_for_unknown_person() {
+        let dialogue = "Ye must be mistaken — I'm but Brigid Connolly.";
+        let player_input = "Do you know Cormac Sweeney?";
+        let speaker = "Brigid Connolly";
+        let known: Vec<String> = vec!["Fr. Declan Tierney".into(), "Brigid Connolly".into()];
+        let result =
+            guard_acquaintance_question_intent_drift(dialogue, player_input, speaker, &known, 0);
+        assert!(
+            !result.to_lowercase().contains("brigid connolly"),
+            "guard must have replaced drift when unknown name asked: {result:?}"
+        );
+        assert!(
+            result.to_lowercase().contains("no")
+                || result.to_lowercase().contains("not known")
+                || result.to_lowercase().contains("never heard")
+                || result.to_lowercase().contains("no one"),
+            "replacement must be a non-recognition decline for unknown person: {result:?}"
+        );
+    }
+
+    /// AC-3 (#1504): when the NPC's reply actually addresses the acquaintance
+    /// question (contains "know", "met", etc.), the guard must NOT fire.
+    #[test]
+    fn acquaintance_intent_drift_guard_does_not_fire_on_correct_response() {
+        let dialogue = "Aye, I know Fr. Declan Tierney well — he's the parish priest.";
+        let player_input = "Do you know Father Declan Tierney?";
+        let speaker = "Seamus Gallagher";
+        let known: Vec<String> = vec!["Fr. Declan Tierney".into(), "Seamus Gallagher".into()];
+        let result =
+            guard_acquaintance_question_intent_drift(dialogue, player_input, speaker, &known, 0);
+        assert_eq!(
+            result, dialogue,
+            "guard must NOT fire when NPC correctly addressed the acquaintance question: {result:?}"
+        );
+    }
+
+    /// AC-4 (#1504): when the player asked a non-acquaintance question, the
+    /// guard must not fire even if the NPC's reply is a self-identification.
+    #[test]
+    fn acquaintance_intent_drift_guard_does_not_fire_on_non_acquaintance_question() {
+        let dialogue = "Aye, I'm Seamus Gallagher, at yer service.";
+        let player_input = "What is your name?";
+        let speaker = "Seamus Gallagher";
+        let known: Vec<String> = vec!["Seamus Gallagher".into()];
+        let result =
+            guard_acquaintance_question_intent_drift(dialogue, player_input, speaker, &known, 0);
+        assert_eq!(
+            result, dialogue,
+            "guard must NOT fire on identity question (not an acquaintance question): {result:?}"
+        );
+    }
+
+    /// AC-5 (#1504): "have you met X?" pattern triggers the acquaintance guard.
+    #[test]
+    fn acquaintance_intent_drift_guard_fires_on_have_you_met_pattern() {
+        let dialogue = "Ye must be mistaken — I'm only Brigid Connolly, the midwife.";
+        let player_input = "Have you met Cormac Duffy?";
+        let speaker = "Brigid Connolly";
+        let known: Vec<String> = vec!["Brigid Connolly".into(), "Cormac Duffy".into()];
+        let result =
+            guard_acquaintance_question_intent_drift(dialogue, player_input, speaker, &known, 2);
+        assert!(
+            !result.to_lowercase().contains("only brigid connolly"),
+            "guard must have fired on 'have you met' pattern: {result:?}"
+        );
+    }
+
+    /// AC-6 (#1504): normal dialogue that happens to use first-person pronouns
+    /// but addresses the acquaintance question must NOT be suppressed.
+    #[test]
+    fn acquaintance_intent_drift_guard_does_not_fire_on_normal_first_person() {
+        let dialogue = "I've not heard of any Cormac Sweeney in these parts.";
+        let player_input = "Do you know Cormac Sweeney?";
+        let speaker = "Seamus Gallagher";
+        let known: Vec<String> = vec!["Seamus Gallagher".into()];
+        let result =
+            guard_acquaintance_question_intent_drift(dialogue, player_input, speaker, &known, 0);
+        assert_eq!(
+            result, dialogue,
+            "guard must NOT fire: NPC's reply addresses the acquaintance question \
+             (contains 'heard'): {result:?}"
+        );
+    }
+
+    /// AC-7 (#1504): "do ye know" (Hiberno-English variant) also triggers detection.
+    #[test]
+    fn acquaintance_intent_drift_guard_fires_on_hiberno_english_variant() {
+        let dialogue = "Ye have the wrong man — I'm just Padraig O'Brien.";
+        let player_input = "Do ye know Father Declan?";
+        let speaker = "Padraig O'Brien";
+        // Father Declan is a first-name-only reference — not roster-matchable by full name.
+        let known: Vec<String> = vec!["Padraig O'Brien".into()];
+        let result =
+            guard_acquaintance_question_intent_drift(dialogue, player_input, speaker, &known, 1);
+        assert!(
+            !result.to_lowercase().contains("just padraig"),
+            "guard must have fired on 'do ye know' variant: {result:?}"
         );
     }
 }

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -2199,19 +2199,13 @@ fn is_acquaintance_question(player_input: &str) -> bool {
         "are you acquainted with ",
         "are ye acquainted with ",
     ];
+    // Use `contains` so that embedded/trailing acquaintance phrases are caught
+    // regardless of word order or presence of a trailing "?" — e.g.
+    // "Seamus, do you know Father Declan" (no "?") and
+    // "do you know Father Declan Tierney?" (leading) both match.
     for prefix in ACQUAINTANCE_PREFIXES {
-        if lower.starts_with(prefix) {
+        if lower.contains(prefix) {
             return true;
-        }
-    }
-    // Also catch "do you know" / "do ye know" when trailing — the question
-    // ends with "?" and the prefix appears anywhere (for inverted word order
-    // e.g. "Seamus, do you know Father Declan?").
-    if lower.ends_with('?') {
-        for prefix in ACQUAINTANCE_PREFIXES {
-            if lower.contains(prefix) {
-                return true;
-            }
         }
     }
     false
@@ -2257,11 +2251,16 @@ fn dialogue_is_only_self_identity(dialogue: &str, speaker_name: &str) -> bool {
     // Guard: the speaker's own name must appear (it's about self-identification).
     if !lower.contains(&speaker_lower) {
         // Also check first-name only.
+        // Strip trailing non-alphabetic chars (e.g. "fr." → "fr") so that
+        // `text_contains_name_as_word` — which also strips punctuation from
+        // dialogue tokens before comparing — does not fail on honorific
+        // abbreviations like "Fr." stored as the roster's first token.
         let speaker_first = speaker_lower
             .split_whitespace()
             .next()
             .unwrap_or("")
-            .to_lowercase();
+            .trim_matches(|c: char| !c.is_alphabetic())
+            .to_string();
         if speaker_first.len() < 2 || !text_contains_name_as_word(dialogue, &speaker_first) {
             return false;
         }

--- a/parish/crates/parish-npc/src/ticks/prompt.rs
+++ b/parish/crates/parish-npc/src/ticks/prompt.rs
@@ -213,6 +213,22 @@ pub fn build_enhanced_system_prompt_with_config(
             location \u{2014} a wrong yarn is worse than an honest \"I don't know \
             it.\"\n",
         );
+        // #1504: distinguish acquaintance questions from identity challenges.
+        // "Do you know X?" is an ACQUAINTANCE question — answer whether you
+        // know the named person. It is NOT asking whether you ARE that person.
+        // Never respond with your own name or identity ("I'm but Seamus") to
+        // "Do you know X?" — that answers a question that was never asked.
+        // Only assert your own identity when directly asked "Are you X?" or
+        // "Who are you?".
+        prompt.push_str(
+            "ACQUAINTANCE vs IDENTITY: \"Do you know X?\" is an ACQUAINTANCE \
+            question \u{2014} answer it directly: \"Aye, I know them\" or \
+            \"I know no one by that name.\" Do NOT respond with your own name or \
+            clarify who you are in answer to an acquaintance question \u{2014} \
+            that addresses a question that was never asked. Reserve first-person \
+            identity assertions (\"I'm ...\", \"My name is ...\") for when someone \
+            directly asks \"Are you X?\" or \"Who are you?\"\n",
+        );
     }
 
     prompt
@@ -2034,6 +2050,58 @@ mod tests {
         assert!(
             context.contains("Tending the cow"),
             "assembled context must include the activity text (#1448):\n{context}"
+        );
+    }
+
+    /// AC-1 (#1504): when grounding is enabled, the system prompt must contain
+    /// the acquaintance-vs-identity directive that prevents the NPC from
+    /// answering "do you know X?" with a self-identification assertion.
+    #[test]
+    fn grounding_block_distinguishes_acquaintance_from_identity_questions() {
+        let npc = make_test_npc(1, "Seamus", 2);
+        let config = NpcConfig::default();
+        let names: HashMap<NpcId, String> = HashMap::new();
+        let lang = LanguageSettings::english_only();
+        let places = vec!["Darcy's Pub".to_string(), "The Mill".to_string()];
+
+        let prompt = build_enhanced_system_prompt_with_config(
+            &npc,
+            false,
+            &lang,
+            &config,
+            &names,
+            None,
+            Some(&places),
+        );
+        assert!(
+            prompt.contains("ACQUAINTANCE vs IDENTITY") || prompt.contains("acquaintance question"),
+            "grounding block must contain acquaintance-vs-identity directive (#1504):\n{prompt}"
+        );
+        assert!(
+            prompt.contains("Do you know X?") || prompt.contains("do you know"),
+            "directive must reference the 'do you know' pattern (#1504):\n{prompt}"
+        );
+        assert!(
+            prompt.contains("identity") || prompt.contains("\"Are you X?\""),
+            "directive must distinguish identity questions (#1504):\n{prompt}"
+        );
+    }
+
+    /// AC-2 (#1504): the acquaintance-vs-identity directive must NOT appear
+    /// when grounding is disabled (location_names is None).
+    #[test]
+    fn acquaintance_vs_identity_directive_absent_when_grounding_disabled() {
+        let npc = make_test_npc(1, "Seamus", 2);
+        let config = NpcConfig::default();
+        let names: HashMap<NpcId, String> = HashMap::new();
+        let lang = LanguageSettings::english_only();
+
+        let prompt = build_enhanced_system_prompt_with_config(
+            &npc, false, &lang, &config, &names, None, None,
+        );
+        assert!(
+            !prompt.contains("ACQUAINTANCE vs IDENTITY"),
+            "acquaintance-vs-identity directive must be absent when grounding is disabled:\n{prompt}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Root cause: the LLM conflates acquaintance questions ("Do you know Father Declan Tierney?") with identity challenges ("Are you Father Declan Tierney?") and answers with self-identification instead of addressing knowledge of the named person.
- Fix: deterministic post-generation guard `guard_acquaintance_question_intent_drift` in `parish-npc/src/repetition.rs` detects the pattern and replaces the drift. Wired into `parish-core/src/game_loop/npc_turn.rs` (shared path for Tauri, server, headless) under flag `npc-acquaintance-intent-guard` (default-on, kill-switch only). Defense-in-depth prompt clause added in `ticks/prompt.rs`.
- Seven unit tests + two integration tests via `execute_via_real_loop` confirm the guard fires and does not suppress correct acquaintance answers.

Fixes #1504.

## Proof

Evidence type: game-loop integration test

Two integration tests in `parish/crates/parish-engine/tests/do_you_know_intent.rs`
drive the acquaintance-intent guard through `execute_via_real_loop`, exercising
the real `handle_game_input` → `handle_npc_conversation` → `run_npc_turn` path
with the mock LLM boundary.

### Literal test output

```
running 2 tests
[proof] acquaintance-intent guard fired: self-identity drift suppressed, replacement = "Aye, I know them well enough."
test acquaintance_intent_guard_passes_correct_acquaintance_answer_through_real_loop ... ok
test acquaintance_intent_guard_fires_through_real_game_loop ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
```

Unit tests (7 pass):

```
running 7 tests
test repetition::tests::acquaintance_intent_drift_guard_does_not_fire_on_correct_response ... ok
test repetition::tests::acquaintance_intent_drift_guard_does_not_fire_on_normal_first_person ... ok
test repetition::tests::acquaintance_intent_drift_guard_does_not_fire_on_non_acquaintance_question ... ok
test repetition::tests::acquaintance_intent_drift_guard_fires_on_run16_repro ... ok
test repetition::tests::acquaintance_intent_drift_guard_fires_on_have_you_met_pattern ... ok
test repetition::tests::acquaintance_intent_drift_guard_fires_on_hiberno_english_variant ... ok
test repetition::tests::acquaintance_intent_drift_guard_declines_for_unknown_person ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

### Wiring path

```
execute_via_real_loop("Do you know Father Declan Tierney?")
→ handle_game_input → handle_npc_conversation → run_npc_turn(seamus)
→ mock returns "Ye must be mistaken... I'm but Seamus Gallagher."
→ verbosity guard → "Ye must be mistaken. I'm but Seamus Gallagher."
→ acquaintance guard:
    is_acquaintance_question(...) → true
    dialogue_is_only_self_identity(...) → true
    name_in_roster("Father Declan Tierney", ...) → true (honorific-normalized)
→ DialogueOccurred { npc_said: "Aye, I know them well enough." }
```

### Judge verdict

Verdict: sufficient
Acceptance criteria: met
Technical debt: clear

## Test plan

- [x] `cargo test --package parish-engine --test do_you_know_intent` — 2 passed
- [x] `cargo test --package parish-npc -- acquaintance_intent_drift` — 7 passed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Full `cargo test` workspace — all Rust tests pass (ui-check fails due to missing node_modules in worktree, pre-existing env limitation unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- parish-proof-bundle:do-you-know-intent v=1 -->

## Proof: do-you-know-intent

### Acceptance criteria

# Acceptance Criteria — #1504 "Do you know X?" treated as "Are you X?"

## Problem

Quality-harness run 16, turn 14: player asked Seamus Gallagher "Do you know
Father Declan Tierney?" The NPC replied "Ye must be mistaken... I'm but Seamus
Gallagher." — answering an identity challenge that was never asked, instead of
addressing whether he knows the priest.

## Root Cause (Five Whys)

1. **Why did Seamus assert his own identity?**
   The model conflated the grounding block's "do not go along with
   presupposed identities" instruction with the acquaintance question, treating
   "Do you know X?" as if someone had challenged Seamus's identity.

2. **Why did no existing guard catch this?**
   `guard_fabricated_person_confirmation` checks for _hallucinated people_ not
   in the roster — Fr. Declan IS in the roster so the guard correctly passed it
   through. `guard_wrong_speaker_identity` checks for the NPC _claiming to be a
   different roster member_, not for asserting their own identity in response to
   an acquaintance question.

3. **Why does the model conflate these?**
   The grounding block's "do not confirm presupposed identities" directive is
   too broad. The model pattern-matches "Do you know Father X?" as a potential
   identity test and fires the "I'm just myself" response defensively.

4. **Why is a prompt-only fix insufficient?**
   Tested in run 9: NPC-dialogue prompt instructions the live 14B model ignores
   reliably. Prompt instructions are defense-in-depth only; durable fixes need
   post-generation guards.

5. **Why is a post-generation guard sufficient?**
   The guard is deterministic: it reads the player's exact input tokens and the
   model's exact output tokens. False-positive rate is controlled by requiring
   both (a) acquaintance-question pattern in input AND (b) pure-self-identity
   pattern in output with no acquaintance content words. This is stable across
   model versions.

## Acceptance Criteria

### AC-1: Run-16 exact repro is fixed (primary criterion)

Given: player asks "Do you know Father Declan Tierney?" and the model returns
"Ye must be mistaken... I'm but Seamus Gallagher."

Expected: the final `DialogueOccurred` event does NOT contain the self-identity
drift ("I'm but Seamus Gallagher"), and the emitted dialogue is an acquaintance
affirmation (e.g. "Aye, I know them well enough.").

Test: `acquaintance_intent_guard_fires_through_real_game_loop` in
`parish/crates/parish-engine/tests/do_you_know_intent.rs`.

### AC-2: Unknown person → decline (not affirmation)

Given: player asks "Do you know Cormac Sweeney?" (not in roster) and the model
returns pure self-identification.

Expected: guard replaces with a non-recognition decline, not an affirmation.

Test: unit test `ac2_unknown_person_yields_decline` in `repetition.rs`.

### AC-3: Correct acquaintance answer passes through unchanged

Given: player asks an acquaintance question and the model returns a proper
acquaintance answer containing "know", "met", "heard", etc.

Expected: guard does NOT fire; dialogue passes through unchanged.

Tests: unit test `ac3_correct_acquaintance_response_passes_through` in
`repetition.rs`; integration test
`acquaintance_intent_guard_passes_correct_acquaintance_answer_through_real_loop`.

### AC-4: Non-acquaintance question → guard does not fire

Given: player asks "What is your name?" and NPC replies with self-identification.

Expected: guard does NOT fire (player asked for identity; self-ID is correct).

Test: unit test `ac4_non_acquaintance_question_guard_does_not_fire` in
`repetition.rs`.

### AC-5: Hiberno-English patterns covered

"Do ye know X?", "Have you met X?", "Have ye heard of X?" all trigger the
acquaintance detection.

Tests: unit tests `ac5_have_you_met_pattern`, `ac6_heard_of_content_word_passes`,
`ac7_hiberno_english_do_ye_know`.

## Implementation

- **Guard (deterministic):** `guard_acquaintance_question_intent_drift` in
  `parish-npc/src/repetition.rs`
- **Wiring:** `npc_turn.rs`, flag `npc-acquaintance-intent-guard` (default-on,
  kill-switch only)
- **Prompt (defense-in-depth):** ACQUAINTANCE vs IDENTITY directive added to
  `build_enhanced_system_prompt_with_config` in `ticks/prompt.rs`

### Evidence

Evidence type: game-loop integration test

## Summary

Two integration tests in `parish/crates/parish-engine/tests/do_you_know_intent.rs`
drive the acquaintance-intent guard through `execute_via_real_loop`, which exercises
the real `handle_game_input` → `handle_npc_conversation` → `run_npc_turn` path with
the mock LLM boundary. This is the game-loop integration test tier accepted for
deterministic post-generation guards (see #1501 / #1502 precedents).

## Evidence map against acceptance criteria

### AC-1: Run-16 exact repro is fixed

Test: `acquaintance_intent_guard_fires_through_real_game_loop`

Literal output (from `cargo test --package parish-engine --test do_you_know_intent
-- --nocapture` with `CARGO_TARGET_DIR=/tmp/parish-agent-target RUSTC_WRAPPER=""`):

```
running 2 tests
[proof] acquaintance-intent guard fired: self-identity drift suppressed, replacement = "Aye, I know them well enough."
test acquaintance_intent_guard_passes_correct_acquaintance_answer_through_real_loop ... ok
test acquaintance_intent_guard_fires_through_real_game_loop ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
```

The test:

1. Places Seamus Gallagher alone at the player location.
2. Injects the run-16 buggy response: `"Ye must be mistaken... I'm but Seamus Gallagher."` via `push_any`.
3. Sends `"Do you know Father Declan Tierney?"` through `execute_via_real_loop`.
4. Asserts `DialogueOccurred` for Seamus (NpcId 9) does NOT contain `"i'm but seamus"`.
5. Asserts the replacement IS an acquaintance affirmation from the pool.

The `[proof]` line confirms the guard intercepted the drift and replaced it with
`"Aye, I know them well enough."` — a correct acquaintance affirmation since
"Fr. Declan Tierney" IS in the parish roster.

### AC-3: Correct acquaintance answer passes through unchanged

Test: `acquaintance_intent_guard_passes_correct_acquaintance_answer_through_real_loop`

Mock returns `"Aye, I know Fr. Tierney well enough — a kind man, the priest."` (contains
`"know"` content word). Guard does NOT fire. The `DialogueOccurred` event contains
`"know Fr. Tierney"`. Test passes (output above: "ok").

### AC-2, AC-4, AC-5, AC-6, AC-7: Unit test coverage

Seven unit tests in `parish-npc/src/repetition.rs` cover the remaining ACs.
Literal output (`cargo test --package parish-npc -- acquaintance_intent_drift`):

```
running 7 tests
test repetition::tests::acquaintance_intent_drift_guard_does_not_fire_on_correct_response ... ok
test repetition::tests::acquaintance_intent_drift_guard_does_not_fire_on_normal_first_person ... ok
test repetition::tests::acquaintance_intent_drift_guard_does_not_fire_on_non_acquaintance_question ... ok
test repetition::tests::acquaintance_intent_drift_guard_fires_on_run16_repro ... ok
test repetition::tests::acquaintance_intent_drift_guard_fires_on_have_you_met_pattern ... ok
test repetition::tests::acquaintance_intent_drift_guard_fires_on_hiberno_english_variant ... ok
test repetition::tests::acquaintance_intent_drift_guard_declines_for_unknown_person ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 654 filtered out; finished in 0.00s
```

## execute_via_real_loop wiring path

`execute_via_real_loop("Do you know Father Declan Tierney?")`
→ `classify_input` → `GameInput`
→ `run_game_input_real` → `handle_game_input` (real production path)
→ intent classification (mock returns `Unknown` for a question)
→ `extract_npc_mentions` (no @-mention, no natural mention found)
→ `handle_npc_conversation(mentions.remaining, targets=[])`
→ falls back to first NPC at player location = Seamus Gallagher
→ `run_npc_turn(seamus_id, "Do you know Father Declan Tierney?", ...)`
→ mock returns `"Ye must be mistaken... I'm but Seamus Gallagher."`
→ verbosity guard runs → `"Ye must be mistaken. I'm but Seamus Gallagher."`
→ **acquaintance guard runs**:
`is_acquaintance_question("Do you know Father Declan Tierney?")` → true
`dialogue_is_only_self_identity("Ye must be mistaken. I'm but Seamus Gallagher.", "Seamus Gallagher")` → true
`name_in_roster("Father Declan Tierney", known_person_names, ...)` → true (matches "Fr. Declan Tierney" via honorific normalization)
→ returns `"Aye, I know them well enough."`
→ `DialogueOccurred { npc_id: NpcId(9), npc_said: Some("Aye, I know them well enough.") }`

## Fix type

Deterministic post-generation guard — not a model-behavior-dependent change.
The guard is wired into `parish-core/src/game_loop/npc_turn.rs` (the shared
path for Tauri, server, and headless) under flag `npc-acquaintance-intent-guard`
(default-on, kill-switch only).

### Judge

# Judge Verdict — #1504 "Do you know X?" treated as "Are you X?"

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

## Evidence reviewed

- `acceptance-criteria.md`: five whys root cause, seven ACs defined
- `evidence.md`: literal test output from `execute_via_real_loop` integration test
  plus seven unit tests; wiring path traced from player input to guard output
- Source: `parish-npc/src/repetition.rs` (guard + unit tests)
- Source: `parish-core/src/game_loop/npc_turn.rs` (wiring + flag)
- Source: `parish-npc/src/ticks/prompt.rs` (defense-in-depth prompt clause)
- Test: `parish-engine/tests/do_you_know_intent.rs` (2 integration tests via
  `execute_via_real_loop`)

## Criterion-by-criterion assessment

**AC-1 (run-16 exact repro fixed):** Integration test injects exact buggy response
("Ye must be mistaken... I'm but Seamus Gallagher.") for player input "Do you know
Father Declan Tierney?" via `execute_via_real_loop`. Literal output confirms guard
fires and replaces with "Aye, I know them well enough." `DialogueOccurred` for
Seamus (NpcId 9) confirmed. Met.

**AC-2 (unknown person → decline):** Unit test
`acquaintance_intent_drift_guard_declines_for_unknown_person` passes. Met.

**AC-3 (correct answer passes through):** Both unit test and integration test
(`acquaintance_intent_guard_passes_correct_acquaintance_answer_through_real_loop`)
confirm guard does not fire when dialogue contains "know" content word. Met.

**AC-4 (non-acquaintance question):** Unit test
`acquaintance_intent_drift_guard_does_not_fire_on_non_acquaintance_question`
passes. Met.

**AC-5/6/7 (Hiberno-English patterns):** Three unit tests cover "have you met",
heard-of content word pass-through, and "do ye know" variant. All pass. Met.

## Fix quality

The fix is deterministic — a post-generation string pattern guard, not a
model-behavior dependency. The evidence.md wiring path demonstrates the full
`handle_game_input` → `run_npc_turn` production path is exercised. The flag
(`npc-acquaintance-intent-guard`, default-on, kill-switch only) follows the
established pattern for all guards in this codebase. The prompt clause in
`ticks/prompt.rs` provides defense-in-depth but is not load-bearing.

Verdict: sufficient

Acceptance criteria: met

Technical debt: clear

<!-- /parish-proof-bundle:do-you-know-intent -->
