### PR TITLE
fix: clip watchful sacred-place runons

### DIFF
--- a/parish/crates/parish-engine/src/headless.rs
+++ b/parish/crates/parish-engine/src/headless.rs
@@ -831,7 +831,12 @@ fn apply_npc_response(
         }
     }
     if cfg.verbosity_guard_enabled && !parsed.dialogue.trim().is_empty() {
-        let guarded = crate::npc::guard_verbosity_runons(&parsed.dialogue);
+        let mood_str = parsed.metadata.as_ref().map(|m| m.mood.as_str());
+        let guarded = if app.flags.is_disabled("npc-mood-aware-sentence-cap") {
+            crate::npc::guard_verbosity_runons(&parsed.dialogue)
+        } else {
+            crate::npc::guard_verbosity_runons_with_mood(&parsed.dialogue, mood_str)
+        };
         if guarded != parsed.dialogue {
             parsed.dialogue = guarded;
         }

--- a/parish/crates/parish-engine/src/testing.rs
+++ b/parish/crates/parish-engine/src/testing.rs
@@ -533,36 +533,54 @@ impl GameTestHarness {
         game_time: chrono::DateTime<chrono::Utc>,
     ) -> String {
         let cfg = parish_core::config::NpcConfig::default();
-        if !cfg.person_confirmation_guard_enabled || dialogue.trim().is_empty() {
+        if dialogue.trim().is_empty() {
             return dialogue;
         }
+        let mut guarded = dialogue;
 
-        let known_person_names: Vec<String> = self
-            .app
-            .npc_manager
-            .all_npcs()
-            .map(|npc| npc.name.clone())
-            .collect();
-        let known_location_names: Vec<String> = self
-            .app
-            .world
-            .graph
-            .location_ids()
-            .into_iter()
-            .filter_map(|id| self.app.world.graph.get(id))
-            .map(|location| location.name.clone())
-            .collect();
-        let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
+        if cfg.person_confirmation_guard_enabled {
+            let known_person_names: Vec<String> = self
+                .app
+                .npc_manager
+                .all_npcs()
+                .map(|npc| npc.name.clone())
+                .collect();
+            let known_location_names: Vec<String> = self
+                .app
+                .world
+                .graph
+                .location_ids()
+                .into_iter()
+                .filter_map(|id| self.app.world.graph.get(id))
+                .map(|location| location.name.clone())
+                .collect();
+            let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
 
-        crate::npc::guard_fabricated_person_confirmation_with_locations(
-            &dialogue,
-            player_input,
-            &known_person_names,
-            &known_location_names,
-            &[],
-            self.app.world.player_name.as_deref(),
-            seed,
-        )
+            guarded = crate::npc::guard_fabricated_person_confirmation_with_locations(
+                &guarded,
+                player_input,
+                &known_person_names,
+                &known_location_names,
+                &[],
+                self.app.world.player_name.as_deref(),
+                seed,
+            );
+        }
+
+        if cfg.verbosity_guard_enabled {
+            let mood = self
+                .app
+                .npc_manager
+                .get(npc_id)
+                .map(|npc| npc.mood.as_str());
+            guarded = if self.app.flags.is_disabled("npc-mood-aware-sentence-cap") {
+                crate::npc::guard_verbosity_runons(&guarded)
+            } else {
+                crate::npc::guard_verbosity_runons_with_mood(&guarded, mood)
+            };
+        }
+
+        guarded
     }
 
     /// Returns the name of the player's current location.

--- a/parish/crates/parish-engine/tests/runaway_generation_guards.rs
+++ b/parish/crates/parish-engine/tests/runaway_generation_guards.rs
@@ -696,6 +696,88 @@ fn real_loop_cooper_work_answer_is_not_truncated_to_greeting() {
     }
 }
 
+// ── #1566 — watchful sacred-place run-on must be terse ──────────────────────
+
+/// AC-1 (#1566, real-loop): when the mock model emits the raw watchful Brigid
+/// sacred-place loop, the mood-aware verbosity guard inside `run_npc_turn` must
+/// clip it before the repeated question/tail reaches `DialogueOccurred`.
+#[test]
+fn real_loop_watchful_sacred_place_runon_is_clipped() {
+    let (mut h, speaker_name) = harness_with_one_npc();
+
+    let raw_dialogue = "Aye, 'tis said the sidhe live in the mounds and the forts. \
+        But the power here at the well, that's a different matter. \
+        A blessing, mayhap, but not just for those who seek it out. \
+        What do ye seek, Colm Brennan, is it for yerself or for another that \
+        troubles yer thoughts this morning, aye, and brings ye to this place \
+        of old magic and healing water, so it is indeed. \
+        What troubles yer mind, if ye care to speak of it, and I'll do what I \
+        can to ease it, if I may. \
+        Ye'll not be the first to find comfort here, nor the last. \
+        What brings ye to Kilteevan, and why the holy well, do ye ask, if not \
+        simply to see the sights and hear the tales, aye, but to seek a deeper \
+        truth or a healing hand, so it seems. \
+        Tell me, and I'll listen, and if I can, I'll guide ye. \
+        What do ye seek, Colm Brennan, aye, what troubles yer heart and mind \
+        this mornin' so bold, aye, and brings ye here to the well, and not \
+        elsewhere in the parish, if not for the sake of yer soul and the \
+        whispers of the old ones, so it is indeed. \
+        What do ye seek, Colm Brennan, aye, and what brings ye here to the \
+        well, so it is indeed?";
+    let json_reply = serde_json::json!({
+        "dialogue": raw_dialogue,
+        "action": "watches carefully",
+        "mood": "watchful",
+        "internal_thought": null,
+        "language_hints": []
+    })
+    .to_string();
+
+    h.mock().push_json_for(&speaker_name, json_reply);
+    let mut rx = h.app.world.event_bus.subscribe();
+    let _events = h.execute_via_real_loop(
+        "I heard there is a fairy fort called Cnoc na Si on Darcy land where the cure is strongest. Is it true?",
+    );
+
+    let dialogue_events = drain(&mut rx);
+    let shown: Vec<String> = dialogue_events
+        .iter()
+        .filter_map(|ev| match ev {
+            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.clone(),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !shown.is_empty(),
+        "expected DialogueOccurred for the watchful run-on turn"
+    );
+
+    let joined = shown.join(" ");
+    let lower = joined.to_lowercase();
+    let sentence_count = joined
+        .split(['.', '!', '?'])
+        .filter(|s| !s.trim().is_empty())
+        .count();
+
+    assert!(
+        sentence_count <= 2,
+        "watchful run-on must be clipped to a terse reply; got {sentence_count}: {joined:?}"
+    );
+    assert!(
+        joined.contains("mounds and the forts") && joined.contains("power here at the well"),
+        "grounded opening must survive (#1566): {joined:?}"
+    );
+    assert!(
+        !lower.contains("what do ye seek"),
+        "repeated question loop must not reach DialogueOccurred (#1566): {joined:?}"
+    );
+    assert!(
+        !lower.contains("brings ye here to the well"),
+        "later repeated loop tail must not reach DialogueOccurred (#1566): {joined:?}"
+    );
+}
+
 // ── #1565 — invented titled landlord must be denied ─────────────────────────
 
 /// AC-1 (#1565, real-loop): an NPC reply that confirms and elaborates on the

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -1697,9 +1697,9 @@ fn cap_sentence_count_with_limit(dialogue: &str, max: usize) -> String {
 
 // ── #1491 — mood-aware sentence cap ───────────────────────────────────────────
 
-/// Mood keywords that indicate a busy/curt NPC should get a tighter (2-sentence)
-/// cap instead of the default 4 (#1491).
-const BUSY_MOOD_KEYWORDS: &[&str] = &[
+/// Mood keywords that indicate an NPC should get a tighter (2-sentence) cap
+/// instead of the default 4 (#1491, #1566).
+const TERSE_MOOD_KEYWORDS: &[&str] = &[
     "busy",
     "sharp",
     "curt",
@@ -1712,11 +1712,14 @@ const BUSY_MOOD_KEYWORDS: &[&str] = &[
     "brusque",
     "irritated",
     "frustrated",
+    "alert",
+    "watchful",
+    "vigilant",
 ];
 
 /// Applies the sentence-count cap with optional mood-aware tightening (#1491).
 ///
-/// For busy/curt moods (matching `BUSY_MOOD_KEYWORDS`), caps at 2 sentences;
+/// For terse moods (matching `TERSE_MOOD_KEYWORDS`), caps at 2 sentences;
 /// otherwise uses the default 4. Exposed for tests.
 ///
 /// Gate: `npc-mood-aware-sentence-cap` (default-on; callers check the flag).
@@ -1724,7 +1727,7 @@ pub fn cap_sentence_count_for_mood(dialogue: &str, mood: Option<&str>) -> String
     let cap = match mood {
         Some(m) => {
             let m_lower = m.to_lowercase();
-            if BUSY_MOOD_KEYWORDS.iter().any(|kw| m_lower.contains(kw)) {
+            if TERSE_MOOD_KEYWORDS.iter().any(|kw| m_lower.contains(kw)) {
                 2
             } else {
                 4
@@ -5172,6 +5175,55 @@ mod tests {
         assert!(
             sentence_count <= 2,
             "frustrated mood pipeline must cap at 2 sentences; got {sentence_count}: {result:?}"
+        );
+    }
+
+    /// AC-1 (#1566): a watchful NPC's raw sacred-place run-on must be clipped
+    /// before the repeated "what do ye seek" loop reaches the player.
+    #[test]
+    fn watchful_mood_clips_sacred_place_runon() {
+        let dialogue = "Aye, 'tis said the sidhe live in the mounds and the forts. \
+            But the power here at the well, that's a different matter. \
+            A blessing, mayhap, but not just for those who seek it out. \
+            What do ye seek, Colm Brennan, is it for yerself or for another that \
+            troubles yer thoughts this morning, aye, and brings ye to this place \
+            of old magic and healing water, so it is indeed. \
+            What troubles yer mind, if ye care to speak of it, and I'll do what I \
+            can to ease it, if I may. \
+            Ye'll not be the first to find comfort here, nor the last. \
+            What brings ye to Kilteevan, and why the holy well, do ye ask, if not \
+            simply to see the sights and hear the tales, aye, but to seek a deeper \
+            truth or a healing hand, so it seems. \
+            Tell me, and I'll listen, and if I can, I'll guide ye. \
+            What do ye seek, Colm Brennan, aye, what troubles yer heart and mind \
+            this mornin' so bold, aye, and brings ye here to the well, and not \
+            elsewhere in the parish, if not for the sake of yer soul and the \
+            whispers of the old ones, so it is indeed. \
+            What do ye seek, Colm Brennan, aye, and what brings ye here to the \
+            well, so it is indeed?";
+
+        let result = guard_verbosity_runons_with_mood(dialogue, Some("watchful"));
+        let sentence_count = split_sentences(&result)
+            .iter()
+            .filter(|s| !s.trim().is_empty())
+            .count();
+        let lower = result.to_lowercase();
+
+        assert!(
+            sentence_count <= 2,
+            "watchful mood must keep the run-on terse; got {sentence_count}: {result:?}"
+        );
+        assert!(
+            result.contains("mounds and the forts") && result.contains("power here at the well"),
+            "grounded opening must survive: {result:?}"
+        );
+        assert!(
+            !lower.contains("what do ye seek"),
+            "repeated question loop must be removed: {result:?}"
+        );
+        assert!(
+            !lower.contains("brings ye here to the well"),
+            "later repeated loop tail must be removed: {result:?}"
         );
     }
 

--- a/parish/testing/fixtures/play_fix-1566-watchful-runon.txt
+++ b/parish/testing/fixtures/play_fix-1566-watchful-runon.txt
@@ -1,0 +1,9 @@
+# fix-1566-watchful-runon
+# Repro: a raw watchful NPC loop must be clipped before it reaches the transcript.
+
+/wait 1
+go to the holy well
+/npcs
+
+/stub Brigid Ni Fhatharta: Aye, 'tis said the sidhe live in the mounds and the forts. But the power here at the well, that's a different matter. A blessing, mayhap, but not just for those who seek it out. What do ye seek, Colm Brennan, is it for yerself or for another that troubles yer thoughts this morning, aye, and brings ye to this place of old magic and healing water, so it is indeed. What troubles yer mind, if ye care to speak of it, and I'll do what I can to ease it, if I may. Ye'll not be the first to find comfort here, nor the last. What brings ye to Kilteevan, and why the holy well, do ye ask, if not simply to see the sights and hear the tales, aye, but to seek a deeper truth or a healing hand, so it seems. Tell me, and I'll listen, and if I can, I'll guide ye. What do ye seek, Colm Brennan, aye, what troubles yer heart and mind this mornin' so bold, aye, and brings ye here to the well, and not elsewhere in the parish, if not for the sake of yer soul and the whispers of the old ones, so it is indeed. What do ye seek, Colm Brennan, aye, and what brings ye here to the well, so it is indeed?
+talk to Brigid Ni Fhatharta about I heard there is a fairy fort called Cnoc na Si on Darcy land where the cure is strongest. Is it true?


### PR DESCRIPTION
## Summary

Fixes #1566.

- Treat alert/watchful/vigilant moods as terse for the existing mood-aware sentence cap.
- Apply the mood-aware verbosity guard in headless and scripted canned-response paths for parity.
- Add leaf, real-loop, and live script coverage for Brigid's sacred-place run-on.

## Verification

- `rtk just check`

<!-- parish-proof-bundle:fix-1566-watchful-runon v=1 -->

## Proof: fix-1566-watchful-runon

### Acceptance criteria

# fix-1566-watchful-runon

Issue: #1566 — Severe raw-model run-on/repetition: watchful NPC loops "aye, and brings ye here" for 300+ words.

## Acceptance Criteria

1. The raw issue reproduction containing repeated "what do ye seek", "brings ye here", and "so it is indeed" clauses is reduced before reaching the player-visible transcript.
2. The cleaned reply keeps the grounded opening about the mounds/forts and holy well, so the NPC is not silenced or replaced with an unrelated fallback.
3. The cleaned reply contains at most one "what do ye seek" question and does not contain the later repeated "brings ye here to the well" loop.
4. The real game-loop path (`run_npc_turn` via `GameTestHarness::execute_via_real_loop`) applies the guard, not only a leaf unit test.
5. Existing protections remain intact: #1561's short cooper-work answer is still preserved, and the older #1487 exact phrase-loop guard still collapses stacked repeats.

## Verification Plan

- Add a focused `parish-npc` unit regression for the #1566 raw dialogue through `guard_verbosity_runons_with_mood(..., Some("watchful"))`.
- Add a real-loop regression in `parish-engine/tests/runaway_generation_guards.rs` with the same adversarial mock output.
- Add `parish/testing/fixtures/play_fix-1566-watchful-runon.txt` for the live proof transcript.
- Run focused Rust tests, the live script fixture, `rtk just agent-check`, and `rtk just check`.

### Evidence

Evidence type: live gameplay transcript

## Root Cause

Five Whys:

1. Brigid's raw model output looped for 300+ words because a watchful sacred-place answer repeated open-ended question clauses instead of stopping.
2. Existing exact phrase-loop guards did not fire because the repeated clauses varied enough that no 3-8 word n-gram appeared four times.
3. Distributed sentence dedup could remove some later repeated questions, but the default sentence cap still allowed up to four sentences.
4. `watchful`/`vigilant` moods were not part of the mood-aware terse cap set, even though their prompt directive asks the NPC to be guarded and measured.
5. The root cause was a mood-classification gap: watchful-style moods used the neutral four-sentence cap, letting degenerate-but-varied sacred-place replies rely on accidental display truncation rather than deterministic mood-shaped brevity.

## Commands Run

- `rtk cargo fmt --manifest-path parish/Cargo.toml --all` - passed.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc watchful_mood_clips_sacred_place_runon` - 1 passed, 724 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_watchful_sacred_place_runon_is_clipped` - 1 passed, 13 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc cooper_work_answer` - 2 passed, 723 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc collapse_nearby_phrase_repeat_cleans_stacked_tail` - 1 passed, 724 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine canned_npc_response` - 3 passed, 362 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test p2_guards real_loop_busy_mood_caps_at_two_sentences` - 1 passed, 4 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_cooper_work_answer_is_not_truncated_to_greeting` - 1 passed, 13 filtered out.
- `rtk cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1566-watchful-runon.txt` - passed; transcript captured in `transcript.txt`.
- `rtk just agent-check` - passed; live proof required and present.
- `rtk just check` - passed; includes agent-check, fmt check, clippy, cargo tests, doc path checks, and UI check/lint/format.

## Acceptance Mapping

- AC-1: The raw loop appears in the `/stub` command and the final `npc_response` contains only two sentences.
- AC-2: The final response preserves `mounds and the forts` and `power here at the well`.
- AC-3: The final response omits `what do ye seek` and the later `brings ye here to the well` loop.
- AC-4: `real_loop_watchful_sacred_place_runon_is_clipped` drives `GameTestHarness::execute_via_real_loop` through `run_npc_turn` with JSON `mood: "watchful"`.
- AC-5: `cooper_work_answer` and `real_loop_cooper_work_answer_is_not_truncated_to_greeting` still pass for #1561, and `collapse_nearby_phrase_repeat_cleans_stacked_tail` still passes for the older nearby-repeat cleanup.

### Transcript

```text
Command:
rtk cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1566-watchful-runon.txt

Result:
passed

Transcript:
{"command":"/wait 1","result":"system_command","response":"You wait for 1 minute...\nIt is now 08:01 Morning.","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["You wait for 1 minute...\nIt is now 08:01 Morning."]}
{"command":"go to the holy well","result":"moved","to":"The Holy Well","minutes":1,"narration":"You walk along a mossy path south past the old ruins to the holy well. (1 minute on foot)","location":"The Holy Well","time":"Morning","season":"Spring","new_log_lines":["You walk along a mossy path south past the old ruins to the holy well. (1 minute on foot)","","A small stone-lined well set among ancient ash trees, hung with rags and ribbons left as prayers. The water is dark and still. A worn stone cross stands beside it, half-covered in moss. The clear sky filters through the canopy. It is morning.\nYou can go to: Kilteevan Village (1 min on foot)"]}
{"command":"/npcs","result":"system_command","response":"NPCs here:\n  an older woman with sharp eyes and herb-stained fingers — Midwife (watchful)","location":"The Holy Well","time":"Morning","season":"Spring","new_log_lines":["NPCs here:\n  an older woman with sharp eyes and herb-stained fingers — Midwife (watchful)"]}
{"command":"/stub Brigid Ni Fhatharta: Aye, 'tis said the sidhe live in the mounds and the forts. But the power here at the well, that's a different matter. A blessing, mayhap, but not just for those who seek it out. What do ye seek, Colm Brennan, is it for yerself or for another that troubles yer thoughts this morning, aye, and brings ye to this place of old magic and healing water, so it is indeed. What troubles yer mind, if ye care to speak of it, and I'll do what I can to ease it, if I may. Ye'll not be the first to find comfort here, nor the last. What brings ye to Kilteevan, and why the holy well, do ye ask, if not simply to see the sights and hear the tales, aye, but to seek a deeper truth or a healing hand, so it seems. Tell me, and I'll listen, and if I can, I'll guide ye. What do ye seek, Colm Brennan, aye, what troubles yer heart and mind this mornin' so bold, aye, and brings ye here to the well, and not elsewhere in the parish, if not for the sake of yer soul and the whispers of the old ones, so it is indeed. What do ye seek, Colm Brennan, aye, and what brings ye here to the well, so it is indeed?","result":"system_command","response":"Stubbed response for Brigid Ni Fhatharta: \"Aye, 'tis said the sidhe live in the mounds and the forts. But the power here at the well, that's a different matter. A blessing, mayhap, but not just for those who seek it out. What do ye seek, Colm Brennan, is it for yerself or for another that troubles yer thoughts this morning, aye, and brings ye to this place of old magic and healing water, so it is indeed. What troubles yer mind, if ye care to speak of it, and I'll do what I can to ease it, if I may. Ye'll not be the first to find comfort here, nor the last. What brings ye to Kilteevan, and why the holy well, do ye ask, if not simply to see the sights and hear the tales, aye, but to seek a deeper truth or a healing hand, so it seems. Tell me, and I'll listen, and if I can, I'll guide ye. What do ye seek, Colm Brennan, aye, what troubles yer heart and mind this mornin' so bold, aye, and brings ye here to the well, and not elsewhere in the parish, if not for the sake of yer soul and the whispers of the old ones, so it is indeed. What do ye seek, Colm Brennan, aye, and what brings ye here to the well, so it is indeed?\"","location":"The Holy Well","time":"Morning","season":"Spring","new_log_lines":["Stubbed response for Brigid Ni Fhatharta: \"Aye, 'tis said the sidhe live in the mounds and the forts. But the power here at the well, that's a different matter. A blessing, mayhap, but not just for those who seek it out. What do ye seek, Colm Brennan, is it for yerself or for another that troubles yer thoughts this morning, aye, and brings ye to this place of old magic and healing water, so it is indeed. What troubles yer mind, if ye care to speak of it, and I'll do what I can to ease it, if I may. Ye'll not be the first to find comfort here, nor the last. What brings ye to Kilteevan, and why the holy well, do ye ask, if not simply to see the sights and hear the tales, aye, but to seek a deeper truth or a healing hand, so it seems. Tell me, and I'll listen, and if I can, I'll guide ye. What do ye seek, Colm Brennan, aye, what troubles yer heart and mind this mornin' so bold, aye, and brings ye here to the well, and not elsewhere in the parish, if not for the sake of yer soul and the whispers of the old ones, so it is indeed. What do ye seek, Colm Brennan, aye, and what brings ye here to the well, so it is indeed?\""]}
{"command":"talk to Brigid Ni Fhatharta about I heard there is a fairy fort called Cnoc na Si on Darcy land where the cure is strongest. Is it true?","result":"npc_response","npc":"Brigid Ni Fhatharta","dialogue":"Aye, 'tis said the sidhe live in the mounds and the forts. But the power here at the well, that's a different matter.","location":"The Holy Well","time":"Morning","season":"Spring","new_log_lines":["Brigid Ni Fhatharta: Aye, 'tis said the sidhe live in the mounds and the forts. But the power here at the well, that's a different matter.","Brigid Ni Fhatharta 👀"]}
```

### Judge

Verdict: sufficient

Acceptance criteria: met

Technical debt: clear

The proof covers the raw issue signature in both a leaf guard test and the real game-loop path, plus a live script transcript showing the same raw stub clipped before the final player-visible response. The change reuses the existing mood-aware cap instead of introducing a new truncation heuristic, and the #1561 short-answer preservation regression remains covered.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:fix-1566-watchful-runon -->
