### PR TITLE
fix: restore bridge chat transcript echoes

### DIFF
--- a/parish/apps/ui/src/components/ChatPanel.svelte
+++ b/parish/apps/ui/src/components/ChatPanel.svelte
@@ -83,6 +83,7 @@
 		if (entry.source === 'player' && entry.subtype === 'command') return 'command';
 		if (entry.source === 'player') return 'player';
 		if (entry.source === 'system') return 'system';
+		if (entry.subtype === 'location') return 'system';
 		// Non-verbal NPC reactions (subtype "action") are rendered as italicised
 		// narration in the system-message style, not as speech bubbles (#1431 item 2).
 		if (entry.subtype === 'action') return 'system';

--- a/parish/apps/ui/src/components/ChatPanel.test.ts
+++ b/parish/apps/ui/src/components/ChatPanel.test.ts
@@ -1017,6 +1017,21 @@ describe('ChatPanel — slash command echo (#1423)', () => {
 		expect(entry?.querySelector('.command-prompt')).toBeTruthy();
 		expect(entry?.querySelector('.command-text')?.textContent).toBe('/resume');
 	});
+
+	it('renders location subtype as system narration even if source drifts', () => {
+		textLog.set([
+			{
+				id: 'loc-1',
+				source: 'narrator',
+				subtype: 'location',
+				content: "The warm interior of Darcy's Pub.",
+			},
+		]);
+		const { container, getByText } = render(ChatPanel);
+		expect(getByText("The warm interior of Darcy's Pub.")).toBeTruthy();
+		expect(container.querySelector('.entry.system.location')).toBeTruthy();
+		expect(container.querySelector('.bubble-row.npc')).toBeFalsy();
+	});
 });
 
 describe('ChatPanel — UI design pass (game-ui-design-ma9ls0)', () => {

--- a/parish/crates/parish-core/src/game_loop/input.rs
+++ b/parish/crates/parish-core/src/game_loop/input.rs
@@ -16,8 +16,10 @@ use tokio_util::sync::CancellationToken;
 
 use crate::config::InferenceCategory;
 use crate::game_loop::{GameLoopContext, handle_movement, handle_npc_conversation};
-use crate::input::{is_physical_action_shaped, parse_intent, parse_intent_local};
-use crate::ipc::{extract_npc_mentions, render_look_text, text_log};
+use crate::input::{
+    is_physical_action_shaped, is_player_dialogue, parse_intent, parse_intent_local,
+};
+use crate::ipc::{extract_npc_mentions, render_look_text, text_log, text_log_typed};
 use crate::npc::reactions::ReactionTemplates;
 use crate::world::transport::TransportMode;
 
@@ -188,6 +190,20 @@ pub async fn handle_game_input(
     // Record the raw player input before any parsing so a bug report filed
     // mid-turn carries the exact action that triggered the failure (#1331).
     ctx.conversation.lock().await.record_player_input(&raw);
+
+    if !is_player_dialogue(&raw) {
+        let echo_enabled = {
+            let config = ctx.config.lock().await;
+            !config.flags.is_disabled("echo-commands")
+        };
+        if echo_enabled {
+            ctx.emitter.emit_event(
+                "text-log",
+                serde_json::to_value(text_log_typed("player", raw.as_str(), "command"))
+                    .unwrap_or(serde_json::Value::Null),
+            );
+        }
+    }
 
     // Resolve the intent client and model (Intent category override, or base).
     let (client, model) = {
@@ -448,6 +464,127 @@ mod tests {
         assert!(
             names.iter().any(|n| n == "text-log"),
             "expected text-log from handle_look; got {names:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_game_input_echoes_non_dialogue_as_command() {
+        let emitter = Arc::new(CapturingEmitter::new());
+        let world = tokio::sync::Mutex::new(WorldState::new());
+        let npc_manager = tokio::sync::Mutex::new(NpcManager::new());
+        let config = tokio::sync::Mutex::new(GameConfig::default());
+        let conversation = tokio::sync::Mutex::new(ConversationRuntimeState::new());
+        let inference_queue = tokio::sync::Mutex::new(None);
+        let client = tokio::sync::Mutex::new(None);
+        let cloud_client = tokio::sync::Mutex::new(None);
+        let inference_config = crate::config::InferenceConfig::default();
+
+        let ctx = GameLoopContext {
+            world: &world,
+            npc_manager: &npc_manager,
+            config: &config,
+            conversation: &conversation,
+            inference_queue: &inference_queue,
+            emitter: Arc::clone(&emitter) as Arc<dyn EventEmitter>,
+            inference_config: &inference_config,
+            pronunciations: &[],
+            client: &client,
+            cloud_client: &cloud_client,
+            language: crate::npc::LanguageSettings::english_only(),
+            inference_failure_messages: &[],
+            idle_messages: &[],
+        };
+
+        let transport = make_transport();
+        let templates = ReactionTemplates::default();
+        super::handle_game_input(
+            &ctx,
+            "look".to_string(),
+            vec![],
+            &transport,
+            &templates,
+            || None,
+        )
+        .await;
+
+        let events = emitter.events.lock().unwrap();
+        let text_logs: Vec<&serde_json::Value> = events
+            .iter()
+            .filter(|(name, _)| name == "text-log")
+            .map(|(_, payload)| payload)
+            .collect();
+        assert!(
+            text_logs.len() >= 2,
+            "expected command echo plus look narration, got {text_logs:?}"
+        );
+        assert_eq!(
+            text_logs[0].get("source").and_then(|v| v.as_str()),
+            Some("player")
+        );
+        assert_eq!(
+            text_logs[0].get("subtype").and_then(|v| v.as_str()),
+            Some("command")
+        );
+        assert_eq!(
+            text_logs[0].get("content").and_then(|v| v.as_str()),
+            Some("look")
+        );
+        assert!(
+            text_logs
+                .iter()
+                .skip(1)
+                .any(|p| p.get("source").and_then(|v| v.as_str()) == Some("system")),
+            "look should still emit system narration after command echo: {text_logs:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_game_input_does_not_command_echo_dialogue() {
+        let emitter = Arc::new(CapturingEmitter::new());
+        let world = tokio::sync::Mutex::new(WorldState::new());
+        let npc_manager = tokio::sync::Mutex::new(NpcManager::new());
+        let config = tokio::sync::Mutex::new(GameConfig::default());
+        let conversation = tokio::sync::Mutex::new(ConversationRuntimeState::new());
+        let inference_queue = tokio::sync::Mutex::new(None);
+        let client = tokio::sync::Mutex::new(None);
+        let cloud_client = tokio::sync::Mutex::new(None);
+        let inference_config = crate::config::InferenceConfig::default();
+
+        let ctx = GameLoopContext {
+            world: &world,
+            npc_manager: &npc_manager,
+            config: &config,
+            conversation: &conversation,
+            inference_queue: &inference_queue,
+            emitter: Arc::clone(&emitter) as Arc<dyn EventEmitter>,
+            inference_config: &inference_config,
+            pronunciations: &[],
+            client: &client,
+            cloud_client: &cloud_client,
+            language: crate::npc::LanguageSettings::english_only(),
+            inference_failure_messages: &[],
+            idle_messages: &[],
+        };
+
+        let transport = make_transport();
+        let templates = ReactionTemplates::default();
+        super::handle_game_input(
+            &ctx,
+            "hello there".to_string(),
+            vec![],
+            &transport,
+            &templates,
+            || None,
+        )
+        .await;
+
+        let events = emitter.events.lock().unwrap();
+        assert!(
+            events.iter().all(|(name, payload)| {
+                name != "text-log"
+                    || payload.get("subtype").and_then(|v| v.as_str()) != Some("command")
+            }),
+            "dialogue must not be echoed as a command: {events:?}"
         );
     }
 

--- a/parish/crates/parish-engine/tests/runaway_generation_guards.rs
+++ b/parish/crates/parish-engine/tests/runaway_generation_guards.rs
@@ -46,13 +46,13 @@ fn harness_with_one_npc() -> (GameTestHarness, String) {
     let mut h = GameTestHarness::new();
     let player_loc = h.app.world.player_location;
 
-    // Pick the first NPC.
-    let speaker_id = h
-        .app
-        .npc_manager
-        .all_npcs()
-        .map(|n| n.id)
-        .next()
+    // Pick a stable NPC. `NpcManager::all_npcs()` is HashMap-backed, so raw
+    // iterator order varies across test worker threads.
+    let mut npc_ids: Vec<_> = h.app.npc_manager.all_npcs().map(|n| n.id).collect();
+    npc_ids.sort_unstable();
+    let speaker_id = npc_ids
+        .first()
+        .copied()
         .expect("harness loads at least one NPC");
 
     let speaker_name = {
@@ -227,10 +227,15 @@ fn real_loop_real_npc_description_not_denied() {
     // Find the name of a SECOND real parish NPC (the one we moved away).
     let other_name: String = {
         let player_loc = h.app.world.player_location;
-        h.app
+        let mut others: Vec<_> = h
+            .app
             .npc_manager
             .all_npcs()
-            .find(|n| n.location != player_loc)
+            .filter(|n| n.location != player_loc)
+            .collect();
+        others.sort_by_key(|n| n.id);
+        others
+            .first()
             .map(|n| n.name.clone())
             .expect("there must be a second NPC in the parish")
     };
@@ -425,7 +430,6 @@ fn real_loop_spelled_out_honorific_of_roster_member_not_denied() {
     );
 
     let joined = shown.join(" ");
-
     // The guard must NOT have fired — the correct reply must reach the player.
     let decline_phrases = [
         "know no one by that name",
@@ -505,10 +509,15 @@ fn real_loop_false_denial_of_roster_npc_corrected() {
     // Find a second real NPC in the parish (the one we moved away).
     let other_name: String = {
         let player_loc = h.app.world.player_location;
-        h.app
+        let mut others: Vec<_> = h
+            .app
             .npc_manager
             .all_npcs()
-            .find(|n| n.location != player_loc)
+            .filter(|n| n.location != player_loc)
+            .collect();
+        others.sort_by_key(|n| n.id);
+        others
+            .first()
             .map(|n| n.name.clone())
             .expect("there must be a second NPC in the parish")
     };

--- a/parish/testing/fixtures/play_fix-bridge-chat-transcript.txt
+++ b/parish/testing/fixtures/play_fix-bridge-chat-transcript.txt
@@ -1,0 +1,18 @@
+# fix-bridge-chat-transcript
+# Covers #1568, #1567, and #1533. #1499 remains a separate exchange-delta bug.
+#
+# Bridge/API-specific assertions belong in server/UI tests. This fixture keeps
+# the player-visible command, scene, and dialogue sequence stable for live proof.
+
+look
+/status
+go to The Crossroads
+look
+go to Darcy's Pub
+look
+/npcs
+
+/stub Padraig Darcy: A fair day to ye. There is turf smoke in the rafters and news at every table.
+hello Padraig, what is the news in the pub?
+
+/status


### PR DESCRIPTION
## Summary

- Emit shared backend command echoes for non-dialogue game input, so bridge-driven movement/look commands appear in chat before their result.
- Render `subtype:"location"` entries as system narration even if their source metadata drifts.
- Stabilize the runaway-generation guard fixture by sorting hash-map-backed NPC choices before picking test actors.

## Issues

Fixes #1568.
Fixes #1567.
Fixes #1533.

Leaves #1499 to the dedicated `/api/submit-input` exchange-delta fix.

## Verification

- `rtk cargo fmt --all`
- `rtk cargo test -p parish-core handle_game_input_`
- `rtk fnm exec --using=22 npx vitest run src/components/ChatPanel.test.ts`
- `rtk fnm exec --using=22 npm run check`
- `rtk cargo run -p parish-engine -- --script testing/fixtures/play_fix-bridge-chat-transcript.txt`
- `rtk cargo test -p parish-engine --test runaway_generation_guards`
- `rtk just agent-check`
- `rtk just check`

<!-- parish-proof-bundle:fix-bridge-chat-transcript v=1 -->

## Proof: fix-bridge-chat-transcript

### Acceptance criteria

# Acceptance Criteria: fix-bridge-chat-transcript

## Task

Fix bridge/API chat transcript fidelity so movement/look inputs have a backend command echo and scene/location text renders as narration rather than NPC speech when source metadata drifts. Covers #1568 and #1567, and rechecks the bare-look path from #1533.

## Criteria

- Non-dialogue game inputs such as `look` produce a backend text-log command echo with `source: "player"` and `subtype: "command"` - observable via the shared `parish-core` game-loop regression test.
- Dialogue input is not echoed as a command, avoiding double-rendering alongside the existing dialogue bubble path - observable via the paired shared game-loop regression test.
- Scene/location descriptions with `subtype: "location"` are classified as system narration even if `source` is not `"system"` - observable via the `ChatPanel` unit test.
- Bare `look` returns a current scene re-description instead of silently consuming the turn - observable via the fixture's first `look` response.
- Movement and dialogue still run end-to-end after the transcript changes - observable via the fixture moving to The Crossroads, moving to Darcy's Pub, and receiving Padraig Darcy's stubbed reply.

## Verification script

Run: `cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-bridge-chat-transcript.txt`

Expected signals in output:

- `look` returns current location narration.
- Movement to The Crossroads and Darcy's Pub returns command/result output in order.
- Dialogue with Padraig Darcy returns `result:"npc_response"`, `npc:"Padraig Darcy"`, and nonblank `dialogue`.
- Targeted tests show the backend text-log echo and UI location classification behavior.

### Evidence

Evidence type: live gameplay transcript

# Evidence: fix-bridge-chat-transcript

Source transcript: `.proofs/fix-bridge-chat-transcript/transcript.txt`
Captured by: `cargo run -p parish-engine -- --script testing/fixtures/play_fix-bridge-chat-transcript.txt`

## Criterion -> transcript mapping

- **Non-dialogue game inputs produce a backend command echo** - targeted test output: `cargo test -p parish-core handle_game_input_` reported `4 passed, 509 filtered out`. The new `handle_game_input_echoes_non_dialogue_as_command` assertion checks the first text-log payload for `source == "player"`, `subtype == "command"`, and `content == "look"`.
- **Dialogue input is not echoed as a command** - targeted test output: `cargo test -p parish-core handle_game_input_` reported `4 passed, 509 filtered out`. The new `handle_game_input_does_not_command_echo_dialogue` assertion checks that a dialogue-shaped input does not emit a `subtype:"command"` text-log.
- **Scene/location descriptions classify as system narration** - targeted UI test output: `fnm exec --using=22 npx vitest run src/components/ChatPanel.test.ts` reported `1 passed (1)` and `59 passed (59)`. The new ChatPanel assertion renders `{source:"narrator", subtype:"location"}` as `.entry.system.location` and not `.bubble-row.npc`.
- **Bare `look` returns a scene re-description** - transcript first JSON row: `{"command":"look","result":"looked","description":"The small village of Kilteevan ...","location":"Kilteevan Village"}`.
- **Movement and dialogue still run end-to-end** - transcript rows show `{"command":"go to The Crossroads","result":"moved","to":"The Crossroads"}`, `{"command":"go to Darcy's Pub","result":"moved","to":"Darcy's Pub"}`, and `{"command":"hello Padraig, what is the news in the pub?","result":"npc_response","npc":"Padraig Darcy","dialogue":"A fair day to ye. There is turf smoke in the rafters and news at every table."}`.
- **Runaway-generation guard fixture remains parallel-stable** - targeted test output: `cargo test -p parish-engine --test runaway_generation_guards` reported `10 passed`. The helper now chooses NPCs by sorted `NpcId` instead of hash-map iteration order.

## Commands run

- `cargo fmt --all`
- `cargo test -p parish-core handle_game_input_`
- `fnm exec --using=22 npx vitest run src/components/ChatPanel.test.ts`
- `fnm exec --using=22 npm run check`
- `cargo run -p parish-engine -- --script testing/fixtures/play_fix-bridge-chat-transcript.txt`
- `cargo test -p parish-engine --test runaway_generation_guards`
- `just check`

## Five whys summary

Problem: bridge-driven movement/look inputs showed results but no player command echo, and location narration could bubble as NPC speech if source metadata drifted.

1. Why was there no echo? The submit paths emitted a player text-log only when `is_player_dialogue(raw)` was true.
2. Why did movement/look skip it? #1351 intentionally stopped rendering deterministic commands as speech bubbles.
3. Why was there no replacement? The command-echo path existed for slash/system commands but not for free-form non-dialogue game input.
4. Why did this only show in bridge/harness driving? The UI no longer creates the canonical echo itself; bridge callers depend entirely on backend text-log events.
5. Why could scene text bubble? ChatPanel fell through any non-player/non-system source to NPC unless the subtype was `action`.

Prevention question: existing AGENTS.md rules already require mode parity and shared orchestration; the missing piece was regression coverage. This change adds shared game-loop tests and a ChatPanel classifier test rather than adding another convention.

### Transcript

```text
{"command":"look","result":"looked","description":"The small village of Kilteevan — a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The clear sky hangs over the quiet street. It is morning.","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["The small village of Kilteevan — a handful of whitewashed cottages clustered around a well and an old stone bridge over a shallow stream. Smoke drifts from chimneys. A rooster crows from behind a low wall. The clear sky hangs over the quiet street. It is morning.","You can go to: The Crossroads (13 min on foot), The Forge (1 min on foot), The Holy Well (1 min on foot), The Mill (1 min on foot), The Weaver's Cottage (2 min on foot), Knockcroghery Village (85 min on foot), St. Brigid's Church (9 min on foot), Murphy's Farm (21 min on foot), The Lime Kiln (1 min on foot), The Letter Office (11 min on foot)","A young woman heads off down the road.","An older man heads off down the road.","A lean, red-haired young man with hard eyes heads off down the road.","An older woman with sharp eyes and herb-stained fingers heads off down the road."]}
{"command":"/status","result":"system_command","response":"Location: Kilteevan Village | Morning | Spring","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["Location: Kilteevan Village | Morning | Spring"]}
{"command":"go to The Crossroads","result":"moved","to":"The Crossroads","minutes":13,"narration":"You walk along the road north past low fields to the crossroads. (13 minutes on foot)","location":"The Crossroads","time":"Morning","season":"Spring","new_log_lines":["You walk along the road north past low fields to the crossroads. (13 minutes on foot)","","A farmer nods to you from the far side of a gate as you pass.","A quiet crossroads where four narrow roads meet. A weathered stone wall lines the eastern side, half-hidden by brambles. The clear sky stretches over the flat midlands. It is morning.\nYou can go to: Darcy's Pub (1 min on foot), St. Brigid's Church (11 min on foot), The Letter Office (4 min on foot), The Hedge School (2 min on foot), Connolly's Shop (1 min on foot), Kilteevan Village (13 min on foot), The Hurling Green (4 min on foot)","  · A boy and his dog come up the road behind you, pass you at a run, and are gone."]}
{"command":"look","result":"looked","description":"A quiet crossroads where four narrow roads meet. A weathered stone wall lines the eastern side, half-hidden by brambles. The clear sky stretches over the flat midlands. It is morning.","location":"The Crossroads","time":"Morning","season":"Spring","new_log_lines":["A quiet crossroads where four narrow roads meet. A weathered stone wall lines the eastern side, half-hidden by brambles. The clear sky stretches over the flat midlands. It is morning.","You can go to: Darcy's Pub (1 min on foot), St. Brigid's Church (11 min on foot), The Letter Office (4 min on foot), The Hedge School (2 min on foot), Connolly's Shop (1 min on foot), Kilteevan Village (13 min on foot), The Hurling Green (4 min on foot)"]}
{"command":"go to Darcy's Pub","result":"moved","to":"Darcy's Pub","minutes":1,"narration":"You walk along a short lane past a row of cottages. (1 minute on foot)","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["You walk along a short lane past a row of cottages. (1 minute on foot)","","The warm interior of Darcy's Pub. Turf smoke hangs in the air. Old prints of hurling matches line the walls beside a faded map of the county. A fiddle sits propped in the corner. It is morning and the weather outside is clear.\nYou can go to: The Crossroads (1 min on foot)","  · An older woman sitting on a wall watches you approach, watches you pass, says nothing."]}
{"command":"look","result":"looked","description":"The warm interior of Darcy's Pub. Turf smoke hangs in the air. Old prints of hurling matches line the walls beside a faded map of the county. A fiddle sits propped in the corner. It is morning and the weather outside is clear.","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["The warm interior of Darcy's Pub. Turf smoke hangs in the air. Old prints of hurling matches line the walls beside a faded map of the county. A fiddle sits propped in the corner. It is morning and the weather outside is clear.","You can go to: The Crossroads (1 min on foot)"]}
{"command":"/npcs","result":"system_command","response":"NPCs here:\n  an older man behind the bar — Publican (content)\n  a young woman — Publican's Daughter (restless)","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["NPCs here:\n  an older man behind the bar — Publican (content)\n  a young woman — Publican's Daughter (restless)"]}
{"command":"/stub Padraig Darcy: A fair day to ye. There is turf smoke in the rafters and news at every table.","result":"system_command","response":"Stubbed response for Padraig Darcy: \"A fair day to ye. There is turf smoke in the rafters and news at every table.\"","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["Stubbed response for Padraig Darcy: \"A fair day to ye. There is turf smoke in the rafters and news at every table.\""]}
{"command":"hello Padraig, what is the news in the pub?","result":"npc_response","npc":"Padraig Darcy","dialogue":"A fair day to ye. There is turf smoke in the rafters and news at every table.","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["Padraig Darcy: A fair day to ye. There is turf smoke in the rafters and news at every table.","Padraig Darcy 😊","Niamh Darcy 😊"]}
{"command":"/status","result":"system_command","response":"Location: Darcy's Pub | Morning | Spring","location":"Darcy's Pub","time":"Morning","season":"Spring","new_log_lines":["Location: Darcy's Pub | Morning | Spring"]}
```

### Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

# Judge: fix-bridge-chat-transcript

## Per-criterion verification

- **Non-dialogue command echo**: met by `handle_game_input_echoes_non_dialogue_as_command`, which asserts `look` emits `source:"player"`, `subtype:"command"`, `content:"look"` before the system narration.
- **No dialogue command echo**: met by `handle_game_input_does_not_command_echo_dialogue`, which asserts dialogue-shaped input emits no command subtype from shared game input.
- **Location narration classification**: met by the ChatPanel regression test rendering a location-subtyped entry as `.entry.system.location` and not an NPC bubble.
- **Bare look scene echo**: met by the live transcript's first row with `command:"look"`, `result:"looked"`, and a nonblank Kilteevan Village description.
- **End-to-end movement/dialogue health**: met by the live transcript's movement rows to The Crossroads and Darcy's Pub plus the stubbed `npc_response` from Padraig Darcy.
- **Guard-suite stability**: met by `cargo test -p parish-engine --test runaway_generation_guards`, which passes under default parallel test execution after the helper stopped using hash-map iteration order for fixture selection.

## Implementation notes

The fix deliberately leaves `/api/submit-input` inline `exchanges[]` work out of scope; that belongs to #1499. This slice fixes the command echo and narration-bubble bugs with shared backend behavior plus UI classifier hardening.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:fix-bridge-chat-transcript -->
