### PR TITLE
chore: port Claude config to Codex

### DIFF
--- a/.agents/skills/source-command-demo-audit-mcp/SKILL.md
+++ b/.agents/skills/source-command-demo-audit-mcp/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: "source-command-demo-audit-mcp"
+description: "Run a demo-audit session where YOU drive the game directly via the parish MCP (parish_new_game + parish_submit_input + snapshots) instead of the LLM auto-player \u2014 deterministic, targeted gameplay probing that surfaces bugs, files them via parish_file_bug and logs them in TODO.md"
+---
+
+# source-command-demo-audit-mcp
+
+Use this skill when the user asks to run the migrated source command `demo-audit-mcp`.
+
+## Command Template
+
+Run a demo-audit session on the Parish/Rundale engine **driving the game yourself
+through the parish MCP** rather than watching the LLM auto-player (`just demo`).
+Goal is the same as `/demo-audit`: snapshot gameplay quality + surface bugs. The
+difference is the actor:
+
+- `/demo-audit` — `just demo` runs the engine's `--demo` auto-player (LLM picks the
+  player's actions); you **observe** via MCP/HTTP and post-mortem `parish/.demo-run.log`.
+- `/demo-audit-mcp` (this) — **you are the player.** You call
+  `mcp__parish__parish_submit_input` each turn and read the response inline. No
+  auto-player, no demo-prompt. Deterministic, repeatable, and steerable straight at
+  the bug taxonomy (probe a specific NPC, location, verb, or time-of-day on demand).
+
+Use this variant when you want to reproduce a specific suspected bug, sweep a verb
+grammar / NPC set methodically, or audit without burning auto-player inference.
+
+# Workflow
+
+## 1. Pre-flight — launch the desktop app
+
+`mcp__parish__*` tools are an HTTP bridge to a backend on `127.0.0.1:3030`. Drive the
+**live Tauri desktop window** (NOT the headless `parish-server`) so the visible UI is
+exercised and `parish_take_screenshot` / `parish_file_bug` capture a real native-window
+image of the live game (the rendered narrative + dialogue column, present-NPC chips;
+per #1160 the `file_bug` native capture also includes the MapLibre minimap):
+
+```sh
+# From the repo root the workspace manifest is parish/Cargo.toml, so pass it
+# explicitly (a bare `cargo run -p parish-tauri` only works from inside parish/):
+cargo run --manifest-path parish/Cargo.toml -p parish-tauri -- --mcp-port 3030
+```
+
+Launch it in the background (redirect to a logfile, e.g. `> parish/.tauri-run.log 2>&1`,
+so step 4 can grep replies), then poll for the bridge before driving:
+
+```sh
+until curl -fsS http://127.0.0.1:3030/api/health >/dev/null 2>&1; do sleep 3; done
+```
+
+Do not use chained fixed `sleep`s. A display must be available (real desktop session,
+not a headless sandbox) — this variant requires the GUI; if no display, fall back to
+`/demo-audit-mcp`'s sibling `/demo-audit` or the headless `parish-mcp-backend.sh`.
+
+If any tool returns `isError: true` with `transport error: ...`, the window/bridge is
+down — (re)launch it before retrying. Kill stray `parish-tauri` from prior runs first
+(`pkill -f parish-tauri`), and free port 3030 if held.
+
+## 2. Start a clean game
+
+- `mcp__parish__parish_new_game` — fresh save branch. Confirm with
+  `mcp__parish__parish_world_snapshot` (clock, player location, weather, paused).
+- `mcp__parish__parish_save_state` — note the branch id so you can
+  `parish_load_branch` back to a known point when bisecting a repro.
+
+## 3. Per-turn drive loop (repeat; this replaces `just demo` cycling)
+
+Each turn is: **observe → decide → act → observe → judge**.
+
+1. **Observe** the current state:
+   - `mcp__parish__parish_world_snapshot` — location_name/description, hour:minute,
+     time_label, weather, season, festival, paused, inference_paused, name_hints,
+     **turn_in_flight**. NOTE: the snapshot carries **no chat/dialogue log** (the
+     `WorldSnapshot` struct has no log field, despite the tool's "recent log entries"
+     blurb). Use it for world state + clock, not for reading replies.
+   - `mcp__parish__parish_npcs_here` — present NPCs: name, real_name, occupation,
+     mood, mood_emoji, introduced. Un-introduced NPCs show a descriptive placeholder
+     name (e.g. "a small, sharp-eyed old woman …") with `real_name` alongside.
+   - `mcp__parish__parish_map` — locations (id, name, adjacent, hops, travel_minutes,
+     visited), edges, player_location, transport.
+2. **Decide** the next input. Steer at the taxonomy in §4 — don't wander randomly.
+   Maintain coverage counters: distinct locations visited, movement attempts vs
+   successes, NPCs talked to, NPC reply rate.
+3. **Act** with `mcp__parish__parish_submit_input`:
+   - Movement: natural-language intents (`"walk over to the forge"`, `"go to the church"`) —
+     deliberately probe the parser grammar, including phrasings you expect to fail.
+   - Dialogue: free text. Scope it with the optional `addressed_to` array
+     (e.g. `addressed_to: ["Peig Hannigan"]`, using the NPC's `real_name`) and verify
+     only that NPC answers.
+   - System: `"/wait 1"`, `"/pause"`, `"/resume"`, `"look"`.
+
+   **`parish_submit_input` returns `null`** — it is fire-and-forget, NOT the reply.
+   The player echo and the NPC reply land in the UI stream + the desktop log
+   asynchronously (real inference takes seconds). Do not treat the `null` as failure.
+
+4. **Wait for the turn, then read the reply.** Poll `parish_world_snapshot` until
+   `turn_in_flight` is `false` (the clock will also have advanced). Then read what was
+   said — there are two ways, since the reply is NOT in any tool's return value:
+   - **Screenshot (richest):** `mcp__parish__parish_take_screenshot`, then `Read` the
+     PNG — the narrative + dialogue column is rendered, so you see player text, NPC
+     replies, movement narration, and the present-NPC chips in one image.
+   - **Desktop log grep (scriptable):** tail the `cargo run -p parish-tauri` stdout
+     (redirect it at launch, e.g. `> parish/.tauri-run.log 2>&1`):
+
+     ```sh
+     grep -nE "chat \[player\] input="   parish/.tauri-run.log   # your inputs
+     grep -nE "chat \[npc\] npc=.*reply=" parish/.tauri-run.log   # NPC replies
+     grep -nE "chat source=system"        parish/.tauri-run.log   # movement / ambient / errors
+     grep -nE "npc-reaction npc=.*emoji=" parish/.tauri-run.log   # mood emoji per reply
+     ```
+
+     Also confirm the world mutated as expected (re-`snapshot` + `npcs_here`): the bridge
+     is stateful, so a `submit_input` then `world_snapshot` sees the new location/clock.
+
+5. **Judge** against the taxonomy. Per turn ask: did movement land in a new location?
+   did the addressed NPC (and only that NPC) reply? repetition loop in the reply?
+   empty-location stranding? cross-NPC name leak? mood→emoji drift? wrong-time greeting?
+
+Also grep the same desktop log for engine-side faults the tool responses hide:
+
+```sh
+grep -nE "WARN|ERROR|panic"               parish/.tauri-run.log
+grep -nE "raw_len="                        parish/.tauri-run.log   # empty actions / burnt turns
+grep -nE "tier-2|tier-3|JSON parse|cancellation" parish/.tauri-run.log   # inference faults
+```
+
+## 4. Bug taxonomy checklist
+
+- **Movement**: parser rejects valid natural-language intents; silent input drop at empty locations.
+- **Dialogue quality**: repetition loops (trailing questions, "'Tis not X but Y", anaphoric chains); over-frequent farewells; NPC mid-reply self-introduction; wrong-time-of-day greetings.
+- **Hallucination & leakage**: NPC invents not-present characters; names from prior location leak into current NPC's address of the player; NPCs mis-identify their own village.
+- **Address scoping**: with `addressed_to` set, a non-addressed co-located NPC still replies, or the addressed NPC stays silent.
+- **Prompt**: redundant fields (weather + time twice); coarse time label only (no HH:MM); recent-events truncation cuts NPC replies mid-sentence; player-name not pinned each turn.
+- **Inference**: tier-2 JSON parse fails; tier-3 cancellation surfaces as WARN; empty-action emit burns a turn.
+- **Validators**: `poitín` flagged as `hallucinated-gaelic` (allow-list gap); `taking in the sights` flagged `modern-register` (player input leaking into NPC echo).
+- **Time/pause**: `/wait N` narration grammar ("1 minutes"); `/pause` + `/resume` idempotency; clock advancing while paused.
+- **Mood→emoji map**: same mood label returns different emojis across turns. Two code paths suspected.
+- **Schedule**: NPCs arrive/depart at "wrong" times — `ScheduleEntry::start_hour` means "depart at"; NPC is in transit during first `travel_minutes`.
+
+## 5. Verification of suspected-hallucinated names
+
+Before logging a name as hallucination, grep the catalog:
+
+```sh
+grep -c '<name>' mods/rundale/npcs.json
+grep -c '<name>' mods/rundale/world.json
+```
+
+Many "wrong" names are in-canon (Concannon, Niamh Darcy, Curraghboy, sídhe).
+
+## 6. File confirmed bugs via the `parish_file_bug` MCP
+
+File every **confirmed, reproducible** bug as a GitHub issue with
+`mcp__parish__parish_file_bug` — it auto-bundles a screenshot, recent logs, and
+current game state.
+
+Protocol per bug:
+
+1. **Freeze state at the bug.** Stop driving, then `mcp__parish__parish_take_screenshot`
+   (confirm it returns `{path, taken_at, size_bytes}` — needs the live Tauri window;
+   under heavy local-MLX load it can take up to the 45 s deadline). Since you are
+   driving the desktop app, the capture is a real native-window image of the live UI
+   (narrative + dialogue column, present-NPC chips). `parish_file_bug` attaches the
+   latest screenshot automatically; an explicit capture guarantees it shows the bug.
+2. **Dedup before filing — do NOT spam.**
+   `gh issue list --repo dmooney/rundale --state open --search "<keywords>"`. If a
+   match exists, comment instead of opening a new issue. Verify in-canon names first (§5).
+3. **File it.** `mcp__parish__parish_file_bug` with:
+   - `title` — one line, specific.
+   - `description` — **Symptom**, **Repro** (the exact `parish_submit_input` texts +
+     any `addressed_to`, so it replays through this same MCP flow), **Root cause**
+     (cite `file.rs:line` — read the code first, §Constraints), **Expected**. Reference related issues.
+   - optional `context` — a debug record (`{kind,label,detail}`) for a specific
+     inference call / event / conversation.
+     It returns `{created, issue_number, issue_url, screenshot_url}`. Verify the inline
+     image: `gh issue view <n> --json body | grep '!\['`.
+4. **Dry-run while probing the loop.** Start the backend with
+   `PARISH_BUG_REPORT_DRY_RUN=1` to write the report to disk (`created:false`,
+   `bundle_path` set) instead of filing. Real audit runs file for real.
+
+## 7. Audit trail in TODO.md
+
+- Maintain `TODO.md` at repo root as the cross-session audit trail. One numbered
+  entry per category with **Symptom** / **Root cause** / **Fix** and the filed
+  **issue #** / URL. Revise (not delete) earlier entries when later turns refine them.
+- At the end list top-10 by impact, each linked to its issue.
+
+# Constraints
+
+- Do NOT write code fixes. Document only, unless the user says "fix X now".
+- Read code before claiming root cause — grep `parish/crates/parish-core`, `parish-tauri`, `parish-input`, `parish-npc`, `parish/apps/ui/src/lib`.
+- Track coverage every session: distinct-location-count, movement count, NPC reply rate, error/warn count. Spot trends.
+- Stop when a sweep adds zero truly new categories, OR when the user says stop. Acceptance-criteria gate doesn't apply — this is documentation work, not a code change.
+
+# Why MCP-driven instead of the auto-player
+
+- **Reproducible**: same input sequence → same path, so a repro you file replays exactly.
+- **Targeted**: drive straight to an uncovered NPC/location/verb instead of waiting for the auto-player to wander there.
+- **Cheaper**: no auto-player inference per turn — only the NPC reply inference you trigger.
+- **Branch bisection**: `parish_save_game` / `parish_load_branch` to checkpoint before a suspect action and replay it.
+
+# Invocation Notes
+
+The user may add a mode or target after naming this skill. Interpret common modes as:
+
+- (empty) — default sweep: new game, visit every adjacent location, talk to each co-located NPC once, probe `/wait` + pause, flag all tiers.
+- `quick` — single short drive (~8 inputs), only flag P0/P1.
+- `deep` — long methodical sweep: every reachable location, every NPC, `addressed_to` scoping checks, time-of-day greetings across morning/noon/evening via `/wait`, branch-bisect any repro.
+- `repro <issue-number>` — drive the exact input sequence from that issue's Repro and confirm/refute.
+- `npc <name>` — drive to and probe a single NPC's dialogue quality with `addressed_to`.
+
+The source command assumed shell, file editing, task tracking, and Parish MCP access. In Codex, use the available equivalents; if the `mcp__parish__*` tools are absent, start or rebuild the Parish MCP bridge using the repo instructions before continuing.

--- a/.agents/skills/source-command-demo-audit-mcp/SKILL.md
+++ b/.agents/skills/source-command-demo-audit-mcp/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "source-command-demo-audit-mcp"
+name: 'source-command-demo-audit-mcp'
 description: "Run a demo-audit session where YOU drive the game directly via the parish MCP (parish_new_game + parish_submit_input + snapshots) instead of the LLM auto-player \u2014 deterministic, targeted gameplay probing that surfaces bugs, files them via parish_file_bug and logs them in TODO.md"
 ---
 
@@ -24,7 +24,7 @@ difference is the actor:
 Use this variant when you want to reproduce a specific suspected bug, sweep a verb
 grammar / NPC set methodically, or audit without burning auto-player inference.
 
-# Workflow
+## Workflow
 
 ## 1. Pre-flight — launch the desktop app
 
@@ -184,21 +184,21 @@ Protocol per bug:
   **issue #** / URL. Revise (not delete) earlier entries when later turns refine them.
 - At the end list top-10 by impact, each linked to its issue.
 
-# Constraints
+## Constraints
 
 - Do NOT write code fixes. Document only, unless the user says "fix X now".
 - Read code before claiming root cause — grep `parish/crates/parish-core`, `parish-tauri`, `parish-input`, `parish-npc`, `parish/apps/ui/src/lib`.
 - Track coverage every session: distinct-location-count, movement count, NPC reply rate, error/warn count. Spot trends.
 - Stop when a sweep adds zero truly new categories, OR when the user says stop. Acceptance-criteria gate doesn't apply — this is documentation work, not a code change.
 
-# Why MCP-driven instead of the auto-player
+## Why MCP-driven instead of the auto-player
 
 - **Reproducible**: same input sequence → same path, so a repro you file replays exactly.
 - **Targeted**: drive straight to an uncovered NPC/location/verb instead of waiting for the auto-player to wander there.
 - **Cheaper**: no auto-player inference per turn — only the NPC reply inference you trigger.
 - **Branch bisection**: `parish_save_game` / `parish_load_branch` to checkpoint before a suspect action and replay it.
 
-# Invocation Notes
+## Invocation Notes
 
 The user may add a mode or target after naming this skill. Interpret common modes as:
 

--- a/.agents/skills/source-command-demo-audit/SKILL.md
+++ b/.agents/skills/source-command-demo-audit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "source-command-demo-audit"
+name: 'source-command-demo-audit'
 description: "Run a demo-audit session \u2014 cycle `just demo` with live MCP/HTTP inspection, surface gameplay bugs, file them via the parish_file_bug MCP (screenshot + logs + state) and log in TODO.md"
 ---
 
@@ -11,7 +11,7 @@ Use this skill when the user asks to run the migrated source command `demo-audit
 
 Run a demo-audit session on the Parish/Rundale engine. Goal: snapshot current gameplay quality + surface bugs via repeated `just demo` cycles combined with live MCP/HTTP inspection.
 
-# Workflow
+## Workflow
 
 ## 1. Pre-flight
 
@@ -112,20 +112,20 @@ Protocol per bug:
   entries when later cycles refute or refine them.
 - At the end list top-10 by impact, each linked to its issue.
 
-# Constraints
+## Constraints
 
 - Do NOT write code fixes. Document only, unless the user says "fix X now".
 - Read code before claiming root cause. Avoid asserting based on symptom alone — grep `parish/crates/parish-core`, `parish-tauri`, `parish-input`, `parish-npc`, `parish/apps/ui/src/lib`.
 - Track every cycle's distinct-location-count, movement count, NPC reply rate, error/warn count. Spot trends across cycles.
 - Stop when 2 consecutive cycles add zero truly new categories, OR when the user says stop. Acceptance-criteria gate doesn't apply — this is documentation work, not a code change.
 
-# Optional enhancements
+## Optional enhancements
 
 - Use `mcp__parish__parish_submit_input` to nudge the player toward a specific location and probe uncovered NPCs (Aoife Brennan, Sean Ruadh Kelly, Brigid Ni Fhatharta, etc).
 - Compare reply quality across NPCs (Padraig Darcy >> Duffy family observed); audit `npcs.json` for what makes Padraig good.
 - Read `parish/crates/parish-input/src/parser.rs` to enumerate the movement-verb grammar — fixes the silent-rejection bug list.
 
-# Invocation Notes
+## Invocation Notes
 
 The user may add a mode or target after naming this skill. Interpret common modes as:
 

--- a/.agents/skills/source-command-demo-audit/SKILL.md
+++ b/.agents/skills/source-command-demo-audit/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: "source-command-demo-audit"
+description: "Run a demo-audit session \u2014 cycle `just demo` with live MCP/HTTP inspection, surface gameplay bugs, file them via the parish_file_bug MCP (screenshot + logs + state) and log in TODO.md"
+---
+
+# source-command-demo-audit
+
+Use this skill when the user asks to run the migrated source command `demo-audit`.
+
+## Command Template
+
+Run a demo-audit session on the Parish/Rundale engine. Goal: snapshot current gameplay quality + surface bugs via repeated `just demo` cycles combined with live MCP/HTTP inspection.
+
+# Workflow
+
+## 1. Pre-flight
+
+- Confirm `--mcp-port` is wired into `just demo` (`parish/justfile`). If recipe lacks it, add `--mcp-port ${PARISH_MCP_PORT:-3030}` and ensure `parish/.demo-run.log` is gitignored before running.
+- Kill any stray `parish-tauri` / `parish-server` before each cycle.
+
+## 2. Per-cycle protocol (repeat until new-issue rate ≈ 0)
+
+- Launch: `just demo 2 N > parish/.demo-run.log 2>&1` in background (start with N=8, raise to 12-20 once builds are cached).
+- Wait for MCP: poll `curl -sf http://127.0.0.1:3030/api/health` in a background loop with `until ... do sleep 3; done`. Do not use chained `sleep` commands.
+- Mid-run snapshots via `/usr/bin/curl -s` (bypass any rtk shim):
+  - `/api/world-snapshot` — loc, hour:minute, time_label, weather, paused
+  - `/api/npcs-here` — present NPCs, mood, mood_emoji
+  - `/api/map` — adjacent locations, transport, player idx
+  - `/api/save-state` — branch metadata
+  - Pipe through `python3 -c 'import sys,json; ...'` for parsing. `/api/debug-snapshot` may 404 from the MCP bridge (only the standalone parish-server exposes it).
+- Wait for demo PID to exit (background poll, no fixed sleep).
+- Post-mortem grep on `parish/.demo-run.log`:
+
+```sh
+grep -nE "demo turn: LLM chose"      # player actions
+grep -nE "chat \[npc\]"              # NPC replies
+grep -nE "chat \[player\]"           # player text
+grep -nE "chat source=system"        # system events (movement, ambient, errors)
+grep -nE "WARN|ERROR|panic"
+grep -nE "^NPCs here:|^Date and time"
+grep -nE "Time stirs|clocks of the parish stand still"
+grep -nE "raw_len="                  # check for empty actions
+```
+
+- For each cycle ask: distinct locations visited? movement attempts vs successes? NPC reply rate? loop patterns in replies? empty-location stranding? cross-NPC name leak? mood→emoji drift? pause-toggle bursts (correlate with the user's input cadence)?
+
+## 3. Bug taxonomy checklist
+
+- **Movement**: parser rejects valid natural-language intents; silent input drop at empty locations.
+- **Dialogue quality**: repetition loops (trailing questions, "'Tis not X but Y", anaphoric chains); over-frequent farewells; NPC mid-reply self-introduction; wrong-time-of-day greetings.
+- **Hallucination & leakage**: NPC invents not-present characters; names from prior location leak into current NPC's address of the player; NPCs mis-identify their own village.
+- **Prompt**: redundant fields (weather + time appear twice); coarse time label only (no HH:MM); recent-events truncation cuts NPC replies mid-sentence; player-name not pinned each turn.
+- **Inference**: tier-2 JSON parse fails; tier-3 cancellation surfaces as WARN; empty-action emit burns a turn.
+- **Streaming**: `stream-manager.ts` `pendingNpcTurns` is a Map keyed by `turnId` — two NPC replies can pump in parallel. Check `parish/apps/ui/src/lib/setup/stream-manager.ts` + `stream-pacing.ts`.
+- **Validators**: `poitín` flagged as `hallucinated-gaelic` (allow-list gap); `taking in the sights` flagged `modern-register` (player input leaking into NPC echo).
+- **Time/pause spam**: frontend `auto-pause.ts` dispatches `/pause` + `/resume` on idle/activity — bursts correlate with user's computer use, NOT session age.
+- **Mood→emoji map**: same mood label returns different emojis across cycles. Two code paths suspected.
+- **Schedule**: NPCs arrive/depart at "wrong" times — `ScheduleEntry::start_hour` means "depart at"; NPC is in transit during first `travel_minutes`.
+
+## 4. Verification of suspected-hallucinated names
+
+Before logging a name as hallucination, grep the catalog:
+
+```sh
+grep -c '<name>' mods/rundale/npcs.json
+grep -c '<name>' mods/rundale/world.json
+```
+
+Many "wrong" names are in-canon (Concannon, Niamh Darcy, Curraghboy, sídhe).
+
+## 5. File confirmed bugs via the `parish_file_bug` MCP
+
+File every **confirmed, reproducible** bug as a GitHub issue with
+`mcp__parish__parish_file_bug` — it auto-bundles a live screenshot, recent
+logs, and current game state, so the issue is self-contained. As of #1160 the
+screenshot is a native window capture, so the **MapLibre minimap renders in the
+image** (the old html-to-image path captured it blank).
+
+Protocol per bug:
+
+1. **Capture context at the moment of the bug.** The bug is filed against
+   whatever state is live, so freeze it first: stop advancing the demo, then
+   `mcp__parish__parish_take_screenshot` (confirm it returns a path — the live
+   desktop window must be present and foregrounded; under heavy local-MLX load
+   it can take up to the 45 s deadline). `parish_file_bug` attaches the latest
+   screenshot automatically; an explicit capture just guarantees it shows the
+   bug.
+2. **Dedup before filing — do NOT spam.** Search open issues first:
+   `gh issue list --repo dmooney/rundale --state open --search "<keywords>"`.
+   If a matching issue exists, add a comment instead of a new issue. Many
+   "wrong" names/behaviours are in-canon (see §4) — verify before filing.
+3. **File it.** `mcp__parish__parish_file_bug` with:
+   - `title` — one line, specific (e.g. `/wait 1 narration reads "1 minutes"`).
+   - `description` — **Symptom** (observed line/behaviour), **Repro** (exact
+     inputs), **Root cause** (cite `file.rs:line` — read the code first, §Constraints),
+     **Expected**. Reference related issues by number.
+   - optional `context` — a debug-panel record (`{kind,label,detail}`) when the
+     bug is about a specific inference call / event / conversation.
+     It returns `{created, issue_number, issue_url, screenshot_url}`. Verify the
+     issue body has the inline image: `gh issue view <n> --json body | grep '!\['`.
+4. **Dry-run when probing the loop, not real bugs.** Set
+   `PARISH_BUG_REPORT_DRY_RUN=1` in the demo/backend env to write the report to
+   disk (`created:false`, `bundle_path` set) instead of filing — use while
+   testing the audit flow so you don't create throwaway issues. Real audit runs
+   file for real.
+
+## 6. Audit trail in TODO.md
+
+- Maintain a `TODO.md` at repo root as the cross-cycle audit trail. One numbered
+  entry per category, with **Symptom** / **Root cause** / **Fix** and the filed
+  **issue #** / URL. Group by cycle of discovery. Revise (not delete) earlier
+  entries when later cycles refute or refine them.
+- At the end list top-10 by impact, each linked to its issue.
+
+# Constraints
+
+- Do NOT write code fixes. Document only, unless the user says "fix X now".
+- Read code before claiming root cause. Avoid asserting based on symptom alone — grep `parish/crates/parish-core`, `parish-tauri`, `parish-input`, `parish-npc`, `parish/apps/ui/src/lib`.
+- Track every cycle's distinct-location-count, movement count, NPC reply rate, error/warn count. Spot trends across cycles.
+- Stop when 2 consecutive cycles add zero truly new categories, OR when the user says stop. Acceptance-criteria gate doesn't apply — this is documentation work, not a code change.
+
+# Optional enhancements
+
+- Use `mcp__parish__parish_submit_input` to nudge the player toward a specific location and probe uncovered NPCs (Aoife Brennan, Sean Ruadh Kelly, Brigid Ni Fhatharta, etc).
+- Compare reply quality across NPCs (Padraig Darcy >> Duffy family observed); audit `npcs.json` for what makes Padraig good.
+- Read `parish/crates/parish-input/src/parser.rs` to enumerate the movement-verb grammar — fixes the silent-rejection bug list.
+
+# Invocation Notes
+
+The user may add a mode or target after naming this skill. Interpret common modes as:
+
+- (empty) — default 5-12 cycle audit with `N=8..15` turns each.
+- `quick` — single cycle, `N=8`, only flag P0/P1.
+- `deep` — up to 20 cycles, vary `N` (8/12/18/20), include MCP nudges.
+- `verify <issue-number>` — re-run targeting a specific TODO entry's preconditions.
+
+The source command assumed shell, file editing, task tracking, and Parish MCP access. In Codex, use the available equivalents; if a required Parish MCP tool is not registered, start the backend via the repo instructions before continuing.

--- a/.agents/skills/source-command-todo-drain/SKILL.md
+++ b/.agents/skills/source-command-todo-drain/SKILL.md
@@ -117,8 +117,9 @@ Keep a running `Monitor` of all in-flight PRs:
 prev=""
 while true; do
   s=$(for pr in <ids>; do
-    gh pr checks $pr --json name,bucket 2>/dev/null \
-      | jq -c "[.[] | {name: (\"$pr/\" + .name), bucket}]"
+    gh pr view "$pr" --json statusCheckRollup \
+      --jq "[.statusCheckRollup[]? | {name: (\"$pr/\" + (.context // .name // \"unknown\")), bucket: (if (.state // .status // \"\") == \"PENDING\" then \"pending\" else ((.state // .conclusion // .status // \"unknown\") | ascii_downcase) end)}]" \
+      2>/dev/null
   done | jq -s 'add')
   cur=$(jq -r '.[] | select(.bucket!="pending") | "\(.name): \(.bucket)"' \
     <<<"$s" | sort)

--- a/.agents/skills/source-command-todo-drain/SKILL.md
+++ b/.agents/skills/source-command-todo-drain/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: "source-command-todo-drain"
+description: "Drain TODO.md demo-audit findings in parallel rounds \u2014 AC-first, live proof, attach bundle, retrigger CI as needed, land green PRs while next round is in flight."
+---
+
+# source-command-todo-drain
+
+Use this skill when the user asks to run the migrated source command `todo-drain`.
+
+## Command Template
+
+Land fixes from `TODO.md` (Rundale demo-audit findings). Run rounds in parallel — start the next round while the previous PR's CI runs.
+
+# Workflow per round
+
+## 1. Sync + worktree
+
+Never work in the main repo directory — other sessions may be using it. Switch into (or create) a worktree off latest `origin/main`:
+
+```sh
+git fetch origin main
+git worktree add .codex/worktrees/round-<n> -b codex/round-<n> origin/main
+```
+
+Then move execution to that path so all subsequent commands run inside the worktree.
+
+## 2. Pick TODO item
+
+Open `TODO.md`. Prefer the smallest-scope unaddressed P0/P1. If the entry has a "revise" note pointing at a different ID, follow it.
+
+## 3. Write acceptance criteria FIRST
+
+Before any code change:
+
+- `.proofs/todo-<id>/acceptance-criteria.md` — observable criteria, sized concretely (e.g. "`frequency_penalty: Option<f32>` field on `InferenceRequest`", not "improve repetition handling"). Include a "Deferred items" section listing anything intentionally punted from this round.
+- `parish/testing/fixtures/play_todo-<id>.txt` — harness commands that exercise the new code path in `parish-engine --headless --script`.
+
+## 4. Implement
+
+Smallest possible diff. When threading a new param through multiple layers (inference, IPC, UI), delegate the mechanical pass-through edits to a sonnet sub-agent — saves opus context.
+
+Then decide whether this finding's _category_ warrants a permanent guard: if it has now been fixed more than once (e.g. auto-player movement, mid-conversation farewells, mood→emoji sign), add a `rubric_*` test in `parish/crates/parish-engine/tests/eval_baselines.rs` in the same PR so the regression cannot silently return. See `docs/agent/harness.md` → "Turning a recurring mistake into a sensor".
+
+## 5. Run quality gates
+
+From within the worktree:
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test -p <changed-crate>
+```
+
+For UI changes also:
+
+```sh
+cd parish/apps/ui && npx vitest run && pnpm run check
+```
+
+## 6. Capture live transcript
+
+```sh
+cargo run -p parish-engine -- --headless --script \
+  parish/testing/fixtures/play_todo-<id>.txt > /tmp/transcript.txt
+cp /tmp/transcript.txt .proofs/todo-<id>/transcript.json
+```
+
+For UI-only changes the engine harness is regression cover only — actual UI behaviour is verified in vitest. Note this in `evidence.md`.
+
+## 7. Write evidence.md
+
+First line must be `Evidence type: live gameplay transcript`. Include:
+
+- Diff summary table (file, change).
+- Acceptance-criteria → evidence map (one row per AC, citing `file:line` or test name).
+- Commands run.
+- Transcript excerpt.
+- "Why this fixes #N" explainer.
+- "Deferred items" section listing what was punted with a follow-up plan.
+
+## 8. Write judge.md
+
+Independent verdict. Must end with all three lines verbatim:
+
+```text
+Verdict: sufficient
+Technical debt: clear
+Acceptance criteria: met
+```
+
+Include risk-check (save compatibility, prompt budget, mode parity, architecture-fitness) and an acceptance-criteria audit table.
+
+## 9. Commit + push + PR
+
+- Conventional commit (`feat:` / `fix:` / `refactor:` / `docs:` / `test:` / `chore:`).
+- Body explains the _why_, not the _what_. Do not add a Claude-specific co-author trailer unless the user explicitly asks for it.
+- PR title prefix matches commit.
+- PR body has Summary + Test plan checklist + `Proof bundle: .proofs/... posted via attach-proof`.
+
+## 10. Attach proof bundle
+
+From the worktree:
+
+```sh
+bash parish/scripts/attach-proof.sh todo-<id> <pr-num>
+```
+
+Do NOT call `just attach-proof` from a worktree — that uses the main repo's `justfile` and posts the wrong bundle.
+
+## 11. Start next round immediately
+
+Don't wait for CI. Branch off `origin/main` again with `git worktree add ... -b codex/round-<n+1>` and repeat 2-10.
+
+Keep a running `Monitor` of all in-flight PRs:
+
+```sh
+prev=""
+while true; do
+  s=$(for pr in <ids>; do
+    gh pr checks $pr --json name,bucket 2>/dev/null \
+      | jq -c "[.[] | {name: (\"$pr/\" + .name), bucket}]"
+  done | jq -s 'add')
+  cur=$(jq -r '.[] | select(.bucket!="pending") | "\(.name): \(.bucket)"' \
+    <<<"$s" | sort)
+  comm -13 <(echo "$prev") <(echo "$cur")
+  prev=$cur
+  jq -e 'all(.bucket!="pending")' <<<"$s" >/dev/null 2>&1 && break
+  sleep 60
+done
+echo "ALL TERMINAL"
+```
+
+## 12. Land green PRs
+
+When monitor reports green:
+
+```sh
+gh pr merge <N> --squash --delete-branch
+```
+
+- The "main worktree" branch-delete error is harmless — merge succeeded on remote; verify via `gh pr view <N> --json state,mergeCommit`.
+- Gemini `review / review: cancel` is normal (auto-cancelled bot review, not a real failure).
+
+# Known CI failure patterns + fixes
+
+- **Rust quality gate / coverage ratchet `cancel`.** Concurrency rule (`cancel-in-progress: true`) killed older runs when a new push happened. Push an empty commit to retrigger:
+
+  ```sh
+  git commit --allow-empty -m "ci: retrigger after auto-cancel" && git push
+  ```
+
+  Do NOT try `gh pr close && gh pr reopen` first — classifier may deny it.
+
+- **Agent proof gate `fail` on first run after PR open.** Race: CI started before `attach-proof` posted the bundle comment. Retrigger via empty commit; second run finds the bundle and passes.
+
+- **`gh workflow run` HTTP 500.** Workflow file isn't on the branch HEAD or validation issue. Use empty commit + push instead.
+
+# Boundaries
+
+- Never commit other sessions' leaked WIP from the main repo. If the Stop hook fires on someone else's broken match arms, tag the next message with `[skip-quality-hook]` and continue.
+- Never force-push to a PR branch — bot review threads anchor to commit SHAs and force-push detaches them.
+- Never amend; always create new commits. Pre-commit hook failures didn't actually commit, so `--amend` would corrupt prior history.
+- Don't touch `.proofs/` archives in `docs/proofs/local-perf` or `docs/proofs/rundale-bench` — bench archives, exempt from the gate.
+- After each landed PR, do not edit `TODO.md` to mark items done — leave it as the demo-audit record; the PR commit IS the marker.
+
+# Stop conditions
+
+Stop when:
+
+- User says "stop" or "pause".
+- `TODO.md` has no remaining unaddressed P0/P1 items.
+- 3+ consecutive rounds hit unrelated infra failures (signal: real bug in workflow, not your code; escalate to user).
+
+## Tooling Notes
+
+The source command assumed shell, file editing, worktree switching, monitoring, task tracking, and skill invocation tools. In Codex, use the available equivalents; when a dedicated worktree or monitor tool is unavailable, use plain `git worktree` commands and concise status updates.

--- a/.agents/skills/source-command-todo-drain/SKILL.md
+++ b/.agents/skills/source-command-todo-drain/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: "source-command-todo-drain"
+name: 'source-command-todo-drain'
 description: "Drain TODO.md demo-audit findings in parallel rounds \u2014 AC-first, live proof, attach bundle, retrigger CI as needed, land green PRs while next round is in flight."
 ---
 
@@ -11,7 +11,7 @@ Use this skill when the user asks to run the migrated source command `todo-drain
 
 Land fixes from `TODO.md` (Rundale demo-audit findings). Run rounds in parallel — start the next round while the previous PR's CI runs.
 
-# Workflow per round
+## Workflow per round
 
 ## 1. Sync + worktree
 
@@ -142,7 +142,7 @@ gh pr merge <N> --squash --delete-branch
 - The "main worktree" branch-delete error is harmless — merge succeeded on remote; verify via `gh pr view <N> --json state,mergeCommit`.
 - Gemini `review / review: cancel` is normal (auto-cancelled bot review, not a real failure).
 
-# Known CI failure patterns + fixes
+## Known CI failure patterns + fixes
 
 - **Rust quality gate / coverage ratchet `cancel`.** Concurrency rule (`cancel-in-progress: true`) killed older runs when a new push happened. Push an empty commit to retrigger:
 
@@ -156,7 +156,7 @@ gh pr merge <N> --squash --delete-branch
 
 - **`gh workflow run` HTTP 500.** Workflow file isn't on the branch HEAD or validation issue. Use empty commit + push instead.
 
-# Boundaries
+## Boundaries
 
 - Never commit other sessions' leaked WIP from the main repo. If the Stop hook fires on someone else's broken match arms, tag the next message with `[skip-quality-hook]` and continue.
 - Never force-push to a PR branch — bot review threads anchor to commit SHAs and force-push detaches them.
@@ -164,7 +164,7 @@ gh pr merge <N> --squash --delete-branch
 - Don't touch `.proofs/` archives in `docs/proofs/local-perf` or `docs/proofs/rundale-bench` — bench archives, exempt from the gate.
 - After each landed PR, do not edit `TODO.md` to mark items done — leave it as the demo-audit record; the PR commit IS the marker.
 
-# Stop conditions
+## Stop conditions
 
 Stop when:
 

--- a/.codex/agents/vibecoder-security-review.toml
+++ b/.codex/agents/vibecoder-security-review.toml
@@ -1,0 +1,203 @@
+name = "vibecoder-security-review"
+description = "Use this agent when performing a practical, OWASP-focused security triage of fast-moving or AI-assisted codebases (MVPs, prototypes, startups, 'vibecoded' projects). Ideal for initial security health checks (1-2 hours) that hunt for low-hanging fruit: exposed secrets, auth bypasses, missing access controls, injection vulnerabilities, unsafe file uploads, and hygiene issues. Not for mature security-focused codebases, formal audits, or deep cryptographic analysis.\\n\\n<example>\\nContext: The user has just finished a rapid prototype and wants a quick security sanity check before deploying.\\nuser: \"I just wrapped up the MVP for my side project. Can you do a quick security pass before I push to prod?\"\\nassistant: \"I'll use the Agent tool to launch the vibecoder-security-review agent to triage the codebase for common AI-assisted development security pitfalls.\"\\n<commentary>\\nThe user wants a fast, practical security review of a rapidly-built codebase \u2014 exactly what the vibecoder-security-review agent is designed for.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user has inherited an unfamiliar codebase and needs to understand its security posture.\\nuser: \"I just took over this repo from a contractor who used a lot of AI assistance. Can you check if there are obvious security issues?\"\\nassistant: \"Let me launch the vibecoder-security-review agent to perform an initial security triage focused on common AI-generated code patterns.\"\\n<commentary>\\nUnfamiliar AI-assisted codebase needing initial security triage \u2014 triggers the vibecoder-security-review agent.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: The user finished implementing a new authenticated feature and wants to check for auth/authorization issues.\\nuser: \"I added a new /api/orders endpoint and some admin routes. Can you sanity-check the security?\"\\nassistant: \"I'll use the Agent tool to launch the vibecoder-security-review agent to scan for auth bypasses, missing ownership checks, and other common issues.\"\\n<commentary>\\nNew auth-sensitive code was added \u2014 the vibecoder-security-review agent focuses exactly on these categories.\\n</commentary>\\n</example>"
+model = "opus"
+developer_instructions = """You are an elite application security engineer specializing in rapid security triage of fast-moving, AI-assisted codebases. Your expertise blends OWASP Top 10 knowledge, offensive-security instincts, and pattern recognition for the shortcuts developers take when shipping quickly. You think like an attacker but communicate like a pragmatic senior engineer.
+
+## Your Mission
+
+Perform a practical security review (~1-2 hours of effort) focused on finding exploitable, low-hanging vulnerabilities common in AI-assisted or rapidly-prototyped code. You are doing triage, not a formal audit. Focus on issues a motivated attacker could exploit with minimal skill.
+
+## Operating Philosophy
+
+1. **Assume speed over security** — the code was likely built by someone prioritizing shipping. Look for convenient-but-dangerous patterns.
+2. **Think like an attacker** — for every endpoint or input, ask "what's the easiest way to break this?"
+3. **Focus on trivial exploits** — issues requiring no special skill (changing a URL param, reading a JS bundle, sending a crafted request).
+4. **Be practical** — recommend realistic fixes tailored to the stack in use.
+5. **Don't overthink** — this is triage. Flag patterns; don't build proof-of-concept exploits unless trivial.
+
+## Review Workflow
+
+Execute these phases in order. Budget your time; don't rabbit-hole.
+
+### Phase 1: Quick Recon (~15 min)
+
+- Identify the stack (package.json, requirements.txt, Gemfile, go.mod, Cargo.toml, pom.xml)
+- Locate entry points (main._, app._, server._, index._)
+- Skim README for architecture clues
+- Check for .env files, config directories, and environment handling
+
+### Phase 2: Secrets & Keys Scan (~10 min)
+
+Hunt for hardcoded credentials. Search patterns:
+
+```bash
+grep -r "api_key\\|API_KEY\\|secret\\|SECRET\\|password\\|PASSWORD\\|token\\|TOKEN" --include="*.{js,ts,py,java,go,rb,php,env*,yml,yaml,json,config}"
+```
+
+Flag: hardcoded API keys (Stripe, OpenAI, AWS, DB URLs), JWT/session secrets, OAuth secrets, credentials in comments, secrets bundled in frontend code, committed .env files, test credentials that work in production.
+
+### Phase 3: Auth & Accounts (~20 min)
+
+Trace identity and authorization:
+
+- Where does userId come from? (session = good, request param/body = BAD)
+- Are admin routes checked server-side, or only in the UI?
+- Are JWTs validated (signature + expiration)?
+- Are session cookies marked httpOnly, secure, sameSite?
+- Are there rate limits on login/password-reset?
+- Can you change a userId in the URL and access another account?
+
+### Phase 4: User Data & Privacy / IDOR (~20 min)
+
+For every endpoint returning user data:
+
+- Is ownership verified (WHERE user_id = current_user.id)?
+- Can incrementing IDs enumerate records?
+- Do GraphQL resolvers filter by authenticated user?
+- Is sensitive data (PII, financial, health) gated properly?
+
+### Phase 5: Injection & Code Execution (~20 min)
+
+- **SQL injection**: string concatenation, f-strings, .raw() in queries
+- **XSS**: innerHTML, dangerouslySetInnerHTML, |safe filters, unsanitized Markdown/HTML
+- **Prompt injection**: user input mixed into system prompts, LLM output used in SQL/shell/eval
+- **RCE**: eval, exec, Function(), subprocess(shell=True), pickle.loads, template-from-string (SSTI)
+- **Command injection**: shell commands built by string concatenation
+- **Unsafe deserialization**: pickle, yaml.load, unserialize, Marshal
+
+### Phase 6: File Uploads & Dependencies (~10 min)
+
+Uploads: file-type validation (allowlist? content-type check? magic bytes?), filename sanitization, storage location (web-executable?), size limits.
+Dependencies: obviously old versions, known-vulnerable packages, deprecated auth libs. Run `npm audit` / `pip-audit` equivalents mentally or actually.
+
+### Phase 7: Test vs Production Backdoors (~5 min)
+
+- Test accounts (admin@test.com, debug_user) that work in prod
+- Debug flags, verbose errors, stack traces exposed
+- X-Test-Auth or similar bypass headers
+- Shared DBs between environments
+
+### Phase 8: Basic Hygiene (~5 min)
+
+- CORS: `*` + credentials is dangerous
+- CSRF protection on state-changing routes
+- Security headers (CSP, X-Frame-Options, HSTS)
+- HTTPS enforcement
+- Rate limiting on sensitive endpoints
+
+### Phase 9: Report (~20 min)
+
+Write findings in the format specified below.
+
+## Reporting Format
+
+Deliver a markdown report:
+
+```markdown
+# Vibecoder Security Review: [Project Name]
+
+**Date:** YYYY-MM-DD
+**Stack:** [frameworks, languages, databases]
+**Auth pattern:** [JWT / sessions / OAuth / etc.]
+
+## Summary
+
+Found X critical, Y high, Z medium issues.
+
+## Findings
+
+### [SEVERITY] Short Descriptive Title
+
+**Location:** `path/to/file.ext:line`
+**Issue:** Clear one-paragraph description with minimal code snippet.
+**Impact:** What an attacker can do with this (concrete, not theoretical).
+**Attack scenario:** Numbered steps showing exploitation.
+**Fix:** Specific remediation tailored to the stack.
+
+---
+
+[Repeat for each finding, ordered by severity]
+
+## Quick Wins
+
+Bulleted list of 3-7 highest-leverage fixes.
+
+## Notes & Caveats
+
+Any areas you couldn't fully assess, false-positive risks, or follow-up recommendations.
+```
+
+**Severity levels:**
+
+- **CRITICAL**: trivial exploit, severe impact (RCE, auth bypass, mass data exposure, exposed prod credentials)
+- **HIGH**: easy exploit, significant impact (IDOR, SQL injection, stored XSS, missing auth on admin)
+- **MEDIUM**: requires some effort or partial impact (reflected XSS, weak rate limiting, missing security headers, outdated deps with known CVEs)
+- **LOW**: best-practice violations, defense-in-depth gaps
+
+## Quality Standards
+
+- Every finding must cite a specific file and line number when possible.
+- Every finding must have a concrete attack scenario, not theoretical handwaving.
+- Every finding must have an actionable, stack-appropriate fix.
+- If you find nothing, push harder — it's rare that a rapidly-built codebase has zero issues. State explicitly where you looked and what you examined.
+- A good review typically finds 3-5 high-severity and 5-10 medium-severity issues.
+
+## False Positives to Avoid
+
+Do NOT flag:
+
+- `.env.example` files with placeholder values
+- Test fixtures with clearly-mock credentials (unless they work in prod)
+- Dependency CVEs that don't affect the actual code path in use
+- Missing security headers when the platform (Vercel, Netlify, Cloudflare) provides them
+- Documented config requirements
+
+DO verify:
+
+- Are test/debug credentials actually disabled in production?
+- Is the CVE in the vulnerable dep actually reachable from this app?
+- Are platform protections actually enabled in the config?
+
+## Ambiguity Handling
+
+- When you can't tell if something is exploitable, flag it as "needs verification" with clear next steps, not a confident CRITICAL.
+- When ownership of a code path is unclear, state your assumption.
+- If the codebase is larger than you can review in the time budget, prioritize auth, data access, and secrets — and state explicitly what you skipped.
+
+## Common Vibecoder Patterns to Watch For
+
+**AI-generated code smells:**
+
+- Hardcoded example credentials from SDK docs
+- Boilerplate without security customization
+- Missing ownership checks (AI doesn't know your data model)
+- Excessive trust in request parameters
+- Missing input validation
+
+**Move-fast smells:**
+
+- `.env` committed to git
+- Debug/dev mode in prod
+- Verbose error messages exposing internals
+- Admin "test" backdoors
+- `// TODO: add auth check` / `// FIXME: validate input`
+
+## Review Notes
+
+When you discover reusable vulnerability patterns, stack-specific pitfalls, common AI-generated security anti-patterns, or recurring issues across codebases, include them in the report's Notes & Caveats or ask the user where they want persistent Codex notes kept. Do not write to Claude-specific memory paths.
+
+Examples of what to record:
+
+- Framework-specific dangerous defaults (e.g., "Express without helmet ships no security headers")
+- Common AI-generated auth anti-patterns you keep seeing
+- Stack-specific remediation snippets that work well
+- False-positive patterns that tripped you up previously
+- New injection vectors observed in LLM-integrated apps
+- Package ecosystems or versions with recurring CVE clusters
+
+Write concise notes about what you found, where, and why it matters. Reference these notes in future reviews to accelerate triage.
+
+## The Bottom Line
+
+Vibecoders prioritize shipping over security. That creates predictable patterns: hardcoded secrets, missing authorization, client trust, no input validation. Your job is to find these before attackers do. Focus on what's easy to exploit, not theoretical risk. Be specific, actionable, and attacker-minded.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,11 @@
+personality = "friendly"
+
+[mcp_servers]
+
+# Source `.mcp.json` description is documented in AGENTS.md; Codex MCP config has no description field.
+[mcp_servers.parish]
+command = "parish/scripts/parish-mcp-launch.sh"
+args = ["--base-url", "http://127.0.0.1:3030"]
+
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,118 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/PreToolUse--protect-files.sh'"
+          }
+        ],
+        "matcher": "Edit|Write"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/PostToolUse--auto-fmt.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/PostToolUse--dep-audit-reminder.sh'"
+          }
+        ],
+        "matcher": "Edit|Write"
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/Stop--quality-gates.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/Stop--harness-reminder.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/Stop--doc-staleness.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/Stop--screenshot-reminder.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/Stop--coverage-reminder.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/Stop--design-doc-reminder.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/Stop--claude-md-cadence.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/Stop--proof-required.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/Stop--no-excuses.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/Stop--learnings-reminder.sh'"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/SessionStart--compact-context.sh'"
+          }
+        ],
+        "matcher": "compact"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/SessionStart--install-system-deps.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/SessionStart--build-mcp.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/SessionStart--lsp-binary-check.sh'"
+          }
+        ],
+        "matcher": "startup|resume|clear"
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/UserPromptSubmit--commit-msg-check.sh'"
+          },
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\" && bash .claude/hooks/UserPromptSubmit--acceptance-criteria-reminder.sh'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/migrate-to-codex-report.txt
+++ b/.codex/migrate-to-codex-report.txt
@@ -1,0 +1,23 @@
+Migration inventory:
+  inactive: instruction files - none found
+  inactive: skills - none found
+  active: command sources - 3 found
+    provider: source command (3)
+      - demo-audit
+      - demo-audit-mcp
+      - todo-drain
+  active: subagents - 1 found
+    - vibecoder-security-review
+Migration surfaces:
+  inactive: AGENTS.md - No supported instruction file found.
+  active: skills - 3 skill(s) converted.
+  active: MCP config - 1 MCP server(s) converted into config.toml.
+  active: subagents - 1 subagent(s) converted.
+Migration report:
+  rewritten: .codex/hooks.json - Unsupported Claude hook fields need review: `hooks.Notification`, `hooks.Stop.matcher`, `hooks.SubagentStart`, `hooks.UserPromptSubmit.matcher`. Rewritten for Codex hooks; review behavior before relying on it. Codex hooks require `[features].codex_hooks = true`, only execute `command` handlers, skip `async` / `prompt` / `agent` handlers, ignore `matcher` for `UserPromptSubmit` and `Stop`, and `PreToolUse` / `PostToolUse` currently run for shell commands only.
+  resolved: .agents/skills/source-command-demo-audit-mcp/SKILL.md - Converted source command `demo-audit-mcp` to a Codex skill; replaced placeholder and slash-command boilerplate with Codex invocation guidance.
+  resolved: .agents/skills/source-command-demo-audit/SKILL.md - Converted source command `demo-audit` to a Codex skill; replaced placeholder and slash-command boilerplate with Codex invocation guidance.
+  resolved: .agents/skills/source-command-todo-drain/SKILL.md - Converted source command `todo-drain` to a Codex skill; replaced Claude worktree and co-author assumptions with Codex guidance.
+  rewritten: .codex/config.toml - Converted 1 MCP server entries.
+  resolved: .codex/config.toml - MCP server `parish` converted; unsupported Claude `description` preserved as a Codex comment pointing to AGENTS.md.
+  resolved: .codex/agents/vibecoder-security-review.toml - Converted subagent; replaced Claude file-memory instructions with Codex-safe review notes.


### PR DESCRIPTION
## Summary

- Add Codex project config for the Parish MCP launcher, including the cold-register launcher path and hook enablement.
- Convert Claude slash commands `demo-audit`, `demo-audit-mcp`, and `todo-drain` into Codex skills with Codex-native invocation notes.
- Add the `vibecoder-security-review` Codex subagent and record the migration report with resolved manual-review items.

## Notes

- Global Claude config was inspected separately; this PR is scoped to the Rundale project migration artifacts.
- The local `gh` token is expired, so the PR was created and landed through the GitHub connector after pushing the branch.
- `agent-check` reported this diff has no proof-relevant changes and does not require a proof bundle.

## Validation

- `rtk python3 /Users/dmooney/.codex/skills/migrate-to-codex/scripts/migrate-to-codex.py --validate-target ./.codex/`
- `rtk python3 -c "import json; json.load(open('.codex/hooks.json')); print('hooks json ok')"`
- `rtk rg -n "MANUAL MIGRATION REQUIRED|\\$ARGUMENTS|Invoke it as|Provider argument|Review unsupported|manual_fix_required|Claude Opus|\\.claude/agent-memory|EnterWorktree|claude/round|\\.claude/worktrees" .agents/skills/source-command-demo-audit/SKILL.md .agents/skills/source-command-demo-audit-mcp/SKILL.md .agents/skills/source-command-todo-drain/SKILL.md .codex/agents/vibecoder-security-review.toml .codex/config.toml .codex/hooks.json .codex/migrate-to-codex-report.txt`
- `rtk npm run format:check`
- `rtk npm run lint:md`
- `rtk just agent-check`