### PR TITLE
fix: preserve shopkeeper voice for unknown-name declines

### DIFF
--- a/parish/crates/parish-core/src/game_loop/npc_turn.rs
+++ b/parish/crates/parish-core/src/game_loop/npc_turn.rs
@@ -172,6 +172,7 @@ pub async fn run_npc_turn(
         dialogue_polish_guard_enabled,
         post_guard_ui_replace_enabled,
         relationship_tone_hints,
+        speaker_context,
     ) = {
         let mut world = ctx.world.lock().await;
         let mut npc_manager = ctx.npc_manager.lock().await;
@@ -236,6 +237,14 @@ pub async fn run_npc_turn(
             &npc_cfg,
         );
         let relationship_tone_hints = npc_manager.relationship_tone_hints(speaker_id);
+        let speaker_context =
+            npc_manager
+                .get(speaker_id)
+                .map(|npc| crate::npc::DialogueSpeakerContext {
+                    name: npc.name.clone(),
+                    occupation: npc.occupation.clone(),
+                    mood: npc.mood.clone(),
+                });
         let time_of_day = world.clock.time_of_day();
         (
             setup,
@@ -254,6 +263,7 @@ pub async fn run_npc_turn(
             dialogue_polish_guard,
             ui_replace,
             relationship_tone_hints,
+            speaker_context,
         )
     };
     let setup = setup?;
@@ -535,12 +545,13 @@ pub async fn run_npc_turn(
     if false_denial_guard_enabled && !parsed.dialogue.trim().is_empty() {
         // both_guards_seed is always Some here (guard enabled + dialogue non-empty).
         let guard_seed = both_guards_seed.unwrap_or(0);
-        let guarded = crate::npc::guard_false_denial_of_roster_person(
+        let guarded = crate::npc::guard_false_denial_of_roster_person_with_speaker(
             &parsed.dialogue,
             prompt_input,
             &setup.known_person_names,
             setup.player_name.as_deref(),
             guard_seed,
+            speaker_context.as_ref(),
         );
         if guarded != parsed.dialogue {
             parsed.dialogue = guarded;
@@ -587,10 +598,11 @@ pub async fn run_npc_turn(
     // false-denial corrections win before generic polish.
     if dialogue_polish_guard_enabled && !parsed.dialogue.trim().is_empty() {
         let guard_seed = both_guards_seed.unwrap_or(0);
-        let guarded = crate::npc::guard_stock_nonrecognition_decline(
+        let guarded = crate::npc::guard_stock_nonrecognition_decline_with_speaker(
             &parsed.dialogue,
             prompt_input,
             guard_seed,
+            speaker_context.as_ref(),
         );
         if guarded != parsed.dialogue {
             parsed.dialogue = guarded;

--- a/parish/crates/parish-engine/src/headless.rs
+++ b/parish/crates/parish-engine/src/headless.rs
@@ -817,6 +817,14 @@ fn apply_npc_response(
     // so we pass &[] — the pronoun follow-up guard is conservative and will
     // only fire when prior_player_inputs is non-empty.
     let cfg = parish_core::config::NpcConfig::default();
+    let speaker_context =
+        app.npc_manager
+            .get(npc_id)
+            .map(|npc| crate::npc::DialogueSpeakerContext {
+                name: npc.name.clone(),
+                occupation: npc.occupation.clone(),
+                mood: npc.mood.clone(),
+            });
     if cfg.person_confirmation_guard_enabled && !parsed.dialogue.trim().is_empty() {
         let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
         let guarded = crate::npc::guard_fabricated_person_confirmation_with_locations(
@@ -836,12 +844,13 @@ fn apply_npc_response(
         && !parsed.dialogue.trim().is_empty()
     {
         let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
-        let guarded = crate::npc::guard_false_denial_of_roster_person(
+        let guarded = crate::npc::guard_false_denial_of_roster_person_with_speaker(
             &parsed.dialogue,
             player_input,
             known_person_names,
             player_name,
             seed,
+            speaker_context.as_ref(),
         );
         if guarded != parsed.dialogue {
             parsed.dialogue = guarded;
@@ -876,8 +885,12 @@ fn apply_npc_response(
         && !parsed.dialogue.trim().is_empty()
     {
         let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
-        let guarded =
-            crate::npc::guard_stock_nonrecognition_decline(&parsed.dialogue, player_input, seed);
+        let guarded = crate::npc::guard_stock_nonrecognition_decline_with_speaker(
+            &parsed.dialogue,
+            player_input,
+            seed,
+            speaker_context.as_ref(),
+        );
         if guarded != parsed.dialogue {
             parsed.dialogue = guarded;
         }

--- a/parish/crates/parish-engine/src/testing.rs
+++ b/parish/crates/parish-engine/src/testing.rs
@@ -553,6 +553,15 @@ impl GameTestHarness {
             .map(|location| location.name.clone())
             .collect();
         let seed = npc_id.0 as u64 ^ (game_time.timestamp() as u64);
+        let speaker_context =
+            self.app
+                .npc_manager
+                .get(npc_id)
+                .map(|npc| crate::npc::DialogueSpeakerContext {
+                    name: npc.name.clone(),
+                    occupation: npc.occupation.clone(),
+                    mood: npc.mood.clone(),
+                });
 
         if cfg.person_confirmation_guard_enabled {
             guarded = crate::npc::guard_fabricated_person_confirmation_with_locations(
@@ -571,12 +580,13 @@ impl GameTestHarness {
             .flags
             .is_disabled(crate::npc::FALSE_DENIAL_GUARD_FLAG)
         {
-            guarded = crate::npc::guard_false_denial_of_roster_person(
+            guarded = crate::npc::guard_false_denial_of_roster_person_with_speaker(
                 &guarded,
                 player_input,
                 &known_person_names,
                 self.app.world.player_name.as_deref(),
                 seed,
+                speaker_context.as_ref(),
             );
             guarded = crate::npc::guard_false_denial_of_known_place(
                 &guarded,
@@ -604,7 +614,12 @@ impl GameTestHarness {
             .flags
             .is_disabled(crate::npc::DIALOGUE_POLISH_GUARD_FLAG)
         {
-            guarded = crate::npc::guard_stock_nonrecognition_decline(&guarded, player_input, seed);
+            guarded = crate::npc::guard_stock_nonrecognition_decline_with_speaker(
+                &guarded,
+                player_input,
+                seed,
+                speaker_context.as_ref(),
+            );
             guarded =
                 crate::npc::guard_time_of_day_phrase(&guarded, self.app.world.clock.time_of_day());
             guarded = crate::npc::guard_priest_tenure_drift(&guarded, player_input);
@@ -2203,6 +2218,41 @@ mod tests {
         assert_ne!(
             person_dialogue, place_dialogue,
             "different unknown-entity prompts should not collapse to one reply"
+        );
+    }
+
+    #[test]
+    fn canned_shopkeeper_stock_decline_keeps_nonrecognition_voice() {
+        let mut h = GameTestHarness::new();
+        let moved = h.execute("go to Connolly's Shop");
+        assert!(matches!(moved, ActionResult::Moved { .. }), "{moved:?}");
+
+        h.add_canned_response(
+            "Roisin Connolly",
+            "That name is not known to me hereabouts.",
+        );
+        let result = h.execute("talk to Roisin Connolly about Martin");
+        let ActionResult::NpcResponse { npc, dialogue, .. } = result else {
+            panic!("expected Roisin to answer through the canned NPC path, got {result:?}");
+        };
+
+        assert_eq!(npc, "Roisin Connolly");
+        let lower = dialogue.to_lowercase();
+        assert!(
+            lower.contains("counter")
+                || lower.contains("shop")
+                || lower.contains("account")
+                || lower.contains("goods")
+                || lower.contains("trade"),
+            "shopkeeper decline should carry trade voice: {dialogue:?}"
+        );
+        assert!(
+            !lower.contains("aye, i know the name"),
+            "stock non-recognition must not be flipped into an affirmation: {dialogue:?}"
+        );
+        assert!(
+            !lower.contains("that name is not known to me hereabouts"),
+            "reported generic stock phrase must not surface unchanged: {dialogue:?}"
         );
     }
 

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -411,6 +411,48 @@ fn non_recognition_decline(seed: u64) -> &'static str {
     DECLINES[(seed as usize) % DECLINES.len()]
 }
 
+/// Minimal speaker context used by deterministic dialogue polish guards.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DialogueSpeakerContext {
+    /// Speaker's display/roster name.
+    pub name: String,
+    /// Speaker's current occupation or role.
+    pub occupation: String,
+    /// Speaker's current mood label.
+    pub mood: String,
+}
+
+impl DialogueSpeakerContext {
+    fn is_shopkeeper(&self) -> bool {
+        self.occupation.to_lowercase().contains("shopkeeper")
+    }
+}
+
+fn shopkeeper_non_recognition_decline(seed: u64) -> &'static str {
+    const DECLINES: &[&str] = &[
+        "I keep a sharp account at this counter, and that is not a name I can place.",
+        "No account in this shop comes to mind for that name.",
+        "I know the names that cross my counter, and that one has not passed it.",
+        "If that name trades in this parish, it has not crossed my counter.",
+        "No order, debt, or bag of goods brings that name to mind.",
+    ];
+    DECLINES[(seed as usize) % DECLINES.len()]
+}
+
+fn non_recognition_decline_for_speaker(
+    seed: u64,
+    speaker: Option<&DialogueSpeakerContext>,
+) -> &'static str {
+    if speaker
+        .map(DialogueSpeakerContext::is_shopkeeper)
+        .unwrap_or(false)
+    {
+        return shopkeeper_non_recognition_decline(seed);
+    }
+
+    non_recognition_decline(seed)
+}
+
 /// Denial markers used by both the affirmation check and the pronoun-referent
 /// check. If any of these appear in the dialogue the NPC is already declining —
 /// the guard must not fire.
@@ -3133,6 +3175,30 @@ pub fn guard_false_denial_of_roster_person(
     player_name: Option<&str>,
     seed: u64,
 ) -> String {
+    guard_false_denial_of_roster_person_with_speaker(
+        dialogue,
+        player_input,
+        known_person_names,
+        player_name,
+        seed,
+        None,
+    )
+}
+
+/// Speaker-aware variant of [`guard_false_denial_of_roster_person`].
+///
+/// In command text like `talk to Roisin Connolly about Martin`, the addressed
+/// NPC's own full name is present in the input but is not the subject being
+/// denied. This variant ignores that addressed-speaker candidate when an
+/// explicit `about ...` topic names someone else.
+pub fn guard_false_denial_of_roster_person_with_speaker(
+    dialogue: &str,
+    player_input: &str,
+    known_person_names: &[String],
+    player_name: Option<&str>,
+    seed: u64,
+    speaker: Option<&DialogueSpeakerContext>,
+) -> String {
     if dialogue.trim().is_empty() {
         return dialogue.to_string();
     }
@@ -3152,6 +3218,14 @@ pub fn guard_false_denial_of_roster_person(
     for candidate in &candidates {
         // Only fire for full names (multi-word) that ARE in the roster.
         if candidate.split_whitespace().count() < 2 {
+            continue;
+        }
+        if speaker
+            .map(|speaker| {
+                addressed_speaker_candidate_is_not_topic(candidate, player_input, speaker)
+            })
+            .unwrap_or(false)
+        {
             continue;
         }
         if !name_in_roster(candidate, known_person_names, player_name) {
@@ -3180,6 +3254,27 @@ pub fn guard_false_denial_of_roster_person(
     }
 
     dialogue.to_string()
+}
+
+fn addressed_speaker_candidate_is_not_topic(
+    candidate: &str,
+    player_input: &str,
+    speaker: &DialogueSpeakerContext,
+) -> bool {
+    let candidate_norm = normalize_for_repetition(candidate);
+    let speaker_norm = normalize_for_repetition(&speaker.name);
+    if candidate_norm.is_empty() || candidate_norm != speaker_norm {
+        return false;
+    }
+
+    let input = normalize_for_repetition(player_input);
+    let Some((address, topic)) = input.split_once(" about ") else {
+        return false;
+    };
+
+    let addressed = address.contains(&speaker_norm);
+    let topic_mentions_speaker = topic.contains(&speaker_norm);
+    addressed && !topic.trim().is_empty() && !topic_mentions_speaker
 }
 
 // ── #1530 — invented place confirmation guard ──────────────────────────────────
@@ -3234,6 +3329,7 @@ fn non_recognition_place_decline(seed: u64) -> &'static str {
 }
 
 const STOCK_NONRECOGNITION_TEMPLATES: &[&str] = &[
+    "that name is not known to me hereabouts",
     "i know no one by that name in these parts",
     "mayhap ye have the wrong parish entirely",
 ];
@@ -3241,6 +3337,16 @@ const STOCK_NONRECOGNITION_TEMPLATES: &[&str] = &[
 /// Replaces old stock non-recognition templates with the same deterministic
 /// fallback families used by the grounding guards (#1564).
 pub fn guard_stock_nonrecognition_decline(dialogue: &str, player_input: &str, seed: u64) -> String {
+    guard_stock_nonrecognition_decline_with_speaker(dialogue, player_input, seed, None)
+}
+
+/// Speaker-aware variant of [`guard_stock_nonrecognition_decline`].
+pub fn guard_stock_nonrecognition_decline_with_speaker(
+    dialogue: &str,
+    player_input: &str,
+    seed: u64,
+    speaker: Option<&DialogueSpeakerContext>,
+) -> String {
     if dialogue.trim().is_empty() {
         return dialogue.to_string();
     }
@@ -3263,7 +3369,7 @@ pub fn guard_stock_nonrecognition_decline(dialogue: &str, player_input: &str, se
     }
 
     tracing::warn!("dialogue polish guard fired: replacing stock person non-recognition (#1564)");
-    non_recognition_decline(prompt_seed).to_string()
+    non_recognition_decline_for_speaker(prompt_seed, speaker).to_string()
 }
 
 fn normalized_alpha_words(text: &str) -> Vec<String> {
@@ -6078,6 +6184,56 @@ mod tests {
     }
 
     #[test]
+    fn false_denial_guard_ignores_addressed_speaker_when_topic_differs() {
+        let known = make_names(&["Roisin Connolly", "Peig Hannigan"]);
+        let speaker = DialogueSpeakerContext {
+            name: "Roisin Connolly".to_string(),
+            occupation: "Shopkeeper".to_string(),
+            mood: "alert".to_string(),
+        };
+        let dialogue = "That name is not known to me hereabouts.";
+        let result = guard_false_denial_of_roster_person_with_speaker(
+            dialogue,
+            "talk to Roisin Connolly about Martin",
+            &known,
+            None,
+            0,
+            Some(&speaker),
+        );
+        assert_eq!(
+            result, dialogue,
+            "speaker addressee must not be mistaken for the denied topic"
+        );
+    }
+
+    #[test]
+    fn false_denial_guard_still_fires_for_known_topic_with_speaker_context() {
+        let known = make_names(&["Roisin Connolly", "Peig Hannigan"]);
+        let speaker = DialogueSpeakerContext {
+            name: "Roisin Connolly".to_string(),
+            occupation: "Shopkeeper".to_string(),
+            mood: "alert".to_string(),
+        };
+        let dialogue = "That name is not known to me hereabouts.";
+        let result = guard_false_denial_of_roster_person_with_speaker(
+            dialogue,
+            "talk to Roisin Connolly about Peig Hannigan",
+            &known,
+            None,
+            0,
+            Some(&speaker),
+        );
+        assert_ne!(
+            result, dialogue,
+            "known topic must still be corrected even when the speaker is addressed"
+        );
+        assert!(
+            result.to_lowercase().contains("known") || result.to_lowercase().contains("parish"),
+            "known-person acknowledgement should survive: {result:?}"
+        );
+    }
+
+    #[test]
     fn stock_nonrecognition_polish_replaces_old_person_template() {
         let dialogue = "I know no one by that name in these parts.";
         let result = guard_stock_nonrecognition_decline(
@@ -6091,6 +6247,33 @@ mod tests {
                 .to_lowercase()
                 .contains("i know no one by that name in these parts"),
             "replacement must not reuse the stale template: {result:?}"
+        );
+    }
+
+    #[test]
+    fn stock_nonrecognition_polish_uses_shopkeeper_voice_when_available() {
+        let speaker = DialogueSpeakerContext {
+            name: "Roisin Connolly".to_string(),
+            occupation: "Shopkeeper".to_string(),
+            mood: "alert".to_string(),
+        };
+        let dialogue = "That name is not known to me hereabouts.";
+        let result = guard_stock_nonrecognition_decline_with_speaker(
+            dialogue,
+            "talk to Roisin Connolly about Martin",
+            0,
+            Some(&speaker),
+        );
+        let lower = result.to_lowercase();
+
+        assert_ne!(result, dialogue, "reported stock phrase must be replaced");
+        assert!(
+            lower.contains("counter")
+                || lower.contains("shop")
+                || lower.contains("account")
+                || lower.contains("goods")
+                || lower.contains("trade"),
+            "replacement should sound like a shopkeeper: {result:?}"
         );
     }
 

--- a/parish/testing/fixtures/play_fix-1518-shopkeeper-grounding-voice.txt
+++ b/parish/testing/fixtures/play_fix-1518-shopkeeper-grounding-voice.txt
@@ -1,0 +1,7 @@
+# fix-1518-shopkeeper-grounding-voice
+# Repro: a model/canned response emits the generic unknown-name decline.
+# The polish layer should keep the denial but recast it in Roisin's shopkeeper voice.
+
+go to Connolly's Shop
+/stub Roisin Connolly: That name is not known to me hereabouts.
+talk to Roisin Connolly about Martin


### PR DESCRIPTION
## Summary

- keep the false-denial guard from treating the addressed NPC's own name as the denied topic in `talk to <npc> about <topic>` commands
- add speaker-aware stock non-recognition declines so Roisin's shopkeeper path uses trade/counter wording
- cover the helper edge cases, harness canned-response path, and live script fixture

Fixes #1518.

## Verification

- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc stock_nonrecognition`
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc false_denial_guard`
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine canned_shopkeeper_stock_decline_keeps_nonrecognition_voice`
- `rtk cargo run --quiet --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1518-shopkeeper-grounding-voice.txt`
- `rtk just agent-check`
- `rtk just check`

<!-- parish-proof-bundle:fix-1518-shopkeeper-grounding-voice v=1 -->

## Proof: fix-1518-shopkeeper-grounding-voice

### Acceptance criteria

# Acceptance Criteria: fix-1518-shopkeeper-grounding-voice

## Task

When Roisin Connolly declines to confirm an unknown person via the grounding or
stock non-recognition recovery path, the replacement line should stay correct
while sounding like an alert shopkeeper rather than a generic system fallback.

## Criteria

- Asking Roisin Connolly about unknown `Martin` still produces a non-recognition decline instead of affirming or locating Martin — observable via: `play_fix-1518-shopkeeper-grounding-voice.txt`.
- Roisin's recovered decline uses shopkeeper/trade-aware wording, such as counter, shop, ledger, shelves, goods, account, or trade — observable via: `play_fix-1518-shopkeeper-grounding-voice.txt`.
- The old generic stock phrase `That name is not known to me hereabouts.` does not surface for Roisin's shopkeeper decline — observable via: `play_fix-1518-shopkeeper-grounding-voice.txt`.

## Verification script

Run: `cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1518-shopkeeper-grounding-voice.txt`

Expected signals in output:

- The final command returns an `npc_response` from `Roisin Connolly`.
- The dialogue denies knowledge of `Martin` without confirming or locating him.
- The dialogue contains shopkeeper/trade voice cues and does not contain `That name is not known to me hereabouts.`

### Evidence

# Evidence: fix-1518-shopkeeper-grounding-voice

Evidence type: live gameplay transcript

Command run:

`rtk cargo run --quiet --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1518-shopkeeper-grounding-voice.txt`

Transcript: `.proofs/fix-1518-shopkeeper-grounding-voice/transcript.txt`

## Criteria Mapping

- Non-recognition decline: transcript line 3 returns `result:"npc_response"` from `npc:"Roisin Connolly"` with dialogue `If that name trades in this parish, it has not crossed my counter.` The line does not affirm Martin or locate him.
- Shopkeeper/trade-aware wording: transcript line 3 includes `trades` and `counter`, matching the requested shopkeeper voice cues.
- Generic stock phrase removed: transcript line 2 stubs `That name is not known to me hereabouts.`, while transcript line 3 returns the replaced shopkeeper line and does not surface the old generic phrase.

### Transcript

```text
{"command":"go to Connolly's Shop","result":"moved","to":"Connolly's Shop","minutes":14,"narration":"You set off along the road north past low fields to the crossroads toward Connolly's Shop. (14 minutes on foot)","location":"Connolly's Shop","time":"Morning","season":"Spring","new_log_lines":["You set off along the road north past low fields to the crossroads toward Connolly's Shop. (14 minutes on foot)","","A farmer nods to you from the far side of a gate as you pass.","A small general shop crammed with everything from spades and tallow candles to bolts of cloth and bags of meal. The bell above the door jangles. It is morning. Outside, the weather is clear.\nYou can go to: The Crossroads (1 min on foot)"]}
{"command":"/stub Roisin Connolly: That name is not known to me hereabouts.","result":"system_command","response":"Stubbed response for Roisin Connolly: \"That name is not known to me hereabouts.\"","location":"Connolly's Shop","time":"Morning","season":"Spring","new_log_lines":["Stubbed response for Roisin Connolly: \"That name is not known to me hereabouts.\""]}
{"command":"talk to Roisin Connolly about Martin","result":"npc_response","npc":"Roisin Connolly","dialogue":"If that name trades in this parish, it has not crossed my counter.","location":"Connolly's Shop","time":"Morning","season":"Spring","new_log_lines":["Roisin Connolly: If that name trades in this parish, it has not crossed my counter."]}
```

### Judge

# Judge: fix-1518-shopkeeper-grounding-voice

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

## Review

- Criterion 1 is met: the final transcript line declines to place the queried name and does not affirm or locate Martin.
- Criterion 2 is met: the final line uses shopkeeper/trade language with `trades` and `counter`.
- Criterion 3 is met: the old generic stock phrase appears only as the stubbed input and is not returned as Roisin's dialogue.

No follow-up debt is needed. The change is covered by focused NPC guard tests, a harness regression, and the live script transcript.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:fix-1518-shopkeeper-grounding-voice -->
