### PR TITLE
fix: prevent false denials of real parish entities

### DIFF
--- a/parish/crates/parish-core/src/game_loop/npc_turn.rs
+++ b/parish/crates/parish-core/src/game_loop/npc_turn.rs
@@ -500,11 +500,11 @@ pub async fn run_npc_turn(
         }
     }
 
-    // Post-generation false-denial guard (#1527, #1528) and invented-place
-    // confirmation guard (#1530): both require a seed derived from the world
-    // clock.  Acquire the async world lock ONCE here if either guard is active
-    // and the dialogue is non-empty, then reuse the seed for both guards to
-    // avoid redundant lock acquisitions.
+    // Post-generation false-denial guards (#1527, #1528, #1563) and
+    // invented-place confirmation guard (#1530): all require a seed derived
+    // from the world clock. Acquire the async world lock ONCE here if any guard
+    // is active and the dialogue is non-empty, then reuse the seed for all
+    // three guards to avoid redundant lock acquisitions.
     let both_guards_seed: Option<u64> = if (false_denial_guard_enabled
         || invented_place_guard_enabled)
         && !parsed.dialogue.trim().is_empty()
@@ -527,6 +527,23 @@ pub async fn run_npc_turn(
             prompt_input,
             &setup.known_person_names,
             setup.player_name.as_deref(),
+            guard_seed,
+        );
+        if guarded != parsed.dialogue {
+            parsed.dialogue = guarded;
+        }
+    }
+
+    // Post-generation false-denial guard for real places (#1563): detect when
+    // an NPC generically denies a real place from the world graph ("that place
+    // does not exist", "no such person") and replace it with a neutral
+    // grounded acknowledgement. Runs before invented-place confirmation.
+    if false_denial_guard_enabled && !parsed.dialogue.trim().is_empty() {
+        let guard_seed = both_guards_seed.unwrap_or(0);
+        let guarded = crate::npc::guard_false_denial_of_known_place(
+            &parsed.dialogue,
+            prompt_input,
+            &setup.known_location_names,
             guard_seed,
         );
         if guarded != parsed.dialogue {

--- a/parish/crates/parish-core/src/ipc/handlers.rs
+++ b/parish/crates/parish-core/src/ipc/handlers.rs
@@ -797,7 +797,7 @@ pub struct NpcConversationSetup {
     pub system_prompt: String,
     /// The assembled context string for the LLM.
     pub context: String,
-    /// Names from the NPC's known-people roster (PEOPLE YOU KNOW list).
+    /// Names from the full parish person registry plus the player when known.
     /// Used by the post-generation person-confirmation guard (#1459) to detect
     /// when the NPC's reply affirms a fabricated person not on this list.
     pub known_person_names: Vec<String>,
@@ -896,13 +896,32 @@ pub fn prepare_npc_conversation_turn(
     } else {
         None
     };
+    // Prompt grounding (#1563): the "PEOPLE YOU KNOW" block is the model's
+    // primary allow-list for real names. The personal relationship roster is
+    // too small for that purpose: a real parish-wide figure absent from this
+    // NPC's local roster (e.g. a publican) can otherwise be denied as
+    // nonexistent. Keep relationship entries first, then append every other
+    // real parish NPC as a "real parish person" entry so the model may
+    // recognise the name without claiming close acquaintance.
+    let mut prompt_roster = roster.clone();
+    if npc_cfg.grounding_enabled {
+        let mut parish_people: Vec<(NpcId, String, String)> = npc_manager
+            .all_npcs()
+            .filter(|other| other.id != npc.id)
+            .filter(|other| !prompt_roster.iter().any(|(id, _, _)| *id == other.id))
+            .map(|other| (other.id, other.name.clone(), other.occupation.clone()))
+            .collect();
+        parish_people.sort_by_key(|(id, _, _)| id.0);
+        prompt_roster.extend(parish_people);
+    }
+
     let system_prompt = ticks::build_enhanced_system_prompt_with_config(
         &npc,
         improv_enabled,
         language,
         npc_cfg,
         &npc_names,
-        Some(&roster),
+        Some(&prompt_roster),
         location_names.as_deref(),
     );
 
@@ -2090,8 +2109,9 @@ mod tests {
 
         let setup = setup.expect("setup must succeed for co-located NPC");
 
-        // The fix: Roisin must appear in known_person_names even though she
-        // is NOT in the priest's personal relationship roster.
+        // The fix: Roisin must appear in both the hidden guard allow-list and
+        // the system prompt even though she is NOT in the priest's personal
+        // relationship roster.
         assert!(
             setup
                 .known_person_names
@@ -2101,6 +2121,13 @@ mod tests {
              even though she has no relationship with the speaking priest (#1488); \
              got: {:?}",
             setup.known_person_names
+        );
+        assert!(
+            setup.system_prompt.contains("Roisin Malone, Shopkeeper")
+                && setup.system_prompt.contains("real parish person"),
+            "Roisin Malone must appear in the prompt as a real parish person \
+             so the model is not instructed to deny her (#1563):\n{}",
+            setup.system_prompt
         );
 
         // Validate that the person-confirmation guard does NOT fire on a good

--- a/parish/crates/parish-engine/src/headless.rs
+++ b/parish/crates/parish-engine/src/headless.rs
@@ -802,6 +802,7 @@ fn apply_npc_response(
     npc_display_name: &str,
     npc_actual_name: &str,
     known_person_names: &[String],
+    known_location_names: &[String],
     player_name: Option<&str>,
 ) {
     let mut parsed = parse_npc_stream_response(response_text);
@@ -818,12 +819,51 @@ fn apply_npc_response(
     let cfg = parish_core::config::NpcConfig::default();
     if cfg.person_confirmation_guard_enabled && !parsed.dialogue.trim().is_empty() {
         let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
-        let guarded = crate::npc::guard_fabricated_person_confirmation(
+        let guarded = crate::npc::guard_fabricated_person_confirmation_with_locations(
             &parsed.dialogue,
             player_input,
             known_person_names,
+            known_location_names,
             &[],
             player_name,
+            seed,
+        );
+        if guarded != parsed.dialogue {
+            parsed.dialogue = guarded;
+        }
+    }
+    if !app.flags.is_disabled(crate::npc::FALSE_DENIAL_GUARD_FLAG)
+        && !parsed.dialogue.trim().is_empty()
+    {
+        let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
+        let guarded = crate::npc::guard_false_denial_of_roster_person(
+            &parsed.dialogue,
+            player_input,
+            known_person_names,
+            player_name,
+            seed,
+        );
+        if guarded != parsed.dialogue {
+            parsed.dialogue = guarded;
+        }
+        let guarded = crate::npc::guard_false_denial_of_known_place(
+            &parsed.dialogue,
+            player_input,
+            known_location_names,
+            seed,
+        );
+        if guarded != parsed.dialogue {
+            parsed.dialogue = guarded;
+        }
+    }
+    if !app.flags.is_disabled(crate::npc::INVENTED_PLACE_GUARD_FLAG)
+        && !parsed.dialogue.trim().is_empty()
+    {
+        let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
+        let guarded = crate::npc::guard_invented_place_confirmation(
+            &parsed.dialogue,
+            player_input,
+            known_location_names,
             seed,
         );
         if guarded != parsed.dialogue {
@@ -879,6 +919,7 @@ async fn stream_headless_npc_dialogue(
     let system_prompt = setup.system_prompt;
     let context = setup.context;
     let known_person_names = setup.known_person_names.clone();
+    let known_location_names = setup.known_location_names.clone();
     let setup_player_name = setup.player_name.clone();
 
     if let Some(queue) = &app.inference_queue {
@@ -970,6 +1011,7 @@ async fn stream_headless_npc_dialogue(
                                 &npc_display_name,
                                 &npc_actual_name,
                                 &known_person_names,
+                                &known_location_names,
                                 setup_player_name.as_deref(),
                             );
                         }

--- a/parish/crates/parish-engine/src/testing.rs
+++ b/parish/crates/parish-engine/src/testing.rs
@@ -537,25 +537,24 @@ impl GameTestHarness {
             return dialogue;
         }
         let mut guarded = dialogue;
+        let known_person_names: Vec<String> = self
+            .app
+            .npc_manager
+            .all_npcs()
+            .map(|npc| npc.name.clone())
+            .collect();
+        let known_location_names: Vec<String> = self
+            .app
+            .world
+            .graph
+            .location_ids()
+            .into_iter()
+            .filter_map(|id| self.app.world.graph.get(id))
+            .map(|location| location.name.clone())
+            .collect();
+        let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
 
         if cfg.person_confirmation_guard_enabled {
-            let known_person_names: Vec<String> = self
-                .app
-                .npc_manager
-                .all_npcs()
-                .map(|npc| npc.name.clone())
-                .collect();
-            let known_location_names: Vec<String> = self
-                .app
-                .world
-                .graph
-                .location_ids()
-                .into_iter()
-                .filter_map(|id| self.app.world.graph.get(id))
-                .map(|location| location.name.clone())
-                .collect();
-            let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
-
             guarded = crate::npc::guard_fabricated_person_confirmation_with_locations(
                 &guarded,
                 player_input,
@@ -563,6 +562,39 @@ impl GameTestHarness {
                 &known_location_names,
                 &[],
                 self.app.world.player_name.as_deref(),
+                seed,
+            );
+        }
+
+        if !self
+            .app
+            .flags
+            .is_disabled(crate::npc::FALSE_DENIAL_GUARD_FLAG)
+        {
+            guarded = crate::npc::guard_false_denial_of_roster_person(
+                &guarded,
+                player_input,
+                &known_person_names,
+                self.app.world.player_name.as_deref(),
+                seed,
+            );
+            guarded = crate::npc::guard_false_denial_of_known_place(
+                &guarded,
+                player_input,
+                &known_location_names,
+                seed,
+            );
+        }
+
+        if !self
+            .app
+            .flags
+            .is_disabled(crate::npc::INVENTED_PLACE_GUARD_FLAG)
+        {
+            guarded = crate::npc::guard_invented_place_confirmation(
+                &guarded,
+                player_input,
+                &known_location_names,
                 seed,
             );
         }
@@ -2043,6 +2075,57 @@ mod tests {
         );
         assert!(!lower.contains("lord fitzwilliam"), "{dialogue}");
         assert!(!lower.contains("owns most of the land"), "{dialogue}");
+    }
+
+    #[test]
+    fn canned_npc_response_corrects_real_entity_false_denials() {
+        let mut h = GameTestHarness::new();
+        let moved = h.execute("go to the forge");
+        assert!(matches!(moved, ActionResult::Moved { .. }), "{moved:?}");
+
+        h.add_canned_response(
+            "Seamus Gallagher",
+            "I cannae guide ye to a place that doesn't exist.",
+        );
+        let place_result = h.execute("talk to Seamus Gallagher about Where is Darcy's Pub?");
+        let ActionResult::NpcResponse {
+            dialogue: place_dialogue,
+            ..
+        } = place_result
+        else {
+            panic!("expected Seamus to answer the known-place turn, got {place_result:?}");
+        };
+        let place_lower = place_dialogue.to_lowercase();
+        assert!(!place_lower.contains("doesn't exist"), "{place_dialogue}");
+        assert!(
+            place_lower.contains("place")
+                && (place_lower.contains("know")
+                    || place_lower.contains("known")
+                    || place_lower.contains("real")),
+            "{place_dialogue}"
+        );
+
+        h.add_canned_response(
+            "Seamus Gallagher",
+            "I know no one by that name in these parts.",
+        );
+        let person_result = h.execute("talk to Seamus Gallagher about Where is Padraig Darcy?");
+        let ActionResult::NpcResponse {
+            dialogue: person_dialogue,
+            ..
+        } = person_result
+        else {
+            panic!("expected Seamus to answer the known-person turn, got {person_result:?}");
+        };
+        let person_lower = person_dialogue.to_lowercase();
+        assert!(
+            !person_lower.contains("no one by that name"),
+            "{person_dialogue}"
+        );
+        assert!(
+            person_lower.contains("name") || person_lower.contains("parish"),
+            "{person_dialogue}"
+        );
     }
 
     #[test]

--- a/parish/crates/parish-engine/tests/runaway_generation_guards.rs
+++ b/parish/crates/parish-engine/tests/runaway_generation_guards.rs
@@ -892,6 +892,113 @@ fn real_loop_known_place_history_not_replaced_by_person_denial() {
     }
 }
 
+// ── #1563 — real parish entities must not be falsely denied ─────────────────
+
+/// AC-1/AC-4 (#1563, real-loop): when the mock model generically denies a real
+/// place from the world graph, the shared `run_npc_turn` guard chain must
+/// replace that denial before it reaches `DialogueOccurred`.
+#[test]
+fn real_loop_known_place_generic_denial_is_corrected() {
+    let (mut h, speaker_name) = harness_with_one_npc();
+
+    assert!(
+        h.app
+            .world
+            .graph
+            .location_ids()
+            .into_iter()
+            .filter_map(|id| h.app.world.graph.get(id))
+            .any(|location| location.name == "Darcy's Pub"),
+        "Rundale fixture must include Darcy's Pub"
+    );
+
+    h.mock().push_for(
+        &speaker_name,
+        "I cannae guide ye to a place that doesn't exist.".to_string(),
+    );
+    let mut rx = h.app.world.event_bus.subscribe();
+    let _events = h.execute_via_real_loop(&format!(
+        "talk to {speaker_name} about Where is Darcy's Pub?"
+    ));
+
+    let dialogue_events = drain(&mut rx);
+    let shown: Vec<String> = dialogue_events
+        .iter()
+        .filter_map(|ev| match ev {
+            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.clone(),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !shown.is_empty(),
+        "expected DialogueOccurred for known-place false-denial turn"
+    );
+
+    let joined = shown.join(" ");
+    let lower = joined.to_lowercase();
+    assert!(
+        !lower.contains("doesn't exist") && !lower.contains("does not exist"),
+        "known place must not reach transcript as nonexistent (#1563); got: {joined:?}"
+    );
+    assert!(
+        lower.contains("place")
+            && (lower.contains("know") || lower.contains("known") || lower.contains("real")),
+        "known-place denial should become a grounded acknowledgement; got: {joined:?}"
+    );
+}
+
+/// AC-2/AC-4 (#1563, real-loop): when the mock model says "I know no one by
+/// that name" after the player asks about a real parish NPC, the shared
+/// `run_npc_turn` guard chain must replace the false denial even though the
+/// dialogue did not repeat the full name.
+#[test]
+fn real_loop_known_person_generic_denial_is_corrected() {
+    let (mut h, speaker_name) = harness_with_one_npc();
+
+    assert!(
+        h.app
+            .npc_manager
+            .all_npcs()
+            .any(|npc| npc.name == "Padraig Darcy"),
+        "Rundale fixture must include Padraig Darcy"
+    );
+
+    h.mock().push_for(
+        &speaker_name,
+        "I know no one by that name in these parts.".to_string(),
+    );
+    let mut rx = h.app.world.event_bus.subscribe();
+    let _events = h.execute_via_real_loop(&format!(
+        "talk to {speaker_name} about Where is Padraig Darcy?"
+    ));
+
+    let dialogue_events = drain(&mut rx);
+    let shown: Vec<String> = dialogue_events
+        .iter()
+        .filter_map(|ev| match ev {
+            GameEvent::DialogueOccurred { npc_said, .. } => npc_said.clone(),
+            _ => None,
+        })
+        .collect();
+
+    assert!(
+        !shown.is_empty(),
+        "expected DialogueOccurred for known-person false-denial turn"
+    );
+
+    let joined = shown.join(" ");
+    let lower = joined.to_lowercase();
+    assert!(
+        !lower.contains("no one by that name") && !lower.contains("no such person"),
+        "known person must not reach transcript as nonexistent (#1563); got: {joined:?}"
+    );
+    assert!(
+        lower.contains("name") || lower.contains("parish"),
+        "known-person denial should become a grounded acknowledgement; got: {joined:?}"
+    );
+}
+
 // ── #1553 — player self-introduction not denied (real-loop) ──────────────────
 
 /// AC-1 (#1553, real-loop): When the player introduces themselves ("I am Aiden

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -2958,6 +2958,56 @@ fn grounded_acknowledgement(seed: u64) -> &'static str {
     POOL[(seed as usize) % POOL.len()]
 }
 
+fn grounded_place_acknowledgement(seed: u64) -> &'static str {
+    const POOL: &[&str] = &[
+        "Aye, that place is known in this parish.",
+        "That is a real place hereabouts, sure enough.",
+        "Aye, the place is known here in the parish.",
+        "That place is no invention; it is known around here.",
+        "Aye, I know the name of that place well enough.",
+    ];
+    POOL[(seed as usize) % POOL.len()]
+}
+
+const GENERIC_PERSON_NONRECOGNITION_MARKERS: &[&str] = &[
+    "no one by that name",
+    "no such person",
+    "know no one by that name",
+    "know of no such person",
+    "never heard of him",
+    "never heard of her",
+    "never heard of them",
+    "that name is not known",
+    "wrong parish",
+];
+
+const GENERIC_ENTITY_NONRECOGNITION_MARKERS: &[&str] = &[
+    "no one by that name",
+    "no such person",
+    "no such place",
+    "no place by that name",
+    "know of no such place",
+    "doesn't exist",
+    "does not exist",
+    "place that doesn't exist",
+    "place that does not exist",
+    "that name is not known",
+    "wrong parish",
+    "wrong place",
+];
+
+fn has_generic_person_nonrecognition(lower_dialogue: &str) -> bool {
+    GENERIC_PERSON_NONRECOGNITION_MARKERS
+        .iter()
+        .any(|marker| lower_dialogue.contains(marker))
+}
+
+fn has_generic_entity_nonrecognition(lower_dialogue: &str) -> bool {
+    GENERIC_ENTITY_NONRECOGNITION_MARKERS
+        .iter()
+        .any(|marker| lower_dialogue.contains(marker))
+}
+
 /// Post-generation guard for false denial of a known roster person (#1527, #1528).
 ///
 /// When an NPC's dialogue contains a denial marker AND the denied name IS in
@@ -2967,12 +3017,10 @@ fn grounded_acknowledgement(seed: u64) -> &'static str {
 ///
 /// Conservative: only fires when ALL of the following hold:
 ///   1. The player's input names a person whose full name IS in `known_person_names`.
-///   2. The NPC dialogue contains that full name (the NPC is talking about them).
-///   3. The NPC dialogue contains a denial marker.
-///   4. The NPC dialogue does NOT contain any of the place-affirmation markers
-///      that would indicate the NPC is correctly locating the person (which
-///      would make the denial non-sensical — already handled by the person-
-///      confirmation guard).
+///   2. The NPC dialogue contains a denial marker.
+///   3. Either the dialogue repeats the full name, or the player input contains
+///      only known full-name candidates and the dialogue uses a generic
+///      "that name/no such person" non-recognition phrase.
 ///
 /// Gate: `dialogue-false-denial-guard` (default-on).
 pub fn guard_false_denial_of_roster_person(
@@ -2996,14 +3044,18 @@ pub fn guard_false_denial_of_roster_person(
 
     // Check each candidate name from the player's input.
     let candidates = extract_candidate_names(player_input);
+    let mut has_known_full_name = false;
+    let mut has_unknown_full_name = false;
     for candidate in &candidates {
         // Only fire for full names (multi-word) that ARE in the roster.
         if candidate.split_whitespace().count() < 2 {
             continue;
         }
         if !name_in_roster(candidate, known_person_names, player_name) {
+            has_unknown_full_name = true;
             continue;
         }
+        has_known_full_name = true;
         // The candidate is a real roster person. Check if the dialogue mentions them.
         let cand_lower = candidate.to_lowercase();
         if !lower.contains(&cand_lower) {
@@ -3013,6 +3065,13 @@ pub fn guard_false_denial_of_roster_person(
         tracing::warn!(
             candidate = %candidate,
             "false-denial guard fired: NPC denied a known roster person (#1527/#1528)"
+        );
+        return grounded_acknowledgement(seed).to_string();
+    }
+
+    if has_known_full_name && !has_unknown_full_name && has_generic_person_nonrecognition(&lower) {
+        tracing::warn!(
+            "false-denial guard fired: NPC generically denied a known roster person (#1563)"
         );
         return grounded_acknowledgement(seed).to_string();
     }
@@ -3143,6 +3202,10 @@ fn extract_candidate_places(player_input: &str) -> Vec<String> {
         "where is ",
         "where's ",
         "where are ",
+        "guide me to ",
+        "take me to ",
+        "bring me to ",
+        "show me to ",
         "how do i find ",
         "how do i get to ",
         "how do we get to ",
@@ -3361,6 +3424,58 @@ pub fn guard_invented_place_confirmation(
             "invented-place guard fired: NPC confirmed invented place (#1530)"
         );
         return non_recognition_place_decline(seed).to_string();
+    }
+
+    dialogue.to_string()
+}
+
+/// Post-generation guard for false denial of a real place (#1563).
+///
+/// If the player asks about a place that exists in the world graph and the NPC
+/// generically denies it as nonexistent or as "no such person", replace that
+/// denial with a neutral acknowledgement. Unlike the invented-place guard, this
+/// does not invent directions; it only prevents the transcript from asserting
+/// that a real parish place is fake.
+pub fn guard_false_denial_of_known_place(
+    dialogue: &str,
+    player_input: &str,
+    known_location_names: &[String],
+    seed: u64,
+) -> String {
+    if dialogue.trim().is_empty() || known_location_names.is_empty() {
+        return dialogue.to_string();
+    }
+
+    let lower = dialogue.to_lowercase();
+    if !has_generic_entity_nonrecognition(&lower) {
+        return dialogue.to_string();
+    }
+
+    let known_location_names_lower: Vec<String> = known_location_names
+        .iter()
+        .map(|loc| loc.to_lowercase())
+        .collect();
+    let candidates = extract_candidate_places(player_input);
+    let mut has_known_place = false;
+    let mut has_unknown_place = false;
+    for candidate in &candidates {
+        let candidate_lower = candidate.to_lowercase();
+        let is_known_place = known_location_names_lower.iter().any(|location_lower| {
+            location_lower.contains(&candidate_lower)
+                || candidate_lower.contains(location_lower.as_str())
+        });
+        if is_known_place {
+            has_known_place = true;
+        } else {
+            has_unknown_place = true;
+        }
+    }
+
+    if has_known_place && !has_unknown_place {
+        tracing::warn!(
+            "false-denial guard fired: NPC generically denied a known parish place (#1563)"
+        );
+        return grounded_place_acknowledgement(seed).to_string();
     }
 
     dialogue.to_string()
@@ -5450,11 +5565,12 @@ mod tests {
         );
     }
 
-    /// AC-4 (#1527): Denial marker present but roster name not in dialogue → unchanged.
+    /// AC-4 (#1563): A generic "that name" denial after the player names one
+    /// real roster person is still a false denial, even if the dialogue does
+    /// not repeat the person's full name.
     #[test]
-    fn false_denial_guard_no_fire_when_name_absent_from_dialogue() {
+    fn false_denial_guard_fires_for_generic_known_person_denial() {
         let known = make_names(&["Peig Hannigan", "Cormac Duffy"]);
-        // Denial is there but Peig Hannigan's name is NOT in the dialogue.
         let dialogue = "I know no one by that name hereabouts.";
         let result = guard_false_denial_of_roster_person(
             dialogue,
@@ -5463,9 +5579,32 @@ mod tests {
             None,
             0,
         );
+        assert_ne!(
+            result, dialogue,
+            "generic denial of one known roster person must be corrected: {result:?}"
+        );
+        assert!(
+            !result.to_lowercase().contains("no one by that name"),
+            "generic false denial must be replaced: {result:?}"
+        );
+    }
+
+    /// Mixed real + invented questions remain conservative: a generic denial
+    /// could refer to the fabricated name, so leave it unchanged.
+    #[test]
+    fn false_denial_guard_leaves_mixed_known_and_unknown_generic_denial() {
+        let known = make_names(&["Peig Hannigan", "Cormac Duffy"]);
+        let dialogue = "I know no one by that name hereabouts.";
+        let result = guard_false_denial_of_roster_person(
+            dialogue,
+            "Where are Peig Hannigan and Fionn MacCathasaigh?",
+            &known,
+            None,
+            0,
+        );
         assert_eq!(
             result, dialogue,
-            "denial without name in dialogue must pass through: {result:?}"
+            "mixed known+unknown generic denial must stay conservative"
         );
     }
 
@@ -5520,6 +5659,62 @@ mod tests {
         assert_eq!(
             result, dialogue,
             "denial without affirmation must pass through: {result:?}"
+        );
+    }
+
+    /// AC-1 (#1563): A real place from the world graph must not be denied as
+    /// nonexistent just because the speaking NPC's local knowledge omitted it.
+    #[test]
+    fn false_denial_place_guard_corrects_known_place_denial() {
+        let known = make_locations(&["Darcy's Pub", "The Forge", "Kilteevan Village"]);
+        let dialogue = "I cannae guide ye to a place that doesn't exist.";
+        let result =
+            guard_false_denial_of_known_place(dialogue, "Where is Darcy's Pub?", &known, 0);
+
+        assert_ne!(
+            result, dialogue,
+            "generic denial of known place must be corrected: {result:?}"
+        );
+        assert!(
+            !result.to_lowercase().contains("doesn't exist"),
+            "known-place denial must be replaced: {result:?}"
+        );
+    }
+
+    /// AC-1 (#1563): The issue repro used navigation wording ("guide me to"),
+    /// so explicit navigation requests are place candidates too.
+    #[test]
+    fn false_denial_place_guard_extracts_guide_me_to_known_place() {
+        let known = make_locations(&["Darcy's Pub", "The Forge", "Kilteevan Village"]);
+        let dialogue = "I cannae guide ye to a place that doesn't exist.";
+        let result = guard_false_denial_of_known_place(
+            dialogue,
+            "Can you guide me to Darcy's Pub?",
+            &known,
+            1,
+        );
+
+        assert_ne!(
+            result, dialogue,
+            "guide-me-to known-place denial must be corrected: {result:?}"
+        );
+        assert!(
+            result.to_lowercase().contains("place"),
+            "replacement should be a grounded place acknowledgement: {result:?}"
+        );
+    }
+
+    /// AC-3 (#1563): A correct denial of an invented place remains a denial.
+    #[test]
+    fn false_denial_place_guard_leaves_unknown_place_denial() {
+        let known = make_locations(&["Darcy's Pub", "The Forge", "Kilteevan Village"]);
+        let dialogue = "I know of no such place in this parish.";
+        let result =
+            guard_false_denial_of_known_place(dialogue, "Where is Ballydrift Abbey?", &known, 0);
+
+        assert_eq!(
+            result, dialogue,
+            "correct denial of invented place must pass through unchanged"
         );
     }
 

--- a/parish/crates/parish-npc/src/ticks/prompt.rs
+++ b/parish/crates/parish-npc/src/ticks/prompt.rs
@@ -132,13 +132,18 @@ pub fn build_enhanced_system_prompt_with_config(
                         name, occupation, rel.kind, strength_desc
                     ));
                 } else {
-                    prompt.push_str(&format!("- {}, {}\n", name, occupation));
+                    prompt.push_str(&format!(
+                        "- {}, {} \u{2014} real parish person\n",
+                        name, occupation
+                    ));
                 }
             }
             prompt.push_str(
                 "Each entry above gives the person's pronouns (where known) and \
                 age \u{2014} use their stated pronouns and never guess gender from \
-                a name. If you \
+                a name. Entries marked as real parish people are real names in \
+                the parish, but do not claim close acquaintance unless your \
+                relationships or memories say so. If you \
                 want to mention anyone not listed above, describe them by role or \
                 appearance \u{2014} never invent a name, and never refer to a \
                 person (he/she/they/her/him) who has not been mentioned.\n",

--- a/parish/testing/fixtures/play_fix-1563-parishwide-grounding.txt
+++ b/parish/testing/fixtures/play_fix-1563-parishwide-grounding.txt
@@ -1,0 +1,12 @@
+# fix-1563-parishwide-grounding
+# Repro: a real parish place/person must not be denied as nonexistent just
+# because the speaker's local relationship list omits them.
+
+go to the forge
+/npcs
+
+/stub Seamus Gallagher: I cannae guide ye to a place that doesn't exist.
+talk to Seamus Gallagher about Where is Darcy's Pub?
+
+/stub Seamus Gallagher: I know no one by that name in these parts.
+talk to Seamus Gallagher about Where is Padraig Darcy?


### PR DESCRIPTION
## Summary

Fixes #1563.

- Add parish-wide real people to grounded NPC prompts while preserving relationship nuance.
- Correct generic false denials of real parish people and places before they reach the transcript.
- Apply the guard in shared real-loop, headless, and scripted canned-response paths with regression coverage.

## Verification

- `rtk just check`

<!-- parish-proof-bundle:fix-1563-parishwide-grounding v=1 -->

## Proof: fix-1563-parishwide-grounding

### Acceptance criteria

# fix-1563-parishwide-grounding

Issue: #1563 - NPCs false-deny real locations/people absent from their local known-list.

## Acceptance Criteria

1. A generic denial of a real parish place from the world graph, such as "Darcy's Pub does not exist", is corrected before it reaches the player-visible transcript.
2. A generic denial of a real parish person from the full NPC roster, such as "I know no one by that name" after the player asks about Padraig Darcy, is corrected even when the NPC reply does not repeat the person's full name.
3. Correct denials of fabricated people and invented places still pass or fire the existing invented-entity guards; the fix does not make all denials into affirmations.
4. The real game-loop path applies the guard, not only a leaf unit test.
5. The scripted canned-response proof path applies the same guard so the live transcript can deterministically show the corrected behavior.

## Verification Plan

- Add focused `parish-npc` tests for generic false denials of a known place and known person.
- Add a real-loop `parish-engine` regression with mock NPC output for Darcy's Pub and Padraig Darcy.
- Add `parish/testing/fixtures/play_fix-1563-parishwide-grounding.txt` for the live proof transcript.
- Run focused Rust tests, the live script fixture, `rtk just agent-check`, and `rtk just check`.

### Evidence

Evidence type: live gameplay transcript

## Root Cause

Five Whys:

1. NPCs denied real entities like Darcy's Pub and Padraig Darcy because the model followed a grounding instruction that only showed the speaker's small local people roster.
2. The prompt's place list was parish-wide, but its people list was relationship-local, so a real person outside the speaker's relationships looked indistinguishable from a fabricated name to the model.
3. The post-generation false-denial guard only corrected real people when the reply repeated the full name, so generic denials like "I know no one by that name" passed through unchanged.
4. There was no equivalent post-generation guard for real places denied as nonexistent, including place queries misclassified as "no such person".
5. The root cause was a split between prompt grounding and guard grounding: real parish entities were available to some guards, but not consistently to the prompt or to generic false-denial correction.

## Commands Run

- `rtk cargo fmt --manifest-path parish/Cargo.toml --all` - passed.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc false_denial` - 8 passed, 721 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-core known_person_names_includes_all_parish_npcs_not_just_roster` - 1 passed, 513 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine canned_npc_response_corrects_real_entity_false_denials` - passed after assertion correction; 1 passed, 367 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_known_place_generic_denial_is_corrected` - 1 passed, 15 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_known_person_generic_denial_is_corrected` - 1 passed, 15 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc invented_place_guard` - 4 passed, 725 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc person_guard_still_declines_fabricated_person_with_location_context` - 1 passed, 728 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_known_place_history_not_replaced_by_person_denial` - 1 passed, 15 filtered out.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_invented_titled_landlord_hearsay_is_declined` - 1 passed, 15 filtered out.
- `rtk cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1563-parishwide-grounding.txt` - passed; transcript captured in `transcript.txt`.
- `rtk just agent-check` - passed; live proof required and present.
- `rtk just check` - passed; includes agent-check, fmt check, clippy, cargo tests, doc path checks, and UI check/lint/format.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc false_denial_place_guard` - 3 passed, 726 filtered out after addressing Gemini's allocation cleanup.
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_known_place_generic_denial_is_corrected` - 1 passed, 15 filtered out after addressing Gemini's allocation cleanup.
- `rtk just check` - passed again after addressing Gemini's allocation cleanup.

## Acceptance Mapping

- AC-1: The live transcript stubs `I cannae guide ye to a place that doesn't exist.` for Darcy's Pub, but the final `npc_response` is `Aye, I know the name of that place well enough.`.
- AC-2: The live transcript stubs `I know no one by that name in these parts.` for Padraig Darcy, but the final `npc_response` is `I've heard that name in these parts, sure enough.`.
- AC-3: `false_denial_guard_leaves_correct_stranger_decline`, `false_denial_place_guard_leaves_unknown_place_denial`, `invented_place_guard`, and `person_guard_still_declines_fabricated_person_with_location_context` keep fabricated-entity protection intact.
- AC-4: `real_loop_known_place_generic_denial_is_corrected` and `real_loop_known_person_generic_denial_is_corrected` drive `GameTestHarness::execute_via_real_loop` through the shared `run_npc_turn` guard chain.
- AC-5: `canned_npc_response_corrects_real_entity_false_denials` and the live script fixture drive the scripted canned-response path used by `parish-engine --script`.

### Transcript

```text
Command:
rtk cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1563-parishwide-grounding.txt

Result:
passed

Transcript:
{"command":"go to the forge","result":"moved","to":"The Forge","minutes":1,"narration":"You walk along a lane toward the ring of the anvil. (1 minute on foot)","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["You walk along a lane toward the ring of the anvil. (1 minute on foot)","","A low stone building open at the front, where a bellows feeds a glowing hearth. The anvil sits dark and scarred in the centre. Horseshoes, tongs, and half-finished ironwork hang from hooks along the wall. Sparks drift in the clear air. It is morning.\nYou can go to: Kilteevan Village (1 min on foot)","  · You hear a man singing to himself — thin and reedy — before you see him around the bend."]}
{"command":"/npcs","result":"system_command","response":"NPCs here:\n  a lanky red-haired lad with soot on his face — Blacksmith's Apprentice (eager)\n  a broad-shouldered man in a leather apron — Blacksmith (cheerful)","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["NPCs here:\n  a lanky red-haired lad with soot on his face — Blacksmith's Apprentice (eager)\n  a broad-shouldered man in a leather apron — Blacksmith (cheerful)"]}
{"command":"/stub Seamus Gallagher: I cannae guide ye to a place that doesn't exist.","result":"system_command","response":"Stubbed response for Seamus Gallagher: \"I cannae guide ye to a place that doesn't exist.\"","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["Stubbed response for Seamus Gallagher: \"I cannae guide ye to a place that doesn't exist.\""]}
{"command":"talk to Seamus Gallagher about Where is Darcy's Pub?","result":"npc_response","npc":"Seamus Gallagher","dialogue":"Aye, I know the name of that place well enough.","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["Seamus Gallagher: Aye, I know the name of that place well enough."]}
{"command":"/stub Seamus Gallagher: I know no one by that name in these parts.","result":"system_command","response":"Stubbed response for Seamus Gallagher: \"I know no one by that name in these parts.\"","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["Stubbed response for Seamus Gallagher: \"I know no one by that name in these parts.\""]}
{"command":"talk to Seamus Gallagher about Where is Padraig Darcy?","result":"npc_response","npc":"Seamus Gallagher","dialogue":"I've heard that name in these parts, sure enough.","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["Seamus Gallagher: I've heard that name in these parts, sure enough."]}
```

### Artifacts

- `transcript.txt` (full transcript)

### Transcript

```text
Command:
rtk cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1563-parishwide-grounding.txt

Result:
passed

Transcript:
{"command":"go to the forge","result":"moved","to":"The Forge","minutes":1,"narration":"You walk along a lane toward the ring of the anvil. (1 minute on foot)","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["You walk along a lane toward the ring of the anvil. (1 minute on foot)","","A low stone building open at the front, where a bellows feeds a glowing hearth. The anvil sits dark and scarred in the centre. Horseshoes, tongs, and half-finished ironwork hang from hooks along the wall. Sparks drift in the clear air. It is morning.\nYou can go to: Kilteevan Village (1 min on foot)","  · You hear a man singing to himself — thin and reedy — before you see him around the bend."]}
{"command":"/npcs","result":"system_command","response":"NPCs here:\n  a lanky red-haired lad with soot on his face — Blacksmith's Apprentice (eager)\n  a broad-shouldered man in a leather apron — Blacksmith (cheerful)","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["NPCs here:\n  a lanky red-haired lad with soot on his face — Blacksmith's Apprentice (eager)\n  a broad-shouldered man in a leather apron — Blacksmith (cheerful)"]}
{"command":"/stub Seamus Gallagher: I cannae guide ye to a place that doesn't exist.","result":"system_command","response":"Stubbed response for Seamus Gallagher: \"I cannae guide ye to a place that doesn't exist.\"","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["Stubbed response for Seamus Gallagher: \"I cannae guide ye to a place that doesn't exist.\""]}
{"command":"talk to Seamus Gallagher about Where is Darcy's Pub?","result":"npc_response","npc":"Seamus Gallagher","dialogue":"Aye, I know the name of that place well enough.","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["Seamus Gallagher: Aye, I know the name of that place well enough."]}
{"command":"/stub Seamus Gallagher: I know no one by that name in these parts.","result":"system_command","response":"Stubbed response for Seamus Gallagher: \"I know no one by that name in these parts.\"","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["Stubbed response for Seamus Gallagher: \"I know no one by that name in these parts.\""]}
{"command":"talk to Seamus Gallagher about Where is Padraig Darcy?","result":"npc_response","npc":"Seamus Gallagher","dialogue":"I've heard that name in these parts, sure enough.","location":"The Forge","time":"Morning","season":"Spring","new_log_lines":["Seamus Gallagher: I've heard that name in these parts, sure enough."]}
```

### Judge

Verdict: sufficient

Acceptance criteria: met

Technical debt: clear

The proof demonstrates the raw false-denial signatures in a live scripted transcript and shows both corrected player-visible outputs. Unit and real-loop tests cover the new known-person and known-place paths, while neighboring fabricated-person and invented-place tests show the fix remains conservative. The implementation reuses the existing guard chain and prompt-grounding feature flag instead of adding an unrelated dialogue layer.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:fix-1563-parishwide-grounding -->
