### PR TITLE
fix: audit newly opened issues

### DIFF
--- a/.github/scripts/portfolio-audit.test.cjs
+++ b/.github/scripts/portfolio-audit.test.cjs
@@ -37,14 +37,47 @@ function activeIssue(overrides = {}) {
   };
 }
 
+function issueTriggerEventTypes(workflow) {
+  const issueTrigger = workflow.match(
+    /^ {2}issues:[ \t]*\r?\n {4,}types:[ \t]*\[([^\]\r\n]+)\][ \t]*\r?$/m,
+  );
+
+  assert.ok(issueTrigger, "triage audit must retain its issues trigger");
+  return issueTrigger[1]
+    .split(",")
+    .map((event) => event.trim().replace(/^(['"])(.*)\1$/, "$2"));
+}
+
 test("triage audit runs for newly opened issues", () => {
   const workflowPath = path.join(__dirname, "..", "workflows", "triage-audit.yml");
   const workflow = fs.readFileSync(workflowPath, "utf8");
-  const issueTrigger = workflow.match(/^  issues:\n    types: \[([^\n]+)\]$/m);
-
-  assert.ok(issueTrigger, "triage audit must retain its issues trigger");
-  const eventTypes = issueTrigger[1].split(",").map((event) => event.trim());
+  const eventTypes = issueTriggerEventTypes(workflow);
   assert.ok(eventTypes.includes("opened"), "issues trigger must include opened");
+});
+test("triage audit parser accepts CRLF, spacing, and quoted inline event types", () => {
+  const workflow = [
+    "on:",
+    "  issues:   ",
+    "      types: [\"opened\", 'edited']",
+    "  pull_request:",
+    "    types: [opened]",
+    "",
+  ].join("\r\n");
+
+  assert.deepEqual(issueTriggerEventTypes(workflow), ["opened", "edited"]);
+});
+
+test("triage audit sensor does not borrow opened from pull_request", () => {
+  const workflow = [
+    "on:",
+    "  issues:",
+    "    types: [edited, closed]",
+    "  pull_request:",
+    "    types: [opened]",
+    "",
+  ].join("\n");
+
+  assert.equal(issueTriggerEventTypes(workflow).includes("opened"), false);
 });
 
 test("a complete active issue passes the portfolio audit", () => {

--- a/.github/scripts/portfolio-audit.test.cjs
+++ b/.github/scripts/portfolio-audit.test.cjs
@@ -1,6 +1,8 @@
 "use strict";
 
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const test = require("node:test");
 const {
   auditIssue,
@@ -34,6 +36,16 @@ function activeIssue(overrides = {}) {
     ...overrides,
   };
 }
+
+test("triage audit runs for newly opened issues", () => {
+  const workflowPath = path.join(__dirname, "..", "workflows", "triage-audit.yml");
+  const workflow = fs.readFileSync(workflowPath, "utf8");
+  const issueTrigger = workflow.match(/^  issues:\n    types: \[([^\n]+)\]$/m);
+
+  assert.ok(issueTrigger, "triage audit must retain its issues trigger");
+  const eventTypes = issueTrigger[1].split(",").map((event) => event.trim());
+  assert.ok(eventTypes.includes("opened"), "issues trigger must include opened");
+});
 
 test("a complete active issue passes the portfolio audit", () => {
   assert.deepEqual(auditIssue(activeIssue(), vocabulary).problems, []);

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -109,6 +109,6 @@ just act-pr         # simulate the pull_request fast lane
 
 ### `triage-audit.yml` — Portfolio and issue triage audit
 
-- **Triggers:** `schedule` (weekly Monday 09:00 UTC), issue lifecycle/label changes after creation, `workflow_dispatch`, and ordinary pull-request lifecycle/label changes on `main`.
+- **Triggers:** `schedule` (weekly Monday 09:00 UTC), issue creation, lifecycle, and label changes, `workflow_dispatch`, and ordinary pull-request lifecycle/label changes on `main`.
 - Checks open issues against `triage-labels.json` for missing P0-P3 severity or theme labels, audits active-item readiness and authoritative closing PR linkage, requires unblock triggers, compares explicitly mapped epic state to roadmap rows, and reports the 3/3 implementation/review buffers. Reports via CI step summary and warning annotations while the reset backlog is reconciled.
 - **Permissions:** `contents: read`, `issues: read`, `pull-requests: read`.

--- a/.github/workflows/triage-audit.yml
+++ b/.github/workflows/triage-audit.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 9 * * MON"
   issues:
-    types: [reopened, edited, labeled, unlabeled, closed]
+    types: [opened, reopened, edited, labeled, unlabeled, closed]
   workflow_dispatch:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Fixes #1705

Parent initiative: #1684

## Summary

- Audit issues immediately when they are opened.
- Add a focused sensor anchored to the `issues:` trigger rather than the separate `pull_request:` trigger.
- Keep the workflow index aligned with the trigger contract.

## Root cause

The portfolio audit subscribed to issue edits, labels, reopenings, and closure, but omitted the initial `opened` event. A new issue therefore depended on a later lifecycle event before the audit could see it.

## Verification

- Focused newly-opened sensor: 1 passed, 0 failed.
- Trigger-parser sensors, including CRLF, spacing, quotes, and pull-request false-match proof: 3 passed, 0 failed.
- Governance script suite: 41 passed, 0 failed.
- `actionlint .github/workflows/triage-audit.yml`: passed.
- Root `npm run format:check`: passed.
- `just check`: passed.
- `just verify`: passed, including the deterministic walkthrough.
- Fast [CI gate](https://github.com/dmooney/Rundale/actions/runs/29401099147): passed on head `038ba111636e2803befaf75bdc8f10a01e3200cd`.
- Durable review-fix proof: https://github.com/dmooney/Rundale/pull/1738#issuecomment-4978559995

Risk: Standard. Runtime and scaling seams are not affected.