### PR TITLE
test(ui): migrate notebook command, stream, scene, and journal E2E

### DIFF
--- a/parish/apps/ui/e2e/chat-feed-rendering.spec.ts
+++ b/parish/apps/ui/e2e/chat-feed-rendering.spec.ts
@@ -1,29 +1,41 @@
 /**
- * E2E proof for the chat-feed rendering fixes:
+ * E2E proof for readable player-log content in the illustrated notebook.
  *
- *  - #1226: a go-to / movement player echo bubble must show the FULL
- *    destination. The destination equals the current location name, so it is
- *    highlighted as a `.term-location`. On the gold player bubble that term
- *    colour (#b58900) was gold-on-gold and the destination vanished. The fix
- *    forces player-bubble term spans to the bubble's readable foreground.
- *
- *  - #1275: when several co-located NPCs react to one player message, the
- *    reaction chips must wrap cleanly and stay aligned under the (right-
- *    aligned) player bubble — not spill to the left of it.
- *
- * Uses the default cream/gold light theme (DEFAULT_THEME_PALETTE) so the
- * conditions match the original bug screenshots. Captures a screenshot used
- * as the proof bundle artifact.
+ * The current Journal deliberately replaces the retired rich-chat bubble CSS.
+ * These checks preserve the original full-destination and message-order
+ * outcomes through that surface. Rich reaction presentation remains tracked by
+ * #1630 instead of reintroducing compatibility DOM solely for old selectors.
  */
 
+import type { Page } from '@playwright/test';
 import { test, expect, installTauriMock, emitEvent } from './fixtures';
+import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-// Proof bundle lives at repo-root/.proofs/fix-1226-1275 (gitignored).
+// Proof bundle lives at repo-root/.proofs/1712-notebook-journal-e2e (gitignored).
 // __dirname is parish/apps/ui/e2e → up four to the repo root.
-const PROOF_DIR = path.resolve(__dirname, '../../../../.proofs/fix-1226-1275');
+const PROOF_DIR = path.resolve(
+	__dirname,
+	'../../../../.proofs/1712-notebook-journal-e2e',
+);
+
+async function openJournal(page: Page) {
+	const trigger = page.getByRole('button', {
+		name: 'Open Journal notebook tab',
+	});
+	await expect(trigger).toBeVisible();
+	await trigger.focus();
+	await page.keyboard.press('Enter');
+	const journal = page.getByLabel('journal drawer');
+	await expect(journal).toBeVisible();
+	return journal;
+}
+
+function journalLine(journal: ReturnType<Page['locator']>, text: string) {
+	return journal.locator('p').filter({ hasText: text });
+}
 
 test.describe('chat-feed rendering (#1226, #1275)', () => {
 	test.beforeEach(async ({ page }) => {
@@ -51,34 +63,26 @@ test.describe('chat-feed rendering (#1226, #1275)', () => {
 		});
 	});
 
-	test('#1226 go-to bubble shows the full destination', async ({ page }) => {
-		// Backend echoes "> go to <dest>"; the frontend strips "> ".
+	test('#1226 Journal shows the full movement destination', async ({
+		page,
+	}) => {
+		const journal = await openJournal(page);
+		// Backend echoes "> go to <dest>"; the controller strips "> ".
 		await emitEvent(page, 'text-log', {
 			id: 'p-goto',
 			source: 'player',
 			content: '> go to The Crossroads',
 		});
 
-		const playerContent = page.locator('.bubble-row.player .content');
-		await expect(playerContent).toHaveText('go to The Crossroads');
-
-		// The destination is highlighted as a location term…
-		const term = page.locator('.bubble-row.player .term-location');
-		await expect(term).toHaveText('The Crossroads');
-
-		// …and that term is legible: its colour must NOT be the page-tuned gold
-		// location colour (which equals the bubble background). The fix sets it
-		// to --color-bg (cream #fafad8 in the default theme).
-		const termColor = await term.evaluate((el) => getComputedStyle(el).color);
-		// --color-bg #fafad8 → rgb(250, 250, 216); the old (buggy) colour was
-		// --color-location #b58900 → rgb(181, 137, 0).
-		expect(termColor).toBe('rgb(250, 250, 216)');
-		expect(termColor).not.toBe('rgb(181, 137, 0)');
+		const movementLine = journalLine(journal, 'go to The Crossroads');
+		await expect(movementLine).toHaveCount(1);
+		await expect(movementLine).toContainText('player: go to The Crossroads');
 	});
 
-	test('#1275 multiple NPC reaction chips wrap cleanly and align under the bubble', async ({
+	test('#1275 reaction events preserve readable Journal content and order (#1630)', async ({
 		page,
 	}) => {
+		const journal = await openJournal(page);
 		// Player message several co-located NPCs will react to.
 		await emitEvent(page, 'text-log', {
 			id: 'p-react',
@@ -99,50 +103,33 @@ test.describe('chat-feed rendering (#1226, #1275)', () => {
 				source: r.source,
 			});
 		}
+		await emitEvent(page, 'text-log', {
+			id: 'sys-after-reactions',
+			source: 'system',
+			content: 'The parish watches in thoughtful silence.',
+		});
 
-		const bar = page.locator('.bubble-row.player [data-testid="reaction-bar"]');
-		await expect(bar).toBeVisible();
-
-		// AC1275-2: every chip is present, none dropped.
-		const badges = page.locator('.bubble-row.player .reaction-badge');
-		await expect(badges).toHaveCount(reactors.length);
-
-		// AC1275-1: the bar is right-aligned (under the right-aligned bubble).
-		await expect(bar).toHaveCSS('justify-content', 'flex-end');
-		await expect(bar).toHaveCSS('flex-wrap', 'wrap');
-
-		// AC1275-3: each chip is an intact, non-shrinking unit.
-		const firstBadge = badges.first();
-		await expect(firstBadge).toHaveCSS('white-space', 'nowrap');
-		await expect(firstBadge).toHaveCSS('flex-shrink', '0');
-
-		// AC1275-1 (alignment): the chips sit under the right-aligned player
-		// bubble. The rightmost chip's right edge aligns with the bubble's right
-		// edge, and no chip spills off the left of the chat panel.
-		const bubble = page.locator('.bubble-row.player .bubble').first();
-		const lastBadge = badges.nth(reactors.length - 1);
-		const lastBox = await lastBadge.boundingBox();
-		const bubbleBox = await bubble.boundingBox();
-		const barBox = await bar.boundingBox();
-		const panelBox = await page
-			.locator('[data-testid="chat-panel"]')
-			.boundingBox();
-		expect(lastBox).not.toBeNull();
-		expect(bubbleBox).not.toBeNull();
-		expect(barBox).not.toBeNull();
-		expect(panelBox).not.toBeNull();
-		if (lastBox && bubbleBox && barBox && panelBox) {
-			// Rightmost chip right edge aligns with the bubble's right edge.
-			const lastRight = lastBox.x + lastBox.width;
-			const bubbleRight = bubbleBox.x + bubbleBox.width;
-			expect(Math.abs(lastRight - bubbleRight)).toBeLessThanOrEqual(4);
-			// No chip spills off the left edge of the chat panel.
-			expect(barBox.x).toBeGreaterThanOrEqual(panelBox.x - 1);
-		}
+		const playerLine = journalLine(journal, 'there is not');
+		const followingLine = journalLine(
+			journal,
+			'The parish watches in thoughtful silence.',
+		);
+		await expect(playerLine).toHaveCount(1);
+		await expect(playerLine).toContainText('player: there is not');
+		await expect(followingLine).toHaveCount(1);
+		const lines = await journal.locator('p').allTextContents();
+		expect(
+			lines.findIndex((line) => line.includes('there is not')),
+		).toBeLessThan(
+			lines.findIndex((line) => line.includes('thoughtful silence')),
+		);
 	});
 
-	test('capture proof screenshot (#1226 + #1275)', async ({ page }) => {
-		// Go-to bubble with full destination (#1226).
+	test('capture current Journal proof (#1226 + #1275 migration)', async ({
+		page,
+	}) => {
+		const journal = await openJournal(page);
+		// Movement line with full destination (#1226).
 		await emitEvent(page, 'text-log', {
 			id: 'p-goto',
 			source: 'player',
@@ -167,16 +154,23 @@ test.describe('chat-feed rendering (#1226, #1275)', () => {
 				source: r.source,
 			});
 		}
+		await emitEvent(page, 'text-log', {
+			id: 'sys-after-reactions',
+			source: 'system',
+			content: 'The parish watches in thoughtful silence.',
+		});
 
-		await expect(
-			page.locator('.bubble-row.player .content').first(),
-		).toHaveText('go to The Crossroads');
-		await expect(
-			page.locator('.bubble-row.player .reaction-badge'),
-		).toHaveCount(5);
+		await expect(journalLine(journal, 'go to The Crossroads')).toContainText(
+			'player: go to The Crossroads',
+		);
+		await expect(journalLine(journal, 'there is not')).toContainText(
+			'player: there is not',
+		);
+		await expect(journalLine(journal, 'thoughtful silence')).toHaveCount(1);
 
+		fs.mkdirSync(PROOF_DIR, { recursive: true });
 		await page.screenshot({
-			path: path.join(PROOF_DIR, 'chat-feed-rendering.png'),
+			path: path.join(PROOF_DIR, 'journal-content-order.png'),
 			fullPage: false,
 		});
 	});

--- a/parish/apps/ui/e2e/chat-feed-rendering.spec.ts
+++ b/parish/apps/ui/e2e/chat-feed-rendering.spec.ts
@@ -118,11 +118,13 @@ test.describe('chat-feed rendering (#1226, #1275)', () => {
 		await expect(playerLine).toContainText('player: there is not');
 		await expect(followingLine).toHaveCount(1);
 		const lines = await journal.locator('p').allTextContents();
-		expect(
-			lines.findIndex((line) => line.includes('there is not')),
-		).toBeLessThan(
-			lines.findIndex((line) => line.includes('thoughtful silence')),
+		const playerIdx = lines.findIndex((line) => line.includes('there is not'));
+		const systemIdx = lines.findIndex((line) =>
+			line.includes('thoughtful silence'),
 		);
+		expect(playerIdx).toBeGreaterThan(-1);
+		expect(systemIdx).toBeGreaterThan(-1);
+		expect(playerIdx).toBeLessThan(systemIdx);
 	});
 
 	test('capture current Journal proof (#1226 + #1275 migration)', async ({

--- a/parish/apps/ui/e2e/interactions.spec.ts
+++ b/parish/apps/ui/e2e/interactions.spec.ts
@@ -262,9 +262,15 @@ test.describe('Streaming simulation', () => {
 			"If it is, I'll bring the cart before sunset.",
 		);
 		const lines = await journal.locator('p').allTextContents();
-		expect(
-			lines.findIndex((line) => line.includes('Siobhan Murphy')),
-		).toBeLessThan(lines.findIndex((line) => line.includes('Padraig Darcy')));
+		const siobhanIdx = lines.findIndex((line) =>
+			line.includes('Siobhan Murphy'),
+		);
+		const padraigIdx = lines.findIndex((line) =>
+			line.includes('Padraig Darcy'),
+		);
+		expect(siobhanIdx).toBeGreaterThan(-1);
+		expect(padraigIdx).toBeGreaterThan(-1);
+		expect(siobhanIdx).toBeLessThan(padraigIdx);
 	});
 });
 

--- a/parish/apps/ui/e2e/interactions.spec.ts
+++ b/parish/apps/ui/e2e/interactions.spec.ts
@@ -2,65 +2,127 @@
  * E2E tests for user interactions: input submission, streaming, paused state.
  */
 
+import type { Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
 import { test, expect, installTauriMock, emitEvent } from './fixtures';
 import { SNAPSHOTS, IRISH_HINTS } from './mock-data';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROOF_DIR = path.resolve(
+	__dirname,
+	'../../../../.proofs/1712-notebook-journal-e2e',
+);
+
+async function openNotebookDrawer(page: Page, name: 'journal' | 'intents') {
+	const triggerName =
+		name === 'journal' ? 'Open Journal notebook tab' : 'Open active intents';
+	const trigger = page.getByRole('button', { name: triggerName });
+	await expect(trigger).toBeVisible();
+	await trigger.focus();
+	await page.keyboard.press('Enter');
+	const drawer = page.getByLabel(`${name} drawer`);
+	await expect(drawer).toBeVisible();
+	return drawer;
+}
+
+async function installSubmitRecorder(page: Page) {
+	await page.evaluate(() => {
+		type Invoke = (
+			command: string,
+			args?: Record<string, unknown>,
+		) => Promise<unknown>;
+		const globals = window as unknown as Record<string, unknown>;
+		const internals = globals.__TAURI_INTERNALS__ as { invoke: Invoke };
+		const originalInvoke = internals.invoke.bind(internals);
+		const submissions: string[] = [];
+		globals.__TEST_SUBMIT_COMMANDS__ = submissions;
+		internals.invoke = async (command, args) => {
+			if (command === 'submit_input') {
+				submissions.push(String(args?.text ?? ''));
+			}
+			return originalInvoke(command, args);
+		};
+	});
+}
+
+async function submittedCommands(page: Page): Promise<string[]> {
+	return page.evaluate(() => {
+		const globals = window as unknown as Record<string, unknown>;
+		return (globals.__TEST_SUBMIT_COMMANDS__ as string[] | undefined) ?? [];
+	});
+}
 
 test.describe('Input field interactions', () => {
 	test.beforeEach(async ({ page }) => {
 		await installTauriMock(page, 'morning');
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
+		await expect(
+			page.locator('[data-testid="illustrated-notebook-game"]'),
+		).toBeVisible();
 	});
 
 	test('can type and submit text via Enter key', async ({ page }) => {
-		const input = page.locator('[data-testid="input-field"]');
+		await installSubmitRecorder(page);
+		const input = page.getByLabel('Player intent');
 		await input.fill('go to Howth');
 		await input.press('Enter');
 
-		// Input should be cleared after submission
-		await expect(input).toHaveText('');
+		await expect(input).toHaveValue('');
+		await expect.poll(() => submittedCommands(page)).toEqual(['go to Howth']);
 	});
 
-	// #1379: the input is always editable — no aria-disabled toggling.
-	// During streaming the field is dimmed (css class "streaming") to signal
-	// the in-flight reply, but it remains contenteditable so the first
-	// keystroke can flush the stream to completion.
+	// #1379: the notebook input remains an enabled native field while its
+	// aria-disabled value communicates the in-flight reply. The first keystroke
+	// flushes that reply and is then accepted into the draft.
 	test('input stays editable during streaming (flush-on-interaction, #1379)', async ({
 		page,
 	}) => {
-		const input = page.locator('[data-testid="input-field"]');
+		const input = page.getByLabel('Player intent');
 
-		// Simulate loading/streaming state
+		// Give the stream manager a real buffered turn. The native notebook input
+		// advertises that the reply is busy, but remains an actual editable input
+		// so the first keystroke can flush the reply.
 		await emitEvent(page, 'loading', { active: true });
+		await emitEvent(page, 'stream-token', {
+			token: 'The whole reply appears when the player starts typing again.',
+			turn_id: 1379,
+			source: 'Siobhan Murphy',
+		});
+		await emitEvent(page, 'stream-turn-end', { turn_id: 1379 });
 
-		// Field must never become aria-disabled; it should have the streaming class.
-		await expect(input).not.toHaveAttribute('aria-disabled', 'true');
-		await expect(input).toHaveAttribute('contenteditable', 'true');
-		await expect(input).toHaveClass(/streaming/);
+		await expect(input).toHaveAttribute('aria-disabled', 'true');
+		await expect(input).not.toHaveAttribute('disabled', '');
+		await input.fill('next thought');
+		await input.press('x');
+		await expect(input).toHaveValue('next thoughtx');
+		await expect(input).toHaveAttribute('aria-disabled', 'false');
 
-		// End loading
-		await emitEvent(page, 'loading', { active: false });
-		await expect(input).not.toHaveClass(/streaming/);
-		await expect(input).not.toHaveAttribute('aria-disabled', 'true');
+		const journal = await openNotebookDrawer(page, 'journal');
+		await expect(journal).toContainText(
+			'The whole reply appears when the player starts typing again.',
+		);
 	});
 
 	// Regression for #991: the backend's handle_npc_conversation cancels
 	// and re-spawns the loading animation per addressed NPC turn, so
 	// `loading {active:false}` arrives mid-chain (between phase-1 NPC
 	// turns, or between phase-1 and the autonomous follow-up chain).
-	// #1379: the input is never aria-disabled; instead streamingActive is
-	// reflected by the "streaming" CSS class. The mid-chain loading=false
-	// must NOT remove the streaming class — only the terminal `stream-end` may.
+	// The mid-chain loading=false must NOT clear the notebook busy state — only
+	// the terminal `stream-end` may return the current reply to idle.
 	test('input stays in streaming state across mid-chain loading=false (#991)', async ({
 		page,
 	}) => {
-		const input = page.locator('[data-testid="input-field"]');
+		const input = page.getByLabel('Player intent');
+		const intents = await openNotebookDrawer(page, 'intents');
 
 		// Chain begins.
 		await emitEvent(page, 'loading', { active: true });
-		// #1379: always editable, never aria-disabled; streaming class is the signal.
-		await expect(input).not.toHaveAttribute('aria-disabled', 'true');
-		await expect(input).toHaveClass(/streaming/);
+		await expect(input).toHaveAttribute('aria-disabled', 'true');
+		await expect(input).not.toHaveAttribute('disabled', '');
+		await expect(intents).toContainText('Parish reply: pending');
 
 		// NPC 1 streams a reply and the per-turn cancel fires.
 		await emitEvent(page, 'stream-token', {
@@ -71,14 +133,15 @@ test.describe('Input field interactions', () => {
 		await emitEvent(page, 'stream-turn-end', { turn_id: 1001 });
 		await emitEvent(page, 'loading', { active: false });
 
-		// Input must remain in streaming state even though loading=false has
-		// arrived, because the chain has not yet emitted `stream-end`.
-		await expect(input).toHaveClass(/streaming/);
-		await expect(input).not.toHaveAttribute('aria-disabled', 'true');
+		// The notebook must remain busy even though loading=false has arrived,
+		// because the chain has not yet emitted `stream-end`.
+		await expect(input).toHaveAttribute('aria-disabled', 'true');
+		await expect(input).not.toHaveAttribute('disabled', '');
+		await expect(intents).toContainText('Parish reply: pending');
 
-		// Capture the mid-chain state as proof for #991 (rule #10 screenshot tier).
+		fs.mkdirSync(PROOF_DIR, { recursive: true });
 		await page.screenshot({
-			path: '../../../docs/proofs/991-streaming-active-chain-gap/screenshots/mid-chain-input-streaming.png',
+			path: path.join(PROOF_DIR, 'mid-chain-input-streaming.png'),
 			fullPage: false,
 		});
 
@@ -90,38 +153,45 @@ test.describe('Input field interactions', () => {
 		});
 		await emitEvent(page, 'stream-turn-end', { turn_id: 1002 });
 
-		// Still streaming — chain still alive.
-		await expect(input).toHaveClass(/streaming/);
+		// Still busy — the chain is still alive.
+		await expect(input).toHaveAttribute('aria-disabled', 'true');
+		await expect(intents).toContainText('Parish reply: pending');
 
 		// Chain terminates.
 		await emitEvent(page, 'stream-end', { hints: [] });
 
-		// Only now does the streaming class clear and the field return to idle.
-		await expect(input).not.toHaveClass(/streaming/);
-		await expect(input).not.toHaveAttribute('aria-disabled', 'true');
+		// Only now does the notebook return to idle.
+		await expect(input).toHaveAttribute('aria-disabled', 'false');
+		await expect(intents).toContainText('Parish reply: idle');
 	});
 });
 
 test.describe('Streaming simulation', () => {
-	test('stream tokens appear incrementally in chat', async ({ page }) => {
+	test('stream tokens appear incrementally in the Journal', async ({
+		page,
+	}) => {
 		await installTauriMock(page, 'morning');
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
+		const journal = await openNotebookDrawer(page, 'journal');
 
 		// Start loading
 		await emitEvent(page, 'loading', { active: true });
 
-		// Send tokens
+		// Send tokens and observe each increment through the notebook Journal.
 		await emitEvent(page, 'stream-token', {
 			token: 'Ah, ',
 			turn_id: 1,
 			source: 'Siobhan Murphy',
 		});
+		const reply = journal.locator('p').filter({ hasText: 'Siobhan Murphy' });
+		await expect(reply).toContainText('Ah,');
 		await emitEvent(page, 'stream-token', {
 			token: "you're ",
 			turn_id: 1,
 			source: 'Siobhan Murphy',
 		});
+		await expect(reply).toContainText("Ah, you're");
 		await emitEvent(page, 'stream-token', {
 			token: 'welcome!',
 			turn_id: 1,
@@ -129,7 +199,7 @@ test.describe('Streaming simulation', () => {
 		});
 		await emitEvent(page, 'stream-turn-end', { turn_id: 1 });
 
-		await expect(page.getByText("Ah, you're welcome!")).toBeVisible();
+		await expect(reply).toContainText("Ah, you're welcome!");
 
 		// End stream
 		await emitEvent(page, 'stream-end', { hints: IRISH_HINTS });
@@ -141,6 +211,7 @@ test.describe('Streaming simulation', () => {
 		await installTauriMock(page, 'morning');
 		await page.goto('/');
 		await page.waitForLoadState('networkidle');
+		const journal = await openNotebookDrawer(page, 'journal');
 
 		await emitEvent(page, 'loading', { active: true });
 
@@ -155,9 +226,11 @@ test.describe('Streaming simulation', () => {
 			turn_id: 11,
 			source: 'Siobhan Murphy',
 		});
-		await expect(
-			page.locator('.bubble-row.npc').nth(0).locator('.label'),
-		).toHaveText('Siobhan Murphy');
+		const siobhan = journal.locator('p').filter({ hasText: 'Siobhan Murphy' });
+		await expect(siobhan).toHaveCount(1);
+		await expect(siobhan).toContainText(
+			'I heard the fair will be lively tonight',
+		);
 
 		// Queue Padraig before Siobhan has finished animating.
 		await emitEvent(page, 'text-log', {
@@ -181,21 +254,26 @@ test.describe('Streaming simulation', () => {
 		await emitEvent(page, 'stream-turn-end', { turn_id: 12 });
 		await emitEvent(page, 'stream-end', { hints: IRISH_HINTS });
 
-		const npcRows = page.locator('.bubble-row.npc');
-		await expect(npcRows).toHaveCount(2);
-		await expect(npcRows.nth(0).locator('.label')).toHaveText('Siobhan Murphy');
-		await expect(npcRows.nth(0).locator('.content')).toContainText(
+		const padraig = journal.locator('p').filter({ hasText: 'Padraig Darcy' });
+		await expect(siobhan).toContainText(
 			'I heard the fair will be lively tonight with music by the square.',
 		);
-		await expect(npcRows.nth(1).locator('.label')).toHaveText('Padraig Darcy');
-		await expect(npcRows.nth(1).locator('.content')).toContainText(
+		await expect(padraig).toContainText(
 			"If it is, I'll bring the cart before sunset.",
 		);
+		const lines = await journal.locator('p').allTextContents();
+		expect(
+			lines.findIndex((line) => line.includes('Siobhan Murphy')),
+		).toBeLessThan(lines.findIndex((line) => line.includes('Padraig Darcy')));
 	});
 });
 
 test.describe('Paused state', () => {
 	test('shows paused indicator when game is paused', async ({ page }) => {
+		test.fixme(
+			true,
+			'#1715 restores a visible and accessible paused-state contract to the illustrated notebook',
+		);
 		const pausedSnapshot = { ...SNAPSHOTS.morning, paused: true };
 		await installTauriMock(page, 'morning');
 
@@ -219,6 +297,10 @@ test.describe('Paused state', () => {
 
 test.describe('Festival badge', () => {
 	test('shows festival badge when festival is active', async ({ page }) => {
+		test.fixme(
+			true,
+			'#1716 restores the active festival to the illustrated notebook world-state surface',
+		);
 		const festivalSnapshot = { ...SNAPSHOTS.morning, festival: 'Samhain' };
 		await installTauriMock(page, 'morning');
 

--- a/parish/apps/ui/e2e/scene-dedup.spec.ts
+++ b/parish/apps/ui/e2e/scene-dedup.spec.ts
@@ -10,8 +10,21 @@
  * still show the destination scene.
  */
 
+import type { Page } from '@playwright/test';
 import { test, expect, installTauriMock, emitEvent } from './fixtures';
 import { SNAPSHOTS } from './mock-data';
+
+async function openJournal(page: Page) {
+	const trigger = page.getByRole('button', {
+		name: 'Open Journal notebook tab',
+	});
+	await expect(trigger).toBeVisible();
+	await trigger.focus();
+	await page.keyboard.press('Enter');
+	const journal = page.getByLabel('journal drawer');
+	await expect(journal).toBeVisible();
+	return journal;
+}
 
 test.describe('Scene description deduplication', () => {
 	test.beforeEach(async ({ page }) => {
@@ -23,6 +36,7 @@ test.describe('Scene description deduplication', () => {
 	test('movement renders the arrival scene once, not twice', async ({
 		page,
 	}) => {
+		const journal = await openJournal(page);
 		// Full arrival text the backend sends as a `location` text-log entry.
 		const arrivalText =
 			'The churchyard lies still beneath a grey sky. Exits: north to the village green.';
@@ -46,16 +60,19 @@ test.describe('Scene description deduplication', () => {
 		});
 
 		// The arrival scene shows exactly once.
-		await expect(page.getByText(arrivalText, { exact: false })).toHaveCount(1);
+		await expect(journal.getByText(arrivalText, { exact: false })).toHaveCount(
+			1,
+		);
 		// The duplicate, shorter world-update scene line was suppressed.
 		await expect(
-			page.getByText(worldUpdateScene, { exact: false }),
+			journal.getByText(worldUpdateScene, { exact: false }),
 		).toHaveCount(0);
 	});
 
 	test('load/restore still shows the destination scene (no location text-log)', async ({
 		page,
 	}) => {
+		const journal = await openJournal(page);
 		// A load/restore world-update changes the location with no preceding
 		// `location` text-log — the scene must be shown.
 		const loadedScene = 'You stand once more in the loaded harbour town.';
@@ -65,6 +82,8 @@ test.describe('Scene description deduplication', () => {
 			location_description: loadedScene,
 		});
 
-		await expect(page.getByText(loadedScene, { exact: false })).toHaveCount(1);
+		await expect(journal.getByText(loadedScene, { exact: false })).toHaveCount(
+			1,
+		);
 	});
 });

--- a/parish/apps/ui/e2e/slash-command-echo.spec.ts
+++ b/parish/apps/ui/e2e/slash-command-echo.spec.ts
@@ -70,9 +70,13 @@ test.describe('slash-command echo rendering (#1423)', () => {
 			'system: The clocks of the parish stand still. Time is now paused.',
 		);
 		const lines = await journal.locator('p').allTextContents();
-		expect(lines.findIndex((line) => line.includes('/pause'))).toBeLessThan(
-			lines.findIndex((line) => line.includes('clocks of the parish')),
+		const pauseIdx = lines.findIndex((line) => line.includes('/pause'));
+		const clocksIdx = lines.findIndex((line) =>
+			line.includes('clocks of the parish'),
 		);
+		expect(pauseIdx).toBeGreaterThan(-1);
+		expect(clocksIdx).toBeGreaterThan(-1);
+		expect(pauseIdx).toBeLessThan(clocksIdx);
 
 		// Capture proof screenshot
 		fs.mkdirSync(PROOF_DIR, { recursive: true });
@@ -127,6 +131,10 @@ test.describe('slash-command echo rendering (#1423)', () => {
 		const resumed = lines.findIndex((line) => line.includes('Time flows'));
 		const wait = lines.findIndex((line) => line.includes('/wait 10'));
 		const waited = lines.findIndex((line) => line.includes('Ten minutes'));
+		expect(resume).toBeGreaterThan(-1);
+		expect(resumed).toBeGreaterThan(-1);
+		expect(wait).toBeGreaterThan(-1);
+		expect(waited).toBeGreaterThan(-1);
 		expect(resume).toBeLessThan(resumed);
 		expect(resumed).toBeLessThan(wait);
 		expect(wait).toBeLessThan(waited);

--- a/parish/apps/ui/e2e/slash-command-echo.spec.ts
+++ b/parish/apps/ui/e2e/slash-command-echo.spec.ts
@@ -1,14 +1,12 @@
 /**
- * E2E proof for slash-command echo rendering (#1423).
+ * E2E proof for slash-command echo ordering in the illustrated notebook.
  *
- * Verifies that a text-log entry with source:"player" and subtype:"command"
- * renders as a distinct command line (`.entry.command`) above the narration
- * that follows it, NOT as a gold dialogue bubble.
- *
- * Captures a screenshot saved to `.proofs/fix-1423-slash-echo/` as the
- * live-proof artifact.
+ * The Journal replaces the retired chat-entry CSS. These checks keep command
+ * text, source attribution, and command-before-result ordering readable without
+ * adding compatibility DOM solely for the old selectors.
  */
 
+import type { Page } from '@playwright/test';
 import { test, expect, installTauriMock, emitEvent } from './fixtures';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -19,8 +17,24 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // __dirname is parish/apps/ui/e2e → up four to the repo root.
 const PROOF_DIR = path.resolve(
 	__dirname,
-	'../../../../.proofs/fix-1423-slash-echo',
+	'../../../../.proofs/1712-notebook-journal-e2e',
 );
+
+async function openJournal(page: Page) {
+	const trigger = page.getByRole('button', {
+		name: 'Open Journal notebook tab',
+	});
+	await expect(trigger).toBeVisible();
+	await trigger.focus();
+	await page.keyboard.press('Enter');
+	const journal = page.getByLabel('journal drawer');
+	await expect(journal).toBeVisible();
+	return journal;
+}
+
+function journalLine(journal: ReturnType<Page['locator']>, text: string) {
+	return journal.locator('p').filter({ hasText: text });
+}
 
 test.describe('slash-command echo rendering (#1423)', () => {
 	test.beforeEach(async ({ page }) => {
@@ -29,9 +43,10 @@ test.describe('slash-command echo rendering (#1423)', () => {
 		await page.waitForLoadState('networkidle');
 	});
 
-	test('#1423 /pause shows as .entry.command, not a dialogue bubble', async ({
+	test('#1423 /pause remains readable before its Journal result', async ({
 		page,
 	}) => {
+		const journal = await openJournal(page);
 		// Emit the command echo (source:player, subtype:command)
 		await emitEvent(page, 'text-log', {
 			id: 'cmd-pause',
@@ -47,19 +62,17 @@ test.describe('slash-command echo rendering (#1423)', () => {
 			content: 'The clocks of the parish stand still. Time is now paused.',
 		});
 
-		// AC-3: command entry exists with .entry.command
-		const commandEntry = page.locator('[data-testid="command-entry"]');
-		await expect(commandEntry).toBeVisible();
-		await expect(commandEntry).toContainText('/pause');
-
-		// AC-3: NOT rendered as a player dialogue bubble
-		await expect(page.locator('.bubble-row.player')).toHaveCount(0);
-
-		// System narration follows below
-		const narration = page
-			.locator('.entry.system')
-			.filter({ hasText: 'clocks of the parish' });
-		await expect(narration).toContainText('clocks of the parish');
+		const commandEntry = journalLine(journal, '/pause');
+		const narration = journalLine(journal, 'clocks of the parish');
+		await expect(commandEntry).toHaveCount(1);
+		await expect(commandEntry).toContainText('player: /pause');
+		await expect(narration).toContainText(
+			'system: The clocks of the parish stand still. Time is now paused.',
+		);
+		const lines = await journal.locator('p').allTextContents();
+		expect(lines.findIndex((line) => line.includes('/pause'))).toBeLessThan(
+			lines.findIndex((line) => line.includes('clocks of the parish')),
+		);
 
 		// Capture proof screenshot
 		fs.mkdirSync(PROOF_DIR, { recursive: true });
@@ -72,6 +85,7 @@ test.describe('slash-command echo rendering (#1423)', () => {
 	test('#1423 /resume and /wait also render as command entries', async ({
 		page,
 	}) => {
+		const journal = await openJournal(page);
 		await emitEvent(page, 'text-log', {
 			id: 'cmd-r',
 			source: 'player',
@@ -95,11 +109,26 @@ test.describe('slash-command echo rendering (#1423)', () => {
 			content: 'Ten minutes pass quietly.',
 		});
 
-		const commandEntries = page.locator('[data-testid="command-entry"]');
-		await expect(commandEntries).toHaveCount(2);
-		await expect(commandEntries.nth(0)).toContainText('/resume');
-		await expect(commandEntries.nth(1)).toContainText('/wait 10');
-		// No player bubbles
-		await expect(page.locator('.bubble-row.player')).toHaveCount(0);
+		await expect(journalLine(journal, '/resume')).toContainText(
+			'player: /resume',
+		);
+		await expect(journalLine(journal, 'Time flows once more')).toContainText(
+			'system: Time flows once more in the parish.',
+		);
+		await expect(journalLine(journal, '/wait 10')).toContainText(
+			'player: /wait 10',
+		);
+		await expect(journalLine(journal, 'Ten minutes pass')).toContainText(
+			'system: Ten minutes pass quietly.',
+		);
+
+		const lines = await journal.locator('p').allTextContents();
+		const resume = lines.findIndex((line) => line.includes('/resume'));
+		const resumed = lines.findIndex((line) => line.includes('Time flows'));
+		const wait = lines.findIndex((line) => line.includes('/wait 10'));
+		const waited = lines.findIndex((line) => line.includes('Ten minutes'));
+		expect(resume).toBeLessThan(resumed);
+		expect(resumed).toBeLessThan(wait);
+		expect(wait).toBeLessThan(waited);
 	});
 });


### PR DESCRIPTION
## Summary

- migrate the 14 stale command, stream, scene, and Journal Playwright contracts to the illustrated notebook native input, keyboard accessibility targets, active-intents drawer, and Journal
- preserve Enter submission/clear, first-key stream flush, mid-chain busy state, incremental and multi-NPC attribution, scene deduplication, and slash-command source/order outcomes
- keep the change test-only: no shared fixture/config edits and no production compatibility DOM

## Parity findings

- paused-state visibility remains as one narrow `test.fixme` linked to #1715
- active-festival visibility remains as one narrow `test.fixme` linked to #1716
- richer reaction/chat presentation remains tracked by #1630
- parallel-worktree server artifact isolation remains tracked by #1717

## Proof

- `CI=1 CARGO_TARGET_DIR=/private/tmp/rundale-1712-target PARISH_TEST_PORT=3102 npx playwright test e2e/interactions.spec.ts e2e/chat-feed-rendering.spec.ts e2e/scene-dedup.spec.ts e2e/slash-command-echo.spec.ts --workers=1 --retries=0 --reporter=line` — 12 passed, 2 expected fixmes, 0 failed
- `npm run check` — 0 errors, 0 warnings
- `npm run build` — passed
- `just check` — passed
- `just verify` — passed
- `cargo run -p parish-engine -- --script testing/fixtures/test_walkthrough.txt` — valid JSON for look, movement to The Crossroads in 13 minutes, status, map, and help

Proof screenshots cover Journal content/order, mid-chain pending state, and command/result ordering.

Parent incident: #1710

Fixes #1712

<!-- parish-proof-bundle:1712-notebook-journal-e2e v=1 -->

## Proof: 1712-notebook-journal-e2e

### Acceptance criteria

# Acceptance Criteria — issue 1712

Parent incident: #1710

## Outcome

Command, streaming, scene/log, and slash-command behavior remains proven end
to end through the illustrated notebook native input, active-intents drawer,
and Journal. The recovery is test-only and does not restore legacy dashboard
DOM.

## Criteria

1. The 14 previously failing tests in the four owned specs no longer fail.
2. `Player intent` proves Enter submission, the `submit_input` command, and
   successful draft clearing.
3. During a streamed reply the native input remains an enabled HTML input,
   reports busy state, and the first player keystroke flushes the complete
   buffered reply into the Journal.
4. A mid-chain `loading { active: false }` does not clear busy state before the
   terminal `stream-end`; the active-intents drawer moves from `pending` to
   `idle` only at the terminal event.
5. Incremental tokens and overlapping multi-NPC streams remain readable and
   attributed to the correct source in Journal order.
6. Movement scene text appears once, the immediately following world snapshot
   does not duplicate it, and load/restore without a location text-log still
   shows the destination scene.
7. Slash-command echoes retain player attribution and precede their system
   results in Journal order without relying on retired bubble CSS.
8. Rich reaction presentation remains tracked by #1630. The missing paused and
   festival indicators retain their full intended tests behind exactly two
   narrow issue-linked fixmes, #1715 and #1716.
9. Shared fixtures/config and production files remain unchanged. The tracked
   diff contains only the four specs owned by #1712.

## Proof

- Targeted Playwright command: 12 passed, 2 expected issue-linked fixmes,
  0 failed, 1 worker, 0 retries.
- `npm run check`: 0 errors and 0 warnings.
- `npm run build`: succeeded.
- `just check`: succeeded.
- `just verify`: succeeded, including the walkthrough harness.
- Direct walkthrough inspection returned valid JSON for `look`, movement to
  The Crossroads in 13 minutes, `/status`, `/map`, and `/help`.
- Screenshots:
  - `journal-content-order.png`
  - `mid-chain-input-streaming.png`
  - `command-echo.png`

### Evidence

# Evidence — issue 1712 notebook Journal E2E recovery

Evidence type: screenshot

Parent incident: #1710

## Diff summary

| File | Current contract proved |
|---|---|
| `parish/apps/ui/e2e/interactions.spec.ts` | Native `Player intent` Enter submission and clear, mocked `submit_input` call, busy-but-enabled input, first-key stream flush, #991 mid-chain busy state, incremental Journal reveal, and multi-NPC source/order. The original paused/festival bodies remain behind exactly two narrow fixmes linked to #1715/#1716. |
| `parish/apps/ui/e2e/chat-feed-rendering.spec.ts` | Full movement destination and readable content/order after reaction events through the Journal. Rich reaction presentation remains #1630. |
| `parish/apps/ui/e2e/scene-dedup.spec.ts` | Movement scene appears once; world-update duplicate is suppressed; load/restore without a location log still shows its destination scene. |
| `parish/apps/ui/e2e/slash-command-echo.spec.ts` | Player command echoes precede readable system results in Journal order without retired bubble CSS. |

No production file, shared fixture, Playwright config, or compatibility DOM is
changed.

## Targeted browser proof

The final run used a fresh managed server whose Cargo target was isolated from
other concurrent worktrees (#1717 containment):

```sh
CI=1 CARGO_TARGET_DIR=/private/tmp/rundale-1712-target \
PARISH_TEST_PORT=3102 npx playwright test \
  e2e/interactions.spec.ts \
  e2e/chat-feed-rendering.spec.ts \
  e2e/scene-dedup.spec.ts \
  e2e/slash-command-echo.spec.ts \
  --workers=1 --retries=0 --reporter=line
```

Result: **12 passed, 2 expected issue-linked fixmes, 0 failed (34.6s)**.

The two fixmes are intentionally narrow:

- paused indicator — #1715
- active festival — #1716

## Acceptance-criteria evidence map

| Outcome | Evidence |
|---|---|
| Enter submits and clears | `interactions.spec.ts` records the Tauri `submit_input` invocation as `go to Howth` and asserts an empty native input value afterward. |
| Busy input remains usable and first key flushes | The test proves `aria-disabled=true` while busy but no native `disabled` attribute, types a draft, presses the first key, observes idle state, and finds the complete buffered reply in the Journal. |
| Mid-chain loading gap stays busy | Active-intents reads `Parish reply: pending` before and after `loading=false`, remains pending for the follow-up NPC, then reads `idle` only after `stream-end`. Screenshot: `mid-chain-input-streaming.png`. |
| Incremental streaming | Journal content is asserted after each of three token events, ending in the complete `Ah, you're welcome!` line. |
| Multi-NPC attribution | Siobhan and Padraig retain their full distinct lines and Siobhan precedes Padraig in Journal DOM order. |
| Scene dedup | Location text-log is present once while the distinct snapshot description is absent; load-only snapshot description is present once. |
| Slash command ordering | `/pause`, `/resume`, and `/wait 10` retain player source and each precedes its system result. Screenshot: `command-echo.png`. |
| Readable reaction-event content | Player text remains present once and before the following system line after five reaction events. Rich presentation remains #1630. Screenshot: `journal-content-order.png`. |

## Commands run

```sh
npm run check
npm run build
just check
just verify
cargo run -p parish-engine -- --script testing/fixtures/test_walkthrough.txt
```

- Svelte diagnostics: 0 errors, 0 warnings.
- UI production build: passed.
- Repository pre-commit and pre-push gates: passed.
- Walkthrough emitted valid JSON for a non-empty `look`, movement from
  Kilteevan to The Crossroads in 13 minutes, and non-empty `/status`, `/map`,
  and `/help` responses.

## Setup failures kept separate from product evidence

Two earlier local attempts did not reach the migrated assertions: the isolated
worktree initially lacked a built UI `dist`, then Playwright reused the stale
port-3102 listener because local `reuseExistingServer` was enabled. Those are
harness/setup failures, not product failures. The final proof built the UI,
verified/stopped the stale listener, used `CI=1`, and isolated the Cargo target;
the systemic parallel-worktree fix remains #1717.

### Judge

# Judge — issue 1712 notebook Journal E2E recovery

## Scope assessed

The tracked change is confined to the four E2E specs owned by #1712. It moves
their contracts from removed dashboard selectors to the illustrated notebook
native input, keyboard-activated accessibility targets, active-intents drawer,
and Journal. No production component, shared fixture, or Playwright config is
changed.

## Correctness assessment

- Enter submission is not inferred only from a cleared field: the test records
  the mocked Tauri invocation and proves `submit_input` received the command.
- Flush-on-interaction uses a realistic token followed by `stream-turn-end`,
  proves the field remains an enabled native input while busy, and confirms the
  complete buffered line appears in the Journal after the next keystroke.
- The #991 sequence retains the exact mid-chain `loading=false` gap and proves
  `pending` persists until `stream-end`, then becomes `idle`.
- Streaming checks observe intermediate text and final text, and the two-NPC
  case proves full content, source attribution, and FIFO Journal order.
- Scene-dedup tests preserve both halves of the original contract through the
  visible Journal rather than merely checking store state.
- Slash-command tests prove command/source/result ordering rather than relying
  on retired `.entry.command` or bubble CSS.
- The reaction-layout assertion is not disguised as current coverage. Rich
  presentation is explicitly preserved on #1630; the active Journal contract
  proves readable content and order after reaction events.
- The missing paused and festival outcomes are not asserted absent. Their
  original test bodies remain behind exactly two narrow fixmes linked to ready
  product bugs #1715 and #1716.

## Evidence reviewed

- Fresh worktree-local browser server with its own Cargo target directory.
- Targeted Playwright suite: 12 passed, 2 skipped fixmes, 0 failed in 34.6s,
  with `--workers=1 --retries=0`.
- Svelte diagnostics: 0 errors and 0 warnings.
- Production UI build: succeeded.
- Repository `just check` and `just verify`: succeeded.
- Walkthrough JSON showed a non-empty starting description, valid movement to
  The Crossroads with positive travel time, and non-empty system responses.
- Three screenshots show Journal content/order, mid-chain pending state, and
  command/result ordering.

## Acceptance-criteria audit

| Criterion | Result |
|---|---|
| 14 owned failures drained | Met: 12 pass, 2 issue-linked fixmes, 0 fail |
| Enter submission and clear | Met |
| Busy/editable and first-key flush | Met |
| Mid-chain busy state | Met |
| Incremental and multi-NPC streaming | Met |
| Scene dedup and load/restore | Met |
| Slash-command readability/order | Met |
| Residual parity tracked honestly | Met: #1630, #1715, #1716 |
| Test-only ownership boundary | Met |

Verdict: sufficient

Technical debt: clear

Acceptance criteria: met

### Artifacts

Drag these files into this PR comment in the GitHub UI to attach them:

- `command-echo.png`
- `journal-content-order.png`
- `mid-chain-input-streaming.png`

<!-- /parish-proof-bundle:1712-notebook-journal-e2e -->
