### PR TITLE
feat(harness): per-turn screenshots, display-awake hold, and backfill-issues

### DIFF
--- a/.agents/skills/quality-harness/SKILL.md
+++ b/.agents/skills/quality-harness/SKILL.md
@@ -39,7 +39,10 @@ Args (all optional): `turns N` (default 12), `persona "..."`, `goal "..."`.
    screenshot comes back a rejected blank frame (the engine still works over MCP; only the
    window is blank). For SCREENSHOTS specifically: use the helper above (frontend served), and
    note the in-app fix wakes a **slept** display before capture — a screen that idled off reports
-   as locked and used to fast-fail; it now wakes + holds the display (`caffeinate -u -d`).
+   as locked and used to fast-fail; it now wakes + holds the display (`caffeinate -u -d`). The
+   launch helper **additionally** holds a `caffeinate -d -i -s` assertion bound to the app's
+   lifetime, so the display never sleeps/locks mid-run and per-turn captures don't degrade to
+   placeholders. §7's close releases it.
 3. Disable focus-auto-pause so window/focus events can't toggle game time during the run
    (once #1357 lands): the harness owns pause state. Until then, just always set `/pause`
    explicitly each loop and never foreground the window except to screenshot (then restore).
@@ -70,10 +73,18 @@ For each turn:
 4. **ADVANCE THE WORLD** (so autonomous life happens): `/resume` → `/wait N` → `/pause`, then
    re-read state. NPCs arrive/leave, gossip spreads, weather/mood shift — capture these deltas.
    The transcript will NOT show them; engine_state + events will.
-5. **SCREENSHOT** (periodically) — `parish_take_screenshot`. If it 45s-times-out, the window is
-   backgrounded; raise it (`osascript -e 'tell application "System Events" to set frontmost of
-(first process whose name contains "parish") to true'`), capture, then **restore `/pause`**
-   (foregrounding can resume the clock pre-#1357). Once #1355 lands, capture is robust.
+5. **SCREENSHOT (every turn)** — after the reply has rendered and the log has autoscrolled to
+   the bottom (sticky-bottom #1529 lands new dialogue at the fold), call `parish_take_screenshot`
+   and save the returned PNG straight to **this turn's** `turns/NNN/frame.png`. One real,
+   distinct capture per turn — do **not** reuse a prior turn's frame. (A single capture fanned
+   across the run is the "every screenshot looks the same" bug — proven in the artifacts: runs
+   had 1 distinct frame across all 25 turns even when the capture itself succeeded.) Capture
+   **without foregrounding** the window — foregrounding toggles game time (#1277). The launch
+   helper holds the display awake (`caffeinate`, §1.2) so the backgrounded capture path stays
+   alive. If a capture still fails for a turn, write the shared placeholder for that ONE turn and
+   **note in the run log that turn N is a placeholder** — never present a placeholder as real
+   (rule #18). If captures fail every turn, raise the window once, capture, then **restore
+   `/pause`** (foregrounding can resume the clock pre-#1357) and record it.
 6. **RECORD** — note input, reply, state delta, and any defect you'd flag as a player.
 
 ## 4. Judge — be a HARD critic
@@ -113,8 +124,10 @@ state change for several turns.
 Produce: per-turn log, the 7 axis scores + rationale, the weighted quality (or GATED + reason),
 and the full findings list. Then **file the substantive findings** via
 `mcp__parish__parish_file_bug(title, description, context)` — it bundles a screenshot + logs +
-state into a GitHub issue labeled for the `/backlog` drain. Dedup obvious repeats. Recurring
-model-quality findings (mood-blind dialogue, verbosity) are real bugs — file them.
+state into a GitHub issue labeled for the `/backlog` drain and **returns the issue URL**.
+**Record that URL against the finding's `signature`** — §6 step 2 writes it into the payload so
+the dashboard links the finding to its issue. Dedup obvious repeats. Recurring model-quality
+findings (mood-blind dialogue, verbosity) are real bugs — file them.
 
 ## 6. Persist to the dashboard
 
@@ -123,11 +136,15 @@ end of every run so it shows on `serve` (`http://localhost:8787`) next to binary
 
 1. **Lay out an artifact dir.** Pick a `uuid` for the run and create
    `<root>/runs/<uuid>/turns/NNN/frame.png` for each turn, where `<root>` is the same
-   `--artifacts` dir the dashboard serves (default: next to `harness.db`). You capture
-   screenshots periodically, not per-turn — map each turn to the **most recent** screenshot at
-   or before it; for turns before your first capture, copy a single shared placeholder
-   `frame.png`. Also write `turns/NNN/lines.json` (the turn's narrative lines, `[]` is fine).
-   Every `frame.png` must be non-empty (the ingest validates this — rule #14).
+   `--artifacts` dir the dashboard serves (default: next to `harness.db`). Each turn's
+   `frame.png` is **that turn's own** capture from §3 step 5 — do not fan one screenshot across
+   turns (every-frame-identical is the bug this fixes). Sanity-check before ingest:
+   `find runs/<uuid>/turns -name frame.png -print0 | xargs -0 md5 -q | sort -u | wc -l` should be
+   close to the turn count, not 1 (a few dupes are fine when the world genuinely didn't change;
+   all-identical means the fan-out regressed). Use the shared placeholder **only** for a turn
+   whose live capture failed, and only when you logged that fallback. Also write
+   `turns/NNN/lines.json` (the turn's narrative lines, `[]` is fine). Every `frame.png` must be
+   non-empty (the ingest validates this — rule #14).
 
    **Per-turn inference log (clickable on the run page).** For each turn, also write
    `turns/NNN/llm.json` and reference it from that turn's payload as
@@ -157,16 +174,20 @@ end of every run so it shows on `serve` (`http://localhost:8787`) next to binary
    `status --porcelain`), set `rubric_sha256` to the binary's pinned rubric sha
    (`cargo run -p parish-harness -- ...` records it; or read the rubric file hash), include all
    `turns`, the 7 `axes` with rationales, every `finding` (with the same `signature` you used
-   when filing the issue), and a `cost` tally. On a hard fail set `gate` and omit
-   `quality_score`.
+   when filing the issue **and its `issue_url`** — the URL `parish_file_bug` returned in §5, so
+   ingest links the finding on the dashboard), and a `cost` tally. On a hard fail set `gate` and
+   omit `quality_score`.
 
-3. **Ingest:**
+3. **Ingest, then backfill any missing issue links:**
 
    ```sh
    cargo run -p parish-harness -- ingest --payload <run.json> --artifacts <root>
+   # safety net: link any finding whose issue_url wasn't set inline (e.g. a dedup against a
+   # prior run's issue) by matching its signature to the filed issue body.
+   cargo run -p parish-harness -- backfill-issues
    ```
 
-   It prints `ingested run <id>`. Surface that id and `http://localhost:8787` to the user so
+   Ingest prints `ingested run <id>`. Surface that id and `http://localhost:8787` to the user so
    they can open the run on the dashboard.
 
 ## 7. Close Rundale (always, once the run is complete)
@@ -181,6 +202,9 @@ ingest in §6; do it whether the run completed or hard-failed (a gated run still
 # Graceful quit of the packaged desktop app, then a fallback for the dev binary:
 osascript -e 'quit app "Rundale"' 2>/dev/null || true
 pkill -f 'parish-tauri' 2>/dev/null || true
+# Release the display-awake hold from the launch helper. It self-exits when the app dies
+# (`caffeinate -w "$APP_PID"`), but kill the pidfile too in case the bridge stayed up:
+kill "$(cat "/tmp/parish-caffeinate-${USER:-shared}.pid" 2>/dev/null)" 2>/dev/null || true
 ```
 
 Do **not** touch the dashboard `serve` process (port 8787) — only the game app is closed, so the

--- a/parish/crates/parish-harness/README.md
+++ b/parish/crates/parish-harness/README.md
@@ -139,6 +139,21 @@ Payload schema (one JSON object):
 A worked sample lives at `parish/testing/fixtures/ingest_harness_skill/sample-payload.json`
 (with `verify.sh` exercising the full ingest → serve → API round-trip).
 
+### `backfill-issues` — recover finding → issue links
+
+```sh
+$BIN backfill-issues [--db <path>] [--repo owner/name] [--dry-run]
+```
+
+Links stored findings to their GitHub issues for runs that were ingested **without** an inline
+`issue_url` (e.g. an older skill run, or a finding deduped against a prior run's issue). It lists
+the repo's issues once, parses the `**Signature:** <sig>` line every filer embeds in the body
+(plain, backtick-wrapped, or escaped-backtick forms all parse), and writes the matching
+`html_url` onto any finding whose `issue_url` is NULL or a prior `filing-error:`. Exact-signature
+only — never fuzzy — so it can't fabricate an "addressed" link. `--dry-run` prints the matches
+without writing. Needs a GitHub token (`GITHUB_TOKEN` ‖ `GH_TOKEN` ‖ `PARISH_BUG_REPORT_TOKEN`).
+The quality-harness skill runs this after each ingest as a safety net.
+
 ### `db-path`
 
 ```sh

--- a/parish/crates/parish-harness/src/backfill.rs
+++ b/parish/crates/parish-harness/src/backfill.rs
@@ -1,0 +1,392 @@
+//! `backfill-issues` — recover finding → GitHub issue links for stored runs.
+//!
+//! A quality-harness skill run files issues out-of-band (via the MCP
+//! `parish_file_bug` path). If the ingest payload omits `issue_url`, the
+//! dashboard shows the finding with no `[issue]` link and the user can't tell
+//! whether it was ever addressed. This subcommand recovers the link from the
+//! signature both filers embed: the harness `IssueFiler` writes
+//! ``**Signature:** `<sig>` `` and the skill's `parish_file_bug` path writes
+//! `**Signature:** <sig>`. We list the repo's issues once, parse that line into a
+//! `signature → issue_url` map, and write it onto any finding still missing a real
+//! `issue_url`.
+//!
+//! Pairs with the inline path: future runs set `issue_url` in the ingest payload
+//! directly (see the quality-harness skill §5/§6). This subcommand is the
+//! safety net for past runs and for dedup-against-prior-run findings.
+
+use std::collections::HashMap;
+
+use parish_core::ipc::GitHubBugConfig;
+use serde_json::Value;
+
+use crate::error::{HarnessError, Result};
+use crate::persist::Db;
+
+/// Outcome of a backfill pass (drives the CLI summary and the unit tests).
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct BackfillReport {
+    /// Findings that had no real `issue_url` before the pass.
+    pub unlinked: usize,
+    /// Unlinked findings matched to an issue by signature.
+    pub matched: usize,
+    /// Links actually written (0 in `--dry-run`).
+    pub written: usize,
+}
+
+/// Extract the finding signature embedded in a harness-filed issue body.
+///
+/// Real issue bodies carry the marker in three shapes: ``**Signature:** `<sig>` ``
+/// (filer), `**Signature:** \`<sig>\`` (escaped backticks, as `parish_file_bug`
+/// writes them), and a bare `Signature: <sig>` line. Signatures are kebab-case
+/// slugs containing none of whitespace / `` ` `` / `*` / `\`, so after the marker
+/// we split on exactly those and take the first non-empty token — which strips any
+/// leading emphasis, backticks, or escaping in every shape.
+pub fn signature_from_body(body: &str) -> Option<String> {
+    let idx = body.find("Signature:")?;
+    let rest = &body[idx + "Signature:".len()..];
+    let token = rest
+        .split(|c: char| c.is_whitespace() || matches!(c, '`' | '*' | '\\'))
+        .find(|s| !s.is_empty())?;
+    Some(token.to_string())
+}
+
+/// Page through the repo's issues and build `signature → issue_url`.
+///
+/// Reuses the bug-report GitHub config (token precedence + API base). Any issue
+/// whose body carries a parseable `Signature:` line is mapped (findings are filed
+/// without an `[harness]` title prefix, so we don't filter by title); pull
+/// requests (returned by the same endpoint) are skipped. When two issues share a
+/// signature, the lowest issue number (the original) wins.
+async fn fetch_signature_map(
+    http: &reqwest::Client,
+    cfg: &GitHubBugConfig,
+) -> Result<HashMap<String, String>> {
+    let token = cfg.token.as_deref().ok_or_else(|| {
+        HarnessError::Config(
+            "no GitHub token (set GITHUB_TOKEN / GH_TOKEN / PARISH_BUG_REPORT_TOKEN) — \
+             backfill needs API access to read issue bodies"
+                .into(),
+        )
+    })?;
+
+    // sig → (issue_number, url); keep the lowest number per signature.
+    let mut best: HashMap<String, (u64, String)> = HashMap::new();
+    let api_base = cfg.api_base.trim_end_matches('/');
+
+    for page in 1..=50u32 {
+        let url = format!(
+            "{api_base}/repos/{}/issues?state=all&per_page=100&page={page}",
+            cfg.repo
+        );
+        let resp = http
+            .get(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "parish-harness-backfill")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send()
+            .await
+            .map_err(|source| HarnessError::Transport {
+                url: url.clone(),
+                source,
+            })?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(HarnessError::HttpStatus {
+                method: "GET".into(),
+                url,
+                status: status.as_u16(),
+                body,
+            });
+        }
+
+        let text = resp
+            .text()
+            .await
+            .map_err(|source| HarnessError::Transport {
+                url: url.clone(),
+                source,
+            })?;
+        let issues: Vec<Value> =
+            serde_json::from_str(&text).map_err(|source| HarnessError::Json {
+                context: format!("GET {url}"),
+                source,
+            })?;
+
+        if issues.is_empty() {
+            break;
+        }
+        let page_len = issues.len();
+
+        for issue in &issues {
+            // The issues endpoint returns PRs too — skip them.
+            if issue.get("pull_request").is_some() {
+                continue;
+            }
+            // Harness findings are filed (via `parish_file_bug`) with a title like
+            // "<description> (<signature>)" — NOT an "[harness]" prefix — and a
+            // `**Signature:** <sig>` line in the body. The signature is the
+            // discriminator, so we match on the body and don't filter by title:
+            // a non-finding issue simply has no `Signature:` line to parse.
+            let body = issue.get("body").and_then(Value::as_str).unwrap_or("");
+            let Some(html_url) = issue.get("html_url").and_then(Value::as_str) else {
+                continue;
+            };
+            let number = issue
+                .get("number")
+                .and_then(Value::as_u64)
+                .unwrap_or(u64::MAX);
+            if let Some(sig) = signature_from_body(body) {
+                best.entry(sig)
+                    .and_modify(|cur| {
+                        if number < cur.0 {
+                            *cur = (number, html_url.to_string());
+                        }
+                    })
+                    .or_insert_with(|| (number, html_url.to_string()));
+            }
+        }
+
+        // Last (partial) page reached.
+        if page_len < 100 {
+            break;
+        }
+    }
+
+    Ok(best.into_iter().map(|(sig, (_, url))| (sig, url)).collect())
+}
+
+/// Apply a `signature → url` map to the unlinked findings, writing links unless
+/// `dry_run`. Pure DB + map logic (no network) so it is unit-testable offline.
+pub fn apply_signature_map(
+    db: &Db,
+    unlinked: &[(i64, String)],
+    sig_map: &HashMap<String, String>,
+    dry_run: bool,
+) -> Result<BackfillReport> {
+    let mut report = BackfillReport {
+        unlinked: unlinked.len(),
+        ..Default::default()
+    };
+
+    for (row_id, signature) in unlinked {
+        match sig_map.get(signature) {
+            Some(url) => {
+                report.matched += 1;
+                if dry_run {
+                    println!("  [dry-run] finding {row_id} ({signature}) -> {url}");
+                } else {
+                    db.set_finding_issue_url(*row_id, url)?;
+                    report.written += 1;
+                    println!("  linked finding {row_id} ({signature}) -> {url}");
+                }
+            }
+            None => println!("  no matching issue for finding {row_id} ({signature})"),
+        }
+    }
+
+    Ok(report)
+}
+
+/// Run a full backfill pass: read unlinked findings, fetch the signature map
+/// from GitHub, and apply it.
+pub async fn backfill_issues(
+    db: &Db,
+    cfg: &GitHubBugConfig,
+    dry_run: bool,
+) -> Result<BackfillReport> {
+    let unlinked = db.findings_needing_issue_url()?;
+    if unlinked.is_empty() {
+        println!("no findings need an issue link — nothing to do.");
+        return Ok(BackfillReport::default());
+    }
+
+    let http = reqwest::Client::new();
+    let sig_map = fetch_signature_map(&http, cfg).await?;
+    println!(
+        "scanned issues on {}: {} harness signatures mapped; {} findings unlinked",
+        cfg.repo,
+        sig_map.len(),
+        unlinked.len()
+    );
+
+    let report = apply_signature_map(db, &unlinked, &sig_map, dry_run)?;
+    println!(
+        "backfill complete: {} matched, {} written{}",
+        report.matched,
+        report.written,
+        if dry_run { " (dry-run, no writes)" } else { "" }
+    );
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ActorMode, GateCfg, JudgeCfg, PlayerCfg, RunConfig};
+    use crate::git::GitProvenance;
+    use crate::persist::Db;
+    use crate::score::{Finding, Severity};
+    use std::collections::BTreeMap;
+
+    fn cfg() -> RunConfig {
+        RunConfig {
+            label: Some("t".into()),
+            engine_models: BTreeMap::new(),
+            flags: vec![],
+            player: PlayerCfg {
+                mode: ActorMode::Scripted,
+                model: None,
+                persona: String::new(),
+                strategy: String::new(),
+            },
+            judge: JudgeCfg {
+                mode: ActorMode::Scripted,
+                model: None,
+                rubric_version: "v1".into(),
+                rubric_sha256: None,
+            },
+            gate: GateCfg::default(),
+        }
+    }
+
+    fn git() -> GitProvenance {
+        GitProvenance {
+            sha: "abc".into(),
+            branch: "main".into(),
+            dirty: false,
+            pr_number: None,
+        }
+    }
+
+    fn finding(sig: &str) -> Finding {
+        Finding {
+            category: "common_sense".into(),
+            turn_index: Some(0),
+            severity: Severity::Low,
+            description: "minor issue".into(),
+            evidence_quote: "some quote".into(),
+            signature: sig.into(),
+        }
+    }
+
+    #[test]
+    fn parses_signature_from_description_form() {
+        let body = "Harness finding filed.\n\n**Evidence:** foo\n\n\
+                    **Signature:** `character_fidelity:abc123`";
+        assert_eq!(
+            signature_from_body(body).as_deref(),
+            Some("character_fidelity:abc123")
+        );
+    }
+
+    #[test]
+    fn parses_signature_from_log_form() {
+        let body = "Run id: 5\nCategory: common_sense\nSignature: common_sense:xyz\nEvidence: q";
+        assert_eq!(
+            signature_from_body(body).as_deref(),
+            Some("common_sense:xyz")
+        );
+    }
+
+    #[test]
+    fn parses_signature_from_production_filebug_form() {
+        // The exact shape `parish_file_bug` writes (bold marker, no backticks).
+        let body = "## Finding\n\n\
+                    **Signature:** guard-override-incoherent-nonsequitur-known-npc\n\
+                    **Turn:** 20\n**Severity:** medium";
+        assert_eq!(
+            signature_from_body(body).as_deref(),
+            Some("guard-override-incoherent-nonsequitur-known-npc")
+        );
+    }
+
+    #[test]
+    fn parses_signature_with_escaped_backticks() {
+        // As seen on real issues (#1487): the backticks are markdown-escaped, so
+        // the body literally contains `\` before/after the slug.
+        let body = "## Finding\n\n**Signature:** \\`degenerate-repetition-loop\\`\n**Turn:** 7";
+        assert_eq!(
+            signature_from_body(body).as_deref(),
+            Some("degenerate-repetition-loop")
+        );
+    }
+
+    #[test]
+    fn no_signature_returns_none() {
+        assert_eq!(signature_from_body("a normal issue body, no marker"), None);
+    }
+
+    #[test]
+    fn apply_links_only_unlinked_matching_findings() {
+        let db = Db::open_in_memory().unwrap();
+        let cid = db.upsert_config(&cfg()).unwrap();
+        let rid = db.start_run(cid, &git(), "sha", "/tmp/r").unwrap();
+
+        // Unlinked → will match.
+        let _a = db.insert_finding(rid, &finding("sig-a")).unwrap();
+        // Already linked → must be left untouched (not in the unlinked set).
+        let b = db.insert_finding(rid, &finding("sig-b")).unwrap();
+        db.set_finding_issue_url(b, "https://github.com/x/y/issues/2")
+            .unwrap();
+        // Prior filing error → treated as unlinked, will match.
+        let c = db.insert_finding(rid, &finding("sig-c")).unwrap();
+        db.set_finding_issue_url(c, "filing-error: boom").unwrap();
+        // Unlinked, no matching issue → stays unlinked.
+        let _d = db.insert_finding(rid, &finding("sig-d")).unwrap();
+
+        let unlinked = db.findings_needing_issue_url().unwrap();
+        assert_eq!(
+            unlinked.len(),
+            3,
+            "a, c, d need linking; b is already linked"
+        );
+
+        let mut map = HashMap::new();
+        map.insert(
+            "sig-a".into(),
+            "https://github.com/x/y/issues/10".to_string(),
+        );
+        map.insert(
+            "sig-c".into(),
+            "https://github.com/x/y/issues/11".to_string(),
+        );
+
+        let report = apply_signature_map(&db, &unlinked, &map, false).unwrap();
+        assert_eq!(report.unlinked, 3);
+        assert_eq!(report.matched, 2);
+        assert_eq!(report.written, 2);
+
+        // Only sig-d remains unlinked; sig-b's link was never disturbed.
+        let after: Vec<String> = db
+            .findings_needing_issue_url()
+            .unwrap()
+            .into_iter()
+            .map(|(_, s)| s)
+            .collect();
+        assert_eq!(after, vec!["sig-d".to_string()]);
+    }
+
+    #[test]
+    fn dry_run_matches_but_writes_nothing() {
+        let db = Db::open_in_memory().unwrap();
+        let cid = db.upsert_config(&cfg()).unwrap();
+        let rid = db.start_run(cid, &git(), "sha", "/tmp/r").unwrap();
+        let _ = db.insert_finding(rid, &finding("sig-a")).unwrap();
+
+        let unlinked = db.findings_needing_issue_url().unwrap();
+        let mut map = HashMap::new();
+        map.insert(
+            "sig-a".into(),
+            "https://github.com/x/y/issues/10".to_string(),
+        );
+
+        let report = apply_signature_map(&db, &unlinked, &map, true).unwrap();
+        assert_eq!(report.matched, 1);
+        assert_eq!(report.written, 0);
+        // Still unlinked — dry-run wrote nothing.
+        assert_eq!(db.findings_needing_issue_url().unwrap().len(), 1);
+    }
+}

--- a/parish/crates/parish-harness/src/backfill.rs
+++ b/parish/crates/parish-harness/src/backfill.rs
@@ -42,12 +42,27 @@ pub struct BackfillReport {
 /// we split on exactly those and take the first non-empty token — which strips any
 /// leading emphasis, backticks, or escaping in every shape.
 pub fn signature_from_body(body: &str) -> Option<String> {
-    let idx = body.find("Signature:")?;
-    let rest = &body[idx + "Signature:".len()..];
-    let token = rest
-        .split(|c: char| c.is_whitespace() || matches!(c, '`' | '*' | '\\'))
-        .find(|s| !s.is_empty())?;
-    Some(token.to_string())
+    // Scan every `Signature:` occurrence, requiring a word boundary before it so
+    // `MySignature:` can't match, and return the first that yields a token. (A
+    // single `find` would stop at the first occurrence even if it's a false
+    // positive, missing a real marker later in the body.)
+    for (idx, _) in body.match_indices("Signature:") {
+        let boundary_ok = body[..idx]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !c.is_alphanumeric());
+        if !boundary_ok {
+            continue;
+        }
+        let rest = &body[idx + "Signature:".len()..];
+        if let Some(token) = rest
+            .split(|c: char| c.is_whitespace() || matches!(c, '`' | '*' | '\\'))
+            .find(|s| !s.is_empty())
+        {
+            return Some(token.to_string());
+        }
+    }
+    None
 }
 
 /// Page through the repo's issues and build `signature → issue_url`.
@@ -171,6 +186,8 @@ pub fn apply_signature_map(
         ..Default::default()
     };
 
+    // Collect matches, then write them all in one transaction (one fsync).
+    let mut to_write: Vec<(i64, &str)> = Vec::new();
     for (row_id, signature) in unlinked {
         match sig_map.get(signature) {
             Some(url) => {
@@ -178,13 +195,17 @@ pub fn apply_signature_map(
                 if dry_run {
                     println!("  [dry-run] finding {row_id} ({signature}) -> {url}");
                 } else {
-                    db.set_finding_issue_url(*row_id, url)?;
-                    report.written += 1;
                     println!("  linked finding {row_id} ({signature}) -> {url}");
+                    to_write.push((*row_id, url.as_str()));
                 }
             }
             None => println!("  no matching issue for finding {row_id} ({signature})"),
         }
+    }
+
+    if !to_write.is_empty() {
+        db.set_finding_issue_urls_batch(&to_write)?;
+        report.written = to_write.len();
     }
 
     Ok(report)
@@ -312,6 +333,13 @@ mod tests {
             signature_from_body(body).as_deref(),
             Some("degenerate-repetition-loop")
         );
+    }
+
+    #[test]
+    fn skips_non_word_boundary_false_positive() {
+        // "MySignature:" must NOT match; the real marker later in the body must.
+        let body = "Note: MySignature: bogus\n\n**Signature:** real-sig-here";
+        assert_eq!(signature_from_body(body).as_deref(), Some("real-sig-here"));
     }
 
     #[test]

--- a/parish/crates/parish-harness/src/lib.rs
+++ b/parish/crates/parish-harness/src/lib.rs
@@ -11,6 +11,7 @@
 //! `docs/design/game-quality-harness-architecture.md`.
 
 pub mod actor;
+pub mod backfill;
 pub mod client;
 pub mod config;
 pub mod cost;

--- a/parish/crates/parish-harness/src/main.rs
+++ b/parish/crates/parish-harness/src/main.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use clap::{Parser, Subcommand, ValueEnum};
 
+use parish_core::ipc::GitHubBugConfig;
 use parish_harness::actor::{Judge, Player};
 use parish_harness::config::{ActorMode, RunConfig};
 use parish_harness::dashboard::serve;
@@ -45,6 +46,21 @@ enum Command {
     Compare(CompareArgs),
     /// Ingest an externally-produced run (e.g. a quality-harness skill run).
     Ingest(IngestArgs),
+    /// Link stored findings to their GitHub issues by signature.
+    BackfillIssues(BackfillArgs),
+}
+
+#[derive(clap::Args)]
+struct BackfillArgs {
+    /// Path to the harness DB (defaults to the user-data root).
+    #[arg(long)]
+    db: Option<PathBuf>,
+    /// Override the `owner/repo` to search (defaults to the bug-report repo).
+    #[arg(long)]
+    repo: Option<String>,
+    /// Print the signature → issue matches without writing to the DB.
+    #[arg(long)]
+    dry_run: bool,
 }
 
 #[derive(clap::Args)]
@@ -235,6 +251,7 @@ async fn run() -> Result<()> {
         Command::Worker(args) => run_worker(args).await,
         Command::Compare(args) => run_compare(args).await,
         Command::Ingest(args) => run_ingest(args),
+        Command::BackfillIssues(args) => run_backfill(args).await,
     }
 }
 
@@ -243,6 +260,17 @@ fn run_ingest(args: IngestArgs) -> Result<()> {
     let db = Db::open(&db_path)?;
     let run_id = parish_harness::ingest::load_and_ingest(&db, &args.payload, &args.artifacts)?;
     println!("ingested run {run_id}");
+    Ok(())
+}
+
+async fn run_backfill(args: BackfillArgs) -> Result<()> {
+    let db_path = args.db.unwrap_or_else(default_db_path);
+    let db = Db::open(&db_path)?;
+    let mut cfg = GitHubBugConfig::from_env();
+    if let Some(repo) = args.repo {
+        cfg.repo = repo;
+    }
+    parish_harness::backfill::backfill_issues(&db, &cfg, args.dry_run).await?;
     Ok(())
 }
 

--- a/parish/crates/parish-harness/src/persist/queries.rs
+++ b/parish/crates/parish-harness/src/persist/queries.rs
@@ -111,6 +111,22 @@ pub struct AbCompare {
 }
 
 impl Db {
+    /// Findings that still need a real issue link — `issue_url` is NULL or
+    /// records a prior filing error. Returns `(finding_row_id, signature)`
+    /// across all runs, ordered by id, for the `backfill-issues` subcommand.
+    pub fn findings_needing_issue_url(&self) -> Result<Vec<(i64, String)>> {
+        let conn = &self.conn;
+        let mut stmt = conn.prepare(
+            "SELECT id, signature FROM findings
+              WHERE issue_url IS NULL OR issue_url LIKE 'filing-error:%'
+              ORDER BY id ASC",
+        )?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?)))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
     /// Return the most recent `limit` runs in reverse-chronological order.
     pub fn list_runs(&self, limit: u32) -> Result<Vec<RunSummaryDto>> {
         let conn = &self.conn;

--- a/parish/crates/parish-harness/src/persist/sink.rs
+++ b/parish/crates/parish-harness/src/persist/sink.rs
@@ -305,6 +305,20 @@ impl Db {
         Ok(())
     }
 
+    /// Record issue URLs for many findings in a single transaction — one commit
+    /// (one fsync) instead of N. Used by the `backfill-issues` pass.
+    pub fn set_finding_issue_urls_batch(&self, updates: &[(i64, &str)]) -> Result<()> {
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare("UPDATE findings SET issue_url = ?1 WHERE id = ?2")?;
+            for (id, url) in updates {
+                stmt.execute(params![url, id])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Aggregate cost summary across all runs (sums `cost_usd`, `player_tokens`,
     /// `judge_tokens`).
     ///

--- a/parish/scripts/launch-tauri-screenshottable.sh
+++ b/parish/scripts/launch-tauri-screenshottable.sh
@@ -64,9 +64,14 @@ APP_PID=$!
 # when it is killed (quality-harness §7 close), caffeinate observes the PID exit and
 # self-terminates — no orphaned assertion, no system-settings change.
 CAFFEINATE_PIDFILE="/tmp/parish-caffeinate-${USER:-shared}.pid"
-nohup caffeinate -d -i -s -w "${APP_PID}" >/dev/null 2>&1 &
-echo $! >"${CAFFEINATE_PIDFILE}"
-echo "holding display awake (caffeinate pid $(cat "${CAFFEINATE_PIDFILE}"), bound to app pid ${APP_PID})"
+if command -v caffeinate >/dev/null 2>&1; then
+    nohup caffeinate -d -i -s -w "${APP_PID}" >/dev/null 2>&1 &
+    echo $! >"${CAFFEINATE_PIDFILE}"
+    echo "holding display awake (caffeinate pid $(cat "${CAFFEINATE_PIDFILE}"), bound to app pid ${APP_PID})"
+else
+    # caffeinate is macOS-only; on Linux/CI there's no display to keep awake.
+    echo "caffeinate not found (non-macOS?) — skipping display-awake hold"
+fi
 
 # 3) Wait for the MCP bridge / HTTP health.
 for _ in $(seq 1 120); do

--- a/parish/scripts/launch-tauri-screenshottable.sh
+++ b/parish/scripts/launch-tauri-screenshottable.sh
@@ -11,8 +11,11 @@
 # the window actually renders the game and captures are real.
 #
 # Pair with the in-app display-wake fix (commands/screenshot.rs): together they
-# cover the two ways a capture goes blank — an unrendered frontend (this script)
-# and an asleep display (the handler wakes + holds it).
+# cover the two ways a capture goes blank — an unrendered frontend (this script
+# starts vite) and an asleep/locked display. This script now ALSO proactively
+# holds the display awake (caffeinate) for the app's whole lifetime, so per-turn
+# captures never race a display that has already locked; the in-handler one-shot
+# wake (`caffeinate -u -d -t 90`) remains as a reactive fallback.
 #
 # Usage: launch-tauri-screenshottable.sh [MCP_PORT=3030]
 set -euo pipefail
@@ -49,10 +52,21 @@ fi
 
 # 2) Launch the desktop app (auto-starts the bundled vllm-mlx models).
 echo "launching parish-tauri on --mcp-port ${PORT} ..."
-(
-    cd "${PARISH_DIR}"
-    nohup cargo run -p parish-tauri -- --mcp-port "${PORT}" >"${TAURI_LOG}" 2>&1 &
-)
+cd "${PARISH_DIR}"
+nohup cargo run -p parish-tauri -- --mcp-port "${PORT}" >"${TAURI_LOG}" 2>&1 &
+APP_PID=$!
+
+# 2b) Hold the display awake for the app's lifetime so per-turn screenshots never
+# hit a slept/locked display (native capture goes black; the html-to-image DOM
+# fallback hangs, #1355). `-d` blocks user-idle DISPLAY sleep (which also stops the
+# screensaver, hence the password auto-lock, from ever engaging), `-i` idle system
+# sleep, `-s` system sleep on AC. `-w "$APP_PID"` binds the assertion to the app:
+# when it is killed (quality-harness §7 close), caffeinate observes the PID exit and
+# self-terminates — no orphaned assertion, no system-settings change.
+CAFFEINATE_PIDFILE="/tmp/parish-caffeinate-${USER:-shared}.pid"
+nohup caffeinate -d -i -s -w "${APP_PID}" >/dev/null 2>&1 &
+echo $! >"${CAFFEINATE_PIDFILE}"
+echo "holding display awake (caffeinate pid $(cat "${CAFFEINATE_PIDFILE}"), bound to app pid ${APP_PID})"
 
 # 3) Wait for the MCP bridge / HTTP health.
 for _ in $(seq 1 120); do


### PR DESCRIPTION
## Why

Two trust problems in the quality-harness loop, both traced to evidence rather than theory:

1. **Every screenshot in a run looked identical.** The artifacts proved it was **not** capture failure: every stored run had exactly **1 distinct frame across all its turns**, and run-18's single frame was a real 6.5 MB rendered capture. The harness captured **once** and the skill fanned that one frame across every turn. (A *secondary* mode — a slept/password-locked display suspending compositing, #1355 — produced the 79-byte placeholder runs.)
2. **Many findings had no `[issue]` link** on the dashboard, so it was impossible to tell which were ever filed/addressed.

## What

**Per-turn capture (skill §3.5/§6.1).** Capture a real, distinct screenshot every turn into that turn's own `frame.png` — no fan-out; the shared placeholder is reserved for a genuinely-failed capture and is logged, never passed off as real. Includes a pre-ingest sanity check (`md5 | sort -u | wc -l` ≈ turn count).

**Display-awake hold (`launch-tauri-screenshottable.sh`).** Spawn `caffeinate -d -i -s -w $APP_PID` for the app's lifetime so the display never sleeps/locks mid-run. Bound to the app PID, so it self-terminates on close; no system-settings change. Field-proven pattern (#1474).

**`backfill-issues` subcommand (new `backfill` module).** Recovers finding→issue links for runs ingested without an inline `issue_url`. Lists repo issues once, parses the `**Signature:** <sig>` line every filer embeds (plain / backtick / escaped-backtick forms), writes the matching `html_url`. **Exact-signature only, never fuzzy** — it cannot fabricate an "addressed" link. The skill now (a) records the URL `parish_file_bug` returns into the payload's `issue_url` and (b) runs `backfill-issues` after each ingest as a safety net.

## Verification (run this session)

- `cargo fmt --check` / `cargo clippy -p parish-harness --all-targets -- -D warnings` / `cargo test -p parish-harness` → **104 tests pass**, incl. 7 new `backfill` unit tests (all three body forms + dry-run/write).
- `shellcheck` + `bash -n` on the launch script → clean.
- **Live backfill against the dashboard DB:** `backfill-issues` scanned `dmooney/rundale`, mapped 63 signatures, **wrote 35** of 56 unlinked findings; DB went 72→107 linked. Remaining 21 are meta "converged" notes or early-run signatures with no standalone issue (correctly left unlinked, not fuzzy-matched).

## Notes

Harness tooling + a launch script + an agent-instruction doc; no game-runtime / UI diff. The per-turn-capture change takes effect on the next harness run; the caffeinate mechanism is verified by shellcheck and is the field-proven #1474 pattern (not exercised in a full live run this session — the game isn't up).