### PR TITLE
fix(deps): restore green Rust security audit

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -66,8 +66,9 @@ just act-pr         # simulate the pull_request fast lane
 
 ### `audit.yml` — Security audit (cargo-audit)
 
-- **Triggers:** `schedule` (daily 06:17 UTC), `push` to `main` on `Cargo.lock`/`Cargo.toml` changes, `workflow_dispatch`.
+- **Triggers:** `schedule` (daily 06:17 UTC), dependency-changing `pull_request`, `push` to `main` on Cargo manifest/lock changes, and `workflow_dispatch`.
 - Installs `cargo-audit` via `cargo install --locked`; caches binary with `Swatinem/rust-cache` (no target dir).
+- While the temporary xcb/wayland-scanner security pins remain, verifies they are unreachable on supported macOS, Linux, and Windows target triples.
 - **Concurrency:** `audit-${{ github.workflow }}-${{ github.ref }}`, cancel-in-progress.
 
 ### `osv-scanner.yml` — OSV vulnerability scanner

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,6 +6,14 @@ on:
   schedule:
     - cron: "17 6 * * *"
   workflow_dispatch:
+  # Dependency-changing PRs must prove the audit before merge; otherwise a new
+  # advisory can leave main red while the fast/full CI workflows remain green.
+  pull_request:
+    paths:
+      - "parish/Cargo.lock"
+      - "parish/Cargo.toml"
+      - "parish/crates/**/Cargo.toml"
+      - ".github/workflows/audit.yml"
   # Re-audit immediately when the dependency tree changes on main, so we
   # don't wait up to 24h to notice a bad lockfile bump.
   push:
@@ -55,3 +63,31 @@ jobs:
 
       - name: Run cargo audit
         run: cargo audit
+
+      # Cargo.lock retains xcap's Linux-only transitive dependencies even
+      # though Parish enables xcap only on macOS and Windows. The exact git
+      # pins in Cargo.toml therefore clear RustSec without changing a compiled
+      # target. Fail before merge if that target-reachability invariant changes:
+      # wayland-scanner's pinned tree contains unreleased breaking codegen.
+      - name: Verify temporary lock-only pins stay unreachable
+        shell: bash
+        run: |
+          set -euo pipefail
+          packages=("xcb@1.7.0" "wayland-scanner@0.31.10")
+          targets=(
+            "aarch64-apple-darwin"
+            "x86_64-apple-darwin"
+            "x86_64-pc-windows-msvc"
+            "x86_64-unknown-linux-gnu"
+          )
+
+          for target in "${targets[@]}"; do
+            for package in "${packages[@]}"; do
+              tree="$(cargo tree --locked --workspace --target "$target" -i "$package" 2>/dev/null)"
+              if [[ -n "$tree" ]]; then
+                echo "error: temporary security pin $package is reachable on $target"
+                echo "$tree"
+                exit 1
+              fi
+            done
+          done

--- a/parish/Cargo.lock
+++ b/parish/Cargo.lock
@@ -375,7 +375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "annotate-snippets",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -410,9 +410,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -540,7 +540,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cairo-sys-rs",
  "glib 0.18.5",
  "libc",
@@ -876,7 +876,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
@@ -889,7 +889,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1228,7 +1228,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -1328,7 +1328,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytemuck",
  "drm-ffi",
  "drm-fourcc",
@@ -1815,7 +1815,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce852e998d3ca5e4a97014fb31c940dc5ef344ec7d364984525fd11e8a547e6a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "drm",
  "drm-fourcc",
  "gbm-sys",
@@ -2055,7 +2055,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -2078,7 +2078,7 @@ version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddbcf514bd1881fc1b960e4e52b4e82873f4da3bceddbd58d42827b508888100"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -2894,7 +2894,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -3026,7 +3026,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b8cfa2a7656627b4c92c6b9ef929433acd673d5ab3708cda1b18478ac00df4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cc",
  "convert_case",
  "cookie-factory",
@@ -3086,7 +3086,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "libc",
 ]
 
@@ -3280,7 +3280,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
  "ndk-sys",
@@ -3310,7 +3310,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3460,7 +3460,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -3481,7 +3481,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "objc2",
@@ -3513,7 +3513,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -3536,7 +3536,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -3546,7 +3546,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -3557,7 +3557,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "libc",
@@ -3570,7 +3570,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "libc",
@@ -3606,7 +3606,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "dispatch2",
  "objc2",
@@ -3622,7 +3622,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3634,7 +3634,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-core-foundation",
@@ -3664,7 +3664,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -3688,7 +3688,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3711,7 +3711,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -3722,7 +3722,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -3734,7 +3734,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -3765,7 +3765,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-app-kit",
@@ -4517,7 +4517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9688b89abf11d756499f7c6190711d6dbe5a3acdb30c8fbf001d6596d06a8d44"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "libc",
  "libspa",
  "libspa-sys",
@@ -4567,13 +4567,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.39.4",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -4597,7 +4597,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4797,18 +4797,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -4835,9 +4826,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -4981,7 +4972,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4996,7 +4987,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5200,7 +5191,7 @@ version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -5230,7 +5221,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -5243,7 +5234,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -5389,7 +5380,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -5402,7 +5393,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5425,7 +5416,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cssparser",
  "derive_more",
  "log",
@@ -5983,7 +5974,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -6030,7 +6021,7 @@ version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "block2",
  "core-foundation 0.10.1",
  "core-graphics",
@@ -6683,7 +6674,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -6701,7 +6692,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -7297,7 +7288,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -7323,7 +7314,7 @@ version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
@@ -7335,7 +7326,7 @@ version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -7347,7 +7338,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -7357,11 +7348,10 @@ dependencies = [
 [[package]]
 name = "wayland-scanner"
 version = "0.31.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+source = "git+https://github.com/Smithay/wayland-rs?rev=d07c4f91f28b42e5a485823ffd9d8d5a210b1053#d07c4f91f28b42e5a485823ffd9d8d5a210b1053"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.4",
+ "quick-xml",
  "quote",
 ]
 
@@ -7371,7 +7361,7 @@ version = "0.31.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc1846eb04c49182e04f4a099e2a830a2b745610bbc1d61246e206f29c7000a0"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "downcast-rs",
  "rustix 1.1.4",
  "wayland-backend",
@@ -8135,7 +8125,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -8270,12 +8260,11 @@ dependencies = [
 [[package]]
 name = "xcb"
 version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4c580d8205abb0a5cf4eb7e927bd664e425b6c3263f9c5310583da96970cf6"
+source = "git+https://github.com/rust-x-bindings/rust-xcb?rev=ae3b2cd080e78173223038ccbebdc644eaf4a9ad#ae3b2cd080e78173223038ccbebdc644eaf4a9ad"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.1",
  "libc",
- "quick-xml 0.30.0",
+ "quick-xml",
 ]
 
 [[package]]

--- a/parish/Cargo.toml
+++ b/parish/Cargo.toml
@@ -118,6 +118,18 @@ serial_test = "3"
 rand_chacha = "0.10"
 tracing-test = "0.2"
 
+# Temporary upstream security pins for target-specific paths retained in the
+# lockfile. Both crates keep their published package versions while the pinned
+# git trees move quick-xml to 0.41, fixing RUSTSEC-2026-0194 and
+# RUSTSEC-2026-0195. The wayland-scanner tree also contains unreleased breaking
+# codegen, edition-2024, and MSRV changes; neither patched crate may become
+# reachable on a supported target while these pins remain. The Security audit
+# workflow enforces that invariant. Remove each patch after its next crates.io
+# release contains the cited commit.
+[patch.crates-io]
+xcb = { git = "https://github.com/rust-x-bindings/rust-xcb", rev = "ae3b2cd080e78173223038ccbebdc644eaf4a9ad" }
+wayland-scanner = { git = "https://github.com/Smithay/wayland-rs", rev = "d07c4f91f28b42e5a485823ffd9d8d5a210b1053" }
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/parish/THIRD_PARTY_NOTICES.rust.md
+++ b/parish/THIRD_PARTY_NOTICES.rust.md
@@ -5,7 +5,7 @@ regenerate after dependency changes.
 
 ## Overview
 
-- [MIT License](#MIT) — 638 crates
+- [MIT License](#MIT) — 637 crates
 - [Apache License 2.0](#Apache-2.0) — 24 crates
 - [Unicode License v3](#Unicode-3.0) — 19 crates
 - [BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License](#BSD-3-Clause) — 9 crates
@@ -3104,7 +3104,7 @@ DEALINGS IN THE SOFTWARE.
 **Used by:**
 
 - [bitflags 1.3.2](https://github.com/bitflags/bitflags)
-- [bitflags 2.11.1](https://github.com/bitflags/bitflags)
+- [bitflags 2.13.1](https://github.com/bitflags/bitflags)
 - [glob 0.3.3](https://github.com/rust-lang/glob)
 - [log 0.4.29](https://github.com/rust-lang/log)
 - [num-bigint-dig 0.8.6](https://github.com/dignifiedquire/num-bigint)
@@ -3434,7 +3434,7 @@ DEALINGS IN THE SOFTWARE.
 
 **Used by:**
 
-- [plist 1.9.0](https://github.com/ebarnard/rust-plist/)
+- [plist 1.10.0](https://github.com/ebarnard/rust-plist/)
 
 ```
 Copyright (c) 2015 Edward Barnard
@@ -3461,11 +3461,11 @@ SOFTWARE.
 
 **Used by:**
 
+- [wayland-scanner 0.31.10](https://github.com/smithay/wayland-rs)
 - [wayland-backend 0.3.15](https://github.com/smithay/wayland-rs)
 - [wayland-client 0.31.14](https://github.com/smithay/wayland-rs)
 - [wayland-protocols-wlr 0.3.12](https://github.com/smithay/wayland-rs)
 - [wayland-protocols 0.32.12](https://github.com/smithay/wayland-rs)
-- [wayland-scanner 0.31.10](https://github.com/smithay/wayland-rs)
 - [wayland-server 0.31.13](https://github.com/smithay/wayland-rs)
 - [wayland-sys 0.31.11](https://github.com/smithay/wayland-rs)
 
@@ -10164,8 +10164,7 @@ SOFTWARE.
 
 **Used by:**
 
-- [quick-xml 0.30.0](https://github.com/tafia/quick-xml)
-- [quick-xml 0.39.4](https://github.com/tafia/quick-xml)
+- [quick-xml 0.41.0](https://github.com/tafia/quick-xml)
 
 ```
 The MIT License (MIT)


### PR DESCRIPTION
## Outcome

Restores the red Security audit by removing all five current RustSec vulnerabilities without suppressing an advisory.

## Changes

- upgrades plist to 1.10.0 / quick-xml 0.41.0 and quinn-proto to 0.11.15
- pins exact official upstream fixes for the two unreleased, target-unreachable quick-xml owners
- records the generated Rust notice changes
- runs the Security audit on dependency-changing pull requests
- fails CI if either unreleased pin becomes reachable on a supported macOS, Linux, or Windows target

## Risk

The active dependency changes are plist, quick-xml, and bitflags. Local macOS checks are green; Linux is delegated to this PR's CI. The repository has no Windows CI, so the exact-target guard proves only that the unreleased pin source stays inactive there. Each git patch has a crates.io release removal trigger.

## Verification

- cargo audit (zero vulnerabilities; 19 inherited allowed warnings)
- cargo check --locked --workspace --all-targets
- cargo test --locked -p parish-tauri (164 passed)
- actionlint .github/workflows/audit.yml
- just notices
- just check
- just verify
- live headless walkthrough
- independent review: cleared

Fixes #1744

<!-- parish-proof-bundle:1744 v=1 -->

## Proof: 1744

### Acceptance criteria

# Acceptance criteria — issue #1744

1. Cargo.lock contains only quick-xml >=0.41.0 and quinn-proto >=0.11.15.
2. cargo audit reports zero vulnerabilities without adding a RustSec ignore or allowlist.
3. The two unreleased upstream security pins are exact revisions, documented as lock-only, and mechanically prevented from becoming reachable on a supported target.
4. The dependency owners and practical exploit surfaces for both advisory families are recorded.
5. The active Tauri dependency path compiles and passes its complete test surface with regenerated Rust notices.
6. A live headless Parish smoke test still renders the world and built-in status, map, and help commands.

### Evidence

Evidence type: live gameplay transcript

# RustSec recovery proof — issue #1744

Exact head: ada830810652035503c752aed6ac18b10607cbdf
Base: c870e4be0ffe99e7ab5327e307323e7fcc9eb6f2

See transcript.txt for the literal command-result summary. The quick-xml
advisories have no current remote runtime path: the active plist owner parses
trusted bundle metadata without the affected APIs, while the xcb and
wayland-scanner owners are retained only by Cargo's cross-target lock
resolution and are empty in every supported exact-target tree. The Quinn
advisory is likewise lock-only because Rundale does not enable reqwest HTTP/3.

The Security audit workflow now runs on dependency-changing pull requests and
fails if either unreleased pin becomes reachable on macOS, Linux, or Windows.

### Transcript

```text
Issue #1744 local proof
head: ada830810652035503c752aed6ac18b10607cbdf
base: c870e4be0ffe99e7ab5327e307323e7fcc9eb6f2

security resolution:
- quick-xml 0.30.0 and 0.39.4 removed
- quick-xml 0.41.0 retained through plist 1.10.0
- quinn-proto 0.11.14 -> 0.11.15
- no new cargo-audit ignore or allowlist

cargo audit:
- advisory database: 1160 advisories
- dependencies scanned: 765
- vulnerabilities: 0
- exit: 0
- 19 pre-existing allowed warnings remain

exact-target reachability:
- aarch64-apple-darwin: xcb 0; wayland-scanner 0
- x86_64-apple-darwin: xcb 0; wayland-scanner 0
- x86_64-pc-windows-msvc: xcb 0; wayland-scanner 0
- x86_64-unknown-linux-gnu: xcb 0; wayland-scanner 0
- cargo tree --target all alone shows the impossible combined cfg graph:
  Parish selects xcap on macOS/Windows while xcap selects these owners on Linux
- audit.yml now enforces the four exact-target empty-tree invariant on PRs
- actionlint .github/workflows/audit.yml: passed

owner and exploit-surface evidence:
- plist 1.10.0 is the only active quick-xml owner; it uses plain Reader for
  trusted Tauri/bundle plist metadata and does not call NsReader or attributes
- xcb uses attributes only over crate-bundled protocol XML at build time;
  target-unreachable in the current Parish graph
- wayland-scanner uses attributes only over bundled Wayland protocol XML at
  build time; target-unreachable in the current Parish graph
- Rundale has no direct quick_xml use
- quinn-proto is retained by reqwest's optional HTTP/3 graph; no Rundale crate
  enables HTTP/3 and exact inverse feature trees are empty

compatibility:
- cargo check --locked --workspace --all-targets: passed (40.11s)
- cargo test --locked -p parish-tauri: 164 passed, 7 suites (2.83s)
- just notices: passed
- Rust notices now list bitflags 2.13.1, plist 1.10.0, quick-xml 0.41.0,
  and the exact wayland-scanner package; UI notices remain unchanged

live deterministic walkthrough:
- started a fresh headless game successfully
- look rendered Kilteevan Village and its exits
- /status returned Kilteevan Village | Morning | Spring
- /map returned the configured no-tile-source state
- /help rendered the command registry
- /quit saved and exited successfully

repository gates:
- the first just check invocation reached the UI gate and stopped because the
  fresh worktree had no node_modules (svelte-kit exit 127)
- npm ci installed the locked 293-package UI tree with zero vulnerabilities
- just check rerun: passed
- just verify: passed, including the scripted gameplay walkthrough
- workflow inventory reconciliation: Prettier check passed
```

### Judge

# Judge verdict — issue #1744

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

The evidence removes all five reported vulnerabilities without suppression,
records the inactive and active dependency paths, exercises the active Tauri
path, and adds a mechanical pre-merge invariant around the deliberately
uncompiled upstream pins. Both pins have explicit release removal triggers, so
the emergency resolution does not create an unowned permanent exception.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:1744 -->
