### PR TITLE
fix: polish guarded dialogue fallbacks

### DIFF
--- a/parish/crates/parish-core/src/game_loop/npc_turn.rs
+++ b/parish/crates/parish-core/src/game_loop/npc_turn.rs
@@ -157,6 +157,7 @@ pub async fn run_npc_turn(
 ) -> Option<TurnOutcome> {
     let (
         setup,
+        time_of_day,
         person_guard_enabled,
         verbosity_guard_enabled,
         mood_sentence_cap_enabled,
@@ -168,6 +169,7 @@ pub async fn run_npc_turn(
         anti_repetition_enabled,
         false_denial_guard_enabled,
         invented_place_guard_enabled,
+        dialogue_polish_guard_enabled,
         post_guard_ui_replace_enabled,
     ) = {
         let mut world = ctx.world.lock().await;
@@ -207,6 +209,10 @@ pub async fn run_npc_turn(
         let invented_place_guard = !config
             .flags
             .is_disabled(parish_npc::INVENTED_PLACE_GUARD_FLAG);
+        // Dialogue polish guard (#1564): default-on, kill-switch only.
+        let dialogue_polish_guard = !config
+            .flags
+            .is_disabled(parish_npc::DIALOGUE_POLISH_GUARD_FLAG);
         // Post-guard UI replace (#1552): emit `dialogue-corrected` event after
         // all guards run so the frontend shows post-guard text, not raw model
         // output. Default-on; kill-switch only.
@@ -228,8 +234,10 @@ pub async fn run_npc_turn(
             &ctx.language,
             &npc_cfg,
         );
+        let time_of_day = world.clock.time_of_day();
         (
             setup,
+            time_of_day,
             person_guard,
             verbosity_guard,
             mood_sentence_cap,
@@ -241,6 +249,7 @@ pub async fn run_npc_turn(
             anti_rep,
             false_denial_guard,
             invented_place_guard,
+            dialogue_polish_guard,
             ui_replace,
         )
     };
@@ -500,13 +509,14 @@ pub async fn run_npc_turn(
         }
     }
 
-    // Post-generation false-denial guards (#1527, #1528, #1563) and
-    // invented-place confirmation guard (#1530): all require a seed derived
-    // from the world clock. Acquire the async world lock ONCE here if any guard
-    // is active and the dialogue is non-empty, then reuse the seed for all
-    // three guards to avoid redundant lock acquisitions.
+    // Post-generation false-denial guards (#1527, #1528, #1563),
+    // invented-place confirmation guard (#1530), and stock decline polish
+    // (#1564): all require a seed derived from the world clock. Acquire the
+    // async world lock ONCE here if any guard is active and the dialogue is
+    // non-empty, then reuse the seed for these guards.
     let both_guards_seed: Option<u64> = if (false_denial_guard_enabled
-        || invented_place_guard_enabled)
+        || invented_place_guard_enabled
+        || dialogue_polish_guard_enabled)
         && !parsed.dialogue.trim().is_empty()
     {
         let ts = ctx.world.lock().await.clock.now().timestamp() as u64;
@@ -563,6 +573,27 @@ pub async fn run_npc_turn(
             &setup.known_location_names,
             guard_seed,
         );
+        if guarded != parsed.dialogue {
+            parsed.dialogue = guarded;
+        }
+    }
+
+    // Post-generation dialogue polish guard (#1564): replace old stock
+    // non-recognition templates and correct obvious morning greeting tics when
+    // the world clock is not Morning. Runs after grounding guards so true
+    // false-denial corrections win before generic polish.
+    if dialogue_polish_guard_enabled && !parsed.dialogue.trim().is_empty() {
+        let guard_seed = both_guards_seed.unwrap_or(0);
+        let guarded = crate::npc::guard_stock_nonrecognition_decline(
+            &parsed.dialogue,
+            prompt_input,
+            guard_seed,
+        );
+        if guarded != parsed.dialogue {
+            parsed.dialogue = guarded;
+        }
+
+        let guarded = crate::npc::guard_time_of_day_phrase(&parsed.dialogue, time_of_day);
         if guarded != parsed.dialogue {
             parsed.dialogue = guarded;
         }

--- a/parish/crates/parish-engine/src/headless.rs
+++ b/parish/crates/parish-engine/src/headless.rs
@@ -870,6 +870,23 @@ fn apply_npc_response(
             parsed.dialogue = guarded;
         }
     }
+    if !app
+        .flags
+        .is_disabled(crate::npc::DIALOGUE_POLISH_GUARD_FLAG)
+        && !parsed.dialogue.trim().is_empty()
+    {
+        let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
+        let guarded =
+            crate::npc::guard_stock_nonrecognition_decline(&parsed.dialogue, player_input, seed);
+        if guarded != parsed.dialogue {
+            parsed.dialogue = guarded;
+        }
+        let guarded =
+            crate::npc::guard_time_of_day_phrase(&parsed.dialogue, app.world.clock.time_of_day());
+        if guarded != parsed.dialogue {
+            parsed.dialogue = guarded;
+        }
+    }
     if cfg.verbosity_guard_enabled && !parsed.dialogue.trim().is_empty() {
         let mood_str = parsed.metadata.as_ref().map(|m| m.mood.as_str());
         let guarded = if app.flags.is_disabled("npc-mood-aware-sentence-cap") {

--- a/parish/crates/parish-engine/src/testing.rs
+++ b/parish/crates/parish-engine/src/testing.rs
@@ -599,6 +599,16 @@ impl GameTestHarness {
             );
         }
 
+        if !self
+            .app
+            .flags
+            .is_disabled(crate::npc::DIALOGUE_POLISH_GUARD_FLAG)
+        {
+            guarded = crate::npc::guard_stock_nonrecognition_decline(&guarded, player_input, seed);
+            guarded =
+                crate::npc::guard_time_of_day_phrase(&guarded, self.app.world.clock.time_of_day());
+        }
+
         if cfg.verbosity_guard_enabled {
             let mood = self
                 .app
@@ -2033,8 +2043,8 @@ mod tests {
     fn test_canned_npc_response() {
         let mut h = GameTestHarness::new();
         h.add_canned_response("Padraig Darcy", "Ah, good morning to ye!");
-        // Advance to 10am when Padraig is scheduled at the pub (9-22)
-        h.advance_time(120);
+        // Advance to 9am, still Morning, when Padraig is scheduled at the pub (9-22).
+        h.advance_time(60);
         h.execute("go to crossroads");
         h.execute("go to pub");
         let result = h.execute("hello there");
@@ -2043,6 +2053,64 @@ mod tests {
             assert_eq!(npc, "Padraig Darcy");
             assert_eq!(dialogue, "Ah, good morning to ye!");
         }
+    }
+
+    #[test]
+    fn canned_npc_response_polishes_stock_declines_and_midday_morning_tic() {
+        let mut h = GameTestHarness::new();
+        h.advance_time(240);
+        h.execute("go to Darcy's Pub");
+
+        h.add_canned_response(
+            "Padraig Darcy",
+            "Good morning to ye, mo chara. What brings ye in this fine morning?",
+        );
+        let time_result = h.execute("talk to Padraig Darcy about Good day, what is the news?");
+        let ActionResult::NpcResponse {
+            dialogue: time_dialogue,
+            ..
+        } = time_result
+        else {
+            panic!("expected Padraig to answer the time-polish turn, got {time_result:?}");
+        };
+        assert!(
+            !time_dialogue.to_lowercase().contains("morn"),
+            "midday dialogue must not retain morning wording: {time_dialogue}"
+        );
+
+        h.add_canned_response(
+            "Padraig Darcy",
+            "I know no one by that name in these parts.",
+        );
+        let person_result = h.execute(
+            "talk to Padraig Darcy about Have you met Sorcha O'Malley from beyond the parish?",
+        );
+        let ActionResult::NpcResponse {
+            dialogue: person_dialogue,
+            ..
+        } = person_result
+        else {
+            panic!("expected Padraig to answer the stock-person turn, got {person_result:?}");
+        };
+        assert_ne!(
+            person_dialogue,
+            "I know no one by that name in these parts."
+        );
+
+        h.add_canned_response("Padraig Darcy", "Mayhap ye have the wrong parish entirely.");
+        let place_result = h.execute("talk to Padraig Darcy about Where is Silver Bridge?");
+        let ActionResult::NpcResponse {
+            dialogue: place_dialogue,
+            ..
+        } = place_result
+        else {
+            panic!("expected Padraig to answer the stock-place turn, got {place_result:?}");
+        };
+        assert_ne!(place_dialogue, "Mayhap ye have the wrong parish entirely.");
+        assert_ne!(
+            person_dialogue, place_dialogue,
+            "different unknown-entity prompts should not collapse to one reply"
+        );
     }
 
     #[test]
@@ -2070,7 +2138,10 @@ mod tests {
                 || lower.contains("no one by that name")
                 || lower.contains("not known to me")
                 || lower.contains("wrong parish")
-                || lower.contains("such a person"),
+                || lower.contains("such a person")
+                || lower.contains("that name")
+                || lower.contains("parish face")
+                || lower.contains("comes to mind"),
             "{dialogue}"
         );
         assert!(!lower.contains("lord fitzwilliam"), "{dialogue}");

--- a/parish/crates/parish-engine/tests/runaway_generation_guards.rs
+++ b/parish/crates/parish-engine/tests/runaway_generation_guards.rs
@@ -832,7 +832,10 @@ fn real_loop_invented_titled_landlord_hearsay_is_declined() {
             || lower.contains("no one by that name")
             || lower.contains("wrong parish")
             || lower.contains("not known to me")
-            || lower.contains("such a person"),
+            || lower.contains("such a person")
+            || lower.contains("that name")
+            || lower.contains("parish face")
+            || lower.contains("comes to mind"),
         "invented landlord reply should become a non-recognition decline (#1565); \
          got: {joined:?}"
     );

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -11,6 +11,10 @@
 // helpers are the deterministic, model-agnostic backstop: they need no live
 // inference and run identically for every provider.
 
+use std::sync::OnceLock;
+
+use parish_types::time::TimeOfDay;
+
 /// Normalizes a dialogue line for repetition comparison.
 ///
 /// Lower-cases, collapses internal whitespace to single spaces, and trims
@@ -22,6 +26,15 @@ fn normalize_for_repetition(s: &str) -> String {
     collapsed
         .trim_matches(|c: char| c.is_whitespace() || matches!(c, '.' | '!' | '?' | '…' | ',' | ';'))
         .to_string()
+}
+
+fn text_seed(s: &str) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in s.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
 }
 
 /// Splits a dialogue body into sentence-ish units on terminal punctuation,
@@ -388,11 +401,11 @@ pub fn guard_against_repetition(
 /// Cycles through a small pool to avoid repeated identical responses.
 fn non_recognition_decline(seed: u64) -> &'static str {
     const DECLINES: &[&str] = &[
-        "I know no one by that name in these parts.",
         "That name is not known to me hereabouts.",
-        "I cannot say I've ever heard of such a person here.",
-        "No one by that name that I know of in this parish.",
-        "I know of no such person — you may have the wrong parish entirely.",
+        "I cannot place that name among the folk here.",
+        "No parish face comes to mind for that name.",
+        "That is not a name I have heard in these parts.",
+        "I cannot put a parish face to that name.",
     ];
     DECLINES[(seed as usize) % DECLINES.len()]
 }
@@ -3086,6 +3099,10 @@ pub fn guard_false_denial_of_roster_person(
 /// `flags.is_disabled(INVENTED_PLACE_GUARD_FLAG)`.
 pub const INVENTED_PLACE_GUARD_FLAG: &str = "dialogue-invented-place-guard";
 
+/// Feature-flag name (default **on**) for small dialogue polish backstops
+/// (#1564): old stock decline templates and time-of-day greeting tics.
+pub const DIALOGUE_POLISH_GUARD_FLAG: &str = "dialogue-polish-guard";
+
 /// Place-affirmation markers: phrases indicating the NPC is confirming or
 /// locating a place. Used by `guard_invented_place_confirmation`.
 const PLACE_AFFIRMATION_MARKERS: &[&str] = &[
@@ -3106,13 +3123,109 @@ const PLACE_AFFIRMATION_MARKERS: &[&str] = &[
 /// Cycles through a small pool to avoid repeated identical responses.
 fn non_recognition_place_decline(seed: u64) -> &'static str {
     const DECLINES: &[&str] = &[
-        "I know of no such place in this parish.",
-        "That name is not known to me hereabouts — ye may have the wrong place.",
-        "No such place that I've heard of in these parts.",
-        "I cannot say I know of any such place in this parish.",
-        "I know of no place by that name near here.",
+        "That place-name is not one I have heard hereabouts.",
+        "No such place comes to mind around here.",
+        "I cannot put that name on any road I know.",
+        "That is not a place I can point you to in this parish.",
+        "No place by that name is known to me near here.",
     ];
     DECLINES[(seed as usize) % DECLINES.len()]
+}
+
+const STOCK_NONRECOGNITION_TEMPLATES: &[&str] = &[
+    "i know no one by that name in these parts",
+    "mayhap ye have the wrong parish entirely",
+];
+
+/// Replaces old stock non-recognition templates with the same deterministic
+/// fallback families used by the grounding guards (#1564).
+pub fn guard_stock_nonrecognition_decline(dialogue: &str, player_input: &str, seed: u64) -> String {
+    if dialogue.trim().is_empty() {
+        return dialogue.to_string();
+    }
+
+    let normalized = normalize_for_repetition(dialogue);
+    if !STOCK_NONRECOGNITION_TEMPLATES
+        .iter()
+        .any(|template| normalized.contains(template))
+    {
+        return dialogue.to_string();
+    }
+
+    let prompt_seed = seed ^ text_seed(player_input);
+    let place_candidates = extract_candidate_places(player_input);
+    if !place_candidates.is_empty() {
+        tracing::warn!(
+            "dialogue polish guard fired: replacing stock place non-recognition (#1564)"
+        );
+        return non_recognition_place_decline(prompt_seed).to_string();
+    }
+
+    tracing::warn!("dialogue polish guard fired: replacing stock person non-recognition (#1564)");
+    non_recognition_decline(prompt_seed).to_string()
+}
+
+fn replacement_greeting(time_of_day: TimeOfDay) -> &'static str {
+    match time_of_day {
+        TimeOfDay::Dawn => "Good day",
+        TimeOfDay::Morning => "Good morning",
+        TimeOfDay::Midday => "Good day",
+        TimeOfDay::Afternoon => "Good afternoon",
+        TimeOfDay::Dusk | TimeOfDay::Night | TimeOfDay::Midnight => "Good evening",
+    }
+}
+
+fn replacement_day_phrase(time_of_day: TimeOfDay) -> &'static str {
+    match time_of_day {
+        TimeOfDay::Dawn => "this early hour",
+        TimeOfDay::Morning => "this morning",
+        TimeOfDay::Midday => "this fine day",
+        TimeOfDay::Afternoon => "this afternoon",
+        TimeOfDay::Dusk | TimeOfDay::Night | TimeOfDay::Midnight => "this evening",
+    }
+}
+
+/// Rewrites obvious opening/greeting morning tics when the actual clock is not
+/// Morning (#1564). The guard intentionally targets greeting phrases and
+/// "this fine morning" style tics rather than every historical mention of
+/// "morning" in a reply.
+pub fn guard_time_of_day_phrase(dialogue: &str, time_of_day: TimeOfDay) -> String {
+    if dialogue.trim().is_empty() || time_of_day == TimeOfDay::Morning {
+        return dialogue.to_string();
+    }
+
+    static GOOD_MORNING: OnceLock<regex::Regex> = OnceLock::new();
+    static THIS_FINE_MORNING: OnceLock<regex::Regex> = OnceLock::new();
+    static THIS_MORNING: OnceLock<regex::Regex> = OnceLock::new();
+
+    let good_morning = GOOD_MORNING.get_or_init(|| {
+        regex::Regex::new(r"(?i)\bgood\s+morn(?:ing|in'?)?\b").expect("valid good-morning regex")
+    });
+    let this_fine_morning = THIS_FINE_MORNING.get_or_init(|| {
+        regex::Regex::new(r"(?i)\bthis\s+fine\s+morn(?:ing|in'?)?\b")
+            .expect("valid this-fine-morning regex")
+    });
+    let this_morning = THIS_MORNING.get_or_init(|| {
+        regex::Regex::new(r"(?i)\bthis\s+morn(?:ing|in'?)?\b").expect("valid this-morning regex")
+    });
+
+    let mut polished = good_morning
+        .replace_all(dialogue, replacement_greeting(time_of_day))
+        .into_owned();
+    polished = this_fine_morning
+        .replace_all(&polished, replacement_day_phrase(time_of_day))
+        .into_owned();
+    polished = this_morning
+        .replace_all(&polished, replacement_day_phrase(time_of_day))
+        .into_owned();
+
+    if polished != dialogue {
+        tracing::warn!(
+            actual_time = %time_of_day,
+            "dialogue polish guard fired: corrected time-of-day phrase (#1564)"
+        );
+    }
+    polished
 }
 
 /// Extracts candidate place-name tokens from the player input.
@@ -3653,7 +3766,10 @@ mod tests {
                 || lower.contains("no one by that name")
                 || lower.contains("wrong parish")
                 || lower.contains("not known to me")
-                || lower.contains("such a person"),
+                || lower.contains("such a person")
+                || lower.contains("that name")
+                || lower.contains("parish face")
+                || lower.contains("comes to mind"),
             "result should be a non-recognition decline: {result:?}"
         );
     }
@@ -5608,6 +5724,54 @@ mod tests {
         );
     }
 
+    #[test]
+    fn stock_nonrecognition_polish_replaces_old_person_template() {
+        let dialogue = "I know no one by that name in these parts.";
+        let result = guard_stock_nonrecognition_decline(
+            dialogue,
+            "Have you met Sorcha O'Malley from beyond the parish?",
+            0,
+        );
+        assert_ne!(result, dialogue, "old stock template must be replaced");
+        assert!(
+            !result
+                .to_lowercase()
+                .contains("i know no one by that name in these parts"),
+            "replacement must not reuse the stale template: {result:?}"
+        );
+    }
+
+    #[test]
+    fn stock_nonrecognition_polish_uses_place_decline_for_place_prompt() {
+        let dialogue = "Mayhap ye have the wrong parish entirely.";
+        let result = guard_stock_nonrecognition_decline(dialogue, "Where is Silver Bridge?", 0);
+        assert_ne!(result, dialogue, "old place template must be replaced");
+        assert!(
+            result.to_lowercase().contains("place")
+                || result.to_lowercase().contains("road")
+                || result.to_lowercase().contains("point you"),
+            "place prompt should receive a place-shaped decline: {result:?}"
+        );
+    }
+
+    #[test]
+    fn time_of_day_phrase_guard_corrects_midday_morning_tic() {
+        let dialogue = "Good morning to ye. What brings ye in this fine morning?";
+        let result = guard_time_of_day_phrase(dialogue, TimeOfDay::Midday);
+        assert_eq!(result, "Good day to ye. What brings ye in this fine day?");
+        assert!(
+            !result.to_lowercase().contains("morn"),
+            "midday greeting must not retain morning wording: {result:?}"
+        );
+    }
+
+    #[test]
+    fn time_of_day_phrase_guard_leaves_actual_morning_alone() {
+        let dialogue = "Good morning to ye. What brings ye in this fine morning?";
+        let result = guard_time_of_day_phrase(dialogue, TimeOfDay::Morning);
+        assert_eq!(result, dialogue);
+    }
+
     // ── #1530 — invented place confirmation guard ──────────────────────────────
 
     fn make_locations(locs: &[&str]) -> Vec<String> {
@@ -5872,7 +6036,10 @@ mod tests {
         assert!(
             result.to_lowercase().contains("no such person")
                 || result.to_lowercase().contains("no one by that name")
-                || result.to_lowercase().contains("wrong parish"),
+                || result.to_lowercase().contains("wrong parish")
+                || result.to_lowercase().contains("that name")
+                || result.to_lowercase().contains("parish face")
+                || result.to_lowercase().contains("comes to mind"),
             "expected a person non-recognition decline, got: {result:?}"
         );
     }

--- a/parish/testing/fixtures/play_fix-1564-dialogue-polish.txt
+++ b/parish/testing/fixtures/play_fix-1564-dialogue-polish.txt
@@ -1,0 +1,28 @@
+# fix-1564-dialogue-polish
+# Repro: polish guarded fallback dialogue, time-of-day wording, and direct
+# feedback for addressed-but-absent NPCs.
+
+# Move to midday and anchor the clock before testing time-sensitive dialogue.
+/wait 240
+/time
+
+# At midday, a stubbed reply that says "morning" should be corrected before it
+# reaches the visible dialogue.
+go to Darcy's Pub
+/npcs
+/stub Padraig Darcy: Good morning to ye, mo chara. What brings ye in this fine morning?
+talk to Padraig Darcy about Good day, what is the news?
+
+# Repeated guarded unknown-entity declines should not repeat the old canned
+# templates verbatim across turns.
+/stub Padraig Darcy: I know no one by that name in these parts.
+talk to Padraig Darcy about Have you met Sorcha O'Malley from beyond the parish?
+
+/stub Padraig Darcy: Mayhap ye have the wrong parish entirely.
+talk to Padraig Darcy about Where is Silver Bridge?
+
+# Maire is scheduled at The Forge at midday. From Darcy's Pub she is a known
+# parish NPC but absent here, so addressing her should produce explicit
+# non-empty feedback instead of silence or fallback routing to Padraig.
+/debug here
+talk to Maire Gallagher about the price of flour


### PR DESCRIPTION
## Summary

- Add a default-on `dialogue-polish-guard` that rewrites the old stock non-recognition templates into varied person/place declines.
- Correct obvious morning greeting tics when the world clock is not Morning, wired through shared live turns, headless, and the deterministic harness.
- Add a #1564 live fixture and regression coverage for stock decline polish, Midday wording, and addressed-absent NPC feedback.

Closes #1564

## Verification

- `cargo fmt --manifest-path parish/Cargo.toml --all`
- `cargo test --manifest-path parish/Cargo.toml -p parish-npc polish -- --nocapture`
- `cargo test --manifest-path parish/Cargo.toml -p parish-npc time_of_day_phrase -- --nocapture`
- `cargo test --manifest-path parish/Cargo.toml -p parish-npc fabricated -- --nocapture`
- `cargo test --manifest-path parish/Cargo.toml -p parish-engine canned_npc_response_polishes_stock_declines_and_midday_morning_tic -- --nocapture`
- `cargo test --manifest-path parish/Cargo.toml -p parish-engine test_canned_npc_response -- --nocapture`
- `cargo test --manifest-path parish/Cargo.toml -p parish-engine --test runaway_generation_guards real_loop_invented_titled_landlord_hearsay_is_declined -- --nocapture`
- `cargo run --quiet --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1564-dialogue-polish.txt`
- `just agent-check`
- `just check`

<!-- parish-proof-bundle:fix-1564-dialogue-polish v=1 -->

## Proof: fix-1564-dialogue-polish

### Acceptance criteria

# Acceptance Criteria: fix-1564-dialogue-polish

## Task

Fix the dialogue-polish cluster from issue #1564 so guarded dialogue declines
stay in-world and varied, NPC time-of-day phrasing does not say morning at
midday, and directly addressing a known-but-absent NPC produces clear feedback
instead of an empty exchange.

## Criteria

- Guard-generated unknown-person/place declines do not emit the exact canned
  templates `I know no one by that name in these parts` or
  `Mayhap ye have the wrong parish entirely` — observable via the fixture's
  stubbed unknown-entity dialogue turns.
- Repeated guarded declines in the same script are not identical verbatim for
  different unknown-entity prompts — observable via two separate stubbed turns.
- A dialogue reply generated at Midday must not surface `morn`, `morning`, or
  `this fine morning`; it should use a neutral or midday/afternoon-compatible
  time phrase — observable via the fixture's Midday `/time` anchor and stubbed
  response containing morning wording.
- Directly addressing Maire Gallagher while she is absent from the player's
  current location returns a non-empty system response naming her as not present,
  and does not route the line to another nearby NPC — observable via the
  fixture's `/debug here` anchor and addressed dialogue turn.

## Verification script

Run: `cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1564-dialogue-polish.txt`

Expected signals in output:

- The two unknown-entity `npc_response.dialogue` strings are non-empty, not
  identical, and do not contain the two canned template strings above.
- The Midday `npc_response.dialogue` does not contain `morn` or `morning`.
- The absent-Maire command returns a non-empty `system_command` response such as
  `Maire Gallagher is not here.`

### Evidence

Evidence type: live gameplay transcript

# Evidence: fix-1564-dialogue-polish

Source transcript: `.proofs/fix-1564-dialogue-polish/transcript.txt`
Captured by: `cargo run --quiet --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1564-dialogue-polish.txt`

## Criterion → transcript mapping

- **Stock templates are not emitted for unknown declines** — transcript lines 7-10 show raw stubs containing `I know no one by that name in these parts` and `Mayhap ye have the wrong parish entirely`, followed by visible replies `I cannot put a parish face to that name.` and `That place-name is not one I have heard hereabouts.`
- **Repeated guarded declines differ for different unknown-entity prompts** — transcript lines 8 and 10 show two distinct visible replies: one person-shaped decline and one place-shaped decline.
- **Midday dialogue does not surface morning wording** — transcript lines 1-2 anchor the clock at `12:00 Midday`; line 5 stubs a morning tic; line 6 shows visible dialogue `Good day to ye, mo chara. What brings ye in this fine day?`
- **Absent Maire receives explicit feedback** — transcript line 11 shows Darcy's Pub contains Niamh Darcy and Padraig Darcy, not Maire Gallagher; line 12 returns `Maire Gallagher is not here.`

### Transcript

```text
{"command":"/wait 240","result":"system_command","response":"You wait for 240 minutes...\nIt is now 12:00 Midday.","location":"Kilteevan Village","time":"Midday","season":"Spring","new_log_lines":["You wait for 240 minutes...\nIt is now 12:00 Midday."]}
{"command":"/time","result":"system_command","response":"12:00 Midday — Spring\nWeather: Clear\nSpeed: 36x\nFestival: none","location":"Kilteevan Village","time":"Midday","season":"Spring","new_log_lines":["12:00 Midday — Spring\nWeather: Clear\nSpeed: 36x\nFestival: none"]}
{"command":"go to Darcy's Pub","result":"moved","to":"Darcy's Pub","minutes":14,"narration":"You set off along the road north past low fields to the crossroads toward Darcy's Pub. (14 minutes on foot)","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["You set off along the road north past low fields to the crossroads toward Darcy's Pub. (14 minutes on foot)","","The warm interior of Darcy's Pub. Turf smoke hangs in the air. Old prints of hurling matches line the walls beside a faded map of the county. A fiddle sits propped in the corner. It is midday and the weather outside is clear.\nYou can go to: The Crossroads (1 min on foot)","  · A man on a cart passes, muttering something to his horse."]}
{"command":"/npcs","result":"system_command","response":"NPCs here:\n  a young woman — Publican's Daughter (restless)\n  an older man behind the bar — Publican (content)","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["NPCs here:\n  a young woman — Publican's Daughter (restless)\n  an older man behind the bar — Publican (content)"]}
{"command":"/stub Padraig Darcy: Good morning to ye, mo chara. What brings ye in this fine morning?","result":"system_command","response":"Stubbed response for Padraig Darcy: \"Good morning to ye, mo chara. What brings ye in this fine morning?\"","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["Stubbed response for Padraig Darcy: \"Good morning to ye, mo chara. What brings ye in this fine morning?\""]}
{"command":"talk to Padraig Darcy about Good day, what is the news?","result":"npc_response","npc":"Padraig Darcy","dialogue":"Good day to ye, mo chara. What brings ye in this fine day?","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["Padraig Darcy: Good day to ye, mo chara. What brings ye in this fine day?","Niamh Darcy 😊","Padraig Darcy 👀"]}
{"command":"/stub Padraig Darcy: I know no one by that name in these parts.","result":"system_command","response":"Stubbed response for Padraig Darcy: \"I know no one by that name in these parts.\"","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["Stubbed response for Padraig Darcy: \"I know no one by that name in these parts.\""]}
{"command":"talk to Padraig Darcy about Have you met Sorcha O'Malley from beyond the parish?","result":"npc_response","npc":"Padraig Darcy","dialogue":"I cannot put a parish face to that name.","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["Padraig Darcy: I cannot put a parish face to that name."]}
{"command":"/stub Padraig Darcy: Mayhap ye have the wrong parish entirely.","result":"system_command","response":"Stubbed response for Padraig Darcy: \"Mayhap ye have the wrong parish entirely.\"","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["Stubbed response for Padraig Darcy: \"Mayhap ye have the wrong parish entirely.\""]}
{"command":"talk to Padraig Darcy about Where is Silver Bridge?","result":"npc_response","npc":"Padraig Darcy","dialogue":"That place-name is not one I have heard hereabouts.","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["Padraig Darcy: That place-name is not one I have heard hereabouts."]}
{"command":"/debug here","result":"system_command","response":"[DEBUG HERE]\n  Darcy's Pub (id: 2)\n  Indoor: true | Public: true\n  NPCs:\n    Niamh Darcy 😟 [restless] (Tier1)\n    Padraig Darcy 🙂 [content] (Tier1)\n  Exits:\n    -> The Crossroads (1min)","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["[DEBUG HERE]","  Darcy's Pub (id: 2)","  Indoor: true | Public: true","  NPCs:","    Niamh Darcy 😟 [restless] (Tier1)","    Padraig Darcy 🙂 [content] (Tier1)","  Exits:","    -> The Crossroads (1min)"]}
{"command":"talk to Maire Gallagher about the price of flour","result":"system_command","response":"Maire Gallagher is not here.","location":"Darcy's Pub","time":"Midday","season":"Spring","new_log_lines":["Maire Gallagher is not here."]}
```

### Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

# Judge: fix-1564-dialogue-polish

## Per-criterion verification

- **Stock templates are not emitted for unknown declines**: lines 8 and 10 replace the raw old templates with `I cannot put a parish face to that name.` and `That place-name is not one I have heard hereabouts.`
- **Repeated guarded declines differ for different unknown-entity prompts**: line 8 and line 10 are visibly different and typed to person/place prompts.
- **Midday dialogue does not surface morning wording**: lines 1-2 establish Midday; line 6 contains `Good day` and `this fine day`, with no `morn` substring in the visible dialogue.
- **Absent Maire receives explicit feedback**: line 11 lists only Niamh and Padraig at Darcy's Pub; line 12 returns the non-empty system response `Maire Gallagher is not here.`

## Implementation notes

The absent-Maire path was already correct in the headless fixture and is retained as regression coverage. The code change is scoped to default-on post-generation polish guards for stale decline templates and obvious time-of-day greeting tics.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:fix-1564-dialogue-polish -->
