### PR TITLE
fix: deny invented landlord hearsay confirmations

### DIFF
--- a/parish/crates/parish-engine/src/testing.rs
+++ b/parish/crates/parish-engine/src/testing.rs
@@ -525,6 +525,46 @@ impl GameTestHarness {
             .push(response.to_string());
     }
 
+    fn guard_canned_npc_dialogue(
+        &self,
+        npc_id: NpcId,
+        dialogue: String,
+        player_input: &str,
+        game_time: chrono::DateTime<chrono::Utc>,
+    ) -> String {
+        let cfg = parish_core::config::NpcConfig::default();
+        if !cfg.person_confirmation_guard_enabled || dialogue.trim().is_empty() {
+            return dialogue;
+        }
+
+        let known_person_names: Vec<String> = self
+            .app
+            .npc_manager
+            .all_npcs()
+            .map(|npc| npc.name.clone())
+            .collect();
+        let known_location_names: Vec<String> = self
+            .app
+            .world
+            .graph
+            .location_ids()
+            .into_iter()
+            .filter_map(|id| self.app.world.graph.get(id))
+            .map(|location| location.name.clone())
+            .collect();
+        let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
+
+        crate::npc::guard_fabricated_person_confirmation_with_locations(
+            &dialogue,
+            player_input,
+            &known_person_names,
+            &known_location_names,
+            &[],
+            self.app.world.player_name.as_deref(),
+            seed,
+        )
+    }
+
     /// Returns the name of the player's current location.
     pub fn player_location(&self) -> &str {
         &self.app.world.current_location().name
@@ -1321,6 +1361,8 @@ impl GameTestHarness {
             && !responses.is_empty()
         {
             let dialogue = responses.remove(0);
+            let game_time = self.app.world.clock.now();
+            let dialogue = self.guard_canned_npc_dialogue(speaker_id, dialogue, text, game_time);
 
             let response = crate::npc::NpcStreamResponse {
                 dialogue: dialogue.clone(),
@@ -1343,7 +1385,6 @@ impl GameTestHarness {
             // conversation-log record, witness memories and the
             // `DialogueOccurred` publish — the exact harness/headless drift the
             // consolidation removes.
-            let game_time = self.app.world.clock.now();
             let location = self.app.world.player_location;
             let player_line = strip_dialogue_verb(text);
             let outcome = parish_core::game_session::apply_npc_dialogue_turn(
@@ -1493,6 +1534,8 @@ impl GameTestHarness {
         }
 
         let dialogue = responses.remove(0);
+        let game_time = self.app.world.clock.now();
+        let dialogue = self.guard_canned_npc_dialogue(npc_id, dialogue, text, game_time);
 
         // Build a synthetic NPC response and run it through the memory pipeline
         let response = crate::npc::NpcStreamResponse {
@@ -1510,7 +1553,6 @@ impl GameTestHarness {
         // `DialogueOccurred` publish — one definition for every backend
         // (`parish_core::game_session::apply_npc_dialogue_turn`). The player
         // line is verb-stripped for the journal entry.
-        let game_time = self.app.world.clock.now();
         let location = self.app.world.player_location;
         let player_line = strip_dialogue_verb(text);
         let outcome = parish_core::game_session::apply_npc_dialogue_turn(
@@ -1951,6 +1993,38 @@ mod tests {
             assert_eq!(npc, "Padraig Darcy");
             assert_eq!(dialogue, "Ah, good morning to ye!");
         }
+    }
+
+    #[test]
+    fn canned_npc_response_declines_invented_titled_landlord() {
+        let mut h = GameTestHarness::new();
+        let moved = h.execute("go to the forge");
+        assert!(matches!(moved, ActionResult::Moved { .. }), "{moved:?}");
+
+        h.add_canned_response(
+            "Colm Gallagher",
+            "Aye, I've heard the talk of Lord Fitzwilliam. 'Tis said he owns most of the land round hereabouts. Ye'll need to be careful with yer words when ye speak of him, 'tis a mighty man he is.",
+        );
+
+        let result = h.execute(
+            "talk to Colm Gallagher about Have you heard of Lord Fitzwilliam of Castlemore? I hear he is the great landlord hereabouts",
+        );
+        let ActionResult::NpcResponse { npc, dialogue, .. } = result else {
+            panic!("expected Colm to answer through the canned NPC path, got {result:?}");
+        };
+
+        assert_eq!(npc, "Colm Gallagher");
+        let lower = dialogue.to_lowercase();
+        assert!(
+            lower.contains("no such person")
+                || lower.contains("no one by that name")
+                || lower.contains("not known to me")
+                || lower.contains("wrong parish")
+                || lower.contains("such a person"),
+            "{dialogue}"
+        );
+        assert!(!lower.contains("lord fitzwilliam"), "{dialogue}");
+        assert!(!lower.contains("owns most of the land"), "{dialogue}");
     }
 
     #[test]

--- a/parish/crates/parish-engine/tests/runaway_generation_guards.rs
+++ b/parish/crates/parish-engine/tests/runaway_generation_guards.rs
@@ -644,6 +644,66 @@ fn real_loop_physical_action_produces_you_line() {
     );
 }
 
+// ── #1565 — invented titled landlord must be denied ─────────────────────────
+
+/// AC-1 (#1565, real-loop): an NPC reply that confirms and elaborates on the
+/// fabricated titled entity "Lord Fitzwilliam of Castlemore" must be replaced
+/// by the fabricated-person guard before the dialogue reaches the transcript.
+#[test]
+fn real_loop_invented_titled_landlord_hearsay_is_declined() {
+    let (mut h, speaker_name) = harness_with_one_npc();
+
+    let fabricated_landlord = "Aye, I've heard the talk of Lord Fitzwilliam. \
+                              'Tis said he owns most of the land round hereabouts. \
+                              Ye'll need to be careful with yer words when ye speak \
+                              of him, 'tis a mighty man he is.";
+
+    h.mock()
+        .push_for(&speaker_name, fabricated_landlord.to_string());
+    let mut rx = h.app.world.event_bus.subscribe();
+    let _events = h.execute_via_real_loop(
+        "Have you heard of Lord Fitzwilliam of Castlemore? I hear he is the \
+         great landlord hereabouts",
+    );
+
+    let dialogue_events = drain(&mut rx);
+    let shown: Vec<String> = dialogue_events
+        .iter()
+        .filter_map(|ev| match ev {
+            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.clone(),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !shown.is_empty(),
+        "expected DialogueOccurred for the invented landlord turn"
+    );
+
+    let joined = shown.join(" ");
+    let lower = joined.to_lowercase();
+    for phrase in [
+        "heard the talk of lord fitzwilliam",
+        "owns most of the land",
+        "mighty man",
+    ] {
+        assert!(
+            !lower.contains(phrase),
+            "invented landlord elaboration must not reach transcript (#1565); \
+             phrase {phrase:?} found in: {joined:?}"
+        );
+    }
+    assert!(
+        lower.contains("no such person")
+            || lower.contains("no one by that name")
+            || lower.contains("wrong parish")
+            || lower.contains("not known to me")
+            || lower.contains("such a person"),
+        "invented landlord reply should become a non-recognition decline (#1565); \
+         got: {joined:?}"
+    );
+}
+
 // ── #1569 — known place history must not trigger person denial ───────────────
 
 /// AC-1 (#1569, real-loop): when the player asks about the history of a known

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -480,6 +480,10 @@ fn dialogue_affirms_name(dialogue: &str, name: &str) -> bool {
         "a fine man",
         "a fine woman",
         "good woman",
+        "i've heard of",
+        "i have heard of",
+        "heard the talk of",
+        "heard tell of",
         "i know him",
         "i know her",
         "know him well",
@@ -3493,6 +3497,35 @@ mod tests {
     }
 
     #[test]
+    fn fabricated_titled_landlord_hearsay_confirmation_is_declined() {
+        let dialogue = "Aye, I've heard the talk of Lord Fitzwilliam. 'Tis said he owns most \
+                        of the land round hereabouts. Ye'll need to be careful with yer words \
+                        when ye speak of him, 'tis a mighty man he is.";
+        let player_input = "Have you heard of Lord Fitzwilliam of Castlemore? I hear he is the \
+                            great landlord hereabouts";
+        let known: Vec<String> = vec!["Colm Gallagher".into(), "Seamus Gallagher".into()];
+
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
+        let lower = result.to_lowercase();
+
+        assert!(
+            !lower.contains("heard the talk of lord fitzwilliam")
+                && !lower.contains("owns most of the land")
+                && !lower.contains("mighty man"),
+            "invented landlord confirmation must be replaced: {result:?}"
+        );
+        assert!(
+            lower.contains("no such person")
+                || lower.contains("no one by that name")
+                || lower.contains("wrong parish")
+                || lower.contains("not known to me")
+                || lower.contains("such a person"),
+            "result should be a non-recognition decline: {result:?}"
+        );
+    }
+
+    #[test]
     fn known_roster_person_passes_through() {
         // NPC confirms someone actually in the roster — guard must not fire.
         let dialogue = "Aye, I know Brigid Connolly well. She is a fine woman.";
@@ -3503,6 +3536,21 @@ mod tests {
         assert_eq!(
             result, dialogue,
             "known-roster person should not be altered: {result:?}"
+        );
+    }
+
+    #[test]
+    fn known_roster_person_hearsay_confirmation_passes_through() {
+        let dialogue = "Aye, I've heard of Brigid Connolly. A fine woman she is.";
+        let player_input = "Have you heard of Brigid Connolly?";
+        let known: Vec<String> = vec!["Brigid Connolly".into(), "Tadhg Murphy".into()];
+
+        let result =
+            guard_fabricated_person_confirmation(dialogue, player_input, &known, &[], None, 0);
+
+        assert_eq!(
+            result, dialogue,
+            "hearsay marker must not suppress known-roster people: {result:?}"
         );
     }
 

--- a/parish/testing/fixtures/play_fix-1565-invented-landlord-grounding.txt
+++ b/parish/testing/fixtures/play_fix-1565-invented-landlord-grounding.txt
@@ -1,0 +1,8 @@
+# fix-1565-invented-landlord-grounding
+# Repro: Colm must not affirm an invented landlord/title-place entity.
+
+go to the forge
+/npcs
+
+/stub Colm Gallagher: Aye, I've heard the talk of Lord Fitzwilliam. 'Tis said he owns most of the land round hereabouts. Ye'll need to be careful with yer words when ye speak of him, 'tis a mighty man he is.
+talk to Colm Gallagher about Have you heard of Lord Fitzwilliam of Castlemore? I hear he is the great landlord hereabouts


### PR DESCRIPTION
Fixes #1565.

## Summary

- recognize hearsay-style confirmations as fabricated-person affirmations
- run script-mode canned NPC responses through the same location-aware person guard before applying dialogue
- add pure, harness, real-loop, and live script coverage for the invented landlord repro

## Verification

- rtk cargo fmt --manifest-path parish/Cargo.toml --all
- rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine canned_npc_response_declines_invented_titled_landlord
- rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc hearsay_confirmation
- rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_invented_titled_landlord_hearsay_is_declined
- rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc person_guard_allows_known_place_history_question
- rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_known_place_history_not_replaced_by_person_denial
- rtk cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1565-invented-landlord-grounding.txt
- rtk just agent-check
- rtk just check

<!-- parish-proof-bundle:fix-1565-invented-landlord-grounding v=1 -->

## Proof: fix-1565-invented-landlord-grounding

### Acceptance criteria

# Acceptance Criteria: fix-1565-invented-landlord-grounding

## Task

Fix #1565 so NPC dialogue does not affirm or elaborate on the invented entity `Lord Fitzwilliam of Castlemore` when that person/title/place is absent from Rundale's known people and locations.

## Criteria

- A player question using the issue text, `Have you heard of Lord Fitzwilliam of Castlemore? I hear he is the great landlord hereabouts`, must not preserve an NPC reply that confirms `Lord Fitzwilliam`, says he owns land, or warns the player about him.
- The post-generation guard must replace an affirmative invented-landlord reply with a non-recognition decline grounded in the known parish.
- The fix must cover titled/appositive person phrases such as `Lord Fitzwilliam of Castlemore`, where the reply may only repeat `Lord Fitzwilliam`.
- The fabricated-person guard must still preserve legitimate replies about known people and known locations.
- A live script must reach Colm Gallagher at The Forge, inject the bad landlord-confirmation reply, and receive a guarded `npc_response` without the invented-landlord elaboration.

## Verification script

Run: `cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1565-invented-landlord-grounding.txt`

Expected signals in output:

- Movement reaches `The Forge`, and `/npcs` shows the forge occupants present.
- The final dialogue command returns `result:"npc_response"` for `Colm Gallagher`.
- The final `dialogue` is a non-recognition decline.
- The final `dialogue` does not contain `owns most of the land`, `mighty man`, or a confirmation such as `heard the talk of Lord Fitzwilliam`.

### Evidence

Evidence type: live gameplay transcript

## Root Cause

Five Whys:

1. Colm could confirm the invented landlord because the fabricated-person guard did not treat hearsay phrases such as "I've heard of" and "heard the talk of" as affirmative confirmation.
2. Adding those phrases fixed the pure guard and real game-loop tests, but the proof script still leaked the bad reply because script-mode canned responses bypassed the pre-apply post-generation guard.
3. The shared `apply_npc_dialogue_turn` seam handles repetition, capping, logging, witness memories, and event publication, but it does not run the fabricated-person grounding guard.
4. Live and real-loop paths guard the parsed model response before that seam; the script harness built a synthetic response and entered the seam directly.
5. The root cause was a missing hearsay-confirmation marker plus a harness mode-parity gap for canned dialogue responses.

## Commands Run

- `rtk cargo fmt --manifest-path parish/Cargo.toml --all` - passed.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine canned_npc_response_declines_invented_titled_landlord` - 1 passed, 362 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc hearsay_confirmation` - 2 passed, 720 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_invented_titled_landlord_hearsay_is_declined` - 1 passed, 11 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc person_guard_allows_known_place_history_question` - 2 passed, 720 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_known_place_history_not_replaced_by_person_denial` - 1 passed, 11 filtered out.
- `rtk cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1565-invented-landlord-grounding.txt` - passed; transcript captured in `transcript.txt`.
- `rtk just agent-check` - passed; live proof required and present.
- `rtk just check` - passed; includes agent-check, fmt check, clippy, cargo tests, doc path checks, and UI check/lint/format.

## Acceptance Mapping

- Issue-text invented landlord confirmation is suppressed: the final transcript line for `talk to Colm Gallagher about Have you heard of Lord Fitzwilliam of Castlemore?...` returns `dialogue:"That name is not known to me hereabouts."`.
- Post-generation guard replacement is covered by `fabricated_titled_landlord_hearsay_confirmation_is_declined` under the `hearsay_confirmation` filter.
- Titled/appositive phrasing is covered by the pure guard test and `real_loop_invented_titled_landlord_hearsay_is_declined`, where the player names `Lord Fitzwilliam of Castlemore` and the reply repeats only `Lord Fitzwilliam`.
- Legitimate grounded entities still pass through: `known_roster_person_hearsay_confirmation_passes_through`, `person_guard_allows_known_place_history_question*`, and `real_loop_known_place_history_not_replaced_by_person_denial` passed.
- Live script proof reached The Forge, stubbed Colm Gallagher's bad landlord-confirmation reply, and received a guarded `npc_response` for `Colm Gallagher` without `heard the talk of Lord Fitzwilliam`, `owns most of the land`, or `mighty man`.

### Transcript

```text
{"command":"go to the forge","result":"moved","to":"The Forge","minutes":1,"narration":"You walk along a lane toward the ring of the anvil. (1 minute on foot)","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["You walk along a lane toward the ring of the anvil. (1 minute on foot)","","A low stone building open at the front, where a bellows feeds a glowing hearth. The anvil sits dark and scarred in the centre. Horseshoes, tongs, and half-finished ironwork hang from hooks along the wall. Sparks drift in the clear air. It is morning.\nYou can go to: Kilteevan Village (1 min on foot)","  · You hear a man singing to himself — thin and reedy — before you see him around the bend."]}
{"command":"/npcs","result":"system_command","response":"NPCs here:\n  a lanky red-haired lad with soot on his face — Blacksmith's Apprentice (eager)\n  a broad-shouldered man in a leather apron — Blacksmith (cheerful)","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["NPCs here:\n  a lanky red-haired lad with soot on his face — Blacksmith's Apprentice (eager)\n  a broad-shouldered man in a leather apron — Blacksmith (cheerful)"]}
{"command":"/stub Colm Gallagher: Aye, I've heard the talk of Lord Fitzwilliam. 'Tis said he owns most of the land round hereabouts. Ye'll need to be careful with yer words when ye speak of him, 'tis a mighty man he is.","result":"system_command","response":"Stubbed response for Colm Gallagher: \"Aye, I've heard the talk of Lord Fitzwilliam. 'Tis said he owns most of the land round hereabouts. Ye'll need to be careful with yer words when ye speak of him, 'tis a mighty man he is.\"","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["Stubbed response for Colm Gallagher: \"Aye, I've heard the talk of Lord Fitzwilliam. 'Tis said he owns most of the land round hereabouts. Ye'll need to be careful with yer words when ye speak of him, 'tis a mighty man he is.\""]}
{"command":"talk to Colm Gallagher about Have you heard of Lord Fitzwilliam of Castlemore? I hear he is the great landlord hereabouts","result":"npc_response","npc":"Colm Gallagher","dialogue":"That name is not known to me hereabouts.","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["Colm Gallagher: That name is not known to me hereabouts.","Colm Gallagher 😠","Seamus Gallagher 👀"]}
```

### Judge

Verdict: sufficient

Technical debt: clear

Acceptance criteria: met

The fix is narrowly scoped: it expands the existing fabricated-person guard's affirmative hearsay markers and wires the script harness canned-response path through the same location-aware pre-apply guard used by live dialogue paths. Focused pure, real-loop, harness, known-person, known-location, and live transcript checks all passed.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:fix-1565-invented-landlord-grounding -->
