### PR TITLE
fix: remove duplicate speaker self-reference

### DIFF
--- a/parish/crates/parish-core/src/game_loop/npc_turn.rs
+++ b/parish/crates/parish-core/src/game_loop/npc_turn.rs
@@ -628,6 +628,12 @@ pub async fn run_npc_turn(
             parsed.dialogue = guarded;
         }
 
+        let guarded =
+            crate::npc::guard_repeated_speaker_name(&parsed.dialogue, speaker_context.as_ref());
+        if guarded != parsed.dialogue {
+            parsed.dialogue = guarded;
+        }
+
         let guarded = crate::npc::guard_rival_target_neutral_tone(
             &parsed.dialogue,
             prompt_input,

--- a/parish/crates/parish-engine/src/testing.rs
+++ b/parish/crates/parish-engine/src/testing.rs
@@ -629,6 +629,7 @@ impl GameTestHarness {
                 &known_person_names,
                 speaker_context.as_ref(),
             );
+            guarded = crate::npc::guard_repeated_speaker_name(&guarded, speaker_context.as_ref());
             let relationship_tone_hints = self.app.npc_manager.relationship_tone_hints(npc_id);
             guarded = crate::npc::guard_rival_target_neutral_tone(
                 &guarded,
@@ -2309,6 +2310,31 @@ mod tests {
         assert!(
             !lower.contains("how do ye find him so far"),
             "presupposing question must not surface unchanged: {dialogue:?}"
+        );
+    }
+
+    #[test]
+    fn canned_npc_response_removes_repeated_speaker_name() {
+        let mut h = GameTestHarness::new();
+        h.add_canned_response(
+            "Peig Hannigan",
+            "Ye can call me Peig Hannigan. As for yer question, it's Peig Hannigan ye're speaking to.",
+        );
+        let result = h.execute("talk to Peig Hannigan about your name");
+        let ActionResult::NpcResponse { npc, dialogue, .. } = result else {
+            panic!("expected Peig to answer through the canned NPC path, got {result:?}");
+        };
+        let lower = dialogue.to_lowercase();
+
+        assert_eq!(npc, "Peig Hannigan");
+        assert_eq!(
+            lower.matches("peig hannigan").count(),
+            1,
+            "speaker full name should appear once: {dialogue:?}"
+        );
+        assert!(
+            !lower.contains("it's peig hannigan ye're speaking to"),
+            "redundant self-reference phrase must not surface unchanged: {dialogue:?}"
         );
     }
 

--- a/parish/crates/parish-npc/src/repetition.rs
+++ b/parish/crates/parish-npc/src/repetition.rs
@@ -3627,6 +3627,83 @@ pub fn guard_presumed_prior_acquaintance(
     prior_acquaintance_checkin(target)
 }
 
+fn count_word_sequence(text: &str, phrase: &str) -> usize {
+    let haystack = normalized_alpha_words(text);
+    let needle = normalized_alpha_words(phrase);
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return 0;
+    }
+    haystack
+        .windows(needle.len())
+        .filter(|window| *window == needle.as_slice())
+        .count()
+}
+
+fn sentence_has_redundant_self_name_reference(sentence: &str, speaker_name: &str) -> bool {
+    if !text_contains_word_sequence(sentence, speaker_name) {
+        return false;
+    }
+    let normalized_sentence =
+        normalize_for_repetition(&sentence.replace('\u{2019}', "'")).replace(',', "");
+    let normalized_name = normalize_for_repetition(speaker_name).replace(',', "");
+    [
+        format!("it's {normalized_name} ye're speaking to"),
+        format!("it's {normalized_name} you're speaking to"),
+        format!("it is {normalized_name} ye're speaking to"),
+        format!("it is {normalized_name} you're speaking to"),
+        format!("ye're speaking to {normalized_name}"),
+        format!("you're speaking to {normalized_name}"),
+    ]
+    .iter()
+    .any(|pattern| normalized_sentence.contains(pattern))
+}
+
+/// Removes redundant repeated self-name references within a single reply
+/// (#1508).
+///
+/// Conservative: only fires when the speaker's full name appears more than
+/// once and a later sentence is a clear self-identity formula such as
+/// "it's Peig Hannigan ye're speaking to." The first self-introduction is
+/// preserved.
+pub fn guard_repeated_speaker_name(
+    dialogue: &str,
+    speaker: Option<&DialogueSpeakerContext>,
+) -> String {
+    let Some(speaker) = speaker else {
+        return dialogue.to_string();
+    };
+    if dialogue.trim().is_empty() || count_word_sequence(dialogue, &speaker.name) <= 1 {
+        return dialogue.to_string();
+    }
+
+    let mut saw_speaker_name = false;
+    let mut changed = false;
+    let mut kept = Vec::new();
+    for sentence in split_sentences(dialogue) {
+        let has_speaker_name = text_contains_word_sequence(&sentence, &speaker.name);
+        if saw_speaker_name
+            && has_speaker_name
+            && sentence_has_redundant_self_name_reference(&sentence, &speaker.name)
+        {
+            changed = true;
+            continue;
+        }
+        if has_speaker_name {
+            saw_speaker_name = true;
+        }
+        kept.push(sentence.trim().to_string());
+    }
+
+    if !changed {
+        return dialogue.to_string();
+    }
+    tracing::warn!(
+        speaker = %speaker.name,
+        "dialogue polish guard fired: removing repeated speaker name (#1508)"
+    );
+    kept.join(" ")
+}
+
 fn rival_tone_fallback(target_name: &str) -> String {
     format!(
         "{target_name}, aye. I'll grant the facts, but there is little warmth between us, so I keep my distance."
@@ -6463,6 +6540,73 @@ mod tests {
             ),
             dialogue,
             "extra honorific tokens must not hide current-turn meeting evidence"
+        );
+    }
+
+    #[test]
+    fn repeated_speaker_name_guard_removes_second_self_reference() {
+        let speaker = DialogueSpeakerContext {
+            name: "Peig Hannigan".to_string(),
+            occupation: "Widow".to_string(),
+            mood: "sharp".to_string(),
+        };
+        let dialogue = "Ye can call me Peig Hannigan. As for yer question, it's Peig Hannigan ye're speaking to.";
+        let result = guard_repeated_speaker_name(dialogue, Some(&speaker));
+
+        assert_ne!(
+            result, dialogue,
+            "redundant second self-reference must be removed"
+        );
+        assert_eq!(
+            count_word_sequence(&result, "Peig Hannigan"),
+            1,
+            "speaker full name should appear exactly once: {result:?}"
+        );
+        assert!(
+            !result
+                .to_lowercase()
+                .contains("it's peig hannigan ye're speaking to"),
+            "redundant self-reference phrase must not survive: {result:?}"
+        );
+    }
+
+    #[test]
+    fn repeated_speaker_name_guard_handles_comma_in_self_reference() {
+        let speaker = DialogueSpeakerContext {
+            name: "Peig Hannigan".to_string(),
+            occupation: "Widow".to_string(),
+            mood: "sharp".to_string(),
+        };
+        let dialogue = "Ye can call me Peig Hannigan. As for yer question, it's Peig Hannigan, ye're speaking to.";
+        let result = guard_repeated_speaker_name(dialogue, Some(&speaker));
+
+        assert_eq!(
+            count_word_sequence(&result, "Peig Hannigan"),
+            1,
+            "comma variant should still remove the redundant self-reference: {result:?}"
+        );
+        assert!(
+            !result
+                .to_lowercase()
+                .contains("it's peig hannigan, ye're speaking to"),
+            "comma variant must not surface unchanged: {result:?}"
+        );
+    }
+
+    #[test]
+    fn repeated_speaker_name_guard_leaves_substantive_second_mention() {
+        let speaker = DialogueSpeakerContext {
+            name: "Peig Hannigan".to_string(),
+            occupation: "Widow".to_string(),
+            mood: "sharp".to_string(),
+        };
+        let dialogue =
+            "Ye can call me Peig Hannigan. My mother gave Peig Hannigan that name after her aunt.";
+
+        assert_eq!(
+            guard_repeated_speaker_name(dialogue, Some(&speaker)),
+            dialogue,
+            "non-formulaic second mentions should stay conservative"
         );
     }
 

--- a/parish/testing/fixtures/play_fix-1508-self-name-stated-twice.txt
+++ b/parish/testing/fixtures/play_fix-1508-self-name-stated-twice.txt
@@ -1,0 +1,6 @@
+# fix-1508-self-name-stated-twice
+# Repro: Peig introduces herself, then repeats her own full name in the next
+# sentence. The polish layer should leave one natural self-introduction.
+
+/stub Peig Hannigan: Ye can call me Peig Hannigan. As for yer question, it's Peig Hannigan ye're speaking to.
+talk to Peig Hannigan about your name


### PR DESCRIPTION
## Summary
- Add a dialogue polish guard that removes redundant repeated speaker full-name self-references.
- Wire the guard through live NPC turns and the script/canned harness path.
- Add deterministic guard and harness coverage plus a proof fixture.

Fixes #1508.

## Verification
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-npc repeated_speaker_name`
- `rtk cargo test --manifest-path parish/Cargo.toml -p parish-engine canned_npc_response_removes_repeated_speaker_name`
- `rtk cargo run --quiet --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1508-self-name-stated-twice.txt`
- `rtk just agent-check`
- `rtk just check`

<!-- parish-proof-bundle:fix-1508-self-name-stated-twice v=1 -->

## Proof: fix-1508-self-name-stated-twice

### Acceptance criteria

# Acceptance Criteria: fix-1508-self-name-stated-twice

## Task

Prevent an NPC from stating their own full name twice in one displayed dialogue reply. A first-meeting line may introduce the speaker once, but a follow-on clause like "it's Peig Hannigan ye're speaking to" should be removed or rewritten so the full name is not repeated word-for-word.

## Criteria

- A canned Peig Hannigan response containing `Peig Hannigan` twice is rewritten before display — observable via: `/stub Peig Hannigan: Ye can call me Peig Hannigan. As for yer question, it's Peig Hannigan ye're speaking to.` followed by `talk to Peig Hannigan about your name`.
- The displayed NPC dialogue contains `Peig Hannigan` exactly once — observable via: the final `dialogue` field in the script output.
- The dialogue still succeeds as an `npc_response` from `Peig Hannigan`, not as a system fallback or empty turn — observable via: the final script output has `result:"npc_response"` and `npc:"Peig Hannigan"`.

## Verification script

Run: `cargo run --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1508-self-name-stated-twice.txt`

Expected signals in output:

- The final JSON response has `result:"npc_response"` and `npc:"Peig Hannigan"`.
- The final `dialogue` contains exactly one `Peig Hannigan`.
- The final `dialogue` does not include `it's Peig Hannigan ye're speaking to`.

### Evidence

Evidence type: live gameplay transcript

# Evidence: fix-1508-self-name-stated-twice

Source transcript: `.proofs/fix-1508-self-name-stated-twice/transcript.txt`
Captured by: `rtk cargo run --quiet --manifest-path parish/Cargo.toml -p parish-engine -- --script parish/testing/fixtures/play_fix-1508-self-name-stated-twice.txt`

## Criterion -> transcript mapping

- **A canned Peig Hannigan response containing `Peig Hannigan` twice is rewritten before display** - transcript line 2 shows the displayed `dialogue:"Ye can call me Peig Hannigan."`, not the two-name stub text from line 1.
- **The displayed NPC dialogue contains `Peig Hannigan` exactly once** - transcript line 2 has a single `Peig Hannigan` occurrence in the final `dialogue` field.
- **The dialogue still succeeds as an `npc_response` from `Peig Hannigan`** - transcript line 2 has `result:"npc_response"` and `npc:"Peig Hannigan"`.

### Transcript

```text
{"command":"/stub Peig Hannigan: Ye can call me Peig Hannigan. As for yer question, it's Peig Hannigan ye're speaking to.","result":"system_command","response":"Stubbed response for Peig Hannigan: \"Ye can call me Peig Hannigan. As for yer question, it's Peig Hannigan ye're speaking to.\"","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["Stubbed response for Peig Hannigan: \"Ye can call me Peig Hannigan. As for yer question, it's Peig Hannigan ye're speaking to.\""]}
{"command":"talk to Peig Hannigan about your name","result":"npc_response","npc":"Peig Hannigan","dialogue":"Ye can call me Peig Hannigan.","location":"Kilteevan Village","time":"Morning","season":"Spring","new_log_lines":["Peig Hannigan: Ye can call me Peig Hannigan.","An older man heads off down the road.","A lean, red-haired young man with hard eyes heads off down the road.","A young woman heads off down the road.","An older woman with sharp eyes and herb-stained fingers heads off down the road."]}
```

### Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

# Judge: fix-1508-self-name-stated-twice

## Per-criterion verification

- **Double self-name response is rewritten**: transcript line 2 displays `Ye can call me Peig Hannigan.` instead of the line 1 stub containing two full-name occurrences.
- **Full name appears once**: transcript line 2's final `dialogue` field contains exactly one `Peig Hannigan`.
- **Turn remains a real NPC response**: transcript line 2 has `result:"npc_response"` and `npc:"Peig Hannigan"`.

## Implementation notes

The change is scoped to the existing default-on dialogue polish guard. It preserves the first self-introduction and only drops later sentences that match a redundant self-identity formula.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:fix-1508-self-name-stated-twice -->
