### PR TITLE
fix: avoid presuming prior NPC acquaintance

### DIFF
--- a/parish/crates/parish-core/src/game_loop/npc_turn.rs
+++ b/parish/crates/parish-core/src/game_loop/npc_turn.rs
@@ -618,6 +618,16 @@ pub async fn run_npc_turn(
             parsed.dialogue = guarded;
         }
 
+        let guarded = crate::npc::guard_presumed_prior_acquaintance(
+            &parsed.dialogue,
+            prompt_input,
+            &setup.known_person_names,
+            speaker_context.as_ref(),
+        );
+        if guarded != parsed.dialogue {
+            parsed.dialogue = guarded;
+        }
+
         let guarded = crate::npc::guard_rival_target_neutral_tone(
             &parsed.dialogue,
             prompt_input,

--- a/parish/crates/parish-engine/src/testing.rs
+++ b/parish/crates/parish-engine/src/testing.rs
@@ -623,6 +623,12 @@ impl GameTestHarness {
             guarded =
                 crate::npc::guard_time_of_day_phrase(&guarded, self.app.world.clock.time_of_day());
             guarded = crate::npc::guard_priest_tenure_drift(&guarded, player_input);
+            guarded = crate::npc::guard_presumed_prior_acquaintance(
+                &guarded,
+                player_input,
+                &known_person_names,
+                speaker_context.as_ref(),
+            );
             let relationship_tone_hints = self.app.npc_manager.relationship_tone_hints(npc_id);
             guarded = crate::npc::guard_rival_target_neutral_tone(
                 &guarded,
@@ -2276,6 +2282,33 @@ mod tests {
         assert!(
             !lower.contains("that name is not known to me hereabouts"),
             "reported generic stock phrase must not surface unchanged: {dialogue:?}"
+        );
+    }
+
+    #[test]
+    fn canned_npc_response_rewrites_presumed_prior_acquaintance() {
+        let mut h = GameTestHarness::new();
+        let moved = h.execute("go to Connolly's Shop");
+        assert!(matches!(moved, ActionResult::Moved { .. }), "{moved:?}");
+
+        h.add_canned_response(
+            "Roisin Connolly",
+            "Colm Gallagher, aye, he's a bright lad at the forge. How do ye find him so far?",
+        );
+        let result = h.execute("talk to Roisin Connolly about Colm Gallagher");
+        let ActionResult::NpcResponse { npc, dialogue, .. } = result else {
+            panic!("expected Roisin to answer through the canned NPC path, got {result:?}");
+        };
+        let lower = dialogue.to_lowercase();
+
+        assert_eq!(npc, "Roisin Connolly");
+        assert!(
+            lower.contains("have ye met colm gallagher yet"),
+            "guard should ask whether the player has met the target: {dialogue:?}"
+        );
+        assert!(
+            !lower.contains("how do ye find him so far"),
+            "presupposing question must not surface unchanged: {dialogue:?}"
         );
     }
 

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -3524,6 +3524,109 @@ fn player_input_mentions_target(player_input: &str, target_name: &str) -> bool {
         })
 }
 
+fn normalized_person_name_eq(left: &str, right: &str) -> bool {
+    normalize_name_honorifics(&left.to_lowercase())
+        == normalize_name_honorifics(&right.to_lowercase())
+}
+
+fn dialogue_has_presumed_prior_acquaintance_question(dialogue: &str) -> bool {
+    let normalized = normalize_for_repetition(dialogue);
+    const PATTERNS: &[&str] = &[
+        "how do ye find him so far",
+        "how do ye find her so far",
+        "how do ye find them so far",
+        "how do you find him so far",
+        "how do you find her so far",
+        "how do you find them so far",
+    ];
+    PATTERNS.iter().any(|pattern| normalized.contains(pattern))
+}
+
+fn word_is_honorific(word: &str) -> bool {
+    let canonical = canonical_honorific(word);
+    HONORIFIC_PAIRS
+        .iter()
+        .any(|(long, short)| word == *long || word == *short || canonical == *long)
+}
+
+fn strip_honorific_words(text: &str) -> String {
+    normalized_alpha_words(text)
+        .into_iter()
+        .filter(|word| !word_is_honorific(word))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn player_input_asserts_prior_acquaintance(player_input: &str, target_name: &str) -> bool {
+    let normalized = strip_honorific_words(&normalize_for_repetition(player_input));
+    let target_lower =
+        strip_honorific_words(&normalize_name_honorifics(&target_name.to_lowercase()));
+    let first_name = target_lower
+        .split_whitespace()
+        .next()
+        .unwrap_or(target_lower.as_str());
+
+    const CONTACT_PATTERNS: &[&str] = &[
+        "i met ",
+        "i have met ",
+        "i've met ",
+        "i spoke with ",
+        "i talked to ",
+        "i was speaking with ",
+        "i know ",
+    ];
+
+    CONTACT_PATTERNS.iter().any(|prefix| {
+        normalized.contains(&format!("{prefix}{target_lower}"))
+            || normalized.contains(&format!("{prefix}{first_name}"))
+    })
+}
+
+fn prior_acquaintance_checkin(target_name: &str) -> String {
+    format!("{target_name}, aye. Have ye met {target_name} yet?")
+}
+
+/// Rewrites replies that ask the player to evaluate a named parishioner as if
+/// the player has already met them (#1509).
+///
+/// Conservative: only fires when the player mentioned exactly one non-speaker
+/// roster person and the reply contains the narrow "How do ye/you find him/her
+/// so far?" presupposition. If the player's input itself says they met or know
+/// the target, the reply is left unchanged.
+pub fn guard_presumed_prior_acquaintance(
+    dialogue: &str,
+    player_input: &str,
+    known_person_names: &[String],
+    speaker: Option<&DialogueSpeakerContext>,
+) -> String {
+    if dialogue.trim().is_empty()
+        || known_person_names.is_empty()
+        || !dialogue_has_presumed_prior_acquaintance_question(dialogue)
+    {
+        return dialogue.to_string();
+    }
+
+    let targets: Vec<&String> = known_person_names
+        .iter()
+        .filter(|name| {
+            speaker.is_none_or(|speaker| !normalized_person_name_eq(&speaker.name, name))
+                && player_input_mentions_target(player_input, name)
+        })
+        .collect();
+    let [target] = targets.as_slice() else {
+        return dialogue.to_string();
+    };
+    if player_input_asserts_prior_acquaintance(player_input, target) {
+        return dialogue.to_string();
+    }
+
+    tracing::warn!(
+        target = %target,
+        "dialogue polish guard fired: replacing presumed prior-acquaintance question (#1509)"
+    );
+    prior_acquaintance_checkin(target)
+}
+
 fn rival_tone_fallback(target_name: &str) -> String {
     format!(
         "{target_name}, aye. I'll grant the facts, but there is little warmth between us, so I keep my distance."
@@ -6287,6 +6390,79 @@ mod tests {
                 || result.to_lowercase().contains("road")
                 || result.to_lowercase().contains("point you"),
             "place prompt should receive a place-shaped decline: {result:?}"
+        );
+    }
+
+    #[test]
+    fn presumed_prior_acquaintance_guard_rewrites_known_target_checkin() {
+        let known = make_names(&["Roisin Connolly", "Colm Gallagher"]);
+        let speaker = DialogueSpeakerContext {
+            name: "Roisin Connolly".to_string(),
+            occupation: "Shopkeeper".to_string(),
+            mood: "alert".to_string(),
+        };
+        let dialogue =
+            "Colm Gallagher, aye, he's a bright lad at the forge. How do ye find him so far?";
+        let result = guard_presumed_prior_acquaintance(
+            dialogue,
+            "talk to Roisin Connolly about Colm Gallagher",
+            &known,
+            Some(&speaker),
+        );
+        let lower = result.to_lowercase();
+
+        assert_ne!(result, dialogue, "presupposing question must be rewritten");
+        assert!(
+            lower.contains("have ye met colm gallagher yet"),
+            "replacement should ask whether the player has met the target: {result:?}"
+        );
+        assert!(
+            !lower.contains("how do ye find him so far"),
+            "presupposing phrase must not survive: {result:?}"
+        );
+    }
+
+    #[test]
+    fn presumed_prior_acquaintance_guard_leaves_declared_meeting() {
+        let known = make_names(&["Roisin Connolly", "Colm Gallagher"]);
+        let speaker = DialogueSpeakerContext {
+            name: "Roisin Connolly".to_string(),
+            occupation: "Shopkeeper".to_string(),
+            mood: "alert".to_string(),
+        };
+        let dialogue = "How do ye find him so far?";
+
+        assert_eq!(
+            guard_presumed_prior_acquaintance(
+                dialogue,
+                "I met Colm Gallagher at the forge. What do you think of him?",
+                &known,
+                Some(&speaker),
+            ),
+            dialogue,
+            "current-turn evidence that the player met the target must pass through"
+        );
+    }
+
+    #[test]
+    fn presumed_prior_acquaintance_guard_leaves_declared_meeting_with_honorific_mismatch() {
+        let known = make_names(&["Roisin Connolly", "Colm Gallagher"]);
+        let speaker = DialogueSpeakerContext {
+            name: "Roisin Connolly".to_string(),
+            occupation: "Shopkeeper".to_string(),
+            mood: "alert".to_string(),
+        };
+        let dialogue = "How do ye find him so far?";
+
+        assert_eq!(
+            guard_presumed_prior_acquaintance(
+                dialogue,
+                "I met Fr. Colm Gallagher at the forge. What do you think of Colm Gallagher?",
+                &known,
+                Some(&speaker),
+            ),
+            dialogue,
+            "extra honorific tokens must not hide current-turn meeting evidence"
         );
     }
 

--- a/parish/testing/fixtures/play_fix-1509-presumed-prior-acquaintance.txt
+++ b/parish/testing/fixtures/play_fix-1509-presumed-prior-acquaintance.txt
@@ -1,0 +1,8 @@
+# fix-1509-presumed-prior-acquaintance
+# Repro: an NPC who knows Colm asks the player to evaluate him as if they
+# already met. The polish layer should keep the topic but ask whether the
+# player has met Colm yet.
+
+go to Connolly's Shop
+/stub Roisin Connolly: Colm Gallagher, aye, he's a bright lad at the forge. How do ye find him so far?
+talk to Roisin Connolly about Colm Gallagher


### PR DESCRIPTION
## Summary
- Add a dialogue polish guard for the narrow "How do ye find him so far?" prior-acquaintance presupposition.
- Wire the guard through live NPC turns and the script/canned harness path.
- Add deterministic guard and harness coverage plus a proof fixture.

Fixes #1509.

## Verification
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc presumed_prior_acquaintance`
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine canned_npc_response_rewrites_presumed_prior_acquaintance`
- `rtk cargo run --quiet --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1509-presumed-prior-acquaintance.txt`
- `rtk just agent-check`
- `rtk just check`

<!-- parish-proof-bundle:fix-1509-presumed-prior-acquaintance v=1 -->

## Proof: fix-1509-presumed-prior-acquaintance

### Acceptance criteria

# Acceptance Criteria: fix-1509-presumed-prior-acquaintance

## Task

Prevent NPC dialogue from presuming that the player has already met a named parishioner when the current exchange only establishes that the NPC knows the parishioner. A generated or canned line such as "How do ye find him so far?" should be recast as a non-presupposing check-in, not shown verbatim.

## Criteria

- A dialogue turn about a known NPC whose response asks "How do ye find him so far?" is rewritten to ask whether the player has met that NPC yet — observable via: `talk to Roisin Connolly about Colm Gallagher` after a `/stub` containing the bad phrase.
- The rewritten response does not contain the presupposing phrase "How do ye find him so far?" — observable via: the same script output for the NPC response.
- The dialogue still succeeds as an NPC response from the addressed speaker rather than becoming a system fallback or silent empty turn — observable via: the script output has `result:"npc_response"` and `npc:"Roisin Connolly"`.

## Verification script

Run: `cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1509-presumed-prior-acquaintance.txt`

Expected signals in output:

- The final JSON response has `result:"npc_response"` and `npc:"Roisin Connolly"`.
- The response includes a non-presupposing question such as "Have ye met Colm Gallagher yet?"
- The response does not include "How do ye find him so far?"

### Evidence

Evidence type: live gameplay transcript

# Evidence: fix-1509-presumed-prior-acquaintance

Source transcript: `.proofs/fix-1509-presumed-prior-acquaintance/transcript.txt`
Captured by: `rtk cargo run --quiet --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1509-presumed-prior-acquaintance.txt`

## Criterion -> transcript mapping

- **A dialogue turn about a known NPC whose response asks "How do ye find him so far?" is rewritten to ask whether the player has met that NPC yet** - transcript line 3 shows `dialogue:"Colm Gallagher, aye. Have ye met Colm Gallagher yet?"`.
- **The rewritten response does not contain the presupposing phrase "How do ye find him so far?"** - transcript line 3 contains the final displayed NPC dialogue and omits that phrase; the bad phrase appears only in the `/stub` setup on line 2.
- **The dialogue still succeeds as an NPC response from the addressed speaker rather than becoming a system fallback or silent empty turn** - transcript line 3 has `result:"npc_response"` and `npc:"Roisin Connolly"`.

### Transcript

```text
{"command":"go to Connolly's Shop","result":"moved","to":"Connolly's Shop","minutes":14,"narration":"You set off along the road north past low fields to the crossroads toward Connolly's Shop. (14 minutes on foot)","location":"Connolly's Shop","time":"Morning","season":"Spring","new_log_lines":["You set off along the road north past low fields to the crossroads toward Connolly's Shop. (14 minutes on foot)","","A small general shop crammed with everything from spades and tallow candles to bolts of cloth and bags of meal. The bell above the door jangles. It is morning. Outside, the weather is clear.\nYou can go to: The Crossroads (1 min on foot)"]}
{"command":"/stub Roisin Connolly: Colm Gallagher, aye, he's a bright lad at the forge. How do ye find him so far?","result":"system_command","response":"Stubbed response for Roisin Connolly: \"Colm Gallagher, aye, he's a bright lad at the forge. How do ye find him so far?\"","location":"Connolly's Shop","time":"Morning","season":"Spring","new_log_lines":["Stubbed response for Roisin Connolly: \"Colm Gallagher, aye, he's a bright lad at the forge. How do ye find him so far?\""]}
{"command":"talk to Roisin Connolly about Colm Gallagher","result":"npc_response","npc":"Roisin Connolly","dialogue":"Colm Gallagher, aye. Have ye met Colm Gallagher yet?","location":"Connolly's Shop","time":"Morning","season":"Spring","new_log_lines":["Roisin Connolly: Colm Gallagher, aye. Have ye met Colm Gallagher yet?"]}
```

### Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

# Judge: fix-1509-presumed-prior-acquaintance

## Per-criterion verification

- **Known-NPC presupposition is rewritten**: transcript line 3 shows `Colm Gallagher, aye. Have ye met Colm Gallagher yet?`, which asks whether the player has met Colm instead of asking for an opinion as if they already had.
- **The bad phrase is absent from the displayed reply**: transcript line 3 is the displayed NPC response and does not contain `How do ye find him so far?`; that phrase is present only in the setup stub on line 2.
- **The turn remains a real NPC response**: transcript line 3 has `result:"npc_response"` and `npc:"Roisin Connolly"`.

## Implementation notes

The change is scoped to the existing default-on dialogue polish guard. It adds a narrow post-generation rewrite for the exact prior-acquaintance presupposition and wires it through both live dialogue and script/canned dialogue paths.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:fix-1509-presumed-prior-acquaintance -->
