### PR TITLE
docs: revise parish diorama compositor plan

### DIFF
--- a/docs/design/ideas/graphical-world-view.md
+++ b/docs/design/ideas/graphical-world-view.md
@@ -1,10 +1,10 @@
 # Graphical World View — Procedural Pixel Scenes
 
-> Status: Superseded — see [Interactive Parish Diorama](parish-diorama.md) · Updated: 2026-06-12 · [Docs Index](../../index.md)
+> Status: Superseded — see [Interactive Parish Diorama](parish-diorama.md) · Updated: 2026-06-17 · [Docs Index](../../index.md)
 >
-> The AI-curated scene-plate approach in the diorama RFC replaces the
-> procedural sprite/scene generation proposed here; the serving route shapes
-> and scene-panel concept below are carried forward.
+> The runtime-composed diorama RFC incorporates this document's deterministic
+> sprite/scene-composition direction while keeping the newer diorama UX,
+> scene-state, and hotspot contract.
 
 > [Docs Index](../../index.md) · [Architecture Overview](../overview.md) · [GUI Design](../gui-design.md) · [Map Evolution](map-evolution.md) — RFC
 

--- a/docs/design/ideas/parish-diorama.md
+++ b/docs/design/ideas/parish-diorama.md
@@ -1,20 +1,21 @@
-# Interactive Parish Diorama — Scene-Based Graphical Direction
+# Interactive Parish Diorama — Runtime-Composed Graphical Direction
 
-> Status: Proposed · Updated: 2026-06-12 · [Docs Index](../../index.md)
+> Status: Proposed · Updated: 2026-06-17 · [Docs Index](../../index.md)
 
-> [Docs Index](../../index.md) · [Architecture Overview](../overview.md) · [GUI Design](../gui-design.md) · Supersedes: [Graphical World View (pixel scenes)](graphical-world-view.md)
+> [Docs Index](../../index.md) · [Architecture Overview](../overview.md) · [GUI Design](../gui-design.md) · Incorporates: [Graphical World View (pixel scenes)](graphical-world-view.md)
 
 ## Vision
 
-The graphical version of Rundale is an **interactive parish diorama**: a retro,
-scene-based village simulation with Stardew-like visual readability, Myst-like
-click navigation, and the existing living-world NPC simulation underneath.
+The graphical version of Rundale is an **interactive parish diorama**: a
+high-fidelity, retro, scene-based village simulation with Stardew-like visual
+readability, Myst-like click navigation, and the existing living-world NPC
+simulation underneath.
 
 Rather than a continuous tile-based open world, the player sees richly composed
-pixel-art views of meaningful locations in and around one Irish village (1820).
-They click paths, doors, people, and objects to move through the world graph,
-speak with villagers, inspect places, and gradually understand the social life
-of the parish.
+views of meaningful locations in and around one Irish village (1820). They
+click paths, doors, people, and objects to move through the world graph, speak
+with villagers, inspect places, and gradually understand the social life of
+the parish.
 
 > You do not build the village. You learn it.
 
@@ -23,29 +24,62 @@ entering a living rural community and discovering how people, places, rumors,
 obligations, grudges, and memories connect. The promise is not "explore a huge
 open world" — it is "**understand a small place deeply**."
 
-### Visual style
+## Visual Target
 
-- Top-down 3/4 perspective, 16-bit pixel-art fidelity
-- Readable and cozy, but grounded — not cartoonish, not cottagecore
-- Muted greens, browns, greys, straw yellows, whitewash, peat-dark accents
-- Muddy paths, puddles, hedges, low stone walls, small fields, streams,
-  thatched cottages; handmade and irregular, never clean or fantasy-medieval
-- Inviting but slightly melancholy — a specific Irish place with memory,
-  poverty, weather, gossip, and social pressure
+The strongest art reference so far is the user-provided ChatGPT sample:
+<https://chatgpt.com/s/m_6a2b4e7a5f188191b62e44e48d3372c0>. It is not
+content-canonical — its date, text labels, road signs, and exact geography are
+reference-only — but its **style and fidelity are the target**:
 
-### Why scene nodes fit Rundale
+- Top-down / isometric 3/4 perspective with a readable village-stage layout.
+- Dense, high-fidelity pixel art: small plants, puddles, stone walls, thatch,
+  chimneys, paths, fences, carts, doorways, bridges, and water edges all have
+  hand-placed texture.
+- Grounded Irish rural material culture: whitewashed cottages, straw thatch,
+  peat smoke, low drystone walls, muddy lanes, small fields, hedgerows, wells,
+  carts, white hand-painted wayfinding signs, bridges, streams, and uneven
+  handmade surfaces.
+- Muted earth palette: moss greens, mud browns, straw yellows, greys, whitewash,
+  peat-dark shadows, and small warm-light accents.
+- Cozy but not sanitized: inviting, lived-in, damp, slightly melancholy, and
+  specific to an Irish parish rather than generic fantasy village art.
 
-A free-walking world needs large tile maps, collision, pathfinding, many
-animation states, and a lot of empty traversable space. A scene-node approach
-gives fewer, more meaningful locations; atmospheric composition; a far lower
-asset burden; and an NPC simulation without an open-world renderer. The
-important map is social, not spatial: who lives where, who avoids whom, where
-gossip travels, what histories attach to each place. The engine already models
-exactly that.
+The sample also demonstrates what **not** to make runtime-dependent: UI title
+plaques, route names, dates, and labels should not be baked into canonical art.
+If a signpost, plaque, or label-like prop appears in scene art, it must be
+treated as a prop and reviewed manually for spelling and setting correctness.
 
-## What the engine already provides
+## Representation Pivot
 
-Everything below exists today and is reused **unchanged**:
+Earlier drafts centered on **AI-curated full-scene backplates**: one composed
+PNG per location, with hotspots and NPCs layered over it. Experiments showed
+that this asks too much of a single generated bitmap. Full scenes often look
+beautiful at a glance but fail in semantically important ways: disconnected
+rivers, broken chimneys, impossible walls, inconsistent roads, baked-in
+characters, wrong signs, or day/night variants whose geometry no longer
+matches.
+
+The updated direction is a **Factorio-style runtime sprite compositor**:
+
+- The engine owns semantic layout: scene size, exits, waterways, buildings,
+  walls, doors, wayfinding signs, prop anchors, z-order, and NPC slots.
+- Art is made of smaller, curated atoms: cottages, roof pieces, chimneys,
+  smoke, wall segments, bridge pieces, wells, carts, trees, hedges, puddles,
+  stream edges, furniture, interior props, and NPC sprites.
+- AI generation is still useful, but primarily for **bounded assets** and style
+  references, not canonical whole-location geometry.
+- Runtime composition produces the final scene from asset instances. Bad assets
+  can be replaced locally without repainting a whole location.
+- Pure procedural / code-drawn fallback assets remain valid for early
+  milestones and CI tests.
+
+Full AI plates may still be used as **mood boards, underpaint sketches, or
+temporary placeholders**, but the source of truth for gameplay-visible space is
+the layout data plus composited assets.
+
+## What The Engine Already Provides
+
+Everything below exists today and is reused unchanged:
 
 | Capability           | Where                                                                                                                                          |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -58,76 +92,104 @@ Everything below exists today and is reused **unchanged**:
 | Click-to-travel      | map clicks already submit `go to <Location Name>` (`MapPanel.svelte`)                                                                          |
 | Mod asset validation | traversal-guarded asset paths under `mods/<mod>/assets/` (`parish-mod/src/assets.rs`)                                                          |
 
-The diorama is a **presentation layer over the existing simulation** — no
-world-graph, schedule, or save-format changes anywhere in this design.
+The diorama is a **presentation layer over the existing simulation**. It does
+not change world graph semantics, NPC schedules, dialogue, or save format.
 
 ## Decisions
 
-1. **Scene-first layout.** The plate becomes the main viewport; the dialogue
-   panel and text input remain alongside (text input keeps full parity).
-   Gated by a `diorama` feature flag: opt-in (`flags.is_enabled`) during the
-   build-out, flipped to a default-on kill-switch (`!flags.is_disabled`) once
-   curated art exists — satisfying AGENTS rule 6 at the point the feature is
-   actually shippable, and keeping Playwright baselines stable until the
-   deliberate flip.
-2. **AI-curated static assets, generated developer-side only.** Background
-   plates and per-NPC sprites are generated with OpenAI (`gpt-image-1`) or
-   Google (Imagen 3), curated by a human, post-processed, and checked into
-   `mods/rundale/assets/scenes/`. No image generation at runtime. This
-   supersedes the procedural `parish-sprite` approach in
-   [graphical-world-view.md](graphical-world-view.md); that RFC's serving
-   route shapes and scene-panel concept are kept.
-3. **Rust CLI art tool** (`parish-art-tool`), following the
-   `parish-geo-tool` / `parish-npc-tool` precedent.
-4. **Reuse the existing 22 nodes.** One plate per location; the `indoor` flag
-   picks interior vs exterior composition. Interior/exterior node splits
-   (Pub Exterior vs Pub Interior) are a possible later content change, not
-   part of the MVP.
-5. **No player avatar — the player is the camera.** The original pitch listed
-   a player-character sprite; this design deliberately drops it for the MVP.
-   Navigation is click-to-travel (Myst-style first person), so an avatar
-   standing in the scene adds nothing mechanically and costs a sprite, slot
-   logic, and ambiguity about who "you" are in every plate. Revisit only if
-   a later phase adds positional mechanics.
+1. **Scene-first layout.** The composed scene becomes the main viewport; the
+   dialogue panel and text input remain alongside, preserving text parity.
+   Gated by a `diorama` feature flag during build-out and flipped to a
+   default-on kill-switch once curated content exists.
+2. **Runtime composition over monolithic plates.** Location views are assembled
+   from asset instances at runtime. Optional backplates are allowed only as
+   temporary underlays or style references; hotspots and NPC slots must align
+   with semantic layout data, not with an opaque bitmap.
+3. **Developer-side art pipeline.** A Rust `parish-art-tool` helps build and
+   curate style references, sprite sheets, prop cutouts, and preview renders.
+   No image generation happens at gameplay runtime.
+4. **Reuse the existing 22 nodes.** One authored layout per location. The
+   `indoor` flag selects interior vs exterior composition. Interior/exterior
+   node splits remain possible later, but are not part of the MVP.
+5. **No player avatar in the MVP.** The player is the camera. The sample image
+   includes a central figure, but Rundale's navigation remains first-person
+   click-to-travel until a later phase introduces positional mechanics.
 
-## Scene data model
+## Scene Data Model
 
-A mod declares scenes in one index file, mirroring the `world.json` /
+A mod declares scene layouts in one index file, mirroring the `world.json` /
 `npcs.json` one-file-per-domain pattern. `mod.toml` `[files]` gains an
 optional `scenes = "scenes.json"`; mods without it load unchanged.
 
+The schema sketch below shows the updated compositor direction. It is more
+explicit than the first draft's `plate + slots` model:
+
 ```json
 {
+  "asset_packs": ["assets/scenes/common/pack.json"],
   "scenes": [
     {
-      "location_id": 2,
-      "slug": "darcys-pub",
-      "plate": "assets/scenes/darcys-pub/plate.png",
-      "variants": { "night": "assets/scenes/darcys-pub/plate_night.png" },
+      "location_id": 15,
+      "slug": "kilteevan-main-lane",
+      "native_size": [640, 480],
+      "underlay": null,
+      "layers": [
+        {
+          "id": "stream",
+          "asset": "stream-bend-a",
+          "x": 6.0,
+          "y": 76.0,
+          "z": 10,
+          "scale": 1.0
+        },
+        {
+          "id": "left-cottage",
+          "asset": "cottage-whitewash-thatched-a",
+          "x": 13.0,
+          "y": 34.0,
+          "z": 30,
+          "scale": 1.0
+        },
+        {
+          "id": "kilteevan-wayfinding",
+          "asset": "wayfinding-sign-three-arm-white-blank-a",
+          "x": 33.0,
+          "y": 57.0,
+          "z": 60,
+          "scale": 1.0,
+          "labels": [
+            { "text": "KILTEEVAN", "anchor": [48.0, 30.0], "rotation": -2.0 },
+            { "text": "CROSSROADS", "anchor": [51.0, 47.0], "rotation": 1.0 },
+            { "text": "CHAPEL", "anchor": [50.0, 64.0], "rotation": -1.0 }
+          ]
+        }
+      ],
       "hotspots": [
         {
-          "id": "door",
-          "shape": { "rect": [82.0, 38.0, 14.0, 50.0] },
-          "label": "Out to the Crossroads",
+          "id": "lane-to-crossroads",
+          "shape": { "rect": [42.0, 39.0, 14.0, 18.0] },
+          "label": "Toward the Crossroads",
           "action": { "travel_to": 1 }
         },
         {
-          "id": "hearth",
-          "shape": { "rect": [5.0, 30.0, 18.0, 40.0] },
-          "label": "The hearth",
-          "action": { "inspect": "A turf fire smoulders in the wide hearth." }
+          "id": "stream",
+          "shape": { "rect": [0.0, 73.0, 42.0, 18.0] },
+          "label": "The stream",
+          "action": { "inspect": "Water hurries under the small footbridge." }
         }
       ],
       "slots": [
-        {
-          "id": "behind-bar",
-          "x": 48.0,
-          "y": 55.0,
-          "scale": 1.0,
-          "prefer_npc": 1
-        },
-        { "id": "bench-left", "x": 22.0, "y": 68.0, "scale": 1.1 }
+        { "id": "lane-center", "x": 52.0, "y": 55.0, "z": 80, "scale": 1.0 },
+        { "id": "cottage-door", "x": 20.0, "y": 44.0, "z": 82, "scale": 0.95 }
       ]
+    }
+  ],
+  "assets": [
+    {
+      "id": "wayfinding-sign-three-arm-white-blank-a",
+      "kind": "wayfinding_sign",
+      "image": "assets/scenes/props/wayfinding-sign-three-arm-white-blank-a.png",
+      "anchor": [50.0, 92.0]
     }
   ],
   "sprites": [
@@ -139,125 +201,148 @@ optional `scenes = "scenes.json"`; mods without it load unchanged.
 }
 ```
 
-- **Coordinates are percentages (0–100) of the plate's native dimensions.**
-  `x,y` is a sprite's foot-anchor; rects are `[x, y, w, h]`. Percentage
-  coordinates keep hotspots, sprites, and the plate congruent at any display
-  size.
+- Coordinates are percentages of the scene's native dimensions. `x,y` is the
+  asset's anchor point; each asset declares its own anchor so cottages, props,
+  and NPC sprites can all be foot- or base-aligned.
+- `z` is an integer draw order. Lower layers draw first; NPC slots can sit
+  between foreground and background props.
+- `labels` are optional runtime text overlays for assets that need readable
+  marks. The MVP uses them primarily for wayfinding signs, with the text
+  validated from known location names instead of trusted to image generation.
+- `underlay` is optional and never authoritative. It can help early prototypes
+  or painterly mood, but every interactive route and NPC position comes from
+  `layers`, `hotspots`, and `slots`.
 - `HotspotAction = TravelTo(location_id) | TalkTo(npc_id) | Inspect(text)`.
-  A `polygon` shape variant is reserved in the enum for later.
-- Slots are NPC anchor positions; `prefer_npc` pins a host to their station
-  (publican behind the bar, smith at the anvil, priest at the altar).
-- Schema lives in a new `parish/crates/parish-mod/src/scenes.rs` module
-  (`SceneIndex::load` / `scene_for` / `sprite_for`) — `parish-mod` is already
-  backend-agnostic, already owns asset-path validation, and ~300 lines does
-  not justify a new crate. Every asset reference passes
-  `assets::canonical_mod_asset_path` at load; cross-validation (location and
-  NPC ids exist, coords in range) logs warnings without failing the load,
-  matching other optional mod files.
+  A `polygon` shape variant is reserved for later.
+- Schema lives in `parish/crates/parish-mod/src/scenes.rs`
+  (`SceneIndex::load` / `scene_for` / `sprite_for` / `asset_for`). Every asset
+  reference passes `assets::canonical_mod_asset_path`; cross-validation
+  confirms ids, coordinate ranges, draw-order sanity, missing assets, and
+  connection coverage.
 
-## Layered scene composition
+## Layered Scene Composition
 
-Each location view is composed at runtime from five layers:
+Each location view is composed at runtime from these layers:
 
-1. **Background plate** — curated PNG (one per location, optional `night` and
-   later weather variants). 480×270 native, displayed with
-   `image-rendering: pixelated`. No baked UI, labels, or characters.
-2. **Hotspot layer** — invisible clickable regions from `scenes.json`
-   (exits, doors, NPCs, objects, signs).
-3. **Character layer** — NPC sprites placed dynamically from
+1. **Base terrain / underlay** — flat fill, procedural fallback, or optional
+   reference underlay. It is not gameplay-authoritative.
+2. **World asset layer** — cottages, roofs, chimneys, wall segments, water
+   pieces, bridges, carts, wayfinding signs, wells, trees, hedges, puddles,
+   interior furniture, and other authored prop instances from `scenes.json`.
+3. **Hotspot layer** — invisible clickable regions, with a debug overlay for
+   authoring and automated geometry tests.
+4. **Character layer** — NPC sprites placed dynamically from
    `npcs_at(player_location)` and the slot list. Who is present comes from the
-   live schedule simulation, never from the art.
-4. **State overlay layer** — palette tint from `parish-palette` (dawn / dusk /
-   night / weather mood) plus optional variant-plate swaps and a CSS rain
-   effect; lit windows and chimney smoke arrive as night-variant art.
-5. **UI layer** — the existing StatusBar, dialogue panel, and input field.
+   live schedule simulation, never from baked art.
+5. **State overlay layer** — palette tint from `parish-palette`, CSS weather,
+   optional smoke/window-light overlays, and later festival/encounter overlays.
+6. **UI layer** — the existing StatusBar, dialogue panel, input field, and any
+   runtime title cards or labels. UI text is not baked into scene images.
 
-## Backend design
+### Wayfinding Signs
 
-Per AGENTS rule 12, the orchestration is written once in `parish-core`
+Wayfinding signs are an important placeable element, not background filler.
+They should read as rural, handmade, and practical: white-painted timber boards
+with black hand-painted lettering, slight irregularity in the boards and brush
+work, and local destination names that match the world graph.
+
+Implementation guidance:
+
+- Treat a sign as a normal composited scene layer with `kind:
+"wayfinding_sign"`.
+- Prefer blank sign-board assets plus runtime black lettering from validated
+  scene data. This preserves correct spelling and lets the same sign asset
+  point toward different connected locations.
+- If a generated/painted sign includes baked lettering, it must go through
+  human review for spelling, destination validity, date/period fit, and
+  legibility.
+- The sign's clickable hotspot should usually be `inspect`, while the road or
+  path region remains the `travel_to` hotspot. A sign helps the player
+  understand routes; it is not the route itself.
+
+## Backend Design
+
+Per AGENTS rule 12, orchestration is written once in `parish-core`
 (`src/ipc/scene.rs`) and adapted by thin wiring in each entry point:
 
 ```rust
 pub fn build_scene_state(
-    world: &World, npcs: &NpcManager, scenes: &SceneIndex, flags: &FeatureFlags,
-    asset_url: &dyn Fn(&str) -> Option<String>,   // the runtime seam
+    world: &World,
+    npcs: &NpcManager,
+    scenes: &SceneIndex,
+    flags: &FeatureFlags,
+    asset_url: &dyn Fn(&str) -> Option<String>,
 ) -> Option<SceneState>;
 
 pub struct SceneState {
     pub location_id: u32,
-    pub plate_url: String,
-    pub variant: String,                 // "day" | "night" | ...
+    pub slug: String,
+    pub native_width: u32,
+    pub native_height: u32,
+    pub variant: String,
+    pub underlay_url: Option<String>,
+    pub layers: Vec<SceneLayerView>,
     pub hotspots: Vec<SceneHotspotView>,
-    pub npcs: Vec<SceneNpcView>,         // display_name, real_name?, introduced, mood_emoji, sprite_url, x, y, scale, flip
-    pub overflow_npcs: Vec<String>,      // present beyond slot capacity
+    pub npcs: Vec<SceneNpcView>,
+    pub overflow_npcs: Vec<String>,
+}
+
+pub struct SceneLayerView {
+    pub id: String,
+    pub asset_url: String,
+    pub kind: String,
+    pub labels: Vec<SceneLayerLabelView>,
+    pub x: f32,
+    pub y: f32,
+    pub z: i32,
+    pub scale: f32,
+    pub flip: bool,
+    pub opacity: f32,
+}
+
+pub struct SceneLayerLabelView {
+    pub text: String,
+    pub anchor: (f32, f32),
+    pub rotation: f32,
 }
 ```
 
 **Introduction semantics (gameplay correctness):** NPCs are anonymous until
-introduced — the dialogue system shows `brief_description` ("an older man
-behind the bar") until the player has met them, and `NpcInfo.introduced`
-already gates this in the chat UI. `SceneNpcView` mirrors those semantics
-exactly: `display_name` is the brief description until introduced,
-`real_name` is populated only after introduction, and sprite tooltips and
-click-to-address follow the same rule. The diorama must never name an NPC
-the dialogue system would still keep anonymous.
+introduced. `SceneNpcView` mirrors the dialogue system exactly:
+`display_name` is the brief description until introduced, `real_name` is
+populated only after introduction, and sprite tooltips and click-to-address
+follow the same rule. The diorama must never name an NPC the dialogue system
+would still keep anonymous.
 
-- Returns `None` when the flag is off or the location has no scene — the
-  frontend falls back to the existing text+map layout. The flag is checked
-  backend-side on every fetch (single source of truth, no stale-at-mount).
-- **Deterministic slot assignment:** pass 1 seats `prefer_npc` occupants;
-  pass 2 fills remaining slots with present NPCs sorted by id, in slot
-  declaration order; leftovers are listed in `overflow_npcs`. Pure function,
-  directly unit-testable.
-- Variant selection by clock hour (Dusk/Night/Midnight → `night` if the
-  variant exists); weather variants reserved. **Weather mood respects
-  `LocationData.indoor`:** weather-driven overlays and the rain effect are
-  suppressed for indoor scenes (it does not rain inside Darcy's Pub) — only
-  the time-of-day tint applies indoors.
+- Returns `None` when the flag is off or the location has no scene.
+- Deterministic slot assignment seats `prefer_npc` occupants first, then fills
+  remaining slots with present NPCs sorted by id. Leftovers go to
+  `overflow_npcs`.
+- Variant selection can choose night/smoke/window-light overlays by clock hour.
+  Weather overlays are suppressed indoors.
+- Server and Tauri serve only validated assets under `assets/scenes/`.
+- Headless CLI exposes `/scene` with scene id, variant, layers, hotspots, and
+  slot assignments.
+- MCP exposes `parish_scene_state` so QA agents can assert the composed scene
+  structurally against `parish_engine_state`, instead of reading pixels.
 
-Runtime wiring:
-
-- **Server** (`parish-server/src/routes/scene.rs`): `GET /api/scene-state`
-  (state-lock pattern of `get_npcs_here`), and `GET /api/scene-asset/{*rel}`
-  serving plate/sprite bytes — re-validated through
-  `canonical_mod_asset_path` (promoted `pub(crate)` → `pub`), restricted to
-  `assets/scenes/`, served like `serve_mod_icon`
-  (`routes/world.rs:163`) with `Cache-Control: immutable` plus `?v=<mtime>`
-  cache-busting.
-- **Tauri** (`parish-tauri/src/commands/scene.rs`): `get_scene_state` with
-  `asset_url` mapping to data URLs via the existing `mod_asset_data_url`
-  helper (`parish-tauri/src/lib.rs:39`). Data URLs sidestep the
-  `assetProtocol` gotcha (its scope is build-time-fixed while the mods dir is
-  runtime-resolved). The frontend caches data URLs by `(slug, variant)`.
-- **Headless CLI**: a `/scene` debug command prints scene id, variant, and
-  slot assignments as text, so all three modes exercise the shared handler
-  and the script harness can assert it (mode parity, rule 2).
-- **MCP exposure** (`parish-mcp`): a `parish_scene_state` tool bridging
-  `GET /api/scene-state` — a thin passthrough like the other bridge tools.
-  Rationale: the repo added `parish_engine_state` so auto-QA agents can
-  assert the UI against canonical engine state (#1331); the diorama
-  introduces a new class of drift — the _rendered scene_ vs the simulation
-  (an NPC seated in a slot who is not present, a stale night variant, a
-  hotspot pointing at a non-adjacent location) — and QA agents need to
-  assert plate/variant/hotspots/slot assignments structurally rather than
-  by reading pixels from screenshots. The demo-audit skills gain a scene
-  assertion step once the tool exists.
-
-## Frontend design
+## Frontend Design
 
 New component tree under `parish/apps/ui/src/components/diorama/`:
 
 ```text
-DioramaView.svelte      // aspect-ratio 480/270 wrapper: layer stack + fallback
-├── ScenePlate.svelte   // <img>, image-rendering: pixelated, cross-fade on change
-├── HotspotLayer.svelte // SVG viewBox="0 0 100 100" preserveAspectRatio="none"
-├── NpcSpriteLayer.svelte // left:{x}%; bottom:{100-y}%; foot-anchored, tooltip
-└── SceneOverlay.svelte // multiply-blend tint from the existing palette store
+DioramaView.svelte        // aspect-ratio wrapper: composed scene + fallback
+├── SceneUnderlay.svelte   // optional underlay, never authoritative
+├── SceneLayerStack.svelte // prop/building/terrain asset instances by z-order
+├── HotspotLayer.svelte    // SVG viewBox="0 0 100 100"
+├── NpcSpriteLayer.svelte  // foot-anchored dynamic NPC sprites
+└── SceneOverlay.svelte    // palette/weather/time/festival overlays
 ```
 
 One CSS `aspect-ratio` wrapper sizes all layers, so percentage coordinates in
-the SVG hotspot layer and the absolutely-positioned sprites align exactly with
-the plate at any viewport size.
+the SVG hotspot layer and absolutely-positioned sprites align at any viewport
+size. The first implementation can be DOM/CSS layered PNGs; a backend-rendered
+composite can be added later if profiling or snapshot tests demand it.
 
 Wiring:
 
@@ -265,163 +350,135 @@ Wiring:
   (`getSceneState()` through the existing `command()` seam).
 - `page-controller.ts` fetches scene-state at mount and on every
   `world-update`, alongside `getMap()` / `getNpcsHere()`.
-- `+page.svelte`: `$sceneState !== null` renders the scene-first grid
-  (DioramaView primary; ChatPanel + InputField below; right column unchanged);
-  `null` renders the existing layout — which doubles as the graceful
-  per-location fallback.
+- `+page.svelte`: `$sceneState !== null` renders the scene-first grid;
+  `null` renders the existing layout, which is also the per-location fallback.
+- `SceneLayerStack` renders wayfinding labels as black, slightly irregular
+  runtime text on top of white sign-board assets. Text comes from scene data
+  validated against known locations.
 - `src/lib/scene-actions.ts` maps clicks onto existing input paths:
-  `travel_to` → `submitInput("go to <name>")` (the map-click path);
-  `talk_to` / sprite click → focus the input with `addressed_to` set (the
-  existing mention mechanism, respecting introduction state); `inspect` →
-  local system entry in the text log.
-- **During travel:** on the existing `travel-start` event the departing plate
-  dims (CSS, no new backend state) while the right-column map plays its
-  animated travel marker as today; the new plate cross-fades in on the
-  arrival `world-update`. No mid-transit scene is rendered in the MVP.
-- **Hotspot accessibility + authoring overlay:** hotspots are
-  keyboard-focusable (`tabindex`, Enter activates) with `aria-label` from the
-  hotspot's `label` field, so the diorama never regresses what the text
-  interface gives for free. When the existing debug panel is open,
-  `HotspotLayer` renders its rects and labels visibly — the feedback loop for
-  hand-authoring percentage coordinates against finished plates (used heavily
-  in M5).
+  `travel_to` -> `submitInput("go to <name>")`; `talk_to` / sprite click ->
+  focus the input with `addressed_to`; `inspect` -> local system entry.
+- During travel, the departing composition dims on `travel-start`; the new
+  composition cross-fades in on arrival `world-update`.
+- When the debug panel is open, `HotspotLayer` renders rects, z-order labels,
+  slot anchors, and asset outlines visibly for authoring.
 
-## The core loop this enables
+## The Core Loop This Enables
 
-1. Arrive at Kilteevan Main Street; the plate shows the village at the current
-   hour and weather, villagers placed by their real schedules.
-2. Click a villager → dialogue (existing inference loop, `addressed_to`).
-3. They mention a rumor; click the lane hotspot → travel to the Crossroads.
+1. Arrive at Kilteevan Main Lane; the runtime composition shows the village
+   with its current hour, weather, props, and villagers.
+2. Click a villager -> dialogue using the existing addressed NPC path.
+3. Click a lane hotspot -> travel to the Crossroads.
 4. Time advances; schedules move people; the grapevine carries what you said.
-5. Return later — the scene has changed: night variant, different faces,
-   someone conspicuously absent.
+5. Return later — same semantic place, different light, different faces,
+   different weather, and maybe a changed prop overlay.
 
 The game rewards attention: noticing who is present, who is absent, where
 people live, and how information moves — all of which the simulation already
-models and the diorama now makes _visible_.
+models and the diorama now makes visible.
 
-## `parish-art-tool` — developer-side asset pipeline
+## `parish-art-tool` — Developer-Side Asset Pipeline
 
-A new workspace binary crate, `parish/crates/parish-art-tool/`, mirroring the
-clap structure of `parish-npc-tool`:
+The art tool now focuses on curated **asset atoms** and preview composition,
+not whole-scene backplates:
 
 ```sh
-parish-art-tool init                      # art/style-bible.md skeleton + empty manifest
-parish-art-tool gen-plate <location-id>  [--provider openai|google] [--ref IMG ...] [--n 3]
-parish-art-tool gen-sprite <npc-id>      [--provider ...] [--ref IMG ...]
-parish-art-tool gen-variant <location-id> --variant night --ref <accepted-day-plate>
-parish-art-tool list [--pending|--accepted]
-parish-art-tool review <asset-id>         # prints path + prompt + history
-parish-art-tool accept <asset-id> [--note "cleaned stray pixels"]
+parish-art-tool init
+parish-art-tool gen-reference kilteevan-main-lane --ref IMG --note "target style"
+parish-art-tool gen-prop cottage-whitewash-thatched --kind building --n 4
+parish-art-tool gen-prop stream-bend --kind terrain --n 4
+parish-art-tool gen-sprite <npc-id> --n 4
+parish-art-tool compose-preview <location-id>
+parish-art-tool list [--pending|--accepted|--rejected]
+parish-art-tool review <asset-id>
+parish-art-tool accept <asset-id> [--note "..."]
 parish-art-tool reject <asset-id> --reason "..."
 ```
 
-- **Providers:** `ImageProvider` trait with `openai.rs` (`gpt-image-1`
-  generations + edits, transparent backgrounds for sprites) and `google.rs`
-  (Imagen 3 via the Gemini API). API keys come from `OPENAI_API_KEY` /
-  `GEMINI_API_KEY` env vars directly — the `parish.toml` provider registry is
-  text-inference plumbing (chat endpoints, streaming, model catalogs) and
-  buys nothing for a dev-only image tool.
-- **Prompts** are built from real engine data — `LocationData.name`,
-  `description_template`, `indoor`, `mythological_significance`;
-  `Npc.name/age/occupation/brief_description` — prefixed by the committed
-  style bible (fixed framing: "1820 rural Irish parish, 16-bit pixel art,
-  top-down 3/4 view, 480×270 plate, muted earth palette…", plus the negative
-  rules: no UI text, no readable labels, no baked characters, no fantasy
-  drift, no clean cottagecore).
-- **Consistency lever:** the first accepted plate and sprite are flagged
-  `anchor: true`; every subsequent generation passes anchors as reference
-  images to the edit/img2img endpoints. Curate aggressively; the human
-  `accept` gate is part of the pipeline, not an afterthought.
-- **Tracking:** `art/manifest.json` (committed) records per asset: id, kind
-  (plate/sprite/variant), target id, provider, model, prompt, reference
-  images, created, status (pending/accepted/rejected), anchor flag, cleanup
-  notes, output path. Candidate PNGs in `art/` stay gitignored; only
-  accepted, post-processed assets land in `mods/rundale/assets/scenes/`.
-- **Post-processing:** generate large (1536×1024 plates / 1024×1024 sprites),
-  downscale to 480×270 plates and 48×72 transparent sprites (`image` crate);
-  display scaling is CSS `image-rendering: pixelated`.
+- **Style bible:** committed `art/style-bible.md` records the ChatGPT sample
+  as the target reference and spells out the desired material culture,
+  perspective, palette, density, and negative rules.
+- **Provider adapters:** OpenAI and Google image providers are initial
+  candidates, but exact model names and request shapes must be rechecked at
+  implementation time. The tool is dev-only and reads image-provider keys from
+  environment variables.
+- **Prompts:** built from real engine data (`LocationData`, NPC fields,
+  `indoor`, mythological notes) plus the style bible. Prompts ask for isolated
+  transparent-background props or sprites whenever possible.
+- **Manifest:** `art/manifest.json` records id, kind, target id, provider,
+  prompt, references, created time, status, anchor/style lineage, cleanup notes,
+  and output path.
+- **Post-processing:** trims transparent bounds, checks alpha/nonblank content,
+  downscales with crisp pixel sampling, rejects obvious wrong dimensions, and
+  exports accepted assets under `mods/rundale/assets/scenes/`.
+- **Human gate:** every accepted asset must be reviewed for setting fit,
+  spelling, impossible geometry, and whether it composes cleanly with existing
+  anchors.
 
-## MVP content scope
+## MVP Content Scope
 
-**8 plates** covering the core social loop: Kilteevan Village (15, start),
-The Crossroads (1), Darcy's Pub (2), St. Brigid's Church (3), The Forge (16),
-The Holy Well (17), Murphy's Farm (9), The Bog Road (12). Interior
-compositions where `indoor: true`; night variants for the pub and village
-first (where evenings happen).
+The first shippable slice should prove the compositor before scaling content:
 
-**~12 sprites:** the NPCs whose homes, workplaces, or schedules put them in
-those locations — Padraig and Niamh Darcy, Fr. Declan Tierney, the Gallaghers,
-Siobhán and Liam Murphy, Aoife Brennan, Mick Flanagan, Brigid Ní Fhátharta,
-Seán Ruadh Kelly — plus a committed generic-villager fallback for everyone
-else who wanders in.
+- **2 exterior scenes:** Kilteevan Main Lane / village start and the Crossroads.
+- **1 interior scene:** Darcy's Pub.
+- **Common asset pack:** mud paths, grass/flower patches, puddles, stream
+  pieces, bridge pieces, wall segments, fences, white-painted wayfinding
+  signboards, cart, well, cottage variants, chimney/smoke overlays, pub
+  furniture, hearth, table/bench props.
+- **NPC sprites:** Padraig and Niamh Darcy, Fr. Declan Tierney, one farmer,
+  one older woman, one child/young person, plus a generic-villager fallback.
+- **Hotspots:** every world connection from the covered scenes, plus at least
+  one inspect hotspot per scene.
 
-**Hotspot authoring:** hand-written against the final plates. Every
-`world.json` connection from a covered location gets a `travel_to` hotspot,
-including to non-plated neighbors — travel always works; arrival at an
-unplated location simply falls back to the text view.
+After the vertical slice is visually convincing, expand to the original eight
+locations: Kilteevan Village, The Crossroads, Darcy's Pub, St. Brigid's Church,
+The Forge, The Holy Well, Murphy's Farm, and The Bog Road.
 
-## Implementation roadmap
+## Implementation Roadmap
 
-> Detailed task breakdown (subagent assignments, model/effort flags, automated
-> test plan): [Implementation Plan](../../plans/parish-diorama-implementation.md).
+> Detailed task breakdown and test plan: [Implementation Plan](../../plans/parish-diorama-implementation.md).
 
 ```text
 M1 ──► M2 ──► M3 ──► M5 ──► M6
-  └──► M4 ─────────────┘        (M4 parallel with M2/M3; M5a plates ∥ M5b sprites)
+        └──► M4 ─────┘
 ```
 
-| Milestone            | Delivers                                                                                                                | Key tests / proof                                                                                                            |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| **M1** Scene schema  | `parish-mod/src/scenes.rs`, `FileRefs.scenes`, loader + validation, `mods/rundale/scenes.json` with placeholder plates  | serde roundtrip, traversal rejection, unknown-id warnings; headless log shows `scenes.json loaded`                           |
-| **M2** Backend       | `parish-core/src/ipc/scene.rs` shared handler; server routes `scene-state` + `scene-asset`; Tauri command; CLI `/scene` | slot determinism, variant-by-hour, flag-off → `None`, asset-route traversal 4xx; live `curl` proof                           |
-| **M3** Frontend      | `components/diorama/` tree, `scene-actions.ts`, scene-first layout behind the flag, fallback path                       | vitest action mapping + geometry; new `e2e/diorama.spec.ts` (click hotspot → location changes); flag-off baselines untouched |
-| **M4** Art tool      | `parish-art-tool` crate, providers, manifest, post-process, export                                                      | golden prompts, manifest roundtrip, postprocess dims, payload-size caps (rule 16); live gen→accept transcript                |
-| **M5** Content       | 8 curated plates, ~12 sprites, authored hotspots/slots                                                                  | loader validation clean; scripted walk of all 8 locations with screenshots, day + night pub                                  |
-| **M6** Polish & flip | tint/rain tuning, fade travel transition, flag → default-on, Playwright baseline regen, README + docs                   | before/after gif; e2e green; this RFC graduates to `docs/design/`                                                            |
+| Milestone            | Delivers                                                                                          | Key tests / proof                                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **M1** Scene schema  | `scenes.json` compositor schema, asset catalog, validation, placeholder asset pack                | serde roundtrip, asset traversal rejection, z-order/coord validation, optional-file back-compat                        |
+| **M2** Backend       | shared `SceneState` builder, scene asset serving, Tauri command, CLI `/scene`, MCP scene tool     | slot determinism, layer ordering, variant rules, asset-route traversal 4xx, structural `parish_scene_state` transcript |
+| **M3** Frontend      | `components/diorama/` runtime compositor, hotspots, debug overlay, scene-first layout             | geometry tests, action mapping, keyboard hotspots, e2e click-to-travel, flag-off baseline stability                    |
+| **M4** Art tool      | style bible, asset manifest, prop/sprite generation, postprocess, compose-preview, accept/reject  | golden prompts, manifest transitions, nonblank/alpha/dim guards, payload caps, preview render proof                    |
+| **M5** Content slice | 3 composed scenes, common asset pack, initial NPC sprites, authored hotspots/slots                | scripted walk with screenshots, structural scene-vs-engine assertions, human visual review                             |
+| **M6** Polish & flip | tint/weather tuning, transitions, expansion path, flag default-on, README/docs/screenshots update | before/after gif, e2e green, deliberate baseline regen                                                                 |
 
-Each milestone is an independently landable PR following the repo's
-acceptance-criteria-first workflow (`/task-start`, live-proof bundle in the
-PR body, `just agent-check`).
+## Risks & Mitigations
 
-End-to-end MVP check: new game → Kilteevan plate renders → click lane hotspot
-→ arrive at the Crossroads plate → click Padraig's sprite → dialogue with
-`addressed_to` set → wait to evening → pub plate swaps to its night variant
-under the palette tint.
+- **Whole-scene AI artifacts** — do not use whole-scene AI plates as canonical
+  geometry. Generate small assets, compose them from deterministic layout data,
+  and use full-scene images only as style references or temporary underlays.
+- **Style drift across assets** — style bible + accepted reference image +
+  anchor assets + manifest lineage + human accept gate.
+- **Composition looks tiled or repetitive** — support variants, flips, scale,
+  small detail props, foreground occluders, and hand-authored layout jitter.
+- **Layer coordinate skew** — one aspect-ratio wrapper, percentage coordinates,
+  asset anchors, and geometry unit tests.
+- **Baked text mistakes** — no baked UI text; wayfinding signs use runtime
+  validated black lettering on white boards where possible; baked sign text
+  requires manual review.
+- **Baseline churn** — flag stays off until the deliberate M6 flip.
+- **Save compatibility** — none at risk; scene state is derived from existing
+  world/NPC data and mod assets.
 
-## Risks & mitigations
+## Future Work
 
-- **Style drift across generations** — style bible + anchor references on
-  every call + the human accept gate; the manifest records each asset's
-  anchor lineage so regeneration is reproducible.
-- **Tauri asset serving** — data URLs over IPC (existing precedent) avoid the
-  build-time `assetProtocol` scope; plates at 480×270 are ~50–200 KB; cached
-  by `(slug, variant)`.
-- **Layer coordinate skew** — one aspect-ratio wrapper + percentage
-  coordinates everywhere + a geometry unit test.
-- **Baseline churn** — the flag stays off until M6's deliberate, documented
-  flip.
-- **Save compatibility** — none at risk; no save-schema or world-graph
-  changes anywhere in the design.
-
-## Future work (recorded, not implied)
-
-Explicitly out of the MVP; listed so they are decisions deferred rather than
-gaps discovered later:
-
-- **Scene merging for `Override` / `Content` mods.** The MVP reads only the
-  base mod's `scenes.json`. The mod system's `Override` kind (mutate base
-  entries — e.g. a re-skin mod swapping plates) and `Content` kind (add
-  scenes for new locations) need a merge strategy in `SceneIndex` loading.
-- **Festival / encounter overlays.** Mods already declare `festivals.json`
-  and `encounters.json`, and the world snapshot carries the active festival;
-  scenes could swap crowd variants or add overlay props on festival days.
-- **Localizable hotspot labels.** Hotspot `label` strings are English in the
-  MVP; the `Localization` mod kind is the natural home for translated labels
-  and should get a key-based lookup when localization lands.
-- **Visual hotspot/slot editor in the Parish Designer.** M3's debug overlay
-  makes hand-authoring tolerable; a drag-to-draw editor in `parish-editor`'s
-  GUI is the real fix if scene count grows past the MVP's eight.
-- **Interior/exterior node splits, player avatar, sprite animation,
-  weather-variant plates** — each noted in its own section above as
-  deliberately deferred.
+- Visual hotspot/slot/layout editor in Parish Designer.
+- Backend-rendered composite PNGs and snapshot tests, if DOM composition proves
+  hard to verify.
+- Interior/exterior node splits for buildings where outside/inside differences
+  become mechanically meaningful.
+- Festival, market-day, encounter, and rumor-state prop overlays.
+- Weather/season asset variants beyond CSS overlays.
+- Localization support for runtime wayfinding text and other plaque-like props.
+- Player avatar and sprite animation, only if later mechanics need explicit
+  player position.

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ Speculative and forward-looking — not (yet) committed work.
 
 | Document                                                                                       | Status     |
 | ---------------------------------------------------------------------------------------------- | ---------- |
-| [Interactive Parish Diorama (scene-based graphics)](design/ideas/parish-diorama.md)            | Proposed   |
+| [Interactive Parish Diorama (runtime-composed scene graphics)](design/ideas/parish-diorama.md) | Proposed   |
 | [RAG Lore Recall](design/ideas/rag-lore-recall.md)                                             | Proposed   |
 | [NPC Sleep & Dream Consolidation](design/ideas/npc-sleep-dream-consolidation.md)               | Proposed   |
 | [Mythology Layer (Future Hooks)](design/ideas/mythology-hooks.md)                              | Proposed   |
@@ -88,18 +88,18 @@ Speculative and forward-looking — not (yet) committed work.
 
 ## Plans — active
 
-| Plan                                                                                  | Status      |
-| ------------------------------------------------------------------------------------- | ----------- |
-| [Interactive Parish Diorama — Implementation](plans/parish-diorama-implementation.md) | Proposed    |
-| [Phase 5F — World Graph Expansion](plans/phase-5f-world-expansion.md)                 | Planned     |
-| [Phase 6 — Polish & Mythology Hooks](plans/phase-6-polish-mythology.md)               | Planned     |
-| [Phase 7 — Web & Mobile Apps](plans/phase-7-web-mobile.md)                            | Partial     |
-| [Save/Load UI Plan](plans/phase-9-save-load-ui.md)                                    | Planned     |
-| [Rundale-Bench](plans/rundale-bench.md)                                               | In progress |
-| [LLM Quality Evals](plans/llm-quality-evals.md)                                       | Proposed    |
-| [Promptfoo Pentest](plans/promptfoo-pentest-plan.md)                                  | Proposed    |
-| [Gemma 4 Hiberno-English Training](plans/gemma4-rundale-training-plan.md)             | Proposed    |
-| [Talkie Methodology Port](plans/talkie-methodology-port.md)                           | Proposed    |
+| Plan                                                                                                     | Status      |
+| -------------------------------------------------------------------------------------------------------- | ----------- |
+| [Interactive Parish Diorama — Runtime Compositor Implementation](plans/parish-diorama-implementation.md) | Proposed    |
+| [Phase 5F — World Graph Expansion](plans/phase-5f-world-expansion.md)                                    | Planned     |
+| [Phase 6 — Polish & Mythology Hooks](plans/phase-6-polish-mythology.md)                                  | Planned     |
+| [Phase 7 — Web & Mobile Apps](plans/phase-7-web-mobile.md)                                               | Partial     |
+| [Save/Load UI Plan](plans/phase-9-save-load-ui.md)                                                       | Planned     |
+| [Rundale-Bench](plans/rundale-bench.md)                                                                  | In progress |
+| [LLM Quality Evals](plans/llm-quality-evals.md)                                                          | Proposed    |
+| [Promptfoo Pentest](plans/promptfoo-pentest-plan.md)                                                     | Proposed    |
+| [Gemma 4 Hiberno-English Training](plans/gemma4-rundale-training-plan.md)                                | Proposed    |
+| [Talkie Methodology Port](plans/talkie-methodology-port.md)                                              | Proposed    |
 
 ## Plans — archived (complete / historical)
 

--- a/docs/plans/parish-diorama-implementation.md
+++ b/docs/plans/parish-diorama-implementation.md
@@ -1,4 +1,4 @@
-# Plan: Interactive Parish Diorama — Implementation
+# Plan: Interactive Parish Diorama — Runtime Compositor Implementation
 
 > Parent design: [Interactive Parish Diorama](../design/ideas/parish-diorama.md) | [Docs Index](../index.md)
 >
@@ -9,225 +9,211 @@
 
 ## Goal
 
-Ship the MVP of the scene-based diorama described in the design doc: per-location
-pixel-art plates as the main viewport, clickable hotspots, simulation-driven NPC
-sprite placement, a `diorama` feature flag, and the `parish-art-tool` asset
-pipeline — as six independently landable PRs (M1–M6).
+Ship the MVP of the revised diorama design: a scene-first graphical viewport
+composed at runtime from curated sprite/prop assets, clickable hotspots,
+simulation-driven NPC placement, a `diorama` feature flag, and a dev-side
+`parish-art-tool` for style references, prop/sprite generation, curation, and
+preview composition.
 
-This plan decomposes each milestone into **subagent tasks**. Each task is
-self-contained enough to hand to one subagent and carries:
+This replaces the earlier full-backplate plan. The desired fidelity is still
+the user-approved ChatGPT sample style, but full generated plates are no longer
+the source of truth for gameplay-visible geometry. The engine owns layout;
+assets are small, replaceable visual atoms.
 
-- **Model** — `haiku` (mechanical, low-ambiguity), `sonnet` (standard
-  implementation), `opus` (architectural seams, cross-cutting judgement,
-  quality-sensitive output).
-- **Effort** — `low` (< ~1 h, narrow diff), `medium` (half-day, one area),
-  `high` (multi-file, design judgement, or flake-prone verification).
-- **Depends** — tasks that must land first.
-- **Tests** — the automated tests the task must add or keep green (the
-  consolidated test plan is in [§ Automated test plan](#automated-test-plan)).
-
-## Orchestration rules (apply to every milestone)
+## Orchestration Rules
 
 1. **One PR per milestone**, branched from the previous milestone's merge.
-2. **AC-first (AGENTS rule 13):** the milestone starts with `/task-start
+2. **AC-first (AGENTS rule 13):** each milestone starts with `/task-start
 diorama-m<N>` producing `.proofs/diorama-m<N>/acceptance-criteria.md` and
-   `parish/testing/fixtures/play_diorama-m<N>.txt` **before any code task is
-   dispatched**. Human approval of the AC gates the rest of the milestone.
-3. **Proof (AGENTS rule 10):** milestones touching runtime paths (all except
-   M4) need a live-proof bundle (transcript and/or screenshot) attached to the
-   PR body via `parish/scripts/compose-proof-body.sh`; `just agent-check`
-   green before push.
-4. Subagents run `just check` (fmt + clippy + tests) before reporting done;
-   the milestone orchestrator runs the full gate (`just check`, `just
-ui-test`/`ui-e2e` where relevant, `just agent-check`) before the PR.
-5. Tasks marked ∥ within a milestone may run as parallel subagents on
-   non-overlapping files.
+   `parish/testing/fixtures/play_diorama-m<N>.txt` before implementation.
+3. **Proof (AGENTS rule 10):** milestones touching runtime paths need a
+   live-proof bundle in the PR body. M4 is tool-only but still needs a transcript
+   or fixture proving the tool behavior claimed.
+4. Subagents run focused tests before reporting done; the milestone orchestrator
+   runs the full gate (`just check`, `just ui-test`/`ui-e2e` where relevant,
+   `just agent-check`) before the PR.
+5. Tasks marked ∥ may run in parallel on non-overlapping files.
 
 ```text
 M1 ──► M2 ──► M3 ──► M5 ──► M6
-  └──► M4 ─────────────┘        (M4 parallel with M2/M3; M5a ∥ M5b)
+        └──► M4 ─────┘
 ```
 
 ---
 
-## M1 — Scene schema, loader, validation (PR 1)
+## M1 — Scene Schema, Asset Catalog, Validation (PR 1)
 
-| #    | Task                                                                                                                                                                                                                                                                                                                                                                 | Model    | Effort | Depends    |
-| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | ---------- |
-| T1.0 | `/task-start diorama-m1`: AC + fixture. Criteria: scenes.json parses; invalid asset path rejected at load; unknown location/NPC ids warn without failing; mods without `scenes` load unchanged; headless log line `scenes.json loaded: N scenes, M sprites`.                                                                                                         | `opus`   | low    | —          |
-| T1.1 | **Schema + loader.** Create `parish/crates/parish-mod/src/scenes.rs`: `SceneIndex`/`SceneDef`/`Hotspot`/`HotspotAction`/`NpcSlot`/`SpriteDef` per the design doc schema (percentage coords, `rect` shape with `polygon` reserved), `SceneIndex::load(mod_dir, rel)` validating every asset ref through `assets::canonical_mod_asset_path`, `scene_for`/`sprite_for`. | `sonnet` | high   | T1.0       |
-| T1.2 | **Mod wiring.** `FileRefs.scenes: Option<String>` in `manifest.rs`; `GameMod.scenes: Option<SceneIndex>` loaded in `GameMod::load` (`parish-mod/src/lib.rs`); cross-validation `validate_scenes(&SceneIndex, &WorldGraph, &NpcManager) -> Vec<String>` warnings (ids exist, coords 0–100) logged at the parish-core mod-load site.                                   | `sonnet` | medium | T1.1       |
-| T1.3 | **Placeholder content.** `mods/rundale/scenes.json` (2 scenes: Darcy's Pub id 2, The Crossroads id 1, with hotspots/slots), 2 flat-colour 480×270 placeholder plates + 1 generic sprite under `mods/rundale/assets/scenes/`, `scenes = "scenes.json"` in `mods/rundale/mod.toml`.                                                                                    | `haiku`  | low    | T1.1       |
-| T1.4 | **Proof.** Run the fixture headless (`just run-headless --script …`), capture transcript showing the load line, write `evidence.md` + `judge.md`, `just agent-check`, compose PR body.                                                                                                                                                                               | `sonnet` | medium | T1.2, T1.3 |
+| #    | Task                                                                                                                                                                                                                                                                                                                                                                                  | Model    | Effort | Depends   |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | --------- |
+| T1.0 | `/task-start diorama-m1`: AC + fixture. Criteria: `scenes.json` parses; invalid asset path rejected; unknown location/NPC/asset ids warn without failing when optional; mods without `scenes` load unchanged; headless load log reports scene/layer/asset counts.                                                                                                                     | `opus`   | low    | —         |
+| T1.1 | **Compositor schema.** Create `parish/crates/parish-mod/src/scenes.rs`: `SceneIndex`, `SceneDef`, `SceneLayer`, `SceneLayerLabel`, `SceneAsset`, `Hotspot`, `HotspotAction`, `NpcSlot`, `SpriteDef`, `FallbackSprites`; percentage coords; integer z-order; optional `underlay`; reserved polygon shape; `kind = "wayfinding_sign"` support.                                          | `sonnet` | high   | T1.0      |
+| T1.2 | **Asset validation.** `SceneIndex::load(mod_dir, rel)` validates every referenced asset through `assets::canonical_mod_asset_path`; export `asset_for`/`scene_for`/`sprite_for`; validate asset anchors, opacity, scale, duplicate ids, label anchors, label text budget, and draw-order sanity.                                                                                      | `sonnet` | medium | T1.1      |
+| T1.3 | **Mod wiring.** Add `FileRefs.scenes: Option<String>` and `GameMod.scenes: Option<SceneIndex>`; cross-validation `validate_scenes(&SceneIndex, &WorldGraph, &NpcManager) -> Vec<String>` checks location ids, travel targets, prefer_npc, coord ranges, missing asset ids, wayfinding labels against known location names, and covered-location connection coverage where configured. | `sonnet` | medium | T1.1      |
+| T1.4 | **Placeholder asset pack.** Add `mods/rundale/scenes.json` with two skeletal scenes (Kilteevan Main Lane/start and Darcy's Pub or Crossroads), flat-colour/procedural placeholder PNGs under `mods/rundale/assets/scenes/`, a generic NPC sprite, and `scenes = "scenes.json"` in `mods/rundale/mod.toml`.                                                                            | `haiku`  | low    | T1.2      |
+| T1.5 | **Proof.** Run the fixture headless, capture the load log and `/scene`-ready structural data if available, write evidence/judge, and run `just agent-check`.                                                                                                                                                                                                                          | `sonnet` | medium | T1.3–T1.4 |
 
-**Task-level tests** (in T1.1/T1.2): serde roundtrip for every action/shape
-variant; `[x,y,w,h]` rect parsing; rejection of `../escape.png` and absolute
-paths; missing plate file → `ParishError::Config`; unknown `location_id` /
-`prefer_npc` / `travel_to` target → warning string; `scene_for`/`sprite_for`
-hit and miss; existing `parish-mod` fixture mod (no `scenes` key) loads
-unchanged.
-
----
-
-## M2 — Backend scene-state + asset serving, three runtimes (PR 2)
-
-| #    | Task                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Model    | Effort | Depends   |
-| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------ | --------- |
-| T2.0 | `/task-start diorama-m2`: AC + fixture (flag off → empty scene-state; flag on → plate URL + hotspots + seated NPCs; traversal on asset route rejected; `/scene` parity output in headless; `parish_scene_state` returns the same view model over MCP).                                                                                                                                                                                                                                                                                                                                                                                                                                                 | `opus`   | low    | M1 merged |
-| T2.1 | **Shared handler (rule 12 seam).** Create `parish-core/src/ipc/scene.rs`: `SceneState`/`SceneNpcView`/`SceneHotspotView`; `build_scene_state(world, npcs, scenes, flags, asset_url)` — flag gate, variant-by-hour (Dusk/Night/Midnight → `night` when present), **deterministic slot assignment** (pass 1 `prefer_npc`, pass 2 remaining present NPCs by id into remaining slots in declaration order, leftovers → `overflow_npcs`); **introduction semantics** (`display_name` = brief description until introduced, `real_name` only after — mirrors `NpcInfo.introduced`); **indoor weather suppression** (weather overlays/variants suppressed when `LocationData.indoor`, time-of-day tint only). | `opus`   | high   | T2.0      |
-| T2.2 | ∥ **Server routes.** `parish-server/src/routes/scene.rs`: `GET /api/scene-state` (state-lock pattern of `get_npcs_here`, `routes/world.rs`), `GET /api/scene-asset/{*rel}` — promote `canonical_mod_asset_path` to `pub`, restrict to `assets/scenes/`, serve like `serve_mod_icon` (`routes/world.rs:163`) with `Cache-Control: immutable` + `?v=<mtime>`. Register in `routes.rs`/`lib.rs`.                                                                                                                                                                                                                                                                                                          | `sonnet` | medium | T2.1      |
-| T2.3 | ∥ **Tauri command.** `parish-tauri/src/commands/scene.rs`: `get_scene_state` with `asset_url = mod_asset_data_url(...)` (`parish-tauri/src/lib.rs:39`); register in the command registry.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | `sonnet` | medium | T2.1      |
-| T2.4 | ∥ **CLI parity.** `/scene` debug command in the headless input path printing scene id, variant, and slot assignments as text; extend the M2 fixture to assert it.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | `sonnet` | low    | T2.1      |
-| T2.5 | ∥ **MCP exposure.** `parish_scene_state` tool in `parish-mcp` — thin bridge over `GET /api/scene-state` (same passthrough shape as `parish_engine_state`); register in the tool list; rows added to the MCP tool tables in `AGENTS.md` and `parish/crates/parish-mcp/README.md`. Gives auto-QA agents structural scene assertions (plate, variant, hotspots, slot seating) instead of pixel-reading screenshots (#1331 pattern).                                                                                                                                                                                                                                                                       | `sonnet` | low    | T2.2      |
-| T2.6 | **Gate + proof.** Architecture-fitness still green (new modules declared; no backend deps leak into leaf crates); live proof: `bash parish/scripts/parish-mcp-backend.sh start`, `/flag enable diorama`, `curl /api/scene-state` + `curl /api/scene-asset/...`, and a `mcp__parish__parish_scene_state` call transcript; evidence/judge; `just agent-check`.                                                                                                                                                                                                                                                                                                                                           | `sonnet` | medium | T2.2–T2.5 |
-
-**Task-level tests:** T2.1 — slot determinism (same inputs → same seating;
-`prefer_npc` honoured; overflow ordering), variant-by-hour table test,
-flag-off → `None`, unplated location → `None`, un-introduced NPC yields
-`display_name` = brief description with `real_name` absent, indoor location
-never selects a weather variant/overlay, empty-slots scene seats nobody
-but still returns hotspots. T2.2 — Axum route test: `../mod.toml` and
-URL-encoded traversal → 4xx; placeholder PNG served with `image/png` and
-immutable cache header; flag-off returns `null` body. T2.3 — data-URL helper
-unit test (prefix + base64 round-trip). T2.5 — bridge unit test: tool
-deserializes a recorded `/api/scene-state` body and surfaces transport
-errors as MCP `isError` (matching the other bridge tools).
+**Task-level tests:** serde roundtrip for every variant; `[x,y,w,h]` rect
+parsing; traversal and absolute-path rejection; missing required asset ->
+`ParishError::Config`; optional unknown ids produce warning strings;
+wayfinding label text must be bounded and validated against known destinations;
+`scene_for`/`asset_for`/`sprite_for` hit and miss; old mods without `scenes`
+load unchanged.
 
 ---
 
-## M3 — Scene-first frontend behind the flag (PR 3)
+## M2 — Shared Scene-State + Asset Serving, Three Runtimes (PR 2)
 
-| #    | Task                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Model    | Effort | Depends    |
-| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | ---------- |
-| T3.0 | `/task-start diorama-m3`: AC + fixture (flag on → plate visible; hotspot click travels; sprite click addresses NPC; flag off → existing layout pixel-identical; unplated location falls back; un-introduced NPC tooltip shows brief description, never the name; `travel-start` dims the plate until the arrival `world-update`).                                                                                                                                                                                                                                                                                               | `opus`   | low    | M2 merged  |
-| T3.1 | **State + IPC wiring.** `src/stores/scene.ts` (`sceneState` writable), `src/lib/ipc/scene.ts` (`getSceneState()` through `command()`, Tauri data-URL cache keyed `(slug, variant)`), `SceneState` types in `src/lib/types.ts` (snake_case matching Rust serde), fetch at mount + on every `world-update` in `page-controller.ts`.                                                                                                                                                                                                                                                                                               | `sonnet` | medium | T3.0       |
-| T3.2 | ∥ **Component tree.** `src/components/diorama/`: `DioramaView` (single `aspect-ratio: 480/270` wrapper, layer stack, null fallback), `ScenePlate` (pixelated `<img>`, cross-fade), `HotspotLayer` (SVG `viewBox="0 0 100 100"` `preserveAspectRatio="none"`), `NpcSpriteLayer` (`left:{x}%; bottom:{100-y}%`, foot anchor, introduction-aware tooltip), `SceneOverlay` (palette tint). Hotspots keyboard-focusable (`tabindex`, Enter activates, `aria-label` from `label`); debug-panel-open state renders hotspot rects + labels visibly (the M5 authoring feedback loop); `travel-start` event dims the plate until arrival. | `sonnet` | high   | T3.1       |
-| T3.3 | ∥ **Action mapping.** `src/lib/scene-actions.ts`: `travel_to` → `submitInput("go to <name>")` (name resolved from `mapData`, same path as `MapPanel` clicks); `talk_to`/sprite click → focus `InputField` with `addressed_to` chip; `inspect` → local `system` entry in `textLog`. Unknown ids are no-ops.                                                                                                                                                                                                                                                                                                                      | `sonnet` | medium | T3.1       |
-| T3.4 | **Layout switch.** `+page.svelte`: `$sceneState !== null` → scene-first grid (DioramaView primary, ChatPanel + InputField below, right column untouched); `null` → existing layout (doubles as per-location fallback). Mobile breakpoint handled like the existing 768 px rules.                                                                                                                                                                                                                                                                                                                                                | `sonnet` | medium | T3.2, T3.3 |
-| T3.5 | **Playwright e2e.** New `e2e/diorama.spec.ts` (see test plan §3). Confirm zero diffs in existing baselines with the flag off.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | `sonnet` | high   | T3.4       |
-| T3.6 | **Proof.** Screenshot pair (flag off / flag on with placeholder plates) + live hotspot-travel transcript via the browser or MCP screenshot tools; evidence/judge; `just agent-check`.                                                                                                                                                                                                                                                                                                                                                                                                                                           | `sonnet` | medium | T3.5       |
+| #    | Task                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Model    | Effort | Depends   |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | --------- |
+| T2.0 | `/task-start diorama-m2`: AC + fixture. Criteria: flag off -> empty scene-state; flag on -> native size + layer list + hotspots + seated NPCs; traversal on asset route rejected; `/scene` parity output in headless; `parish_scene_state` returns the same view model over MCP.                                                                                                                                                                        | `opus`   | low    | M1 merged |
+| T2.1 | **Shared handler (rule 12 seam).** Create `parish-core/src/ipc/scene.rs`: `SceneState`, `SceneLayerView`, `SceneLayerLabelView`, `SceneNpcView`, `SceneHotspotView`; `build_scene_state(world, npcs, scenes, flags, asset_url)` handles flag gate, optional underlay, asset URL resolution, z-order sorting, wayfinding labels, deterministic slot assignment, introduction semantics, overflow NPCs, variant overlays, and indoor weather suppression. | `opus`   | high   | T2.0      |
+| T2.2 | ∥ **Server routes.** `parish-server/src/routes/scene.rs`: `GET /api/scene-state`, `GET /api/scene-asset/{*rel}`. Promote `canonical_mod_asset_path` to `pub`, restrict to `assets/scenes/`, serve immutable PNG/WebP assets with `?v=<mtime>` cache busting.                                                                                                                                                                                            | `sonnet` | medium | T2.1      |
+| T2.3 | ∥ **Tauri command.** `parish-tauri/src/commands/scene.rs`: `get_scene_state` maps assets to data URLs through the existing mod-asset data URL helper; register in the command registry.                                                                                                                                                                                                                                                                 | `sonnet` | medium | T2.1      |
+| T2.4 | ∥ **CLI parity.** `/scene` debug command prints scene id, variant, layers in z-order, hotspots, slot assignments, and overflow NPCs; extend the M2 fixture to assert it.                                                                                                                                                                                                                                                                                | `sonnet` | low    | T2.1      |
+| T2.5 | ∥ **MCP exposure.** Add `parish_scene_state` to `parish-mcp` as a thin bridge over `/api/scene-state`; document in `AGENTS.md` and `parish/crates/parish-mcp/README.md`.                                                                                                                                                                                                                                                                                | `sonnet` | low    | T2.2      |
+| T2.6 | **Gate + proof.** Live proof with `parish-mcp-backend.sh start`, `/flag enable diorama`, `curl /api/scene-state`, `curl /api/scene-asset/...`, and an MCP `parish_scene_state` transcript; evidence/judge; `just agent-check`.                                                                                                                                                                                                                          | `sonnet` | medium | T2.2–T2.5 |
 
-**Task-level tests:** T3.1 — store update on world-update event (vitest, mocked
-transport); cache hit avoids refetch for same `(slug, variant)`. T3.2 —
-render test: mocked `SceneState` places a hotspot rect and a sprite at the
-expected percentage geometry; missing `plate_url` renders fallback. T3.3 —
-`scene-actions.test.ts`: every action variant maps to the right
-`submitInput`/`addressed_to`/log call; unknown location id is a safe no-op;
-tooltip never renders `real_name` for an un-introduced NPC; hotspots are
-reachable and activatable by keyboard (focus + Enter); `travel-start` applies
-the dimmed state and the arrival `world-update` clears it.
+**Task-level tests:** slot determinism, prefer_npc, overflow order, z-order
+sort, asset-url failures, flag-off -> `None`, unplated location -> `None`,
+unintroduced NPC display name, indoor overlay suppression, empty-slots scene
+still returns hotspots. Axum route tests cover URL-encoded traversal, mime
+type, immutable cache header, and flag-off null body.
 
 ---
 
-## M4 — `parish-art-tool` crate (PR 4 — runs in parallel with M2/M3)
+## M3 — Frontend Runtime Compositor Behind The Flag (PR 3)
 
-| #    | Task                                                                                                                                                                                                                                                                                                                              | Model    | Effort | Depends   |
-| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | --------- |
-| T4.0 | `/task-start diorama-m4`: AC (each subcommand's observable behaviour, dry-run without API keys, manifest invariants).                                                                                                                                                                                                             | `opus`   | low    | M1 merged |
-| T4.1 | **Crate skeleton + manifest.** `parish/crates/parish-art-tool/` (workspace member, clap structure mirroring `parish-npc-tool`): `main.rs` command enum (`init`, `gen-plate`, `gen-sprite`, `gen-variant`, `list`, `review`, `accept`, `reject`), `manifest.rs` (`ArtManifest` records + status transitions + atomic save).        | `sonnet` | medium | T4.0      |
-| T4.2 | **Prompt builder + style bible.** `prompt.rs` building production prompts from `LocationData` (name, description_template, indoor, mythological_significance) and `Npc` (name, age, occupation, brief_description) + the committed `art/style-bible.md` (written by this task: style rules + negative rules from the design doc). | `opus`   | medium | T4.1      |
-| T4.3 | ∥ **Providers.** `providers/`: `ImageProvider` trait; `openai.rs` (`gpt-image-1` generations + edits, transparent background for sprites, reference images); `google.rs` (Imagen 3 via Gemini API). Env keys `OPENAI_API_KEY`/`GEMINI_API_KEY`; request-size caps client-side per AGENTS rule 16.                                 | `sonnet` | high   | T4.1      |
-| T4.4 | ∥ **Postprocess + export.** `postprocess.rs` (`image` crate: Lanczos downscale → 480×270 plates / 48×72 sprites, alpha preserved, sprite trim); `export.rs` (accepted asset → `mods/rundale/assets/scenes/<slug>/`, `scenes.json` plate/sprite path upsert, path must land under `assets/scenes/`).                               | `sonnet` | medium | T4.1      |
-| T4.5 | **Docs + gate.** Crate README (workflow: anchors, curation, env keys), root `.gitignore` for `art/` (manifest + style bible excepted), `just notices` for new deps, full `just check`. Live transcript of one real `gen-plate → review → accept` run attached to the PR.                                                          | `haiku`  | low    | T4.2–T4.4 |
+| #    | Task                                                                                                                                                                                                                                                                                                                                                                                            | Model    | Effort | Depends   |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | --------- |
+| T3.0 | `/task-start diorama-m3`: AC + fixture. Criteria: flag on -> composed scene visible; layers draw in z-order; hotspot click travels; sprite click addresses NPC; flag off -> existing layout pixel-stable; unplated location falls back; unintroduced NPC tooltip shows brief description only; `travel-start` dims the scene until arrival.                                                     | `opus`   | low    | M2 merged |
+| T3.1 | **State + IPC wiring.** `src/stores/scene.ts`, `src/lib/ipc/scene.ts`, `SceneState` types in `src/lib/types.ts`; fetch at mount + every `world-update`; cache Tauri data URLs by asset path + mtime/hash where available.                                                                                                                                                                       | `sonnet` | medium | T3.0      |
+| T3.2 | ∥ **Component tree.** `components/diorama/`: `DioramaView`, `SceneUnderlay`, `SceneLayerStack`, `HotspotLayer`, `NpcSpriteLayer`, `SceneOverlay`; one aspect-ratio wrapper; absolutely-positioned asset instances; `z-index` derived from scene z-order; runtime black hand-painted wayfinding labels on white sign assets; debug mode shows layer boxes, z labels, slot anchors, and hotspots. | `sonnet` | high   | T3.1      |
+| T3.3 | ∥ **Action mapping.** `src/lib/scene-actions.ts`: `travel_to` -> existing map-click `submitInput("go to <name>")` path; `talk_to` / sprite click -> focus input with `addressed_to`; `inspect` -> local system entry; unknown ids are no-ops with debug warning.                                                                                                                                | `sonnet` | medium | T3.1      |
+| T3.4 | **Layout switch.** `+page.svelte`: `$sceneState !== null` -> scene-first grid; `null` -> existing layout. Mobile breakpoint follows current 768 px behavior.                                                                                                                                                                                                                                    | `sonnet` | medium | T3.2–T3.3 |
+| T3.5 | **Playwright e2e.** New `e2e/diorama.spec.ts`: enable flag, assert layered scene, click hotspot, click sprite, verify fallback, verify flag-off screenshot stability.                                                                                                                                                                                                                           | `sonnet` | high   | T3.4      |
+| T3.6 | **Proof.** Screenshot pair (flag off/on with placeholder composition), live hotspot-travel transcript, structural scene-state dump, evidence/judge, `just agent-check`.                                                                                                                                                                                                                         | `sonnet` | medium | T3.5      |
 
-**Task-level tests:** manifest serde roundtrip + illegal status transitions
-rejected; golden prompt strings for Darcy's Pub plate and Padraig Darcy sprite
-(snapshot, update-reviewed); `payload.len() <= budget` for both providers
-(rule 16); provider request-body construction against recorded JSON (no live
-API in CI); postprocess fixture PNG → exact output dims + alpha preserved;
-export rejects targets outside `assets/scenes/`.
-
----
-
-## M5 — Curated content (PR 5a plates ∥ PR 5b sprites)
-
-Human-in-the-loop milestone: subagents drive the tool and propose; a human
-accepts every asset.
-
-| #    | Task                                                                                                                                                                                                                                                                                                                                                                                                                           | Model    | Effort | Depends        |
-| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------ | -------------- |
-| T5.0 | `/task-start diorama-m5`: AC (8 locations render their plates in-game; night variant swaps at dusk in the pub; every connection from a covered location is clickable; ~12 named NPCs render their own sprite, others the fallback).                                                                                                                                                                                            | `opus`   | low    | M3 + M4 merged |
-| T5.1 | **Anchor round.** Generate candidate batches for the two anchor assets (Kilteevan Village plate, Padraig Darcy sprite) with both providers, present a curation sheet (paths + prompts) for human accept; mark `anchor: true`.                                                                                                                                                                                                  | `opus`   | high   | T5.0           |
-| T5.2 | ∥ **Plates (PR 5a).** With anchors as refs: The Crossroads (1), Darcy's Pub (2), St. Brigid's Church (3), Murphy's Farm (9), The Bog Road (12), Kilteevan Village (15), The Forge (16), The Holy Well (17); night variants for pub + village. Iterate per rejection feedback.                                                                                                                                                  | `opus`   | high   | T5.1           |
-| T5.3 | ∥ **Sprites (PR 5b).** ~12 NPCs whose schedules hit the 8 locations (per the design doc roster) + generic-villager fallback.                                                                                                                                                                                                                                                                                                   | `opus`   | high   | T5.1           |
-| T5.4 | **Hotspot/slot authoring.** Hand-write `mods/rundale/scenes.json` against the final plates: every world.json connection from a covered location → `travel_to` hotspot; 2–4 slots per scene; `prefer_npc` for pub bar (1), forge anvil (9), church altar (3); inspect hotspots. Author against the live game with the debug hotspot overlay (T3.2) for placement feedback.                                                      | `sonnet` | medium | T5.2           |
-| T5.5 | **Content gate + proof.** Loader cross-validation warning-free; content sanity test (every referenced file exists, every covered-location connection has a hotspot); scripted walk of all 8 locations capturing per-location screenshots, day + night pub, **plus structural assertions per stop via `mcp__parish__parish_scene_state`** (expected plate slug, variant, seated NPCs vs `parish_engine_state`); evidence/judge. | `sonnet` | medium | T5.3, T5.4     |
+**Task-level tests:** scene-store refresh, asset-cache behavior, z-order
+rendering from mocked `SceneState`, percentage geometry, runtime wayfinding
+label placement, missing underlay fallback, action mapping, keyboard hotspot
+activation, unintroduced tooltip privacy, travel dim/clear behavior.
 
 ---
 
-## M6 — Polish, flag flip, docs (PR 6)
+## M4 — `parish-art-tool` Asset-Atom Pipeline (PR 4)
 
-| #    | Task                                                                                                                                                                                                                                 | Model    | Effort | Depends   |
-| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------ | --------- |
-| T6.0 | `/task-start diorama-m6`: AC (default-on behaviour, kill-switch works, transition smoothness criteria, baseline set regenerated deliberately).                                                                                       | `opus`   | low    | M5 merged |
-| T6.1 | ∥ **Visual polish.** Palette-tint strength tuning; CSS rain effect keyed off `worldState.weather` and gated on `!indoor`; fade travel transition reusing the theme cross-fade pattern.                                               | `sonnet` | medium | T6.0      |
-| T6.2 | **Flag flip.** `build_scene_state` gate → `!flags.is_disabled("diorama")` (default-on kill-switch per AGENTS rule 6); regenerate Playwright baselines (`just ui-e2e -- -u`) — the one PR where baseline churn is expected; document. | `sonnet` | medium | T6.1      |
-| T6.3 | ∥ **Docs.** README feature list + structure (rule 7); `just screenshots`; graduate the design doc from `docs/design/ideas/` to `docs/design/diorama.md` (Status: Implemented) and update `docs/index.md`.                            | `haiku`  | low    | T6.2      |
-| T6.4 | **Final proof.** Before/after gif of travel + day/night; full gate (`just check`, `just ui-test`, `just ui-e2e`, `just agent-check`); evidence/judge.                                                                                | `sonnet` | medium | T6.2      |
+| #    | Task                                                                                                                                                                                                                                                                                                                                                                                                      | Model    | Effort | Depends   |
+| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | --------- |
+| T4.0 | `/task-start diorama-m4`: AC. Criteria: every subcommand has observable behavior; dry-run works without image-provider keys; manifest invariants hold; compose-preview can render a nonblank mock scene.                                                                                                                                                                                                  | `opus`   | low    | M2 merged |
+| T4.1 | **Crate skeleton + manifest.** `parish/crates/parish-art-tool/` workspace member; clap commands `init`, `gen-reference`, `gen-prop`, `gen-sprite`, `compose-preview`, `list`, `review`, `accept`, `reject`; `ArtManifest` records assets, references, status transitions, and atomic save.                                                                                                                | `sonnet` | medium | T4.0      |
+| T4.2 | **Style bible.** `art/style-bible.md` captures the approved ChatGPT sample as reference-only, records target fidelity/material culture/perspective/palette, and states negative rules: no baked UI labels, no invented readable signs, no fantasy drift, no impossible water/buildings, no baked NPCs in scene props. Wayfinding signs are white-painted timber boards with black hand-painted lettering. | `opus`   | medium | T4.1      |
+| T4.3 | ∥ **Prompt builder.** `prompt.rs` builds prop/sprite prompts from `LocationData`, NPC fields, asset kind, and the style bible. Golden prompts cover cottage, stream segment, blank white wayfinding signboard, pub hearth, and Padraig Darcy sprite.                                                                                                                                                      | `opus`   | medium | T4.1      |
+| T4.4 | ∥ **Provider adapters.** Image-provider trait plus OpenAI/Google adapters. Exact model names and request schemas are verified during implementation. Enforce client-side request-size caps per AGENTS rule 16.                                                                                                                                                                                            | `sonnet` | high   | T4.1      |
+| T4.5 | ∥ **Postprocess + export.** Trim transparent bounds, preserve alpha, downscale crisply, reject blank/degenerate assets, enforce target dimensions by kind, export accepted assets under `mods/rundale/assets/scenes/`, and optionally upsert asset ids into `scenes.json`.                                                                                                                                | `sonnet` | medium | T4.1      |
+| T4.6 | **Preview renderer.** `compose-preview <location-id>` reads `scenes.json`, layers accepted/placeholder assets, draws NPC placeholders, and writes a PNG with a nonblank-content guard.                                                                                                                                                                                                                    | `sonnet` | medium | T4.5      |
+| T4.7 | **Docs + gate.** Crate README, root `.gitignore` for generated candidate assets, `just notices` if dependencies change, full `just check`, transcript of init -> dry-run generate -> accept -> compose-preview.                                                                                                                                                                                           | `haiku`  | low    | T4.2–T4.6 |
+
+**Task-level tests:** manifest roundtrip and illegal transition rejection;
+golden prompts; provider body construction against recorded JSON; payload
+budget assertions; postprocess exact dims and alpha preservation; blank/solid
+asset rejection; export path guard; preview render nonblank check.
 
 ---
 
-## Automated test plan
+## M5 — Curated Vertical Slice Content (PR 5)
 
-Every layer of the stack gets automated coverage; per-task lists above are the
-source of truth for _what_, this section fixes _where and how it runs_.
+Human-in-the-loop milestone: agents can generate and organize candidates, but
+a human accepts every visible asset.
 
-### 1. Rust unit + integration (`just check` / `cargo test`, every PR)
+| #    | Task                                                                                                                                                                                                                                                                                               | Model    | Effort | Depends        |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | -------------- |
+| T5.0 | `/task-start diorama-m5`: AC. Criteria: 3 scenes render in-game; all covered-location connections are clickable; initial NPC sprites render or fall back; style resembles the accepted sample; no full-scene AI plate is required for correctness.                                                 | `opus`   | low    | M3 + M4 merged |
+| T5.1 | **Anchor asset round.** Generate/curate a small reference set: cottage, wall segment, stream bend, muddy path tile/patch, white wayfinding signboard, cart, pub hearth/interior prop, generic villager, Padraig Darcy. Mark accepted anchors in manifest.                                          | `opus`   | high   | T5.0           |
+| T5.2 | ∥ **Exterior scenes.** Author Kilteevan Main Lane and The Crossroads layouts from accepted atoms; compose stream/bridge/path/walls/cottages/wayfinding signs/props with deterministic z-order; use runtime black sign lettering from validated destination names rather than baked generated text. | `sonnet` | high   | T5.1           |
+| T5.3 | ∥ **Interior scene.** Author Darcy's Pub layout with bar/hearth/tables/door hotspots and slots for Padraig/Niamh/visitors.                                                                                                                                                                         | `sonnet` | medium | T5.1           |
+| T5.4 | ∥ **Sprites.** Padraig and Niamh Darcy, Fr. Declan Tierney, one farmer, one older woman, one younger villager, plus generic fallback.                                                                                                                                                              | `opus`   | high   | T5.1           |
+| T5.5 | **Hotspot/slot pass.** Ensure every world connection from the 3 covered scenes has a `travel_to` hotspot; 2–5 NPC slots per scene; `prefer_npc` for pub bar; inspect hotspots for stream, wayfinding sign, hearth, cart/well.                                                                      | `sonnet` | medium | T5.2–T5.3      |
+| T5.6 | **Content gate + proof.** Loader validation warning-free; content sanity test; scripted walk through all covered scenes with screenshots; `parish_scene_state` asserted against `parish_engine_state` for location, variant, present NPCs, layers, and hotspots; evidence/judge.                   | `sonnet` | medium | T5.4–T5.5      |
 
-| Suite                             | Lives in                                    | Covers                                                                                                                                     |
-| --------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Scene schema (`scenes::tests`)    | `parish-mod/src/scenes.rs`                  | serde roundtrips, rect/action parsing, traversal + absolute-path rejection, missing-file error, lookup hit/miss, optional-file back-compat |
-| Cross-validation                  | parish-core mod-load tests                  | unknown location/NPC ids warn (not fail), coord range checks                                                                               |
-| Scene-state (`ipc::scene::tests`) | `parish-core/src/ipc/scene.rs`              | **slot-assignment determinism**, prefer_npc, overflow, variant-by-hour, flag-off/unplated → `None`                                         |
-| Server routes                     | `parish-server/src/routes/tests.rs`         | scene-asset traversal → 4xx, mime + immutable cache headers, scene-state flag-off `null`                                                   |
-| Art tool                          | `parish-art-tool` unit tests                | manifest transitions, golden prompts, provider bodies (recorded, offline), rule-16 payload caps, postprocess dims/alpha, export path guard |
-| Architecture fitness              | `parish-core/tests/architecture_fitness.rs` | new modules declared (orphan check), no `tauri`/`axum` deps leak into leaf crates, `parish-art-tool` registered as a tool crate            |
+After this PR, decide whether to expand directly to the original 8-location
+scope or improve tooling/authoring first.
 
-### 2. Frontend unit (`just ui-test`, M3+)
+---
 
-`scene-actions.test.ts` (action→command mapping, no-op safety),
-`scene.store.test.ts` (world-update refresh, `(slug, variant)` cache),
-`DioramaView.test.ts` (layer geometry from mocked state, fallback render) —
-vitest + JSDOM with the existing mocked-Tauri setup.
+## M6 — Polish, Expansion Path, Flag Flip, Docs (PR 6)
 
-### 3. End-to-end (`just ui-e2e`, M3+)
+| #    | Task                                                                                                                                                                                                                               | Model    | Effort | Depends   |
+| ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------ | --------- |
+| T6.0 | `/task-start diorama-m6`: AC. Criteria: default-on behavior, kill-switch works, transition smoothness, visual quality checklist for the 3-scene slice, and deliberate baseline regeneration.                                       | `opus`   | low    | M5 merged |
+| T6.1 | ∥ **Visual polish.** Palette-tint strength, CSS rain/fog/smoke overlays gated by indoor/outdoor, travel fade, focus styles for hotspots, mobile layout polish.                                                                     | `sonnet` | medium | T6.0      |
+| T6.2 | ∥ **Expansion plan.** Document asset/layout strategy for the next 5 locations: St. Brigid's Church, The Forge, The Holy Well, Murphy's Farm, The Bog Road. Add TODO-backed content checklist rather than silently expanding scope. | `opus`   | low    | T6.0      |
+| T6.3 | **Flag flip.** `build_scene_state` gate -> default-on kill-switch (`!flags.is_disabled("diorama")`); regenerate Playwright baselines intentionally and document the churn.                                                         | `sonnet` | medium | T6.1      |
+| T6.4 | ∥ **Docs.** README feature list + structure; `just screenshots`; graduate the design doc from `docs/design/ideas/` to `docs/design/diorama.md` only if the runtime slice is accepted.                                              | `haiku`  | low    | T6.3      |
+| T6.5 | **Final proof.** Before/after gif or screenshot strip, full gate (`just check`, `just ui-test`, `just ui-e2e`, `just agent-check`), evidence/judge.                                                                                | `sonnet` | medium | T6.3      |
+
+---
+
+## Automated Test Plan
+
+Every layer gets automated coverage; task lists above are the source of truth
+for exact cases.
+
+### 1. Rust Unit + Integration (`just check` / `cargo test`, every PR)
+
+| Suite                             | Lives in                                    | Covers                                                                                                                                                  |
+| --------------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Scene schema (`scenes::tests`)    | `parish-mod/src/scenes.rs`                  | serde roundtrips, asset/layer/label/action parsing, traversal rejection, missing-file error, lookup hit/miss, optional-file back-compat                 |
+| Cross-validation                  | parish-core mod-load tests                  | unknown ids warn, coord/range/z-order checks, connection coverage, asset anchors, wayfinding labels                                                     |
+| Scene-state (`ipc::scene::tests`) | `parish-core/src/ipc/scene.rs`              | slot determinism, prefer_npc, overflow, layer sorting, layer labels, asset URL mapping, variant selection, flag-off/unplated -> `None`                  |
+| Server routes                     | `parish-server/src/routes/tests.rs`         | scene-asset traversal -> 4xx, mime + immutable cache headers, scene-state flag-off `null`                                                               |
+| Art tool                          | `parish-art-tool` unit tests                | manifest transitions, golden prompts, provider bodies, payload caps, postprocess alpha/dims, blank rejection, export path guard, preview nonblank guard |
+| Architecture fitness              | `parish-core/tests/architecture_fitness.rs` | new modules declared, no backend deps leak into leaf crates, `parish-art-tool` registered as a tool crate                                               |
+
+### 2. Frontend Unit (`just ui-test`, M3+)
+
+`scene-actions.test.ts` (action mapping), `scene.store.test.ts`
+(world-update refresh + asset cache), `DioramaView.test.ts` (layer geometry,
+z-order, runtime wayfinding labels, fallback render), `HotspotLayer.test.ts`
+(keyboard activation and aria labels), and tooltip privacy tests for
+unintroduced NPCs.
+
+### 3. End-To-End (`just ui-e2e`, M3+)
 
 `e2e/diorama.spec.ts` against the real auto-started server:
 
-1. Enable the flag through the real input (`/flag enable diorama`), reload.
-2. Assert the plate `<img>` is visible and the hotspot SVG overlays it.
-3. Click the travel hotspot → StatusBar location name changes; scene swaps.
-4. Click an NPC sprite → input gains the `addressed_to` chip.
-5. Flag off → existing baseline screenshots byte-stable (until the deliberate
-   M6 regeneration).
+1. Enable the flag through real input (`/flag enable diorama`), reload.
+2. Assert the composed scene is visible and layer count matches scene-state.
+3. Click a travel hotspot -> StatusBar location changes; scene swaps.
+4. Click an NPC sprite -> input gains the `addressed_to` chip.
+5. Open debug overlay -> hotspots/slots/layer boxes are visible.
+6. Flag off -> existing baseline screenshots remain stable until M6.
 
-### 4. Script-harness fixtures (`just game-test-one play_diorama-m<N>`, every milestone)
+### 4. Script-Harness Fixtures
 
-`parish/testing/fixtures/play_diorama-m<N>.txt` written at `/task-start` time;
-deterministic headless runs asserting the load line (M1), `/flag enable
-diorama` + `/scene` output (M2+), and the 8-location walk (M5). MCP-driven QA
-(demo-audit skills) gains scene drift checks: `parish_scene_state` asserted
-against `parish_engine_state` at each stop. These run in
-the CI fixture sweep.
+`parish/testing/fixtures/play_diorama-m<N>.txt` written at `/task-start` time.
+Runs assert the load line (M1), `/flag enable diorama` + `/scene` output
+(M2+), clickable route parity where practical, and the 3-scene walk (M5).
+MCP-driven QA asserts `parish_scene_state` against `parish_engine_state` at
+each stop.
 
-### 5. Determinism & snapshots
+### 5. Visual And Artifact Guards
 
-Slot assignment and variant selection are pure functions — table tests, no
-golden images. Golden artifacts are limited to: art-tool prompt strings
-(reviewed snapshots) and Playwright screenshot baselines (regenerated once,
-in M6). No PNG byte-snapshots of game scenes: plates are hand-curated content,
-not generated output.
+Runtime screenshots and generated preview PNGs must be nonblank and
+nondegenerate. Asset postprocessing checks alpha coverage, dimensions, and
+trim bounds. Human review remains required for semantic content: disconnected
+water, impossible buildings, wrong signs, baked text, and setting mismatch.
+Wayfinding signs get an extra check: white board, black hand-painted lettering,
+valid destination names, and no AI-invented route text.
 
-### 6. CI gates that must stay green
+### 6. CI Gates
 
-Rust quality gate, UI quality, Playwright e2e, full fixture sweep, docs
-consistency, and the **agent proof gate** (per-milestone bundle in the PR
-body). M4 adds `just notices` output to the diff when provider/image deps
-land.
+Rust quality gate, UI quality, Playwright e2e, fixture sweep, docs consistency,
+and the agent proof gate must stay green. M4 adds `just notices` output to the
+diff when provider/image dependencies land.
 
-## Risks carried from the design doc
+## Risks Carried From The Design Doc
 
-Style drift (anchors + human accept gate), Tauri asset serving (data URLs,
-payload size watched), layer coordinate skew (single aspect-ratio wrapper +
-geometry tests), baseline churn (flag off until M6), save compatibility
-(none — no schema changes).
+Whole-scene AI artifacts, style drift, repetitive tiling, layer coordinate
+skew, baked text mistakes, historically wrong signs, baseline churn, and proof burden. The central
+mitigation is the compositor pivot: semantic layout is owned by data and code;
+AI art supplies bounded assets that can be rejected or replaced locally.


### PR DESCRIPTION
## Summary
- Pivot the parish diorama docs from full-scene AI backplates to a runtime-composed sprite/prop compositor direction.
- Add the ChatGPT sample as the art-style and fidelity target.
- Make hand-painted black-on-white wayfinding signs a first-class placable scene element.
- Update the implementation plan, graphical-world-view note, and docs index to match the new direction.

## Verification
- rtk git diff --check
- rtk npx prettier --check docs/design/ideas/graphical-world-view.md docs/design/ideas/parish-diorama.md docs/index.md docs/plans/parish-diorama-implementation.md
- rtk ./node_modules/.bin/markdownlint-cli2 docs/design/ideas/graphical-world-view.md docs/design/ideas/parish-diorama.md docs/index.md docs/plans/parish-diorama-implementation.md

Docs-only change; proof bundle not required.