### PR TITLE
fix: preserve short multi-sentence dialogue answers

### DIFF
--- a/parish/crates/parish-engine/tests/runaway_generation_guards.rs
+++ b/parish/crates/parish-engine/tests/runaway_generation_guards.rs
@@ -644,6 +644,58 @@ fn real_loop_physical_action_produces_you_line() {
     );
 }
 
+// ── #1561 — ordinary answers must not truncate to opener ─────────────────────
+
+/// AC-1 (#1561, real-loop): a short, distinct multi-sentence answer that
+/// contains a harmless repeated phrase ("work for a") must not be trimmed back
+/// to only its greeting by the post-generation verbosity guards.
+#[test]
+fn real_loop_cooper_work_answer_is_not_truncated_to_greeting() {
+    let (mut h, speaker_name) = harness_with_one_npc();
+
+    let cooper_answer = "Good morning, Aiden Carney. Work for a cooper? \
+                         Aye, there's always work for a man with that skill. \
+                         This place needs barrels for ale and salt, surely. \
+                         Ye know yer trade?";
+
+    h.mock().push_for(&speaker_name, cooper_answer.to_string());
+    let mut rx = h.app.world.event_bus.subscribe();
+    let _events = h.execute_via_real_loop(
+        "I am Aiden Carney, a cooper newly arrived in Kilteevan. Might there be work here?",
+    );
+
+    let dialogue_events = drain(&mut rx);
+    let shown: Vec<String> = dialogue_events
+        .iter()
+        .filter_map(|ev| match ev {
+            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.clone(),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !shown.is_empty(),
+        "expected DialogueOccurred for the cooper-work turn"
+    );
+
+    let joined = shown.join(" ");
+    assert_ne!(
+        joined, "Good morning, Aiden Carney.",
+        "cooper-work answer must not be truncated to only the greeting"
+    );
+    for phrase in [
+        "Work for a cooper?",
+        "there's always work",
+        "barrels for ale and salt",
+        "Ye know yer trade?",
+    ] {
+        assert!(
+            joined.contains(phrase),
+            "cooper-work answer lost phrase {phrase:?}: {joined:?}"
+        );
+    }
+}
+
 // ── #1565 — invented titled landlord must be denied ─────────────────────────
 
 /// AC-1 (#1565, real-loop): an NPC reply that confirms and elaborates on the

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -1646,6 +1646,8 @@ pub fn strip_consecutive_short_phrase_repeat(dialogue: &str) -> String {
 ///   first (N-1) sentences plus the trailing question — so the NPC remains
 ///   interactive. If the kept-N sentences already end with a `?`, no swap is made.
 /// - Short replies (<= `MAX_SENTENCE_COUNT` sentences) are returned unchanged.
+/// - Short replies (<= 45 words) are returned unchanged by the default
+///   4-sentence cap even when they contain 5 terse sentence units (#1561).
 ///
 /// The cap is intentionally conservative (4 sentences) — a natural NPC
 /// turn should deliver one thought in 2-3 sentences and optionally ask one
@@ -1668,6 +1670,11 @@ fn cap_sentence_count_with_limit(dialogue: &str, max: usize) -> String {
         .collect();
 
     if sentences.len() <= max {
+        return dialogue.trim().to_string();
+    }
+
+    const DEFAULT_SHORT_REPLY_WORD_BUDGET: usize = 45;
+    if max >= 4 && dialogue.split_whitespace().count() <= DEFAULT_SHORT_REPLY_WORD_BUDGET {
         return dialogue.trim().to_string();
     }
 
@@ -1795,6 +1802,14 @@ pub fn collapse_nearby_phrase_repeat(dialogue: &str) -> String {
                     // Look for the last sentence-end marker in the prefix.
                     if let Some(last_end) = prefix.rfind(['.', '!', '?']) {
                         let sentence_end = last_end + 1;
+                        if !prefix[sentence_end..].trim().is_empty() {
+                            // The only clean boundary is before the first
+                            // occurrence of the repeated phrase. Trimming there
+                            // would drop the whole substantive sentence and keep
+                            // only an earlier opener (#1561), so this is not a
+                            // safe loop-collapse candidate.
+                            continue;
+                        }
                         let trimmed = prefix[..sentence_end].trim();
                         if !trimmed.is_empty() {
                             tracing::debug!(
@@ -5098,9 +5113,12 @@ mod tests {
     /// AC-3 (#1491): A neutral mood keeps the default 4-sentence cap.
     #[test]
     fn mood_aware_sentence_cap_neutral_mood_keeps_4() {
-        let dialogue = "Good day to ye. The weather's been mild. \
-            The cattle are doing well. I saw the priest this morning. \
-            He sent his regards.";
+        let dialogue = "Good day to ye, friend, and welcome into the house. \
+            The weather has been mild enough for the cattle in the lower meadow. \
+            The spring grass came early, so every beast has kept a little strength. \
+            I saw the priest this morning walking the road toward the chapel. \
+            He sent his regards and asked after every family by name.";
+        assert!(dialogue.split_whitespace().count() > 45);
         let result = cap_sentence_count_for_mood(dialogue, Some("neutral"));
         let sentence_count = split_sentences(&result)
             .iter()
@@ -5119,7 +5137,12 @@ mod tests {
     /// AC-4 (#1491): None mood uses default 4-sentence cap (no panic).
     #[test]
     fn mood_aware_sentence_cap_none_mood_uses_default() {
-        let dialogue = "One. Two. Three. Four. Five.";
+        let dialogue = "One long sentence gathers enough words for the default cap to matter. \
+            Two long sentence adds a little more local news for the test. \
+            Three long sentence keeps the reply ordinary while staying above the budget. \
+            Four long sentence should remain after the default cap trims the tail. \
+            Five long sentence should be dropped only when the budgeted cap applies.";
+        assert!(dialogue.split_whitespace().count() > 45);
         let result = cap_sentence_count_for_mood(dialogue, None);
         let sentence_count = split_sentences(&result)
             .iter()
@@ -5128,6 +5151,10 @@ mod tests {
         assert!(
             sentence_count <= 4,
             "None mood must cap at 4; got {sentence_count}: {result:?}"
+        );
+        assert!(
+            sentence_count >= 4,
+            "None mood with a long 5-sentence reply must keep 4; got {sentence_count}: {result:?}"
         );
     }
 
@@ -5713,6 +5740,43 @@ mod tests {
         assert_eq!(
             result, input,
             "distant repetition (> 20 words) must not trigger the guard"
+        );
+    }
+
+    /// #1561: The phrase "work for a" repeats in adjacent substantive
+    /// sentences, but the only clean boundary before the first occurrence is the
+    /// greeting. The guard must not trim back to that opener and drop the actual
+    /// cooper-work answer.
+    #[test]
+    fn collapse_nearby_phrase_repeat_preserves_cooper_work_answer() {
+        let input = "Good morning, Aiden Carney. Work for a cooper? Aye, there's \
+                     always work for a man with that skill. This place needs \
+                     barrels for ale and salt, surely. Ye know yer trade?";
+        let result = collapse_nearby_phrase_repeat(input);
+        assert_eq!(
+            result, input,
+            "nearby phrase guard must not truncate a normal answer to its greeting"
+        );
+    }
+
+    /// #1561: The full verbosity pipeline must preserve the same short,
+    /// distinct multi-sentence reply instead of storing only the opener.
+    #[test]
+    fn verbosity_guard_preserves_cooper_work_answer() {
+        let input = "Good morning, Aiden Carney. Work for a cooper? Aye, there's \
+                     always work for a man with that skill. This place needs \
+                     barrels for ale and salt, surely. Ye know yer trade?";
+        let result = guard_verbosity_runons(input);
+        assert!(
+            result.contains("Work for a cooper?")
+                && result.contains("there's always work")
+                && result.contains("barrels for ale and salt")
+                && result.contains("Ye know yer trade?"),
+            "verbosity guard must preserve the substantive answer: {result:?}"
+        );
+        assert_ne!(
+            result, "Good morning, Aiden Carney.",
+            "verbosity guard must not collapse to only the greeting"
         );
     }
 }

--- a/parish/testing/fixtures/play_fix-1561-dialogue-overtruncation.txt
+++ b/parish/testing/fixtures/play_fix-1561-dialogue-overtruncation.txt
@@ -1,0 +1,9 @@
+# fix-1561-dialogue-overtruncation
+# Repro: an ordinary multi-sentence answer must not be truncated to only the greeting.
+
+/wait 120
+go to pub
+/npcs
+
+/stub Padraig Darcy: Good morning, Aiden Carney. Work for a cooper? Aye, there's always work for a man with that skill. This place needs barrels for ale and salt, surely. Ye know yer trade?
+talk to Padraig Darcy about I am Aiden Carney, a cooper newly arrived in Kilteevan. Might there be work here?


### PR DESCRIPTION
Fixes #1561.

## Summary

- skip unsafe nearby-phrase trims when the only clean boundary would drop the substantive sentence
- exempt short replies from the default 4-sentence run-on cap
- add pure, real-loop, and live fixture coverage for the cooper-work truncation repro

## Verification

- rtk cargo fmt --manifest-path parish/Cargo.toml --all
- rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc cooper_work_answer
- rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc collapse_nearby_phrase_repeat_cleans_stacked_tail
- rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc verbosity_guard_caps_8_sentence_ramble_end_to_end
- rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_cooper_work_answer_is_not_truncated_to_greeting
- rtk cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1561-dialogue-overtruncation.txt
- rtk just agent-check
- rtk just check

<!-- parish-proof-bundle:fix-1561-dialogue-overtruncation v=1 -->

## Proof: fix-1561-dialogue-overtruncation

### Acceptance criteria

# Acceptance Criteria: fix-1561-dialogue-overtruncation

## Task

Fix #1561 so post-generation dialogue processing does not drop substantive later sentences from a grounded multi-sentence NPC answer.

## Criteria

- A multi-sentence NPC reply beginning with `Good morning, Aiden Carney.` and continuing with a cooper-work answer must not be stored or displayed as only the greeting.
- The post-generation guards may still remove true runaway repetition or excessive rambling, but they must preserve ordinary short multi-sentence answers with distinct content.
- The stored/displayed dialogue must preserve the substantive answer phrases `Work for a cooper?`, `there's always work`, `barrels for ale and salt`, and `Ye know yer trade?`.
- Regression coverage must exercise the guard function directly and the shared dialogue-apply path that records the canonical transcript.
- A live script must reach Padraig Darcy at Darcy's Pub, inject the issue's raw reply, and receive an `npc_response` that includes the later cooper-work sentences.

## Verification script

Run: `cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1561-dialogue-overtruncation.txt`

Expected signals in output:

- `/wait 120` advances to late morning, then movement reaches `Darcy's Pub`.
- `/npcs` shows pub occupants present.
- The final dialogue command returns `result:"npc_response"` for `Padraig Darcy`.
- The final `dialogue` contains `Good morning, Aiden Carney. Work for a cooper?` and keeps the later cooper-work answer rather than stopping after the first sentence.

### Evidence

Evidence type: live gameplay transcript

## Root Cause

Five Whys:

1. The stored dialogue could collapse to `Good morning, Aiden Carney.` because post-generation verbosity cleanup over-trimmed a normal answer after detecting a repeated phrase.
2. `collapse_nearby_phrase_repeat` saw the harmless phrase `work for a` in `Work for a cooper?` and `work for a man`, then trimmed to the nearest preceding sentence boundary.
3. In this reply, that preceding boundary was the greeting before the substantive answer, so the guard kept only the opener.
4. After that was fixed, the default 4-sentence cap still dropped the `barrels for ale and salt` sentence because the reply has five terse sentence units even though it is short overall.
5. The root cause was treating local phrase overlap and terse sentence count as runaway evidence without checking whether the trim would discard the substantive sentence or whether the reply was short enough to preserve.

## Commands Run

- `rtk cargo fmt --manifest-path parish/Cargo.toml --all` - passed.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc mood_aware_sentence_cap` - 4 passed, 720 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc cooper_work_answer` - 2 passed, 722 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc collapse_nearby_phrase_repeat_cleans_stacked_tail` - 1 passed, 723 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc verbosity_guard_caps_8_sentence_ramble_end_to_end` - 1 passed, 723 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_cooper_work_answer_is_not_truncated_to_greeting` - 1 passed, 12 filtered out.
- `rtk cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1561-dialogue-overtruncation.txt` - passed; transcript captured in `transcript.txt`.
- `rtk just agent-check` - passed; live proof required and present.
- `rtk just check` - passed; includes agent-check, fmt check, clippy, cargo tests, doc path checks, and UI check/lint/format.

## Acceptance Mapping

- The issue's multi-sentence cooper-work reply is preserved in the live transcript: final `dialogue` begins `Good morning, Aiden Carney. Work for a cooper?` and continues through `Ye know yer trade?`.
- Nearby phrase overlap is covered by `collapse_nearby_phrase_repeat_preserves_cooper_work_answer`.
- The full verbosity pipeline is covered by `verbosity_guard_preserves_cooper_work_answer`, while existing guard behavior is preserved by the #1554 and 8-sentence cap regressions.
- The canonical real-loop transcript path is covered by `real_loop_cooper_work_answer_is_not_truncated_to_greeting`, which asserts `DialogueOccurred` keeps `Work for a cooper?`, `there's always work`, `barrels for ale and salt`, and `Ye know yer trade?`.
- The live script reaches Darcy's Pub, stubs Padraig Darcy with the issue reply, and receives an `npc_response` for Padraig Darcy that keeps the later cooper-work sentences.

### Transcript

```text
{"command":"/wait 120","result":"system_command","response":"You wait for 120 minutes...\nIt is now 10:00 Midday.","location":"Kilteevan Village","time":"Midday","season":"Spring","new_log_lines":["You wait for 120 minutes...\nIt is now 10:00 Midday."]}
{"command":"go to pub","result":"moved","to":"Darcy's Pub","minutes":14,"narration":"You set off along the road north past low fields to the crossroads toward Darcy's Pub. (14 minutes on foot)","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["You set off along the road north past low fields to the crossroads toward Darcy's Pub. (14 minutes on foot)","","The warm interior of Darcy's Pub. Turf smoke hangs in the air. Old prints of hurling matches line the walls beside a faded map of the county. A fiddle sits propped in the corner. It is midday and the weather outside is clear.\nYou can go to: The Crossroads (1 min on foot)"]}
{"command":"/npcs","result":"system_command","response":"NPCs here:\n  a young woman — Publican's Daughter (restless)\n  an older man behind the bar — Publican (content)","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["NPCs here:\n  a young woman — Publican's Daughter (restless)\n  an older man behind the bar — Publican (content)"]}
{"command":"/stub Padraig Darcy: Good morning, Aiden Carney. Work for a cooper? Aye, there's always work for a man with that skill. This place needs barrels for ale and salt, surely. Ye know yer trade?","result":"system_command","response":"Stubbed response for Padraig Darcy: \"Good morning, Aiden Carney. Work for a cooper? Aye, there's always work for a man with that skill. This place needs barrels for ale and salt, surely. Ye know yer trade?\"","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["Stubbed response for Padraig Darcy: \"Good morning, Aiden Carney. Work for a cooper? Aye, there's always work for a man with that skill. This place needs barrels for ale and salt, surely. Ye know yer trade?\""]}
{"command":"talk to Padraig Darcy about I am Aiden Carney, a cooper newly arrived in Kilteevan. Might there be work here?","result":"npc_response","npc":"Padraig Darcy","dialogue":"Good morning, Aiden Carney. Work for a cooper? Aye, there's always work for a man with that skill. This place needs barrels for ale and salt, surely. Ye know yer trade?","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["Padraig Darcy: Good morning, Aiden Carney. Work for a cooper? Aye, there's always work for a man with that skill. This place needs barrels for ale and salt, surely. Ye know yer trade?","Niamh Darcy 😊","Padraig Darcy 😊"]}
```

### Judge

Verdict: sufficient

Technical debt: clear

Acceptance criteria: met

The fix is targeted to two conservative guard conditions: unsafe nearby-phrase trims are skipped when the only clean boundary would drop the first repeated phrase's sentence, and the default sentence cap no-ops for short replies under 45 words. Focused pure, real-loop, preservation, and live transcript checks passed.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:fix-1561-dialogue-overtruncation -->
