### PR TITLE
test(ui): migrate notebook tools, overlays, and retired proof contracts

### DIFF
--- a/parish/apps/ui/e2e/bug-report-hotkey.spec.ts
+++ b/parish/apps/ui/e2e/bug-report-hotkey.spec.ts
@@ -16,13 +16,15 @@ test.describe('Bug report modal — hotkey isolation', () => {
 	test('typing "m" in the description does not open the map', async ({
 		parishPage: page,
 	}) => {
-		// Open the bug-report modal from the status-bar ⋯ dev menu.
-		const devMenuButton = page.locator('[aria-label="Developer tools menu"]');
-		await expect(devMenuButton).toBeVisible();
-		await devMenuButton.click();
-		const bugButton = page.locator(
-			'[data-testid="dev-menu"] [aria-label="Report a bug"]',
-		);
+		// Open the bug-report modal from the current notebook tools drawer.
+		const toolsButton = page.getByRole('button', { name: 'Notebook tools' });
+		await expect(toolsButton).toBeVisible();
+		await toolsButton.click();
+		const toolsDrawer = page.locator('aside[aria-label="tools drawer"]');
+		await expect(toolsDrawer).toBeVisible();
+		const bugButton = toolsDrawer.getByRole('button', {
+			name: 'Bug Report',
+		});
 		await expect(bugButton).toBeVisible();
 		await bugButton.click();
 		await expect(page.locator('[data-testid="bug-report-modal"]')).toBeVisible({

--- a/parish/apps/ui/e2e/features.spec.ts
+++ b/parish/apps/ui/e2e/features.spec.ts
@@ -15,6 +15,27 @@ async function pressKey(page: import('@playwright/test').Page, key: string) {
 	);
 }
 
+async function activateNotebookControl(
+	page: import('@playwright/test').Page,
+	name: string,
+) {
+	const control = page.getByRole('button', { name, exact: true });
+	await expect(control).toHaveCount(1);
+	await control.focus();
+	await expect(control).toBeFocused();
+	await page.keyboard.press('Enter');
+}
+
+async function openNotebookTools(page: import('@playwright/test').Page) {
+	const toggle = page.getByRole('button', { name: 'Notebook tools' });
+	await expect(toggle).toBeVisible();
+	await toggle.click();
+
+	const drawer = page.locator('aside[aria-label="tools drawer"]');
+	await expect(drawer).toBeVisible();
+	return drawer;
+}
+
 test.describe('Debug panel', () => {
 	test.beforeEach(async ({ page }) => {
 		await installTauriMock(page, 'morning');
@@ -166,74 +187,88 @@ test.describe('Save picker', () => {
 	});
 });
 
-test.describe('Sidebar toggle', () => {
+test.describe('Notebook drawers', () => {
 	test.beforeEach(async ({ page }) => {
 		await installTauriMock(page, 'morning');
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
 	});
 
-	test('sidebar details can be toggled open and closed', async ({ page }) => {
-		const sidebar = page.locator('[data-testid="sidebar"]');
-		// Two collapsible sections now (Present + language hints); exercise the first.
-		const details = sidebar.locator('details').first();
+	test('People drawer lists nearby people and returns to the notebook', async ({
+		page,
+	}) => {
+		await activateNotebookControl(page, 'Open People notebook tab');
 
-		await expect(details).toHaveAttribute('open');
+		const drawer = page.locator('aside[aria-label="people drawer"]');
+		await expect(drawer).toBeVisible();
+		await expect(drawer).toContainText('Séamas Ó Briain');
+		await expect(drawer).toContainText('Publican');
+		await expect(drawer).toContainText('Aoife Ní Cheallaigh');
+		await expect(drawer).toContainText('Scholar');
 
-		await details.locator('summary').click();
-		await expect(details).not.toHaveAttribute('open');
-
-		await details.locator('summary').click();
-		await expect(details).toHaveAttribute('open');
+		await drawer.getByRole('button', { name: /Aoife Ní Cheallaigh/ }).click();
+		await expect(drawer).not.toBeVisible();
+		await expect(
+			page.getByTestId('illustrated-notebook-pixi-host'),
+		).toBeVisible();
 	});
 
-	test('sidebar shows language hints on load', async ({ page }) => {
-		await expect(
-			page.getByTestId('sidebar').getByText('Baile Átha Cliath'),
-		).toBeVisible();
-		await expect(page.getByText('[EE-fa]')).toBeVisible();
+	test('Journal drawer shows the latest parish lines', async ({ page }) => {
+		await emitEvent(page, 'text-log', {
+			id: 'journal-proof',
+			source: 'Séamas Ó Briain',
+			content: 'The bridge road is clear before dusk.',
+		});
+		await activateNotebookControl(page, 'Open Journal notebook tab');
+
+		const drawer = page.locator('aside[aria-label="journal drawer"]');
+		await expect(drawer).toBeVisible();
+		await expect(drawer).toContainText('Séamas Ó Briain');
+		await expect(drawer).toContainText('The bridge road is clear before dusk.');
+		// Focail and rich reaction/chat parity remain product work on #1630.
 	});
 });
 
-test.describe('Reactions', () => {
+test.describe('Notebook tools', () => {
 	test.beforeEach(async ({ page }) => {
 		await installTauriMock(page, 'morning');
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
 	});
 
-	test('reaction bar appears for NPC messages with reactions', async ({
-		page,
-	}) => {
-		await emitEvent(page, 'text-log', {
-			id: 'npc-msg-1',
-			source: 'Séamas Ó Briain',
-			content: 'Welcome to the tavern!',
-		});
+	test('routes Save/Load and Map from the tools drawer', async ({ page }) => {
+		let drawer = await openNotebookTools(page);
+		await drawer.getByRole('button', { name: 'Save/Load' }).click();
+		const picker = page.getByTestId('save-picker');
+		await expect(picker).toBeVisible();
+		await picker.getByText('Close').click();
 
-		await emitEvent(page, 'npc-reaction', {
-			message_id: 'npc-msg-1',
-			emoji: '\u{1F44D}',
-			source: 'player',
-		});
-
-		const reactionBar = page.locator('[data-testid="reaction-bar"]');
-		await expect(reactionBar).toBeVisible();
-		await expect(reactionBar).toContainText('\u{1F44D}');
+		drawer = await openNotebookTools(page);
+		await drawer.getByRole('button', { name: 'Map', exact: true }).click();
+		const map = page.getByTestId('full-map');
+		await expect(map).toBeVisible();
+		await page.getByRole('button', { name: 'Close full map' }).click();
+		await expect(map).not.toBeVisible();
 	});
 
-	test('reaction picker appears on NPC message hover', async ({ page }) => {
-		await emitEvent(page, 'text-log', {
-			id: 'npc-msg-2',
-			source: 'Séamas Ó Briain',
-			content: 'Good day to you!',
-		});
+	test('routes Debug, Mod, and Bug Report from the tools drawer', async ({
+		page,
+	}) => {
+		let drawer = await openNotebookTools(page);
+		await drawer.getByRole('button', { name: 'Debug' }).click();
+		const debugPanel = page.getByTestId('debug-panel');
+		await expect(debugPanel).toBeVisible();
+		await debugPanel.locator('.debug-close').click();
 
-		const bubbleAnchor = page.locator('.bubble-anchor').first();
-		await bubbleAnchor.hover();
+		drawer = await openNotebookTools(page);
+		await drawer.getByRole('button', { name: 'Mod' }).click();
+		const modDialog = page.getByRole('dialog', { name: 'Select mod' });
+		await expect(modDialog).toBeVisible();
+		await modDialog.getByRole('button', { name: 'Close' }).click();
 
-		const picker = page.locator('[data-testid="reaction-picker"]');
-		await expect(picker).toBeVisible();
+		drawer = await openNotebookTools(page);
+		await drawer.getByRole('button', { name: 'Bug Report' }).click();
+		await expect(page.getByTestId('bug-report-modal')).toBeVisible();
 	});
 });
 
@@ -281,6 +316,13 @@ test.describe('Editor', () => {
 
 		await page.locator('.back-link').click();
 		await page.waitForLoadState('networkidle');
-		await expect(page.locator('[data-testid="status-bar"]')).toBeVisible();
+		await expect(page).toHaveURL(/\/$/);
+		await expect(page.getByTestId('illustrated-notebook-game')).toBeVisible();
+		await expect(
+			page.getByTestId('illustrated-notebook-pixi-host'),
+		).toBeVisible();
+		await expect(
+			page.getByTestId('illustrated-notebook-pixi-host').locator('canvas'),
+		).toBeVisible();
 	});
 });

--- a/parish/apps/ui/e2e/proof-1431.spec.ts
+++ b/parish/apps/ui/e2e/proof-1431.spec.ts
@@ -136,9 +136,9 @@ test('Journal keeps the newest lines in its bounded current window', async ({
 	await expect(journal).toContainText('Journal message 3');
 	const journalLines = journal.locator('.journal-lines > p');
 	await expect(journalLines).toHaveCount(8);
-	await expect(
-		journalLines.filter({ hasText: /Journal message 1$/ }),
-	).toHaveCount(0);
+	await expect(journalLines).toContainText(
+		Array.from({ length: 8 }, (_, index) => `Journal message ${index + 3}`),
+	);
 
 	await page.screenshot({
 		path: path.join(PROOF_DIR, 'journal-latest-lines.png'),

--- a/parish/apps/ui/e2e/proof-1431.spec.ts
+++ b/parish/apps/ui/e2e/proof-1431.spec.ts
@@ -1,17 +1,14 @@
 /**
- * Proof screenshots for #1431 items 2, 4, and 5.
+ * Current-notebook replacements for the retired #1431 dashboard proofs.
  *
- * Item 2: NPC gesture / action subtype renders as italic system narration
- *         (entry.subtype === "action" → entryType() returns "system"),
- *         not as a speech bubble.
+ * The illustrated notebook no longer renders the status-bar developer menu,
+ * chat bubbles, or scrollable ChatPanel that #1431 originally exercised.
+ * These tests preserve the player outcomes on the live surface instead:
+ * tools remain reachable and unclipped, action narration remains readable in
+ * Journal, the newest journal lines remain present, and People returns cleanly
+ * to the Pixi notebook before another drawer opens.
  *
- * Item 4: Sending a player message auto-scrolls the chat panel to the bottom
- *         so the echoed bubble is always visible.
- *
- * Item 5: The "⋯" developer menu opens fully visible below the status bar —
- *         not clipped by overflow:hidden on .status-bar (now overflow-x:clip).
- *
- * Saves PNG proof artifacts to .proofs/1431-render/ (repo-root relative).
+ * Saves PNG proof artifacts to .proofs/1713-notebook-tools/.
  */
 
 import { test, expect, installTauriMock, emitEvent } from './fixtures';
@@ -20,107 +17,83 @@ import * as fs from 'fs';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-// __dirname is parish/apps/ui/e2e → up four levels to repo root
-const PROOF_DIR = path.resolve(__dirname, '../../../../.proofs/1431-render');
+const PROOF_DIR = path.resolve(
+	__dirname,
+	'../../../../.proofs/1713-notebook-tools',
+);
 
 test.beforeAll(() => {
 	fs.mkdirSync(PROOF_DIR, { recursive: true });
 });
 
-// ── Shared setup ─────────────────────────────────────────────────────────────
-
 async function setupPage(page: import('@playwright/test').Page) {
 	await installTauriMock(page, 'morning');
 	await page.goto('/');
 	await page.waitForLoadState('networkidle');
-	// Seed a world-update so the status bar renders with real content.
-	await emitEvent(page, 'world-update', {
-		location_name: 'Kilteevan Village',
-		location_description: 'The small village of Kilteevan.',
-		time_label: 'Morning',
-		hour: 8,
-		minute: 0,
-		weather: 'Clear',
-		season: 'Spring',
-		festival: null,
-		paused: false,
-		inference_paused: false,
-		game_epoch_ms: 0,
-		speed_factor: 0,
-		name_hints: [],
-		day_of_week: 'Monday',
-	});
 }
 
-// ── Item 5: dev menu visible, not clipped ────────────────────────────────────
+async function activateNotebookControl(
+	page: import('@playwright/test').Page,
+	name: string,
+) {
+	const control = page.getByRole('button', { name, exact: true });
+	await expect(control).toHaveCount(1);
+	await control.focus();
+	await expect(control).toBeFocused();
+	await page.keyboard.press('Enter');
+}
 
-test('item5 — dev menu opens below status bar (not clipped)', async ({
+async function openNotebookTools(page: import('@playwright/test').Page) {
+	const toggle = page.getByRole('button', { name: 'Notebook tools' });
+	await expect(toggle).toBeVisible();
+	await toggle.click();
+
+	const drawer = page.locator('aside[aria-label="tools drawer"]');
+	await expect(drawer).toBeVisible();
+	return drawer;
+}
+
+test('tools drawer replaces the retired dev-menu visibility proof', async ({
 	page,
 }) => {
 	await setupPage(page);
+	const drawer = await openNotebookTools(page);
 
-	// Click the ⋯ dev-tools button to open the menu.
-	const devToggle = page.getByRole('button', { name: 'Developer tools menu' });
-	await expect(devToggle).toBeVisible();
-	await devToggle.click();
-
-	const devMenu = page.getByTestId('dev-menu');
-	await expect(devMenu).toBeVisible();
-
-	// The menu must be visible with positive dimensions — prior to the fix,
-	// overflow:hidden on .status-bar clipped the absolutely-positioned dropdown
-	// to zero height and it was rendered but invisible. After the fix
-	// (overflow-x:clip + overflow-y:visible) the menu has real painted area.
-	const menuBox = await devMenu.boundingBox();
-	expect(menuBox).not.toBeNull();
-	if (menuBox) {
-		expect(menuBox.height).toBeGreaterThan(0);
-		expect(menuBox.width).toBeGreaterThan(0);
+	for (const name of ['Save/Load', 'Map', 'Debug', 'Mod', 'Bug Report']) {
+		await expect(
+			drawer.getByRole('button', { name, exact: true }),
+		).toBeVisible();
 	}
 
-	// The menu must contain the expected items (Designer, Dbg).
-	// The Designer link has role="menuitem"; the Dbg toggle has role="menuitemcheckbox"
-	// but we locate it by text to avoid role-resolution quirks in headless Chromium.
-	await expect(
-		devMenu.getByRole('menuitem', { name: /Designer/i }),
-	).toBeVisible();
-	await expect(devMenu.locator('text=Dbg')).toBeVisible();
-
-	// The toggle button itself must be inside the status bar.
-	const statusBarBox = await page.getByTestId('status-bar').boundingBox();
-	const toggleBox = await devToggle.boundingBox();
-	expect(statusBarBox).not.toBeNull();
-	expect(toggleBox).not.toBeNull();
-	if (statusBarBox && toggleBox) {
-		// Toggle sits within status bar vertical bounds.
-		expect(toggleBox.y).toBeGreaterThanOrEqual(statusBarBox.y - 1);
-		expect(toggleBox.y + toggleBox.height).toBeLessThanOrEqual(
-			statusBarBox.y + statusBarBox.height + 1,
-		);
+	const drawerBox = await drawer.boundingBox();
+	const viewport = page.viewportSize();
+	expect(drawerBox).not.toBeNull();
+	expect(viewport).not.toBeNull();
+	if (drawerBox && viewport) {
+		expect(drawerBox.width).toBeGreaterThan(0);
+		expect(drawerBox.height).toBeGreaterThan(0);
+		expect(drawerBox.x).toBeGreaterThanOrEqual(0);
+		expect(drawerBox.y).toBeGreaterThanOrEqual(0);
+		expect(drawerBox.x + drawerBox.width).toBeLessThanOrEqual(viewport.width);
+		expect(drawerBox.y + drawerBox.height).toBeLessThanOrEqual(viewport.height);
 	}
 
-	// Capture a full-app screenshot showing the menu open and unclipped.
 	await page.screenshot({
-		path: path.join(PROOF_DIR, 'item5-dev-menu-visible.png'),
+		path: path.join(PROOF_DIR, 'tools-drawer-visible.png'),
 		fullPage: false,
 	});
 });
 
-// ── Item 2: gesture/action subtype → system narration, not speech bubble ─────
-
-test('item2 — action subtype renders as system narration, not NPC bubble', async ({
+test('action narration remains readable in the Journal drawer', async ({
 	page,
 }) => {
 	await setupPage(page);
 
-	// Seed a regular NPC speech bubble first (regression guard).
 	await emitEvent(page, 'text-log', {
 		id: 'npc-greeting',
 		source: 'Brigid Flanagan',
 		content: 'Good morrow to ye.',
 	});
-
-	// Now seed a gesture/action line with subtype "action".
 	await emitEvent(page, 'text-log', {
 		id: 'npc-gesture',
 		source: 'a tall stranger',
@@ -128,120 +101,78 @@ test('item2 — action subtype renders as system narration, not NPC bubble', asy
 		subtype: 'action',
 	});
 
-	// The greeting must be a speech bubble.
-	const greetingBubble = page.locator('.bubble-row.npc').first();
-	await expect(greetingBubble).toBeVisible();
-
-	// The gesture must render as a system entry, not a bubble.
-	const systemEntries = page.locator('.entry.system');
-	// There should be at least one system entry (gesture + any splash).
-	await expect(systemEntries.last()).toBeVisible();
-
-	// The gesture text must appear in a system entry, NOT in an NPC bubble.
-	await expect(
-		page.locator('.entry.system').filter({ hasText: 'nods silently' }),
-	).toBeVisible();
-	await expect(
-		page.locator('.bubble-row.npc').filter({ hasText: 'nods silently' }),
-	).toHaveCount(0);
+	await activateNotebookControl(page, 'Open Journal notebook tab');
+	const journal = page.locator('aside[aria-label="journal drawer"]');
+	await expect(journal).toBeVisible();
+	await expect(journal).toContainText('Brigid Flanagan');
+	await expect(journal).toContainText('Good morrow to ye.');
+	const gesture = journal.locator('p').filter({ hasText: 'nods silently' });
+	await expect(gesture).toHaveCount(1);
+	await expect(gesture).toContainText('a tall stranger');
 
 	await page.screenshot({
-		path: path.join(PROOF_DIR, 'item2-gesture-as-system.png'),
+		path: path.join(PROOF_DIR, 'journal-action-narration.png'),
 		fullPage: false,
 	});
 });
 
-// ── Item 4: player submit auto-scrolls chat to bottom ────────────────────────
-
-test('item4 — submitting a message scrolls chat to bottom', async ({
+test('Journal keeps the newest lines in its bounded current window', async ({
 	page,
 }) => {
 	await setupPage(page);
 
-	// Fill the chat with enough entries to make it scrollable.
-	for (let i = 1; i <= 20; i++) {
+	for (let i = 1; i <= 10; i += 1) {
 		await emitEvent(page, 'text-log', {
-			id: `entry-${i}`,
-			source: i % 3 === 0 ? 'player' : 'NPC',
-			content: `Message number ${i} — filling the chat log to ensure it overflows.`,
+			id: `journal-entry-${i}`,
+			source: i % 2 === 0 ? 'player' : 'NPC',
+			content: `Journal message ${i}`,
 		});
 	}
 
-	// Wait for entries to render, then scroll the panel to the top to simulate
-	// a user who has scrolled up to read back through history.
-	const chatPanel = page.getByTestId('chat-panel');
-	await page.waitForTimeout(100);
-	await chatPanel.evaluate((el) => {
-		el.scrollTop = 0;
-	});
-
-	// Confirm we are NOT at the bottom before submitting.
-	const scrolledAway = await chatPanel.evaluate((el) => el.scrollTop === 0);
-	expect(scrolledAway).toBe(true);
-
-	// Type a message and press Enter — this triggers handleSubmit in InputField,
-	// which increments playerSubmittedCount before the backend echo arrives.
-	// The submit_input mock call returns null (no-op in the Tauri mock), so the
-	// IPC round-trip completes silently. We then emit the player echo manually
-	// (as the backend would) to drive the text-log update that triggers the
-	// ChatPanel $effect scroll.
-	const inputField = page.getByTestId('input-field');
-	await inputField.click();
-	await inputField.fill('What shall I do here?');
-	await inputField.press('Enter');
-
-	// Emit the backend echo that normally arrives after submit_input returns.
-	await emitEvent(page, 'text-log', {
-		id: 'player-submit',
-		source: 'player',
-		content: 'What shall I do here?',
-	});
-
-	// Allow the Svelte tick + scroll effect to settle.
-	await page.waitForTimeout(200);
-
-	// The chat panel must now be scrolled to the bottom — the player-submitted
-	// flag bypasses the near-bottom guard (#1431 item 4).
-	const isAtBottom = await chatPanel.evaluate((el) => {
-		const delta = el.scrollHeight - el.scrollTop - el.clientHeight;
-		return delta < 10;
-	});
-	expect(isAtBottom).toBe(true);
+	await activateNotebookControl(page, 'Open Journal notebook tab');
+	const journal = page.locator('aside[aria-label="journal drawer"]');
+	await expect(journal).toBeVisible();
+	await expect(journal).toContainText('Journal message 10');
+	await expect(journal).toContainText('Journal message 3');
+	const journalLines = journal.locator('.journal-lines > p');
+	await expect(journalLines).toHaveCount(8);
+	await expect(
+		journalLines.filter({ hasText: /Journal message 1$/ }),
+	).toHaveCount(0);
 
 	await page.screenshot({
-		path: path.join(PROOF_DIR, 'item4-auto-scroll.png'),
+		path: path.join(PROOF_DIR, 'journal-latest-lines.png'),
 		fullPage: false,
 	});
 });
 
-// ── Combined proof screenshot ─────────────────────────────────────────────────
-
-test('combined — action narration + dev menu visible in one view', async ({
-	page,
-}) => {
+test('People returns to the notebook before tools reopen', async ({ page }) => {
 	await setupPage(page);
 
-	// Seed a gesture entry so the system narration is visible in the chat.
-	await emitEvent(page, 'text-log', {
-		id: 'npc-gesture-combined',
-		source: 'a tall stranger',
-		content: 'A tall stranger nods silently in your direction.',
-		subtype: 'action',
-	});
-
-	// Seed a regular NPC bubble for contrast.
-	await emitEvent(page, 'text-log', {
-		id: 'npc-greeting-combined',
-		source: 'Brigid Flanagan',
-		content: 'Good morrow to ye.',
-	});
-
-	// Open the dev menu.
-	await page.getByRole('button', { name: 'Developer tools menu' }).click();
-	await expect(page.getByTestId('dev-menu')).toBeVisible();
+	await activateNotebookControl(page, 'Open People notebook tab');
+	const people = page.locator('aside[aria-label="people drawer"]');
+	await expect(people).toBeVisible();
+	await expect(people).toContainText('Séamas Ó Briain');
+	await expect(people).toContainText('Aoife Ní Cheallaigh');
 
 	await page.screenshot({
-		path: path.join(PROOF_DIR, 'combined-proof.png'),
+		path: path.join(PROOF_DIR, 'people-drawer.png'),
+		fullPage: false,
+	});
+
+	await people.getByRole('button', { name: /Aoife Ní Cheallaigh/ }).click();
+	await expect(people).not.toBeVisible();
+	await expect(
+		page.getByTestId('illustrated-notebook-pixi-host'),
+	).toBeVisible();
+	await expect(
+		page.getByTestId('illustrated-notebook-pixi-host').locator('canvas'),
+	).toBeVisible();
+
+	const tools = await openNotebookTools(page);
+	await expect(tools).toBeVisible();
+	await page.screenshot({
+		path: path.join(PROOF_DIR, 'people-to-tools.png'),
 		fullPage: false,
 	});
 });


### PR DESCRIPTION
## Summary

- migrate the ten stale notebook-adjacent E2E failures from the retired status bar, sidebar, chat bubbles, and developer menu to the current illustrated-notebook surface
- preserve and extend live coverage for Debug, Save/Load, Editor return, local inference, People, Journal, Map, Mod, and Bug Report
- prove that `m` typed in the bug-report textarea stays isolated while the global `m` shortcut still opens the map
- replace historical #1431 screenshots with current tools, Journal, People, and Pixi-notebook proof artifacts

## Why

The illustrated-notebook cutover retired the DOM contracts these tests asserted, while the player outcomes moved to notebook drawers and tools. The stale suite therefore reported ten failures even though the server and current notebook shell were healthy. This PR migrates those contracts without adding compatibility DOM or blanket skips.

## Validation

- baseline exact issue command: **10 failed, 20 passed**
- final exact issue command with one worker and zero retries: **30 passed (52.9s)**
- owned three-file subset: **26 passed (43.9s)**
- `npm run check`: **0 errors, 0 warnings**
- `npm run build`: **passed**
- `just check`: **passed**
- `just verify`: **passed**, including the game-harness walkthrough
- `just agent-check`: **passed**

The green Playwright runs used a worktree-local `CARGO_TARGET_DIR` as run-only containment. One earlier run was interrupted by the separately proven cross-worktree server/CSP artifact race; that infrastructure result is tracked in #1717 and is not counted as assertion proof.

## Residuals

- Focail and rich chat/reaction parity remain explicit product work on #1630.
- The shared-target Playwright/CSP race remains isolated in #1717; no shared test or build configuration changes are included here.

Parent incident: #1710

Fixes #1713

<!-- parish-proof-bundle:1713-notebook-tools v=1 -->

## Proof: 1713-notebook-tools

### Acceptance criteria

# Acceptance criteria — #1713

1. The ten failures in `features.spec.ts`, `proof-1431.spec.ts`, and
   `bug-report-hotkey.spec.ts` are migrated, replaced, or retired against the
   illustrated notebook without compatibility DOM or blanket skips.
2. Existing passing coverage for Debug, Save/Load, Editor, and the local
   inference fork remains intact.
3. Returning from the Editor lands on the notebook root with the Pixi host and
   canvas visible.
4. Notebook tools expose and route Save/Load, Map, Debug, Mod, and Bug Report.
5. Typing `m` inside the bug-report description does not open the map, while a
   global `m` keypress still opens it.
6. Retired sidebar, dev-menu, bubble, and reaction proofs are replaced by
   current People, Journal, and tools contracts; remaining Focail and rich
   chat/reaction parity stays explicitly tracked on #1630.

## Proof method

- Run the four issue-owned Playwright files with one worker and no retries
  against a live `parish-server`.
- Inspect the browser screenshots in this bundle for tools, Journal, People,
  and the return to the notebook.
- Run UI diagnostics and a production build.
- Inspect the final diff for the three owned test files only.

### Evidence

Evidence type: live gameplay transcript

# Evidence — #1713

## Live browser proof

After rebasing onto `main` `307622f6` (which contains both sibling PRs #1720
and #1719), the issue command ran against a real `parish-server` on port 3104 with a
worktree-local Cargo target to isolate the independently tracked cross-worktree
artifact race (#1717):

```text
CARGO_TARGET_DIR=/tmp/rundale-main-red.tS0w27/parish/target-1713-refresh-307622f6 \
PARISH_TEST_PORT=3104 npx playwright test \
  e2e/features.spec.ts e2e/proof-1431.spec.ts \
  e2e/bug-report-hotkey.spec.ts e2e/local-inference-fork.spec.ts \
  --workers=1 --retries=0 --reporter=line

30 passed (1.3m)
```

The earlier pre-rebase proof also passed 30/30 in 52.9 seconds. The refresh
preserved the exact three-file scope and confirmed no changed-file overlap with
#1720 or #1719.

The initial unmodified issue command established the advertised failure set:
10 failed and 20 passed. After the migration, the owned three-file subset also
passed independently: 26 passed (43.9s).

One intermediate run was interrupted because a different worktree overwrote
the shared server artifact with mismatched CSP hashes. That infrastructure
result is recorded on #1717 and is not counted as assertion evidence. The
passing runs above used only the run-local `CARGO_TARGET_DIR` containment.

## Criterion mapping

1. The final issue command passed all 30 contracts with no retries. The diff
   contains no skipped tests and changes only the three assigned E2E specs.
2. The same run passed nine Debug tests, four Save picker tests, three Editor
   tests, and four unchanged local-inference tests.
3. `features.spec.ts` verifies `/`, `illustrated-notebook-game`, the Pixi host,
   and a visible canvas after the Editor back link.
4. `tools-drawer-visible.png` shows the current tools drawer; the passing tools
   tests exercise Save/Load, Map, Debug, Mod, and Bug Report routes.
5. Both bug-report hotkey-isolation tests passed in the live browser run.
6. `people-drawer.png`, `people-to-tools.png`,
   `journal-action-narration.png`, and `journal-latest-lines.png` prove the
   current People/Journal/tools contracts. The remaining product parity was
   recorded explicitly in a #1630 comment before assertions were changed.

## Additional gates

```text
npm run check
svelte-check found 0 errors and 0 warnings

npm run build
exit 0; production site written to dist

just check
initial run: failed only in the independently tracked #1706 trigger
(`guard_false_positive_known_npc` selected `Fr. Declan Tierney` and the shared
sentence splitter/opener deduper removed the honorific); no #1718 assertion failed

clean rerun: exit 0; agent-check, Rust format/clippy/tests, witness scan,
documentation paths, UI diagnostics, ESLint, and Prettier all passed

just verify
exit 0; the pre-push gate and game-harness walkthrough passed
```

## Review follow-up

The review-requested Journal assertion was strengthened to verify the complete
ordered eight-line window (messages 3 through 10), avoiding an end-anchored
regular expression and proving the older messages were evicted:

```text
npx playwright test e2e/proof-1431.spec.ts \
  --workers=1 --retries=0 --reporter=line

4 passed (39.7s)

npm run check
svelte-check found 0 errors and 0 warnings

npx prettier --check e2e/proof-1431.spec.ts
All files formatted correctly
```

The generated local-inference documentation screenshot was restored after the
required run, and the isolated Cargo target was removed before diff review.

### Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

# Judge review — #1713

1. **Met.** The initial 10-failure baseline became a 30/30 passing exact issue
   run. The implementation uses current notebook controls and adds neither
   compatibility DOM nor blanket skips.
2. **Met.** Debug, Save/Load, Editor, and all four local-inference contracts
   passed in the same single-worker, zero-retry run.
3. **Met.** The Editor return contract asserts the notebook route, root, Pixi
   host, and visible canvas.
4. **Met.** Live-browser tests route all five required tool actions, and the
   tools screenshot records their visible current UI.
5. **Met.** The two focused browser contracts distinguish textarea input from
   the global map shortcut.
6. **Met.** The proof screenshots and passing assertions cover People, Journal,
   and tools. Focail and rich reaction/chat work was not hidden in stale test
   assertions; it remains explicitly tracked on #1630.

No production behavior changed. The only discovered infrastructure defect was
the pre-existing shared-target CSP race, separately filed as #1717. The test
migration introduces no residual debt.

### Artifacts

Drag these files into this PR comment in the GitHub UI to attach them:

- `journal-action-narration.png`
- `journal-latest-lines.png`
- `people-drawer.png`
- `people-to-tools.png`
- `tools-drawer-visible.png`

<!-- /parish-proof-bundle:1713-notebook-tools -->
