### PR TITLE
feat(ui): complete notebook command strip visual states

### DIFF
--- a/parish/apps/ui/e2e/app.spec.ts
+++ b/parish/apps/ui/e2e/app.spec.ts
@@ -110,7 +110,8 @@ test.describe('App layout', () => {
 		page,
 	}) => {
 		const input = page.getByLabel('Player intent');
-		await expect(input).toHaveAttribute('aria-disabled', 'false');
+		await expect(input).not.toHaveAttribute('aria-disabled');
+		await expect(input).toHaveAttribute('aria-busy', 'false');
 		await input.focus();
 		await expect(input).toBeFocused();
 		await page.keyboard.insertText('ask what happened');

--- a/parish/apps/ui/e2e/illustrated-notebook-interactions.spec.ts
+++ b/parish/apps/ui/e2e/illustrated-notebook-interactions.spec.ts
@@ -111,6 +111,8 @@ async function proveCommandVisualStates(
 	viewport: 'desktop' | 'mobile',
 ) {
 	const input = page.getByLabel('Player intent');
+	const status = page.locator('#notebook-command-status');
+	const askStamp = page.getByRole('button', { name: 'Ask action stamp' });
 	const stableBox = await notebookBox(page);
 
 	await input.focus();
@@ -121,15 +123,29 @@ async function proveCommandVisualStates(
 		fullPage: false,
 	});
 
+	const longCommand =
+		'ask Roisin to recount every detail because the latest typing stays visible';
+	await input.fill(longCommand);
+	await expect(input).toHaveAttribute('data-command-state', 'typing');
+	await expect(input).toHaveValue(longCommand);
+	await settleNotebookFrame(page);
+	await page.screenshot({
+		path: path.join(PROOF_DIR, `${viewport}-long-command.png`),
+		fullPage: false,
+	});
+	await input.fill('');
+	await expect(input).toHaveAttribute('data-command-state', 'focused');
+
 	await emitEvent(page, 'loading', { active: true, phrase: 'Listening...' });
 	await expect(input).toHaveAttribute('data-command-state', 'busy');
 	await expect(input).not.toHaveAttribute('aria-disabled');
 	await expect(input).not.toHaveAttribute('disabled', '');
 	await expect(input).not.toHaveAttribute('readonly', '');
 	await expect(input).toBeEditable();
-	await expect(page.locator('#notebook-command-status')).toContainText(
-		'Parish reply in progress',
-	);
+	await expect(status).toHaveAttribute('role', 'status');
+	await expect(status).not.toHaveAttribute('aria-live');
+	await expect(status).toContainText('Parish reply in progress');
+	await expect(askStamp).toBeEnabled();
 	await settleNotebookFrame(page);
 	await expectNotebookNative(page);
 	expect(await notebookBox(page)).toEqual(stableBox);
@@ -150,9 +166,20 @@ async function proveCommandVisualStates(
 	await expect(input).toHaveValue('ask Roisin what she saw');
 	await input.press('x');
 	await expect(input).toHaveValue('ask Roisin what she saw');
-	await expect(page.locator('#notebook-command-status')).toContainText(
-		'Sending your line',
+	await expect(askStamp).toBeDisabled();
+	const askStampBox = await askStamp.boundingBox();
+	expect(askStampBox).not.toBeNull();
+	if (!askStampBox) throw new Error('ask stamp must have a layout box');
+	await page.mouse.click(
+		askStampBox.x + askStampBox.width / 2,
+		askStampBox.y + askStampBox.height / 2,
 	);
+	await expect(input).toHaveValue('ask Roisin what she saw');
+	await askStamp.dispatchEvent('click');
+	await expect(input).toHaveValue('ask Roisin what she saw');
+	await expect(status).toHaveAttribute('role', 'status');
+	await expect(status).not.toHaveAttribute('aria-live');
+	await expect(status).toContainText('Sending your line');
 	await settleNotebookFrame(page);
 	expect(await notebookBox(page)).toEqual(stableBox);
 	await page.screenshot({
@@ -164,9 +191,12 @@ async function proveCommandVisualStates(
 	await expect(input).toHaveAttribute('data-command-state', 'error');
 	await expect(input).toHaveAttribute('aria-invalid', 'true');
 	await expect(input).toHaveValue('ask Roisin what she saw');
-	await expect(page.locator('#notebook-command-status')).toContainText(
+	await expect(status).toHaveAttribute('role', 'alert');
+	await expect(status).not.toHaveAttribute('aria-live');
+	await expect(status).toContainText(
 		'Ink blotted — Could not send input: bridge unavailable',
 	);
+	await expect(askStamp).toBeEnabled();
 	await settleNotebookFrame(page);
 	await expectNotebookNative(page);
 	expect(await notebookBox(page)).toEqual(stableBox);

--- a/parish/apps/ui/e2e/illustrated-notebook-interactions.spec.ts
+++ b/parish/apps/ui/e2e/illustrated-notebook-interactions.spec.ts
@@ -11,6 +11,10 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PROOF_DIR = path.resolve(__dirname, '../../../../.proofs/1636');
+// Setup plus the five visual states each wait up to 10 seconds for a
+// texture-complete WebGL frame. The ordinary 60-second test timeout therefore
+// cannot cover the proof's own bounded waits under a loaded full-suite run.
+const VISUAL_PROOF_TIMEOUT_MS = 120_000;
 
 type NotebookBox = NonNullable<
 	Awaited<ReturnType<import('@playwright/test').Locator['boundingBox']>>
@@ -117,6 +121,8 @@ async function proveCommandVisualStates(
 
 	await input.focus();
 	await expect(input).toHaveAttribute('data-command-state', 'focused');
+	await expect(input).not.toHaveAttribute('aria-disabled');
+	await expect(input).toHaveAttribute('aria-busy', 'false');
 	await settleNotebookFrame(page);
 	await page.screenshot({
 		path: path.join(PROOF_DIR, `${viewport}-focused.png`),
@@ -139,6 +145,7 @@ async function proveCommandVisualStates(
 	await emitEvent(page, 'loading', { active: true, phrase: 'Listening...' });
 	await expect(input).toHaveAttribute('data-command-state', 'busy');
 	await expect(input).not.toHaveAttribute('aria-disabled');
+	await expect(input).toHaveAttribute('aria-busy', 'true');
 	await expect(input).not.toHaveAttribute('disabled', '');
 	await expect(input).not.toHaveAttribute('readonly', '');
 	await expect(input).toBeEditable();
@@ -156,11 +163,14 @@ async function proveCommandVisualStates(
 
 	await emitEvent(page, 'loading', { active: false });
 	await expect(input).toHaveAttribute('data-command-state', 'focused');
+	await expect(input).not.toHaveAttribute('aria-disabled');
+	await expect(input).toHaveAttribute('aria-busy', 'false');
 	await installControlledSubmitFailure(page);
 	await input.fill('ask Roisin what she saw');
 	await input.press('Enter');
 	await expect(input).toHaveAttribute('data-command-state', 'disabled');
 	await expect(input).toHaveAttribute('aria-disabled', 'true');
+	await expect(input).toHaveAttribute('aria-busy', 'true');
 	await expect(input).toHaveAttribute('readonly', '');
 	await expect(input).not.toBeEditable();
 	await expect(input).toHaveValue('ask Roisin what she saw');
@@ -189,6 +199,8 @@ async function proveCommandVisualStates(
 
 	await rejectControlledSubmit(page);
 	await expect(input).toHaveAttribute('data-command-state', 'error');
+	await expect(input).not.toHaveAttribute('aria-disabled');
+	await expect(input).toHaveAttribute('aria-busy', 'false');
 	await expect(input).toHaveAttribute('aria-invalid', 'true');
 	await expect(input).toHaveValue('ask Roisin what she saw');
 	await expect(status).toHaveAttribute('role', 'alert');
@@ -207,6 +219,8 @@ async function proveCommandVisualStates(
 }
 
 test.describe('illustrated notebook interactions', () => {
+	test.describe.configure({ timeout: VISUAL_PROOF_TIMEOUT_MS });
+
 	test.beforeAll(() => {
 		fs.mkdirSync(PROOF_DIR, { recursive: true });
 	});

--- a/parish/apps/ui/e2e/illustrated-notebook-interactions.spec.ts
+++ b/parish/apps/ui/e2e/illustrated-notebook-interactions.spec.ts
@@ -123,8 +123,10 @@ async function proveCommandVisualStates(
 
 	await emitEvent(page, 'loading', { active: true, phrase: 'Listening...' });
 	await expect(input).toHaveAttribute('data-command-state', 'busy');
-	await expect(input).toHaveAttribute('aria-disabled', 'true');
+	await expect(input).not.toHaveAttribute('aria-disabled');
 	await expect(input).not.toHaveAttribute('disabled', '');
+	await expect(input).not.toHaveAttribute('readonly', '');
+	await expect(input).toBeEditable();
 	await expect(page.locator('#notebook-command-status')).toContainText(
 		'Parish reply in progress',
 	);
@@ -142,6 +144,11 @@ async function proveCommandVisualStates(
 	await input.fill('ask Roisin what she saw');
 	await input.press('Enter');
 	await expect(input).toHaveAttribute('data-command-state', 'disabled');
+	await expect(input).toHaveAttribute('aria-disabled', 'true');
+	await expect(input).toHaveAttribute('readonly', '');
+	await expect(input).not.toBeEditable();
+	await expect(input).toHaveValue('ask Roisin what she saw');
+	await input.press('x');
 	await expect(input).toHaveValue('ask Roisin what she saw');
 	await expect(page.locator('#notebook-command-status')).toContainText(
 		'Sending your line',

--- a/parish/apps/ui/e2e/illustrated-notebook-interactions.spec.ts
+++ b/parish/apps/ui/e2e/illustrated-notebook-interactions.spec.ts
@@ -1,18 +1,91 @@
-import { expect, installTauriMock, test } from './fixtures';
+import {
+	emitEvent,
+	expect,
+	installTauriMock,
+	test,
+	waitForTextureCompleteNotebookFrame,
+} from './fixtures';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const PROOF_DIR = path.resolve(
-	__dirname,
-	'../../../../.proofs/notebook-pixi-interactions',
-);
+const PROOF_DIR = path.resolve(__dirname, '../../../../.proofs/1636');
+
+type NotebookBox = NonNullable<
+	Awaited<ReturnType<import('@playwright/test').Locator['boundingBox']>>
+>;
+
+async function settleNotebookFrame(page: import('@playwright/test').Page) {
+	await page.evaluate(
+		() =>
+			new Promise<void>((resolve) => {
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+			}),
+	);
+	await waitForTextureCompleteNotebookFrame(page);
+}
+
+async function notebookBox(
+	page: import('@playwright/test').Page,
+): Promise<NotebookBox> {
+	const box = await page.getByTestId('illustrated-notebook-game').boundingBox();
+	expect(box).not.toBeNull();
+	if (!box) throw new Error('notebook game must have a layout box');
+	return box;
+}
+
+async function expectNotebookNative(page: import('@playwright/test').Page) {
+	for (const selector of [
+		'.input-wrapper',
+		'.input-form',
+		'[data-testid="input-field"]',
+		'[data-testid="chat-panel"]',
+	]) {
+		await expect(page.locator(selector)).toHaveCount(0);
+	}
+	await expect(page.getByRole('button', { name: /^send$/i })).toHaveCount(0);
+}
+
+async function installControlledSubmitFailure(
+	page: import('@playwright/test').Page,
+) {
+	await page.evaluate(() => {
+		type Invoke = (
+			command: string,
+			args?: Record<string, unknown>,
+		) => Promise<unknown>;
+		const globals = window as unknown as Record<string, unknown>;
+		const internals = globals.__TAURI_INTERNALS__ as { invoke: Invoke };
+		const originalInvoke = internals.invoke.bind(internals);
+		const control: { reject: (reason?: unknown) => void } = {
+			reject: () => {},
+		};
+		globals.__TEST_REJECT_NOTEBOOK_SUBMIT__ = () =>
+			control.reject(new Error('bridge unavailable'));
+		internals.invoke = (command, args) => {
+			if (command !== 'submit_input') return originalInvoke(command, args);
+			return new Promise<unknown>((_resolve, reject) => {
+				control.reject = reject;
+			});
+		};
+	});
+}
+
+async function rejectControlledSubmit(page: import('@playwright/test').Page) {
+	await page.evaluate(() => {
+		const reject = (
+			window as unknown as Record<string, (() => void) | undefined>
+		).__TEST_REJECT_NOTEBOOK_SUBMIT__;
+		if (!reject)
+			throw new Error('controlled submit rejection was not installed');
+		reject();
+	});
+}
 
 async function setupNotebookPage(page: import('@playwright/test').Page) {
 	await installTauriMock(page, 'morning');
-	await page.goto('/');
-	await page.waitForLoadState('networkidle');
+	await page.goto('/', { waitUntil: 'domcontentloaded' });
 	await expect(
 		page.locator('[data-testid="illustrated-notebook-game"]'),
 	).toBeVisible();
@@ -25,6 +98,75 @@ async function setupNotebookPage(page: import('@playwright/test').Page) {
 	await expect(
 		page.getByRole('button', { name: 'Ask action stamp' }),
 	).toHaveCount(1);
+	const input = page.getByLabel('Player intent');
+	await expect(input).toHaveCSS('opacity', '0');
+	await expect(input).toHaveCSS('pointer-events', 'none');
+	await expect(input).toHaveCSS('width', '1px');
+	await waitForTextureCompleteNotebookFrame(page);
+	await expectNotebookNative(page);
+}
+
+async function proveCommandVisualStates(
+	page: import('@playwright/test').Page,
+	viewport: 'desktop' | 'mobile',
+) {
+	const input = page.getByLabel('Player intent');
+	const stableBox = await notebookBox(page);
+
+	await input.focus();
+	await expect(input).toHaveAttribute('data-command-state', 'focused');
+	await settleNotebookFrame(page);
+	await page.screenshot({
+		path: path.join(PROOF_DIR, `${viewport}-focused.png`),
+		fullPage: false,
+	});
+
+	await emitEvent(page, 'loading', { active: true, phrase: 'Listening...' });
+	await expect(input).toHaveAttribute('data-command-state', 'busy');
+	await expect(input).toHaveAttribute('aria-disabled', 'true');
+	await expect(input).not.toHaveAttribute('disabled', '');
+	await expect(page.locator('#notebook-command-status')).toContainText(
+		'Parish reply in progress',
+	);
+	await settleNotebookFrame(page);
+	await expectNotebookNative(page);
+	expect(await notebookBox(page)).toEqual(stableBox);
+	await page.screenshot({
+		path: path.join(PROOF_DIR, `${viewport}-busy.png`),
+		fullPage: false,
+	});
+
+	await emitEvent(page, 'loading', { active: false });
+	await expect(input).toHaveAttribute('data-command-state', 'focused');
+	await installControlledSubmitFailure(page);
+	await input.fill('ask Roisin what she saw');
+	await input.press('Enter');
+	await expect(input).toHaveAttribute('data-command-state', 'disabled');
+	await expect(input).toHaveValue('ask Roisin what she saw');
+	await expect(page.locator('#notebook-command-status')).toContainText(
+		'Sending your line',
+	);
+	await settleNotebookFrame(page);
+	expect(await notebookBox(page)).toEqual(stableBox);
+	await page.screenshot({
+		path: path.join(PROOF_DIR, `${viewport}-disabled.png`),
+		fullPage: false,
+	});
+
+	await rejectControlledSubmit(page);
+	await expect(input).toHaveAttribute('data-command-state', 'error');
+	await expect(input).toHaveAttribute('aria-invalid', 'true');
+	await expect(input).toHaveValue('ask Roisin what she saw');
+	await expect(page.locator('#notebook-command-status')).toContainText(
+		'Ink blotted — Could not send input: bridge unavailable',
+	);
+	await settleNotebookFrame(page);
+	await expectNotebookNative(page);
+	expect(await notebookBox(page)).toEqual(stableBox);
+	await page.screenshot({
+		path: path.join(PROOF_DIR, `${viewport}-error.png`),
+		fullPage: false,
+	});
 }
 
 test.describe('illustrated notebook interactions', () => {
@@ -38,11 +180,9 @@ test.describe('illustrated notebook interactions', () => {
 		await page.setViewportSize({ width: 1440, height: 900 });
 		await setupNotebookPage(page);
 
+		await proveCommandVisualStates(page, 'desktop');
 		const input = page.getByLabel('Player intent');
-
-		await page.mouse.click(630, 758);
-		await expect(input).toHaveValue(/ask /);
-		await expect(input).toBeFocused();
+		await input.fill('');
 
 		await page.getByRole('button', { name: 'Open time details' }).focus();
 		await page.keyboard.press('Enter');
@@ -52,11 +192,6 @@ test.describe('illustrated notebook interactions', () => {
 		await page.getByRole('button', { name: 'Open parish map' }).focus();
 		await page.keyboard.press('Enter');
 		await expect(page.locator('[data-testid="full-map"]')).toBeVisible();
-
-		await page.screenshot({
-			path: path.join(PROOF_DIR, 'desktop.png'),
-			fullPage: false,
-		});
 	});
 
 	test('mobile viewport keeps notebook controls and old chrome absent', async ({
@@ -65,13 +200,6 @@ test.describe('illustrated notebook interactions', () => {
 		await page.setViewportSize({ width: 390, height: 844 });
 		await setupNotebookPage(page);
 
-		await page.getByRole('button', { name: 'Ask action stamp' }).focus();
-		await page.keyboard.press('Enter');
-		await expect(page.getByLabel('Player intent')).toHaveValue(/ask /);
-
-		await page.screenshot({
-			path: path.join(PROOF_DIR, 'mobile.png'),
-			fullPage: false,
-		});
+		await proveCommandVisualStates(page, 'mobile');
 	});
 });

--- a/parish/apps/ui/e2e/interactions.spec.ts
+++ b/parish/apps/ui/e2e/interactions.spec.ts
@@ -74,9 +74,9 @@ test.describe('Input field interactions', () => {
 		await expect.poll(() => submittedCommands(page)).toEqual(['go to Howth']);
 	});
 
-	// #1379: the notebook input remains an enabled native field while its
-	// aria-disabled value communicates the in-flight reply. The first keystroke
-	// flushes that reply and is then accepted into the draft.
+	// #1379: the notebook input remains an enabled native field while aria-busy
+	// communicates the in-flight reply. The first keystroke flushes that reply
+	// and is then accepted into the draft.
 	test('input stays editable during streaming (flush-on-interaction, #1379)', async ({
 		page,
 	}) => {
@@ -93,12 +93,14 @@ test.describe('Input field interactions', () => {
 		});
 		await emitEvent(page, 'stream-turn-end', { turn_id: 1379 });
 
-		await expect(input).toHaveAttribute('aria-disabled', 'true');
+		await expect(input).not.toHaveAttribute('aria-disabled');
+		await expect(input).toHaveAttribute('aria-busy', 'true');
 		await expect(input).not.toHaveAttribute('disabled', '');
 		await input.fill('next thought');
 		await input.press('x');
 		await expect(input).toHaveValue('next thoughtx');
-		await expect(input).toHaveAttribute('aria-disabled', 'false');
+		await expect(input).not.toHaveAttribute('aria-disabled');
+		await expect(input).toHaveAttribute('aria-busy', 'false');
 
 		const journal = await openNotebookDrawer(page, 'journal');
 		await expect(journal).toContainText(
@@ -120,7 +122,8 @@ test.describe('Input field interactions', () => {
 
 		// Chain begins.
 		await emitEvent(page, 'loading', { active: true });
-		await expect(input).toHaveAttribute('aria-disabled', 'true');
+		await expect(input).not.toHaveAttribute('aria-disabled');
+		await expect(input).toHaveAttribute('aria-busy', 'true');
 		await expect(input).not.toHaveAttribute('disabled', '');
 		await expect(intents).toContainText('Parish reply: pending');
 
@@ -135,7 +138,8 @@ test.describe('Input field interactions', () => {
 
 		// The notebook must remain busy even though loading=false has arrived,
 		// because the chain has not yet emitted `stream-end`.
-		await expect(input).toHaveAttribute('aria-disabled', 'true');
+		await expect(input).not.toHaveAttribute('aria-disabled');
+		await expect(input).toHaveAttribute('aria-busy', 'true');
 		await expect(input).not.toHaveAttribute('disabled', '');
 		await expect(intents).toContainText('Parish reply: pending');
 
@@ -154,14 +158,16 @@ test.describe('Input field interactions', () => {
 		await emitEvent(page, 'stream-turn-end', { turn_id: 1002 });
 
 		// Still busy — the chain is still alive.
-		await expect(input).toHaveAttribute('aria-disabled', 'true');
+		await expect(input).not.toHaveAttribute('aria-disabled');
+		await expect(input).toHaveAttribute('aria-busy', 'true');
 		await expect(intents).toContainText('Parish reply: pending');
 
 		// Chain terminates.
 		await emitEvent(page, 'stream-end', { hints: [] });
 
 		// Only now does the notebook return to idle.
-		await expect(input).toHaveAttribute('aria-disabled', 'false');
+		await expect(input).not.toHaveAttribute('aria-disabled');
+		await expect(input).toHaveAttribute('aria-busy', 'false');
 		await expect(intents).toContainText('Parish reply: idle');
 	});
 });

--- a/parish/apps/ui/src/components/illustrated-notebook/IllustratedNotebookGame.svelte
+++ b/parish/apps/ui/src/components/illustrated-notebook/IllustratedNotebookGame.svelte
@@ -22,6 +22,7 @@
 	import { modSelectorVisible, savePickerVisible } from '../../stores/save';
 	import {
 		draftForNotebookAction,
+		resolveNotebookCommandPresentation,
 		submitNotebookCommand,
 	} from '$lib/illustrated-notebook/command';
 	import {
@@ -29,7 +30,10 @@
 		type NotebookHitTarget,
 	} from '$lib/illustrated-notebook/interactions';
 	import { IllustratedNotebookRenderer } from '$lib/illustrated-notebook/renderer';
-	import type { NotebookTab } from '$lib/illustrated-notebook/types';
+	import type {
+		NotebookCommandState,
+		NotebookTab,
+	} from '$lib/illustrated-notebook/types';
 
 	let hostEl: HTMLDivElement;
 	let inputEl: HTMLInputElement;
@@ -39,6 +43,7 @@
 	let intentText = $state('');
 	let inputFocused = $state(false);
 	let isSubmitting = $state(false);
+	let commandError = $state<string | null>(null);
 	let drawer = $state<NotebookTab | 'tools' | 'time' | 'intents' | null>(null);
 	let hitTargets = $state<NotebookHitTarget[]>([]);
 	let focusedHitTargetId = $state<string | null>(null);
@@ -50,6 +55,16 @@
 	);
 	const focusableHitTargets = $derived(
 		sortNotebookHitTargetsForFocus(hitTargets),
+	);
+	const commandState = $derived<NotebookCommandState>({
+		text: intentText,
+		focused: inputFocused,
+		busy: $streamingActive,
+		disabled: isSubmitting,
+		error: commandError,
+	});
+	const commandPresentation = $derived(
+		resolveNotebookCommandPresentation(commandState),
 	);
 
 	$effect(() => {
@@ -80,9 +95,7 @@
 			npcs: $npcsHere,
 			selectedNpc,
 			selectedRealName,
-			intentText,
-			inputFocused,
-			busy: $streamingActive || isSubmitting,
+			command: commandState,
 			callbacks: {
 				onAction: seedAction,
 				onFocusInput: focusInput,
@@ -152,8 +165,13 @@
 	}
 
 	function seedAction(action: NotebookAction) {
+		commandError = null;
 		intentText = draftForNotebookAction(action, selectedNpc);
 		focusInput();
+	}
+
+	function clearCommandError() {
+		commandError = null;
 	}
 
 	function openTab(tab: NotebookTab) {
@@ -202,6 +220,7 @@
 	async function submitCurrent() {
 		const text = intentText;
 		if (!text.trim() || isSubmitting || $streamingActive) return;
+		commandError = null;
 		isSubmitting = true;
 		try {
 			const didSubmit = await submitNotebookCommand({
@@ -215,7 +234,8 @@
 			});
 			if (didSubmit) intentText = '';
 		} catch (err) {
-			pushErrorLog(`Could not send input: ${formatIpcError(err)}`);
+			commandError = `Could not send input: ${formatIpcError(err)}`;
+			pushErrorLog(commandError);
 		} finally {
 			isSubmitting = false;
 		}
@@ -260,12 +280,25 @@
 		type="text"
 		aria-label="Player intent"
 		aria-disabled={$streamingActive || isSubmitting}
+		aria-busy={$streamingActive || isSubmitting}
+		aria-invalid={Boolean(commandError)}
+		aria-describedby={commandError ? 'notebook-command-status' : undefined}
+		data-command-state={commandPresentation.phase}
 		autocomplete="off"
 		spellcheck="false"
+		oninput={clearCommandError}
 		onfocus={() => (inputFocused = true)}
 		onblur={() => (inputFocused = false)}
 		onkeydown={handleKeydown}
 	/>
+	<span
+		id="notebook-command-status"
+		class="notebook-command-status"
+		role={commandError ? 'alert' : 'status'}
+		aria-live="polite"
+	>
+		{commandPresentation.statusText ?? 'Command line ready'}
+	</span>
 
 	<div class="notebook-accessibility-targets" aria-label="Notebook controls">
 		{#each focusableHitTargets as target (target.id)}
@@ -398,6 +431,20 @@
 		border: 0;
 		opacity: 0;
 		pointer-events: none;
+	}
+
+	.notebook-command-status {
+		position: fixed;
+		left: 1px;
+		top: 1px;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip-path: inset(50%);
+		white-space: nowrap;
+		border: 0;
 	}
 
 	.notebook-accessibility-targets {

--- a/parish/apps/ui/src/components/illustrated-notebook/IllustratedNotebookGame.svelte
+++ b/parish/apps/ui/src/components/illustrated-notebook/IllustratedNotebookGame.svelte
@@ -279,11 +279,12 @@
 		class="notebook-native-input"
 		type="text"
 		aria-label="Player intent"
-		aria-disabled={$streamingActive || isSubmitting}
+		aria-disabled={isSubmitting || undefined}
 		aria-busy={$streamingActive || isSubmitting}
 		aria-invalid={Boolean(commandError)}
 		aria-describedby={commandError ? 'notebook-command-status' : undefined}
 		data-command-state={commandPresentation.phase}
+		readonly={isSubmitting}
 		autocomplete="off"
 		spellcheck="false"
 		oninput={clearCommandError}

--- a/parish/apps/ui/src/components/illustrated-notebook/IllustratedNotebookGame.svelte
+++ b/parish/apps/ui/src/components/illustrated-notebook/IllustratedNotebookGame.svelte
@@ -165,6 +165,7 @@
 	}
 
 	function seedAction(action: NotebookAction) {
+		if (isSubmitting) return;
 		commandError = null;
 		intentText = draftForNotebookAction(action, selectedNpc);
 		focusInput();
@@ -296,7 +297,6 @@
 		id="notebook-command-status"
 		class="notebook-command-status"
 		role={commandError ? 'alert' : 'status'}
-		aria-live="polite"
 	>
 		{commandPresentation.statusText ?? 'Command line ready'}
 	</span>

--- a/parish/apps/ui/src/components/illustrated-notebook/IllustratedNotebookGame.test.ts
+++ b/parish/apps/ui/src/components/illustrated-notebook/IllustratedNotebookGame.test.ts
@@ -146,7 +146,8 @@ function seedStores() {
 		target('time-card', 'Open time details', 60),
 		target('active-intents-card', 'Open active intents', 70),
 	];
-	mockSubmitInput.mockClear();
+	mockSubmitInput.mockReset();
+	mockSubmitInput.mockResolvedValue(undefined);
 }
 
 describe('IllustratedNotebookGame', () => {
@@ -204,6 +205,68 @@ describe('IllustratedNotebookGame', () => {
 		await waitFor(() =>
 			expect(mockSubmitInput).toHaveBeenCalledWith('ask Roisin Connolly'),
 		);
+	});
+
+	it('renders focus and streaming as distinct command states while the hidden input stays editable', async () => {
+		const { getByLabelText } = render(IllustratedNotebookGame);
+		const input = getByLabelText('Player intent') as HTMLInputElement;
+
+		await waitFor(() => expect(lastRenderState?.command.focused).toBe(true));
+		expect(input.dataset.commandState).toBe('focused');
+		expect(input.disabled).toBe(false);
+
+		streamingActive.set(true);
+		await waitFor(() => expect(lastRenderState?.command.busy).toBe(true));
+		expect(lastRenderState?.command.disabled).toBe(false);
+		expect(input.dataset.commandState).toBe('busy');
+		expect(input.getAttribute('aria-disabled')).toBe('true');
+		expect(input.disabled).toBe(false);
+	});
+
+	it('renders the local pending submit as disabled without clearing the draft early', async () => {
+		const deferred = { resolve: () => {} };
+		mockSubmitInput.mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					deferred.resolve = resolve;
+				}),
+		);
+		const { getByLabelText } = render(IllustratedNotebookGame);
+		const input = getByLabelText('Player intent') as HTMLInputElement;
+
+		await fireEvent.input(input, { target: { value: 'look around' } });
+		await fireEvent.keyDown(input, { key: 'Enter' });
+
+		await waitFor(() => expect(lastRenderState?.command.disabled).toBe(true));
+		expect(lastRenderState?.command.busy).toBe(false);
+		expect(input.dataset.commandState).toBe('disabled');
+		expect(input.value).toBe('look around');
+
+		deferred.resolve();
+		await waitFor(() => expect(input.value).toBe(''));
+	});
+
+	it('renders a failed submit as an accessible Pixi error and preserves the draft for retry', async () => {
+		mockSubmitInput.mockRejectedValueOnce(new Error('bridge unavailable'));
+		const { container, getByLabelText, getByText } = render(
+			IllustratedNotebookGame,
+		);
+		const input = getByLabelText('Player intent') as HTMLInputElement;
+
+		await fireEvent.input(input, { target: { value: 'look around' } });
+		await fireEvent.keyDown(input, { key: 'Enter' });
+
+		await waitFor(() => expect(input.dataset.commandState).toBe('error'));
+		expect(lastRenderState?.command.error).toContain('bridge unavailable');
+		expect(input.value).toBe('look around');
+		expect(input.getAttribute('aria-invalid')).toBe('true');
+		expect(getByText(/Ink blotted — Could not send input/)).toBeTruthy();
+		expect(container.querySelector('.input-wrapper')).toBeNull();
+		expect(container.querySelector('.input-form')).toBeNull();
+
+		await fireEvent.input(input, { target: { value: 'look' } });
+		await waitFor(() => expect(input.dataset.commandState).toBe('typing'));
+		expect(input.getAttribute('aria-invalid')).toBe('false');
 	});
 
 	it('routes notebook tabs and cards through overlay state', async () => {

--- a/parish/apps/ui/src/components/illustrated-notebook/IllustratedNotebookGame.test.ts
+++ b/parish/apps/ui/src/components/illustrated-notebook/IllustratedNotebookGame.test.ts
@@ -219,8 +219,9 @@ describe('IllustratedNotebookGame', () => {
 		await waitFor(() => expect(lastRenderState?.command.busy).toBe(true));
 		expect(lastRenderState?.command.disabled).toBe(false);
 		expect(input.dataset.commandState).toBe('busy');
-		expect(input.getAttribute('aria-disabled')).toBe('true');
+		expect(input.hasAttribute('aria-disabled')).toBe(false);
 		expect(input.disabled).toBe(false);
+		expect(input.readOnly).toBe(false);
 	});
 
 	it('renders the local pending submit as disabled without clearing the draft early', async () => {
@@ -240,10 +241,14 @@ describe('IllustratedNotebookGame', () => {
 		await waitFor(() => expect(lastRenderState?.command.disabled).toBe(true));
 		expect(lastRenderState?.command.busy).toBe(false);
 		expect(input.dataset.commandState).toBe('disabled');
+		expect(input.getAttribute('aria-disabled')).toBe('true');
+		expect(input.readOnly).toBe(true);
 		expect(input.value).toBe('look around');
 
 		deferred.resolve();
 		await waitFor(() => expect(input.value).toBe(''));
+		expect(input.hasAttribute('aria-disabled')).toBe(false);
+		expect(input.readOnly).toBe(false);
 	});
 
 	it('renders a failed submit as an accessible Pixi error and preserves the draft for retry', async () => {

--- a/parish/apps/ui/src/components/illustrated-notebook/IllustratedNotebookGame.test.ts
+++ b/parish/apps/ui/src/components/illustrated-notebook/IllustratedNotebookGame.test.ts
@@ -208,7 +208,7 @@ describe('IllustratedNotebookGame', () => {
 	});
 
 	it('renders focus and streaming as distinct command states while the hidden input stays editable', async () => {
-		const { getByLabelText } = render(IllustratedNotebookGame);
+		const { getByLabelText, getByRole } = render(IllustratedNotebookGame);
 		const input = getByLabelText('Player intent') as HTMLInputElement;
 
 		await waitFor(() => expect(lastRenderState?.command.focused).toBe(true));
@@ -222,6 +222,8 @@ describe('IllustratedNotebookGame', () => {
 		expect(input.hasAttribute('aria-disabled')).toBe(false);
 		expect(input.disabled).toBe(false);
 		expect(input.readOnly).toBe(false);
+		const status = getByRole('status');
+		expect(status.hasAttribute('aria-live')).toBe(false);
 	});
 
 	it('renders the local pending submit as disabled without clearing the draft early', async () => {
@@ -244,6 +246,8 @@ describe('IllustratedNotebookGame', () => {
 		expect(input.getAttribute('aria-disabled')).toBe('true');
 		expect(input.readOnly).toBe(true);
 		expect(input.value).toBe('look around');
+		lastRenderState?.callbacks.onAction('ask');
+		await waitFor(() => expect(input.value).toBe('look around'));
 
 		deferred.resolve();
 		await waitFor(() => expect(input.value).toBe(''));
@@ -253,7 +257,7 @@ describe('IllustratedNotebookGame', () => {
 
 	it('renders a failed submit as an accessible Pixi error and preserves the draft for retry', async () => {
 		mockSubmitInput.mockRejectedValueOnce(new Error('bridge unavailable'));
-		const { container, getByLabelText, getByText } = render(
+		const { container, getByLabelText, getByRole, getByText } = render(
 			IllustratedNotebookGame,
 		);
 		const input = getByLabelText('Player intent') as HTMLInputElement;
@@ -266,6 +270,7 @@ describe('IllustratedNotebookGame', () => {
 		expect(input.value).toBe('look around');
 		expect(input.getAttribute('aria-invalid')).toBe('true');
 		expect(getByText(/Ink blotted — Could not send input/)).toBeTruthy();
+		expect(getByRole('alert').hasAttribute('aria-live')).toBe(false);
 		expect(container.querySelector('.input-wrapper')).toBeNull();
 		expect(container.querySelector('.input-form')).toBeNull();
 

--- a/parish/apps/ui/src/lib/illustrated-notebook/command.test.ts
+++ b/parish/apps/ui/src/lib/illustrated-notebook/command.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-import { draftForNotebookAction, submitNotebookCommand } from './command';
+import {
+	draftForNotebookAction,
+	NOTEBOOK_COMMAND_PLACEHOLDER,
+	resolveNotebookCommandPresentation,
+	submitNotebookCommand,
+} from './command';
+import type { NotebookCommandState } from './types';
 
 const roisin = {
 	name: 'Roisin Connolly',
@@ -11,6 +17,102 @@ const roisin = {
 };
 
 describe('illustrated notebook command input', () => {
+	function visualState(
+		overrides: Partial<NotebookCommandState> = {},
+	): NotebookCommandState {
+		return {
+			text: '',
+			focused: false,
+			busy: false,
+			disabled: false,
+			error: null,
+			...overrides,
+		};
+	}
+
+	it('resolves distinct idle, focus, text, busy, disabled, and error presentations', () => {
+		expect(resolveNotebookCommandPresentation(visualState())).toMatchObject({
+			phase: 'idle',
+			displayText: NOTEBOOK_COMMAND_PLACEHOLDER,
+			statusText: null,
+			showCaret: false,
+			sendDisabled: true,
+		});
+		expect(
+			resolveNotebookCommandPresentation(visualState({ focused: true })),
+		).toMatchObject({
+			phase: 'focused',
+			statusText: 'Writing',
+			showCaret: true,
+		});
+		expect(
+			resolveNotebookCommandPresentation(
+				visualState({ text: 'ask Roisin', focused: true }),
+			),
+		).toMatchObject({
+			phase: 'typing',
+			displayText: 'ask Roisin',
+			showCaret: true,
+			sendDisabled: false,
+		});
+		expect(
+			resolveNotebookCommandPresentation(visualState({ busy: true })),
+		).toMatchObject({
+			phase: 'busy',
+			displayText: 'waiting on the parish...',
+			statusText: 'Parish reply in progress',
+			showCaret: false,
+			sendDisabled: true,
+		});
+		expect(
+			resolveNotebookCommandPresentation(visualState({ disabled: true })),
+		).toMatchObject({
+			phase: 'disabled',
+			displayText: 'setting ink to paper...',
+			statusText: 'Sending your line',
+			showCaret: false,
+			sendDisabled: true,
+		});
+		expect(
+			resolveNotebookCommandPresentation(
+				visualState({
+					text: 'look',
+					focused: true,
+					error: '  bridge   unavailable ',
+				}),
+			),
+		).toMatchObject({
+			phase: 'error',
+			displayText: 'look',
+			statusText: 'Ink blotted — bridge unavailable',
+			showCaret: true,
+			sendDisabled: false,
+		});
+	});
+
+	it('gives busy and error precedence without discarding the written line', () => {
+		expect(
+			resolveNotebookCommandPresentation(
+				visualState({
+					text: 'ask Roisin',
+					busy: true,
+					disabled: true,
+				}),
+			),
+		).toMatchObject({
+			phase: 'busy',
+			displayText: 'ask Roisin',
+		});
+		expect(
+			resolveNotebookCommandPresentation(
+				visualState({ busy: true, error: 'connection lost' }),
+			),
+		).toMatchObject({
+			phase: 'error',
+			statusText: 'Ink blotted — connection lost',
+		});
+	});
+
 	it('seeds action stamps from the selected person', () => {
 		expect(draftForNotebookAction('ask', roisin)).toBe('ask Roisin Connolly ');
 		expect(draftForNotebookAction('observe', roisin)).toBe(

--- a/parish/apps/ui/src/lib/illustrated-notebook/command.test.ts
+++ b/parish/apps/ui/src/lib/illustrated-notebook/command.test.ts
@@ -4,6 +4,7 @@ import {
 	NOTEBOOK_COMMAND_PLACEHOLDER,
 	resolveNotebookCommandPresentation,
 	submitNotebookCommand,
+	windowNotebookCommandText,
 } from './command';
 import type { NotebookCommandState } from './types';
 
@@ -111,6 +112,21 @@ describe('illustrated notebook command input', () => {
 			phase: 'error',
 			statusText: 'Ink blotted — connection lost',
 		});
+	});
+
+	it('keeps the newest command characters visible at desktop and mobile widths', () => {
+		const command =
+			'ask Roisin to recount every detail because the latest typing stays visible';
+		const desktop = windowNotebookCommandText(command, 58);
+		const mobile = windowNotebookCommandText(command, 30);
+
+		expect(desktop).toHaveLength(58);
+		expect(desktop).toMatch(/^\.\.\./);
+		expect(desktop).toMatch(/the latest typing stays visible$/);
+		expect(mobile).toHaveLength(30);
+		expect(mobile).toMatch(/^\.\.\./);
+		expect(mobile).toBe('...latest typing stays visible');
+		expect(windowNotebookCommandText('look around', 30)).toBe('look around');
 	});
 
 	it('seeds action stamps from the selected person', () => {

--- a/parish/apps/ui/src/lib/illustrated-notebook/command.ts
+++ b/parish/apps/ui/src/lib/illustrated-notebook/command.ts
@@ -27,6 +27,16 @@ export function draftForNotebookAction(
 	return notebookActionDraft(action, selectedNpc);
 }
 
+export function windowNotebookCommandText(
+	text: string,
+	maxChars: number,
+): string {
+	const characters = Array.from(text);
+	if (characters.length <= maxChars) return text;
+	if (maxChars <= 3) return '.'.repeat(Math.max(0, maxChars));
+	return `...${characters.slice(-(maxChars - 3)).join('')}`;
+}
+
 export function resolveNotebookCommandPresentation(
 	state: NotebookCommandState,
 ): NotebookCommandPresentation {

--- a/parish/apps/ui/src/lib/illustrated-notebook/command.ts
+++ b/parish/apps/ui/src/lib/illustrated-notebook/command.ts
@@ -1,10 +1,16 @@
 import type { NpcInfo } from '$lib/types';
+import type {
+	NotebookCommandPresentation,
+	NotebookCommandState,
+} from './types';
 import {
 	notebookActionDraft,
 	type NotebookAction,
 } from '$lib/notebook/actions';
 
 export type SubmitInput = (text: string) => Promise<void>;
+
+export const NOTEBOOK_COMMAND_PLACEHOLDER = 'ask Roisin what she saw';
 
 export interface SubmitNotebookCommandOptions {
 	text: string;
@@ -19,6 +25,49 @@ export function draftForNotebookAction(
 	selectedNpc: NpcInfo | null,
 ): string {
 	return notebookActionDraft(action, selectedNpc);
+}
+
+export function resolveNotebookCommandPresentation(
+	state: NotebookCommandState,
+): NotebookCommandPresentation {
+	const text = state.text.trim();
+	const error = state.error?.replace(/\s+/g, ' ').trim() || null;
+	const phase = error
+		? 'error'
+		: state.busy
+			? 'busy'
+			: state.disabled
+				? 'disabled'
+				: text
+					? 'typing'
+					: state.focused
+						? 'focused'
+						: 'idle';
+
+	const displayText =
+		state.text ||
+		(phase === 'busy'
+			? 'waiting on the parish...'
+			: phase === 'disabled'
+				? 'setting ink to paper...'
+				: NOTEBOOK_COMMAND_PLACEHOLDER);
+	const statusText = error
+		? `Ink blotted — ${error}`
+		: state.busy
+			? 'Parish reply in progress'
+			: state.disabled
+				? 'Sending your line'
+				: state.focused
+					? 'Writing'
+					: null;
+
+	return {
+		phase,
+		displayText,
+		statusText,
+		showCaret: state.focused && !state.busy && !state.disabled,
+		sendDisabled: state.busy || state.disabled || !text,
+	};
 }
 
 export async function submitNotebookCommand({

--- a/parish/apps/ui/src/lib/illustrated-notebook/renderer.ts
+++ b/parish/apps/ui/src/lib/illustrated-notebook/renderer.ts
@@ -12,7 +12,10 @@ import {
 } from 'pixi.js';
 import type { NotebookAction } from '$lib/notebook/actions';
 import { NOTEBOOK_ASSET_URLS, NOTEBOOK_ASSETS } from './assets';
-import { resolveNotebookCommandPresentation } from './command';
+import {
+	resolveNotebookCommandPresentation,
+	windowNotebookCommandText,
+} from './command';
 import {
 	activateNotebookTarget,
 	notebookHitTarget,
@@ -917,6 +920,7 @@ export class IllustratedNotebookRenderer {
 	): void {
 		NOTEBOOK_ACTIONS.forEach((action, i) => {
 			const rect = layout.actionStamps[i];
+			const disabled = state.command.disabled;
 			const target = this.target(
 				`action:${action}`,
 				'action-stamp',
@@ -924,6 +928,7 @@ export class IllustratedNotebookRenderer {
 				rect,
 				{ type: 'action', action },
 				400 + i,
+				disabled,
 			);
 			this.drawTargetTreatment(target);
 			const group = new Container();
@@ -1035,9 +1040,10 @@ export class IllustratedNotebookRenderer {
 				height: layout.mode === 'mobile' ? 28 : 34,
 			}),
 		);
-		const displayText = shortText(
+		const maxDisplayChars = layout.mode === 'mobile' ? 30 : 58;
+		const displayText = windowNotebookCommandText(
 			command.displayText,
-			layout.mode === 'mobile' ? 30 : 58,
+			maxDisplayChars,
 		);
 		const textFill =
 			command.phase === 'error'
@@ -1058,6 +1064,18 @@ export class IllustratedNotebookRenderer {
 				fontStyle: command.phase === 'disabled' ? 'italic' : 'normal',
 			},
 		);
+		const maxDisplayWidth = lineW - 48;
+		let visibleChars = Math.min(
+			Array.from(command.displayText).length,
+			maxDisplayChars,
+		);
+		while (inputText.width > maxDisplayWidth && visibleChars > 4) {
+			visibleChars -= 1;
+			inputText.text = windowNotebookCommandText(
+				command.displayText,
+				visibleChars,
+			);
+		}
 		this.drawCommandStatus(layout, lineX, lineY, lineW, command);
 		if (command.showCaret) {
 			const caret = new Graphics();

--- a/parish/apps/ui/src/lib/illustrated-notebook/renderer.ts
+++ b/parish/apps/ui/src/lib/illustrated-notebook/renderer.ts
@@ -12,6 +12,7 @@ import {
 } from 'pixi.js';
 import type { NotebookAction } from '$lib/notebook/actions';
 import { NOTEBOOK_ASSET_URLS, NOTEBOOK_ASSETS } from './assets';
+import { resolveNotebookCommandPresentation } from './command';
 import {
 	activateNotebookTarget,
 	notebookHitTarget,
@@ -38,6 +39,7 @@ import type {
 const INK = 0x312316;
 const INK_SOFT = 0x6f5836;
 const INK_RED = 0x874534;
+const INK_BUSY = 0x55603e;
 const PAPER_LIGHT = 0xf4e4bd;
 const TAB_LABELS: NotebookTab[] = [
 	'notes',
@@ -967,7 +969,7 @@ export class IllustratedNotebookRenderer {
 				},
 			);
 			label.anchor.set(0.5, 0);
-			if (state.busy) group.alpha = 0.72;
+			if (state.command.busy || state.command.disabled) group.alpha = 0.72;
 		});
 	}
 
@@ -976,6 +978,7 @@ export class IllustratedNotebookRenderer {
 		state: NotebookRenderState,
 	): void {
 		this.clear(this.layers.intent);
+		const command = resolveNotebookCommandPresentation(state.command);
 		const strip = this.sprite(
 			NOTEBOOK_ASSETS.intentParchmentStrip,
 			layout.intentStrip,
@@ -987,6 +990,7 @@ export class IllustratedNotebookRenderer {
 			layout.intentStrip,
 			{ type: 'focus-input' },
 			500,
+			state.command.disabled,
 		);
 		this.drawTargetTreatment(inputTarget);
 		this.bindTarget(strip, inputTarget);
@@ -1004,6 +1008,25 @@ export class IllustratedNotebookRenderer {
 		const lineX = layout.intentStrip.x + layout.intentStrip.width * 0.22;
 		const lineY = layout.intentStrip.y + layout.intentStrip.height * 0.43;
 		const lineW = layout.intentStrip.width * 0.58;
+		const focusMark = new Graphics();
+		if (state.command.focused && !state.command.disabled) {
+			focusMark
+				.moveTo(lineX + 8, lineY + (layout.mode === 'mobile' ? 29 : 34))
+				.lineTo(
+					lineX + lineW * 0.48,
+					lineY + (layout.mode === 'mobile' ? 31 : 36),
+				)
+				.lineTo(
+					lineX + lineW - 10,
+					lineY + (layout.mode === 'mobile' ? 29 : 34),
+				)
+				.stroke({
+					color: command.phase === 'error' ? INK_RED : FOCUS_INK,
+					width: 2,
+					alpha: command.phase === 'busy' ? 0.38 : 0.82,
+				});
+			this.layers.intent.addChild(focusMark);
+		}
 		this.layers.intent.addChild(
 			this.sprite(NOTEBOOK_ASSETS.handwrittenInputLine, {
 				x: lineX,
@@ -1012,9 +1035,18 @@ export class IllustratedNotebookRenderer {
 				height: layout.mode === 'mobile' ? 28 : 34,
 			}),
 		);
-		const displayText =
-			state.intentText ||
-			(state.busy ? 'waiting on the parish...' : 'ask Roisin what she saw');
+		const displayText = shortText(
+			command.displayText,
+			layout.mode === 'mobile' ? 30 : 58,
+		);
+		const textFill =
+			command.phase === 'error'
+				? INK_RED
+				: command.phase === 'busy'
+					? INK_BUSY
+					: state.command.text
+						? INK
+						: INK_SOFT;
 		const inputText = this.addText(
 			this.layers.intent,
 			displayText,
@@ -1022,14 +1054,14 @@ export class IllustratedNotebookRenderer {
 			lineY,
 			layout.mode === 'mobile' ? 15 : 20,
 			{
-				fill: state.intentText ? INK : INK_SOFT,
-				wordWrap: true,
-				wordWrapWidth: lineW - 24,
+				fill: textFill,
+				fontStyle: command.phase === 'disabled' ? 'italic' : 'normal',
 			},
 		);
-		if (state.inputFocused && !state.busy) {
+		this.drawCommandStatus(layout, lineX, lineY, lineW, command);
+		if (command.showCaret) {
 			const caret = new Graphics();
-			const typedWidth = state.intentText ? inputText.width : 0;
+			const typedWidth = state.command.text ? inputText.width : 0;
 			const caretX = Math.min(
 				lineX + lineW - 18,
 				lineX + 16 + Math.min(typedWidth, lineW - 34),
@@ -1046,7 +1078,6 @@ export class IllustratedNotebookRenderer {
 			width: sendSize,
 			height: sendSize,
 		});
-		const sendDisabled = state.busy || !state.intentText.trim();
 		const sendTarget = this.target(
 			'send',
 			'send',
@@ -1059,12 +1090,88 @@ export class IllustratedNotebookRenderer {
 			},
 			{ type: 'send' },
 			510,
-			sendDisabled,
+			command.sendDisabled,
 		);
-		send.alpha = sendDisabled ? 0.48 : 1;
+		send.alpha = command.sendDisabled
+			? command.phase === 'disabled'
+				? 0.32
+				: 0.48
+			: 1;
 		this.drawTargetTreatment(sendTarget);
 		this.bindTarget(send, sendTarget);
 		this.layers.intent.addChild(send);
+		if (command.phase === 'error' && !command.sendDisabled) {
+			const retryMark = new Graphics();
+			retryMark
+				.circle(
+					send.x + send.width / 2,
+					send.y + send.height / 2,
+					send.width * 0.48,
+				)
+				.stroke({ color: INK_RED, width: 2, alpha: 0.72 });
+			this.layers.intent.addChild(retryMark);
+		}
+	}
+
+	private drawCommandStatus(
+		layout: NotebookLayout,
+		lineX: number,
+		lineY: number,
+		lineW: number,
+		command: ReturnType<typeof resolveNotebookCommandPresentation>,
+	): void {
+		if (!command.statusText) return;
+		const mark = new Graphics();
+		const markX = lineX + 12;
+		const markY = layout.intentStrip.y + (layout.mode === 'mobile' ? 15 : 14);
+		const color =
+			command.phase === 'error'
+				? INK_RED
+				: command.phase === 'busy'
+					? INK_BUSY
+					: INK_SOFT;
+
+		if (command.phase === 'busy') {
+			for (let i = 0; i < 3; i += 1) {
+				mark.circle(markX + i * 6, markY + (i % 2), 1.8).fill({
+					color,
+					alpha: 0.86 - i * 0.12,
+				});
+			}
+		} else if (command.phase === 'disabled') {
+			mark
+				.moveTo(markX - 1, markY + 4)
+				.lineTo(markX + 5, markY - 2)
+				.moveTo(markX + 4, markY + 4)
+				.lineTo(markX + 10, markY - 2)
+				.stroke({ color, width: 1.5, alpha: 0.74 });
+		} else if (command.phase === 'error') {
+			mark
+				.moveTo(markX, markY - 3)
+				.lineTo(markX + 7, markY + 4)
+				.moveTo(markX + 7, markY - 3)
+				.lineTo(markX, markY + 4)
+				.stroke({ color, width: 1.8, alpha: 0.86 });
+		} else {
+			mark
+				.moveTo(markX, markY + 3)
+				.lineTo(markX + 7, markY - 2)
+				.stroke({ color, width: 1.6, alpha: 0.72 });
+		}
+		this.layers.intent.addChild(mark);
+		this.addText(
+			this.layers.intent,
+			shortText(command.statusText, layout.mode === 'mobile' ? 34 : 68),
+			lineX + 28,
+			layout.intentStrip.y + (layout.mode === 'mobile' ? 8 : 7),
+			layout.mode === 'mobile' ? 10 : 12,
+			{
+				fill: color,
+				fontStyle: 'normal',
+				wordWrap: false,
+				wordWrapWidth: lineW - 32,
+			},
+		);
 	}
 
 	private drawLowerCards(

--- a/parish/apps/ui/src/lib/illustrated-notebook/types.ts
+++ b/parish/apps/ui/src/lib/illustrated-notebook/types.ts
@@ -70,14 +70,36 @@ export interface RenderCallbacks {
 	onSend: () => void;
 }
 
+export type NotebookCommandPhase =
+	| 'idle'
+	| 'focused'
+	| 'typing'
+	| 'busy'
+	| 'disabled'
+	| 'error';
+
+export interface NotebookCommandState {
+	text: string;
+	focused: boolean;
+	busy: boolean;
+	disabled: boolean;
+	error: string | null;
+}
+
+export interface NotebookCommandPresentation {
+	phase: NotebookCommandPhase;
+	displayText: string;
+	statusText: string | null;
+	showCaret: boolean;
+	sendDisabled: boolean;
+}
+
 export interface NotebookRenderState {
 	world: WorldSnapshot | null;
 	map: MapData | null;
 	npcs: NpcInfo[];
 	selectedNpc: NpcInfo | null;
 	selectedRealName: string | null;
-	intentText: string;
-	inputFocused: boolean;
-	busy: boolean;
+	command: NotebookCommandState;
 	callbacks: RenderCallbacks;
 }


### PR DESCRIPTION
## Summary

- model idle, focused, typing, busy, pending-submit disabled, and retryable error states as one notebook command presentation
- render each state directly in the Pixi parchment strip while retaining the one-pixel native input for keyboard and accessibility behavior
- preserve the draft on failed submission, announce streaming as busy without disabling editing, and make only the local pending-submit draft read-only and `aria-disabled`
- make Pixi and accessibility action stamps unavailable during a local pending submit, with a callback guard protecting the in-flight draft
- keep the newest long-command suffix and caret visible within the desktop and mobile strip, and rely on the implicit live semantics of dynamic `status`/`alert` roles
- cover desktop and mobile state transitions with stable-layout and texture-complete browser proof

## Portfolio linkage

Closes #1636
Parent: #1629
Epic: #1626

## Verification

- `CARGO_TARGET_DIR=/private/tmp/rundale-1636-target just check`
- `CARGO_TARGET_DIR=/private/tmp/rundale-1636-target just verify`
- `npm exec -- vitest run src/lib/illustrated-notebook/command.test.ts src/components/illustrated-notebook/IllustratedNotebookGame.test.ts` — 15/15 passed
- `npm run check` — 0 errors and 0 warnings
- `npm run lint -- --quiet`
- `npm run format:check`
- `npm run build`
- `PARISH_TEST_PORT=31842 CARGO_TARGET_DIR=/private/tmp/rundale-1636-target npm exec -- playwright test e2e/illustrated-notebook-interactions.spec.ts --reporter=line` — desktop/mobile 2/2 passed

The proof bundle below records ten fresh 1440×900 and 390×844 focused/long-command/busy/disabled/error screenshots, their hashes, the live browser transcript, and the acceptance-criteria verdict.

<!-- parish-proof-bundle:1636 v=1 -->

## Proof: 1636

### Acceptance criteria

# Acceptance criteria

1. The Pixi command strip visibly distinguishes command text, placeholder, caret/focus, streaming busy, pending-submit disabled, and retryable error states.
   - Proof: focused command presentation/component tests and the ten desktop/mobile screenshots listed in `evidence.md`; long-command captures show suffix-preserving text with the newest characters and caret visible.
2. Busy, disabled, and error transitions do not move the notebook first viewport or restore retired dashboard/input chrome.
   - Proof: the focused Playwright spec compares the notebook bounding box after every transition, rejects `.input-wrapper`, `.input-form`, `[data-testid="input-field"]`, `[data-testid="chat-panel"]`, and an old exact-name Send button, and proves pending-submit action stamps cannot replace the in-flight draft.
3. The native input remains an accessibility/keyboard implementation detail.
   - Proof: the running-app spec verifies the input stays at one pixel, transparent, and pointer-inert; streaming is announced as busy without disabling editing, only a local pending submit becomes read-only and `aria-disabled`, and status/alert roles rely on their correct implicit live-region semantics.
4. Desktop 1440x900 and mobile 390x844 preserve the notebook first viewport for focused, busy, disabled, and error states.
   - Proof: `.proofs/1636/{desktop,mobile}-{focused,long-command,busy,disabled,error}.png`.

### Evidence

Evidence type: live gameplay transcript

# Evidence

Exact tested head: `2389c02327c57235a09aa3f129767a574fb7f533`.

The shipped UI was built, served by the real `parish-server` process on a fresh port, and driven in Chromium through the existing notebook interaction Playwright spec. Tauri IPC was controlled at the existing test boundary so the same running page could deterministically enter every command state.

## Live command

`CI=1 PARISH_TEST_PORT=3194 rtk npx playwright test e2e/illustrated-notebook-interactions.spec.ts --reporter=line`

Result: 2 tests passed and 0 failed in 22.1 seconds. The desktop and mobile runs each traversed focused -> long typing -> streaming busy -> pending-submit disabled -> rejected-submit error. The spec asserted a stable notebook bounding box after every transition, suffix-preserving long text, hidden native input CSS/ARIA, streaming editability without disabled semantics, pending-submit read-only protection, pending action-stamp rejection at both the Pixi and accessibility surfaces, correct implicit status/alert live-region semantics, retained error draft, and absence of retired input/dashboard selectors.

## Screenshot artifacts

- `desktop-focused.png` — 1440x900 — SHA-256 `880d8573741aa076d7ee6aaa5091029c25413378a36713fb8824c7bfb48b17f8`
- `desktop-long-command.png` — 1440x900 — SHA-256 `cf5953e2c1507689397201514464515fd85f0a4a4524c58f1255317bfa737a60`
- `desktop-busy.png` — 1440x900 — SHA-256 `2348c4155b8c58433f1fe60fdcebfe5c3ba320b8c7a01c9884cbca42b9ebe9ca`
- `desktop-disabled.png` — 1440x900 — SHA-256 `35dccbeb6babaee6f87247c159ec11a30b02cc3dbeb6f04bfa9d35d87aed7234`
- `desktop-error.png` — 1440x900 — SHA-256 `43c6d2a99c89d09a726f50a6d1bbc2721421b42294178a8760a70a66ba898665`
- `mobile-focused.png` — 390x844 — SHA-256 `14993c208561825fc88d4dcac6f5851607912dbe59254db70da9a08f9b6868d6`
- `mobile-long-command.png` — 390x844 — SHA-256 `45180feea6e71af610732685c028e291fac6dc6bb22e4949fb6e557c3229f6ec`
- `mobile-busy.png` — 390x844 — SHA-256 `e9a76c9d5c5559713fbf73b5eb915fc9905c530e5825ad749b2e5648e3d14264`
- `mobile-disabled.png` — 390x844 — SHA-256 `fb42fade253a71c64b19253b780078bd17987196f84b39ad1156e9ad994eb4b7`
- `mobile-error.png` — 390x844 — SHA-256 `3a4acfbace584101cde758e54cc97430c000e97d84af50bb70dcf55202321060`

All ten images passed the repository's texture-complete Pixi frame sensor immediately before capture and were visually inspected for black/degenerate textures, legibility, old chrome, newest-character/caret visibility, action-stamp availability, and first-viewport stability.

## Focused automated evidence

- Focused CI-mode Playwright regression set (idle input, desktop command proof, editable streaming, and mid-chain streaming) — 4 passed, 0 failed in 18.4 seconds.
- Complete CI-mode Playwright suite on fresh port 3193 — 64 passed, 6 expected skips, 0 failed in 115.4 seconds.
- `rtk proxy npx vitest run src/components/illustrated-notebook/IllustratedNotebookGame.test.ts src/lib/illustrated-notebook/command.test.ts` — 15 tests passed.
- `rtk npm run check` — zero errors and zero warnings.
- `rtk npm run lint -- --quiet` — passed.
- `rtk npm run format:check` — passed.
- `rtk npm run build` — production build passed.
- `rtk just check` — passed.
- `rtk just verify` — passed, including the deterministic game walkthrough.

### Transcript

```text
Evidence type: live gameplay transcript

Command:
CI=1 PARISH_TEST_PORT=3194 rtk npx playwright test e2e/illustrated-notebook-interactions.spec.ts --reporter=line

Exact tested head:
2389c02327c57235a09aa3f129767a574fb7f533

Observed output:
Running 2 tests using 1 worker
[1/2] desktop Pixi hit targets and keyboard routing stay notebook-native
[2/2] mobile viewport keeps notebook controls and old chrome absent
2 passed, 0 failed (22.1s)

Runtime process:
/Users/dmooney/.cargo/target/debug/parish-server --port 3194

State sequence asserted in both viewports:
focused -> long typing -> busy -> disabled -> error

Observable results:
- Focused: handwritten placeholder and caret visible with the notebook Writing mark.
- Long typing: the strip shows a leading ellipsis, the newest `latest typing stays visible` suffix, and the caret without colliding with the send stamp on desktop or mobile.
- Busy: action stamps and send affordance muted; green ink status says Parish reply in progress; native input remains editable and is not announced disabled.
- Disabled: pending line remains visible; status says Sending your line; the native input is read-only and `aria-disabled`, and disabled Pixi/accessibility action stamps cannot replace the in-flight draft.
- Error: written line remains for retry; red ink status and send-ring treatment appear; ARIA invalid/error status is exposed through the implicit assertive `alert` role without a conflicting explicit live value.
- Notebook bounding box is unchanged across all four states.
- Old InputField/dashboard selectors remain absent.
```

### Judge

# Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

- Criterion 1 is met: the tested presentation model has six distinct phases, the running Pixi strip shows separate focus/caret, busy, disabled, and error treatments, and long commands preserve the newest suffix plus caret at both layout widths.
- Criterion 2 is met: the browser proof asserts identical first-viewport geometry after each state, re-runs the retired-chrome selector contract during busy and error states, and proves both Pixi-coordinate and synthetic accessibility action-stamp activation leave the pending draft unchanged.
- Criterion 3 is met: the native input is still one-pixel, transparent, pointer-inert, keyboard-focusable, and described by ARIA status/error state. Streaming leaves it editable and announces only `aria-busy`; a local pending submit alone makes it read-only and `aria-disabled`, preventing draft mutation before the request resolves. Dynamic `status` and `alert` roles carry their own non-conflicting implicit live-region behavior.
- Criterion 4 is met: ten texture-complete screenshots at the required desktop and mobile dimensions show the same notebook composition in all representative states, including the long-command window.

The exact committed head passes the focused visual proof, the complete Playwright suite, `just check`, and `just verify`. The proof-heavy spec now has an explicit cumulative timeout budget for its six independently bounded texture-completeness waits; individual assertions retain their existing timeouts and coverage. The change is bounded to the illustrated-notebook renderer/state/component, focused unit/component coverage, and the existing notebook interaction specs. It does not change Playwright configuration, shared E2E infrastructure, backend behavior, or legacy `InputField.svelte`.

### Artifacts

Drag these files into this PR comment in the GitHub UI to attach them:

- `desktop-busy.png`
- `desktop-disabled.png`
- `desktop-error.png`
- `desktop-focused.png`
- `desktop-long-command.png`
- `mobile-busy.png`
- `mobile-disabled.png`
- `mobile-error.png`
- `mobile-focused.png`
- `mobile-long-command.png`
- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:1636 -->
