### PR TITLE
feat(harness): click-to-zoom lightbox for run turn frames

### DIFF
--- a/parish/crates/parish-harness/dashboard-ui/index.html
+++ b/parish/crates/parish-harness/dashboard-ui/index.html
@@ -95,11 +95,36 @@
     }
     .turn-gallery { display: flex; gap: .5rem; flex-wrap: wrap; margin: .5rem 0; }
     .turn-thumb { display: flex; flex-direction: column; align-items: center; gap: .2rem; }
-    .turn-thumb img { width: 80px; height: 60px; object-fit: cover; border: 1px solid #2a2a2a; border-radius: 3px; background: #111; }
-    .turn-thumb.clickable { cursor: pointer; }
+    .turn-thumb img { width: 80px; height: 60px; object-fit: cover; border: 1px solid #2a2a2a; border-radius: 3px; background: #111; cursor: zoom-in; transition: border-color .12s ease; }
+    .turn-thumb img:hover { border-color: #7fa3d8; }
+    .turn-thumb.clickable { cursor: default; }
     .turn-thumb.clickable:hover img, .turn-thumb.active img { border-color: #5080c0; }
     .turn-thumb.active img { box-shadow: 0 0 0 1px #5080c0; }
     .turn-thumb-label { font-size: .68rem; color: #666; }
+    .turn-thumb-label.log-link { cursor: pointer; color: var(--blue); }
+    .turn-thumb-label.log-link:hover { text-decoration: underline; text-underline-offset: 2px; }
+    /* Lightbox overlay */
+    #zoom-overlay {
+      display: none; position: fixed; inset: 0; z-index: 9999;
+      background: rgba(0,0,0,.88);
+      align-items: center; justify-content: center;
+      cursor: zoom-out;
+    }
+    #zoom-overlay.open { display: flex; animation: overlay-in .15s ease both; }
+    @keyframes overlay-in { from { opacity: 0; } }
+    #zoom-overlay img {
+      max-width: min(96vw, 1200px); max-height: 90vh;
+      object-fit: contain; border-radius: 4px;
+      box-shadow: 0 4px 32px rgba(0,0,0,.7);
+      cursor: default;
+    }
+    #zoom-close {
+      position: fixed; top: 1rem; right: 1.25rem;
+      font-size: 1.6rem; line-height: 1; color: #bbb;
+      background: none; border: none; cursor: pointer;
+      padding: .25rem .5rem; border-radius: 4px;
+    }
+    #zoom-close:hover { color: #fff; background: rgba(255,255,255,.08); }
     .turn-log { margin: .5rem 0 1rem; background: #14141c; border: 1px solid #23232e; border-radius: 5px; padding: .6rem .8rem; font-size: .82rem; }
     .turn-log h4 { font-size: .9rem; color: #a89880; margin: 0 0 .4rem; }
     .tl-line { margin: .15rem 0; line-height: 1.45; }
@@ -202,6 +227,12 @@
   <footer style="margin-top:2rem;padding-top:.75rem;border-top:1px solid #1e1e2a;font-size:.75rem;color:#555;">
     <span id="cost-footer">Cost: loading…</span>
   </footer>
+
+  <!-- Lightbox overlay for full-size turn frame zoom. -->
+  <div id="zoom-overlay" role="dialog" aria-modal="true" aria-label="Full-size frame">
+    <button id="zoom-close" aria-label="Close">&times;</button>
+    <img id="zoom-img" src="" alt="Full-size turn frame">
+  </div>
 
   <!-- Per-turn inference log: appended at the end of the page, grows naturally. -->
   <div id="turn-log"></div>
@@ -397,17 +428,19 @@
         }
       }
 
-      // Turn gallery — a turn with a captured inference log is clickable.
+      // Turn gallery — thumbnails zoom on image click; turns with a transcript
+      // show a clickable label that opens the inference log.
       if (d.turns.length > 0) {
         const anyLog = d.turns.some(t => t.has_transcript);
-        const hint = anyLog ? ' <span style="font-size:.7rem;color:#666;font-weight:400">— click a turn to view its inference log</span>' : '';
+        const hint = anyLog ? ' <span style="font-size:.7rem;color:#666;font-weight:400">— click a label to view inference log; click image to zoom</span>' : ' <span style="font-size:.7rem;color:#666;font-weight:400">— click an image to zoom</span>';
         html += `<h3>Turns (${d.turns.length})${hint}</h3><div class="turn-gallery" id="turn-gallery">`;
         for (const t of d.turns) {
           const imgSrc = `/api/runs/${s.id}/turns/${t.turn_index}/frame.png`;
           const clk = t.has_transcript ? ' clickable' : '';
+          const labelCls = t.has_transcript ? ' log-link' : '';
           html += `<div class="turn-thumb${clk}" data-turn="${t.turn_index}">
-            <img src="${imgSrc}" alt="turn ${t.turn_index}" loading="lazy" title="${escHtml(t.player_input)}">
-            <span class="turn-thumb-label">t${t.turn_index} ${(t.game_clock||'')}</span>
+            <img src="${imgSrc}" alt="turn ${t.turn_index}" loading="lazy" title="Click to zoom — turn ${t.turn_index}: ${escHtml(t.player_input)}" data-zoom-src="${imgSrc}">
+            <span class="turn-thumb-label${labelCls}">t${t.turn_index} ${(t.game_clock||'')}</span>
           </div>`;
         }
         html += `</div>`;
@@ -415,10 +448,19 @@
 
       container.innerHTML = html;
 
-      // Wire turn clicks → deep-link to that turn's log.
-      container.querySelectorAll('.turn-thumb.clickable').forEach(el => {
+      // Wire image clicks → zoom lightbox.
+      container.querySelectorAll('.turn-thumb img[data-zoom-src]').forEach(img => {
+        img.addEventListener('click', (e) => {
+          e.stopPropagation();
+          openZoom(img.dataset.zoomSrc, img.alt);
+        });
+      });
+
+      // Wire label clicks (transcript turns only) → deep-link to that turn's log.
+      container.querySelectorAll('.turn-thumb .turn-thumb-label.log-link').forEach(el => {
         el.addEventListener('click', () => {
-          location.hash = 'run/' + s.id + '/turn/' + el.dataset.turn;
+          const turn = el.closest('.turn-thumb').dataset.turn;
+          location.hash = 'run/' + s.id + '/turn/' + turn;
         });
       });
     }
@@ -481,6 +523,32 @@
     function escHtml(s) {
       return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
     }
+
+    // ── Lightbox zoom ─────────────────────────────────────────────────────────
+
+    function openZoom(src, alt) {
+      const overlay = $('zoom-overlay');
+      const img = $('zoom-img');
+      img.src = src;
+      img.alt = alt || 'Full-size turn frame';
+      overlay.classList.add('open');
+      overlay.focus();
+    }
+
+    function closeZoom() {
+      const overlay = $('zoom-overlay');
+      overlay.classList.remove('open');
+      $('zoom-img').src = '';
+    }
+
+    // Close on overlay background click (but not the image itself).
+    $('zoom-overlay').addEventListener('click', (e) => {
+      if (e.target === $('zoom-overlay')) closeZoom();
+    });
+    $('zoom-close').addEventListener('click', closeZoom);
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && $('zoom-overlay').classList.contains('open')) closeZoom();
+    });
 
     $('back-btn').addEventListener('click', () => { location.hash = ''; });
     $('refresh-btn').addEventListener('click', loadRuns);

--- a/parish/crates/parish-harness/dashboard-ui/index.html
+++ b/parish/crates/parish-harness/dashboard-ui/index.html
@@ -108,7 +108,7 @@
       display: none; position: fixed; inset: 0; z-index: 9999;
       background: rgba(0,0,0,.88);
       align-items: center; justify-content: center;
-      cursor: zoom-out;
+      cursor: zoom-out; outline: none;
     }
     #zoom-overlay.open { display: flex; animation: overlay-in .15s ease both; }
     @keyframes overlay-in { from { opacity: 0; } }
@@ -229,7 +229,7 @@
   </footer>
 
   <!-- Lightbox overlay for full-size turn frame zoom. -->
-  <div id="zoom-overlay" role="dialog" aria-modal="true" aria-label="Full-size frame">
+  <div id="zoom-overlay" role="dialog" aria-modal="true" aria-label="Full-size frame" tabindex="-1">
     <button id="zoom-close" aria-label="Close">&times;</button>
     <img id="zoom-img" src="" alt="Full-size turn frame">
   </div>

--- a/parish/crates/parish-harness/src/dashboard/routes.rs
+++ b/parish/crates/parish-harness/src/dashboard/routes.rs
@@ -512,6 +512,51 @@ mod tests {
     }
 
     #[test]
+    fn dashboard_html_has_lightbox() {
+        let html = include_str!("../../dashboard-ui/index.html");
+        // Lightbox overlay element is present.
+        assert!(
+            html.contains("id=\"zoom-overlay\""),
+            "dashboard must contain the zoom-overlay element"
+        );
+        assert!(
+            html.contains("id=\"zoom-img\""),
+            "dashboard must contain the zoom-img element"
+        );
+        assert!(
+            html.contains("id=\"zoom-close\""),
+            "dashboard must contain the zoom-close button"
+        );
+        // JS functions for opening/closing the lightbox.
+        assert!(
+            html.contains("function openZoom"),
+            "dashboard must define openZoom()"
+        );
+        assert!(
+            html.contains("function closeZoom"),
+            "dashboard must define closeZoom()"
+        );
+        // Images carry the data-zoom-src attribute for lightbox hookup.
+        assert!(
+            html.contains("data-zoom-src"),
+            "dashboard must mark thumbnails with data-zoom-src for lightbox"
+        );
+        // Escape key closes the lightbox.
+        assert!(
+            html.contains("Escape") && html.contains("closeZoom"),
+            "dashboard must close lightbox on Escape key"
+        );
+        // No external dependency introduced.
+        let lower = html.to_lowercase();
+        assert!(
+            !lower.contains("glightbox")
+                && !lower.contains("fancybox")
+                && !lower.contains("lightbox.js"),
+            "dashboard lightbox must be pure vanilla JS with no external dependency"
+        );
+    }
+
+    #[test]
     fn dashboard_html_has_axes_radar() {
         let html = include_str!("../../dashboard-ui/index.html");
         // Radar renderer is present and wired into the detail view (C1, C3).


### PR DESCRIPTION
## Summary

- Clicking any turn thumbnail image in the run detail page now opens `frame.png` at full natural size in a dependency-free lightbox modal.
- Three close mechanisms: Escape key, X button, and clicking the overlay background.
- Transcript-log click (label -> `#run/<id>/turn/<idx>`) is preserved — image click uses `stopPropagation` so both coexist on the same thumb.
- No external JS/CSS framework added; pure vanilla JS + CSS consistent with the existing dashboard style.

Closes #1525

## Files changed

- `parish/crates/parish-harness/dashboard-ui/index.html` — lightbox CSS (`#zoom-overlay`, `#zoom-close`, `#zoom-img`), overlay HTML element, `openZoom`/`closeZoom` JS, `data-zoom-src` on thumbnails, log-link labels for transcript turns.
- `parish/crates/parish-harness/src/dashboard/routes.rs` — new `dashboard_html_has_lightbox` test asserting overlay elements, JS functions, `data-zoom-src`, Escape handler, and no external dependency.

## Test plan

- [x] `cargo test -p parish-harness` — 99 passed (includes new `dashboard_html_has_lightbox`)
- [x] `cargo clippy -p parish-harness --all-targets -- -D warnings` — exit 0
- [x] `cargo fmt -p parish-harness` — applied

## Proof

Evidence type: non-runtime (pure dashboard HTML/JS; no Rust runtime path changed)

Proof bundle: `.proofs/dash-screenshot-zoom/` (acceptance-criteria.md, evidence.md, judge.md)

```
Verdict: sufficient
Technical debt: clear
Acceptance criteria: met
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)