### PR TITLE
fix(ui): source-agnostic sticky-bottom autoscroll in ChatPanel

### DIFF
--- a/parish/apps/ui/src/components/ChatPanel.svelte
+++ b/parish/apps/ui/src/components/ChatPanel.svelte
@@ -11,6 +11,12 @@
 	let hoveredMessageId: string | null = $state(null);
 	const pendingReactions = new SvelteSet<string>();
 
+	// Sticky-bottom flag: true when the panel is at (or near) the bottom.
+	// Default true so the initial load scrolls into view.
+	// Updated by the scroll listener below — the ONLY place user scroll intent
+	// is read (after content mutation, not during it).
+	let stickToBottom = true;
+
 	// Track the last playerSubmittedCount value we handled so we can detect a
 	// fresh increment. Initialised to the store's current value so that
 	// pre-existing submissions at component mount don't trigger a spurious
@@ -26,6 +32,16 @@
 	// can exceed the near-bottom threshold and the panel stops short (#1431).
 	let scrollOnNextLogGrowth = false;
 
+	/** Called on every real user scroll event. Measures whether the panel is
+	 *  near the bottom and updates stickToBottom accordingly. We read geometry
+	 *  here (on actual scroll) rather than after content mutations so the
+	 *  measurement is never contaminated by newly-rendered content. */
+	function handleScroll() {
+		if (!logEl) return;
+		stickToBottom =
+			logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 50;
+	}
+
 	$effect(() => {
 		const entries = $textLog;
 		// Re-read the counter inside the effect so Svelte tracks it as a
@@ -37,8 +53,12 @@
 		lastSubmittedCount = currentCount;
 		lastLogLength = entries.length;
 
-		// Arm the one-shot flag on every player submit.
-		if (countIncremented) scrollOnNextLogGrowth = true;
+		// Player submit: arm the one-shot flag and re-stick so the player
+		// always follows their own message.
+		if (countIncremented) {
+			scrollOnNextLogGrowth = true;
+			stickToBottom = true;
+		}
 
 		// Force-scroll when: (a) the count just incremented, OR (b) the log
 		// grew while the one-shot flag was armed (the player's echo arrived in
@@ -46,11 +66,12 @@
 		const forceScroll = countIncremented || (scrollOnNextLogGrowth && logGrew);
 		if (logGrew && scrollOnNextLogGrowth) scrollOnNextLogGrowth = false;
 
-		const nearBottom = forceScroll || (logEl
-			? logEl.scrollHeight - logEl.scrollTop - logEl.clientHeight < 50
-			: true);
+		// Scroll on any log growth when sticky (covers backend/bridge-driven
+		// turns that never touch playerSubmittedCount), OR force-scroll on
+		// player submit regardless.
+		const shouldScroll = forceScroll || (logGrew && stickToBottom);
 		tick().then(() => {
-			if (logEl && nearBottom) {
+			if (logEl && shouldScroll) {
 				logEl.scrollTop = logEl.scrollHeight;
 			}
 		});
@@ -201,7 +222,7 @@
 	}
 </script>
 
-<div class="chat-panel" data-testid="chat-panel" bind:this={logEl} role="log" aria-live="polite" aria-label="Game chat log">
+<div class="chat-panel" data-testid="chat-panel" bind:this={logEl} role="log" aria-live="polite" aria-label="Game chat log" onscroll={handleScroll}>
 	{#each $textLog as entry, index (entry.id || entry.stream_turn_id || `${entry.source}:${index}`)}
 		{#if entryType(entry) === 'command'}
 			<div class="entry command" data-testid="command-entry" role="log">

--- a/parish/apps/ui/src/components/ChatPanel.svelte
+++ b/parish/apps/ui/src/components/ChatPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tick } from 'svelte';
+	import { tick, untrack } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
 	import { textLog, streamingActive, loadingPhrase, loadingColor, addReaction, removeReaction, messageHints, worldState, nameHints, pushErrorLog, formatIpcError, playerSubmittedCount } from '../stores/game';
 	import type { TextLogEntry } from '$lib/types';
@@ -15,7 +15,7 @@
 	// Default true so the initial load scrolls into view.
 	// Updated by the scroll listener below — the ONLY place user scroll intent
 	// is read (after content mutation, not during it).
-	let stickToBottom = true;
+	let stickToBottom = $state(true);
 
 	// Track the last playerSubmittedCount value we handled so we can detect a
 	// fresh increment. Initialised to the store's current value so that
@@ -69,7 +69,9 @@
 		// Scroll on any log growth when sticky (covers backend/bridge-driven
 		// turns that never touch playerSubmittedCount), OR force-scroll on
 		// player submit regardless.
-		const shouldScroll = forceScroll || (logGrew && stickToBottom);
+		// Read stickToBottom via untrack so scroll events don't re-trigger
+		// this effect — only $textLog / $playerSubmittedCount changes should.
+		const shouldScroll = forceScroll || (logGrew && untrack(() => stickToBottom));
 		tick().then(() => {
 			if (logEl && shouldScroll) {
 				logEl.scrollTop = logEl.scrollHeight;

--- a/parish/apps/ui/src/components/ChatPanel.test.ts
+++ b/parish/apps/ui/src/components/ChatPanel.test.ts
@@ -280,6 +280,163 @@ describe('ChatPanel', () => {
 			expect(container.querySelector('.chat-panel')).toBeTruthy();
 		});
 
+		// Sticky-bottom semantics (#1524):
+		//
+		// The panel uses a `stickToBottom` flag (default true) updated by the
+		// scroll event listener.  The $effect scrolls on ANY log growth when
+		// sticky, covering backend/bridge-driven turns that never touch
+		// playerSubmittedCount.  If the user has scrolled up (sticky=false) only
+		// a player submit re-sticks.
+		//
+		// Strategy: monkey-patch scrollHeight/clientHeight on the container so
+		// the sticky guard reads non-zero geometry.  To simulate "user scrolled
+		// up" we fire a real scroll event with scrollTop=0 so handleScroll()
+		// sets stickToBottom=false before the store update under test.
+		describe('#1524 sticky-bottom — source-agnostic autoscroll', () => {
+			it('DOES scroll when a backend/bridge-driven log entry arrives and panel is sticky', async () => {
+				// No playerSubmittedCount change — simulates a bridge/harness turn.
+				playerSubmittedCount.set(0);
+				textLog.set([{ source: 'system', content: 'Welcome.' }]);
+				const { container } = render(ChatPanel);
+
+				const logEl = container.querySelector('.chat-panel') as HTMLDivElement;
+				expect(logEl).toBeTruthy();
+
+				// Drain the mount effect's async tick().
+				await Promise.resolve();
+				await Promise.resolve();
+				await Promise.resolve();
+
+				// Geometry: tall enough that the sticky guard is meaningful.
+				Object.defineProperty(logEl, 'scrollHeight', {
+					value: 500,
+					configurable: true,
+				});
+				Object.defineProperty(logEl, 'clientHeight', {
+					value: 200,
+					configurable: true,
+				});
+				// scrollTop=450 → 500-450-200=−150 < 50 → panel is near-bottom.
+				// Assign via property (not the setter spy which isn't installed yet).
+				Object.defineProperty(logEl, 'scrollTop', {
+					value: 450,
+					configurable: true,
+					writable: true,
+				});
+
+				// Fire a real scroll event so handleScroll() sees the near-bottom
+				// geometry and sets stickToBottom=true.
+				await fireEvent.scroll(logEl);
+
+				const scrollTopSpy = vi.spyOn(logEl, 'scrollTop', 'set');
+
+				// Backend/bridge-driven log growth: no playerSubmittedCount change.
+				textLog.set([
+					{ source: 'system', content: 'Welcome.' },
+					{ source: 'Brigid', content: 'Good evening.' },
+				]);
+				await Promise.resolve();
+				await Promise.resolve();
+				await Promise.resolve();
+
+				// Panel was sticky → must scroll.
+				expect(scrollTopSpy).toHaveBeenCalledWith(500);
+			});
+
+			it('does NOT scroll when the user has scrolled up (sticky=false) and no submit', async () => {
+				playerSubmittedCount.set(1);
+				textLog.set([{ source: 'system', content: 'Welcome.' }]);
+				const { container } = render(ChatPanel);
+
+				const logEl = container.querySelector('.chat-panel') as HTMLDivElement;
+				expect(logEl).toBeTruthy();
+
+				// Drain the mount effect.
+				await Promise.resolve();
+				await Promise.resolve();
+				await Promise.resolve();
+
+				// Geometry: user is near the top, far from the bottom.
+				Object.defineProperty(logEl, 'scrollHeight', {
+					value: 500,
+					configurable: true,
+				});
+				Object.defineProperty(logEl, 'clientHeight', {
+					value: 200,
+					configurable: true,
+				});
+				Object.defineProperty(logEl, 'scrollTop', {
+					value: 0,
+					configurable: true,
+					writable: true,
+				});
+
+				// Fire scroll event: 500-0-200=300 > 50 → handleScroll sets sticky=false.
+				await fireEvent.scroll(logEl);
+
+				const scrollTopSpy = vi.spyOn(logEl, 'scrollTop', 'set');
+
+				// Passive backend-driven update (no playerSubmittedCount change).
+				textLog.set([
+					{ source: 'system', content: 'Welcome.' },
+					{ source: 'Brigid', content: 'Good day to ye.' },
+				]);
+				await Promise.resolve();
+				await Promise.resolve();
+				await Promise.resolve();
+
+				// sticky=false → must NOT scroll.
+				expect(scrollTopSpy).not.toHaveBeenCalled();
+			});
+
+			it('DOES force-scroll on player submit even when user scrolled up, and re-sticks', async () => {
+				playerSubmittedCount.set(1);
+				textLog.set([{ source: 'system', content: 'Welcome.' }]);
+				const { container } = render(ChatPanel);
+
+				const logEl = container.querySelector('.chat-panel') as HTMLDivElement;
+				expect(logEl).toBeTruthy();
+
+				// Drain the mount effect.
+				await Promise.resolve();
+				await Promise.resolve();
+				await Promise.resolve();
+
+				// Simulate user scrolled to top.
+				Object.defineProperty(logEl, 'scrollHeight', {
+					value: 500,
+					configurable: true,
+				});
+				Object.defineProperty(logEl, 'clientHeight', {
+					value: 200,
+					configurable: true,
+				});
+				Object.defineProperty(logEl, 'scrollTop', {
+					value: 0,
+					configurable: true,
+					writable: true,
+				});
+
+				// Scroll event → sticky=false.
+				await fireEvent.scroll(logEl);
+
+				const scrollTopSpy = vi.spyOn(logEl, 'scrollTop', 'set');
+
+				// Player submits: count 1→2, echo lands.
+				playerSubmittedCount.set(2);
+				textLog.set([
+					{ source: 'system', content: 'Welcome.' },
+					{ source: 'player', content: 'go north' },
+				]);
+				await Promise.resolve();
+				await Promise.resolve();
+				await Promise.resolve();
+
+				// Force-scroll on player submit regardless of sticky.
+				expect(scrollTopSpy).toHaveBeenCalledWith(500);
+			});
+		});
+
 		// #1431 item 4 regression: the original fix used `$playerSubmittedCount > 0`
 		// which is ALWAYS true after the first send, so every passive NPC/world
 		// update force-scrolled the user back to the bottom even when they had
@@ -318,7 +475,17 @@ describe('ChatPanel', () => {
 					value: 200,
 					configurable: true,
 				});
-				// scrollTop stays 0 (user scrolled to top).
+				Object.defineProperty(logEl, 'scrollTop', {
+					value: 0,
+					configurable: true,
+					writable: true,
+				});
+
+				// Fire scroll event so handleScroll() sets stickToBottom=false.
+				// (The new sticky-bottom logic requires this — without it the
+				// component's default stickToBottom=true would cause a scroll
+				// even without a submit.)
+				await fireEvent.scroll(logEl);
 
 				// Now install the spy — any call from here on is attributable to
 				// the store change below.
@@ -362,7 +529,14 @@ describe('ChatPanel', () => {
 					value: 200,
 					configurable: true,
 				});
-				// scrollTop = 0 (user is at top of history).
+				Object.defineProperty(logEl, 'scrollTop', {
+					value: 0,
+					configurable: true,
+					writable: true,
+				});
+
+				// Fire scroll event to set stickToBottom=false.
+				await fireEvent.scroll(logEl);
 
 				const scrollTopSpy = vi.spyOn(logEl, 'scrollTop', 'set');
 


### PR DESCRIPTION
## Summary

- Replaces the `playerSubmittedCount`-only scroll guard with a `stickToBottom` flag that is updated by an `onscroll` listener on the chat panel element.
- Backend/bridge/harness-driven turns now autoscroll the panel whenever the user is near the bottom (< 50 px from bottom), independent of how input was submitted.
- Player submit still force-scrolls (via the existing `scrollOnNextLogGrowth` one-shot flag) and re-arms `stickToBottom = true`.
- User scroll intent is measured only on real `scroll` events — never after a content mutation — eliminating the false "not near bottom" readings that caused the bug.

Fixes #1524

## Root cause

The `$effect` only force-scrolled when `$playerSubmittedCount` incremented. That counter is set only by the UI `InputField`. Quality-harness and bridge-driven turns never increment it, so they fell back to a near-bottom guard that was measured _after_ the new (often tall) entry rendered — reading "not near bottom" every time and never scrolling.

## Before / after

**Before:** bridge/harness turns never autoscroll; panel stays pinned at top. Every harness screenshot captured the same un-scrolled view.

**After:** any log growth scrolls to bottom when sticky. User who has scrolled up to read history is not yanked back unless they submit a message.

## Test changes (`ChatPanel.test.ts`)

Three new tests under `#1524 sticky-bottom — source-agnostic autoscroll`:
- (a) backend/bridge-driven log growth scrolls when `stickToBottom=true`
- (b) backend/bridge-driven log growth does NOT scroll when user has scrolled up (`stickToBottom=false`)
- (c) player submit force-scrolls and re-sticks even when `stickToBottom=false`

Existing `#1431 item 4` regression tests updated to fire a `scroll` event to set `stickToBottom=false` before asserting no-scroll (required by the new logic).

All 754 vitest tests pass locally.

## Evidence

Evidence type: screenshot

Local vitest run: **754 tests passed, 0 failed** (56 files). See `.proofs/chatpanel-autoscroll/evidence.md`.

Playwright visual baselines are unchanged — this fix adds scroll behavior without altering any layout or pixel-level rendering. If CI disagrees, baselines can be regenerated with `just ui-e2e -- -u`.

## Checklist

- [x] Issue filed: #1524
- [x] Acceptance criteria written: `.proofs/chatpanel-autoscroll/acceptance-criteria.md`
- [x] All existing tests pass (754/754)
- [x] Three new tests covering AC-1, AC-2, AC-3
- [x] Frontend-only change — no backend, no Rust, no DB
- [x] `git status` clean