### PR TITLE
chore(deps): refresh bench-site presentation packages

### DIFF
--- a/promptfoo/bench-site/package.json
+++ b/promptfoo/bench-site/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@astrojs/svelte": "^9.0.1",
     "astro": "^7.0.7",
-    "simple-icons": "^16.24.0",
-    "svelte": "^5.56.3"
+    "simple-icons": "^16.26.0",
+    "svelte": "^5.56.5"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",

--- a/promptfoo/bench-site/pnpm-lock.yaml
+++ b/promptfoo/bench-site/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       '@astrojs/svelte':
         specifier: ^9.0.1
-        version: 9.0.1(@types/node@22.20.1)(astro@7.0.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@22.20.1)(rollup@4.62.2)(yaml@2.9.0))(esbuild@0.28.1)(svelte@5.56.3)(typescript@5.9.3)(yaml@2.9.0)
+        version: 9.0.1(@types/node@22.20.1)(astro@7.0.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@22.20.1)(rollup@4.62.2)(yaml@2.9.0))(esbuild@0.28.1)(svelte@5.56.5)(typescript@5.9.3)(yaml@2.9.0)
       astro:
         specifier: ^7.0.7
         version: 7.0.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@22.20.1)(rollup@4.62.2)(yaml@2.9.0)
       simple-icons:
-        specifier: ^16.24.0
-        version: 16.24.0
+        specifier: ^16.26.0
+        version: 16.26.0
       svelte:
-        specifier: ^5.56.3
-        version: 5.56.3
+        specifier: ^5.56.5
+        version: 5.56.5
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.9
@@ -1162,8 +1162,8 @@ packages:
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
-  esrap@2.2.11:
-    resolution: {integrity: sha512-gPdx+I+BjYEinNMQaBXFjbaJVyoPMU4ZODg5mE+M4DqVG9VusAVHHjcBX+zqyITlI0DIARwDMMzZwAWj36dRoQ==}
+  esrap@2.2.13:
+    resolution: {integrity: sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==}
     peerDependencies:
       '@typescript-eslint/types': ^8.2.0
     peerDependenciesMeta:
@@ -1573,8 +1573,8 @@ packages:
     resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
     engines: {node: '>=20'}
 
-  simple-icons@16.24.0:
-    resolution: {integrity: sha512-lAPW1rqgwPQ4tdIY15TtcKSgSelvJexz8q/B+a7Igg1dJoXR0LPjScLkLMI8UbLSkS41/fLVZWIhsH7HPUwAgQ==}
+  simple-icons@16.26.0:
+    resolution: {integrity: sha512-T9rNJtyOshULM8heLlvrZY346g9zOgZILQ3vxP+FWcX13RhaOLez7YM/hNCEx3b5gJckSCNDoNsjZuDncSMYSQ==}
     engines: {node: '>=0.12.18'}
 
   sisteransi@1.0.5:
@@ -1608,8 +1608,8 @@ packages:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0 || ^6.0.0
 
-  svelte@5.56.3:
-    resolution: {integrity: sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==}
+  svelte@5.56.5:
+    resolution: {integrity: sha512-P03YJmUy2JoOxYHb4Ka3oFat1hq2ko2it1MOItSjsJ4B6WgZPLc3+RyyU+57OGWhs3Ieq74EJpZtSnNXdAGgDw==}
     engines: {node: '>=18'}
 
   svgo@4.0.2:
@@ -2072,12 +2072,12 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/svelte@9.0.1(@types/node@22.20.1)(astro@7.0.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@22.20.1)(rollup@4.62.2)(yaml@2.9.0))(esbuild@0.28.1)(svelte@5.56.3)(typescript@5.9.3)(yaml@2.9.0)':
+  '@astrojs/svelte@9.0.1(@types/node@22.20.1)(astro@7.0.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@22.20.1)(rollup@4.62.2)(yaml@2.9.0))(esbuild@0.28.1)(svelte@5.56.5)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 7.2.0(svelte@5.56.3)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 7.2.0(svelte@5.56.5)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))
       astro: 7.0.7(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@22.20.1)(rollup@4.62.2)(yaml@2.9.0)
-      svelte: 5.56.3
-      svelte2tsx: 0.7.56(svelte@5.56.3)(typescript@5.9.3)
+      svelte: 5.56.5
+      svelte2tsx: 0.7.56(svelte@5.56.5)(typescript@5.9.3)
       typescript: 5.9.3
       vite: 8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))
@@ -2610,12 +2610,12 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.3)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.5)(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.3
-      svelte: 5.56.3
+      svelte: 5.56.5
       vite: 8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.1.4(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))
 
@@ -2990,7 +2990,7 @@ snapshots:
 
   esm-env@1.2.2: {}
 
-  esrap@2.2.11:
+  esrap@2.2.13:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
@@ -3425,7 +3425,7 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.5
 
-  simple-icons@16.24.0: {}
+  simple-icons@16.26.0: {}
 
   sisteransi@1.0.5: {}
 
@@ -3450,14 +3450,14 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  svelte2tsx@0.7.56(svelte@5.56.3)(typescript@5.9.3):
+  svelte2tsx@0.7.56(svelte@5.56.5)(typescript@5.9.3):
     dependencies:
       dedent-js: 1.0.1
       scule: 1.3.0
-      svelte: 5.56.3
+      svelte: 5.56.5
       typescript: 5.9.3
 
-  svelte@5.56.3:
+  svelte@5.56.5:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3470,7 +3470,7 @@ snapshots:
       clsx: 2.1.1
       devalue: 5.8.1
       esm-env: 1.2.2
-      esrap: 2.2.11
+      esrap: 2.2.13
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.21


### PR DESCRIPTION
## Summary

- refresh the static benchmark site's `simple-icons` package within major 16
- refresh Svelte from 5.56.3 to the compatible 5.56.5 patch
- keep Astro 7, the Astro/Svelte integration, benchmark data, and published routes unchanged

Parent initiative: #1685

Fixes #1724

## Verification

- exact PR head `e9eb96be41334ecf3f62e10d186f0158404190b6` against merged-main parent `083c659f306908ff1ccb85e02d240ccf3537cf8e`
- clean `pnpm install --frozen-lockfile`
- `pnpm check`
- `pnpm build`
- exact before/after benchmark-loader JSON, route-list, source-data, and visible-page-text comparisons
- `just notices` (unrelated UI notice drift restored)
- `just check`
- `just verify`

No paid or model evaluation was used.

<!-- parish-proof-bundle:1724 v=1 -->

## Proof: 1724

### Acceptance criteria

# Acceptance criteria — #1724

1. Update only `simple-icons` within major 16 and Svelte within major 5 minor/patch compatibility; do not change Astro, `@astrojs/svelte`, or unrelated direct dependencies.
2. All tracked package and lockfile changes remain inside `promptfoo/bench-site/`.
3. A clean frozen install, `pnpm check`, and production `pnpm build` pass.
4. Benchmark source-data fingerprints, generated semantic result content, and the complete published HTML route set are unchanged before and after the refresh.
5. `just notices`, `just check`, and `just verify` pass; any unrelated notice drift is restored rather than added to this issue.
6. No paid or model evaluation is used as proof.

### Evidence

# Evidence — #1724

Evidence type: gameplay transcript

## Dependency boundary

- Exact PR head: `e9eb96be41334ecf3f62e10d186f0158404190b6`.
- Base: merged `main` parent `083c659f306908ff1ccb85e02d240ccf3537cf8e`.
- `simple-icons`: `16.24.0` → `16.26.0` (major 16 retained).
- `svelte`: `5.56.3` → `5.56.5` (patch-only within major 5).
- `astro` remains `7.0.7`; `@astrojs/svelte` remains `9.0.1`; all other direct dependencies remain unchanged.
- The only additional resolved-package movement is Svelte's direct `esrap` dependency, `2.2.11` → `2.2.13`.
- `git diff --name-status 083c659f306908ff1ccb85e02d240ccf3537cf8e...HEAD` contains only `promptfoo/bench-site/package.json` and `promptfoo/bench-site/pnpm-lock.yaml`.

## Clean install and site gates

Runtime: Node `v26.0.0`, pnpm `10.33.2`.

After moving the baseline `node_modules`, `.astro`, and `dist` trees out of the worktree:

- `pnpm install --frozen-lockfile` installed 290 packages and resolved exactly `simple-icons 16.26.0`, `svelte 5.56.5`, `astro 7.0.7`, and `@astrojs/svelte 9.0.1`.
- `pnpm check` reported 9 files, 0 errors, 0 warnings, and 0 hints.
- `pnpm build` completed successfully and generated 10 static pages.
- The exact base parent installed its own frozen lockfile cleanly (290 packages), reported the same zero-diagnostic check, and built the same 10 routes.

## Benchmark data and published routes

The exact-base and exact-head semantic snapshots call each side's real `loadBenchData()` function directly. Both independently produced the same canonical pretty-JSON SHA-256:

- Snapshot SHA-256: `dcca0ebf023cea5e873115b49625641062c3253a1afacc1a2c53e0d1f545650d`.
- 8 candidates and 8 histories; `hasRuns=true`; latest timestamp `2026-06-15T19:00:00Z`.
- Judge `claude-sonnet-4-6`; dataset Merkle `12b7a39f0cffe796ae5dcd78129ee597c558f9feaa0dfdb11d297e16b9601cf8`; category order `dialogue`.

The build-time source inputs are unchanged before/after:

- `leaderboard.jsonl`: `a2927f70b6b66a5490dc0eb9d5372050929e3ed69a1f548f3bbc9b9d93b63933`.
- `candidates.jsonl`: `bd7c0dffe9465f6692de871c761ef0ba56febb496ba3989c8728b92a55f92c80`.
- `MANIFEST.json`: `8d92ef18cee8b179674d81887f8b726f55c28b6f6580427aa85a58de1d242c20`.
- `judge.yaml`: `50fe026a3a5b3318c8f90af87b425e1cc491503d65b371843120441325dba267`.

The complete exact-base/exact-head HTML route lists are byte-identical (SHA-256 `27b06e6414a98cac2e42303c2b81972fb81475dfba3d46dc2e9ba8dca333c1aa`): `/`, `/methodology/`, and all eight generated `/models/<slug>/` routes. A script/style-stripped visible-text snapshot of every generated route is also byte-identical, SHA-256 `3fc0e66a791656ee6cf4e25e65ff145747995b6af8aca74035783a410ce4ca8a`. This preserves published benchmark content while allowing presentation-package implementation bytes to change.

## Repository gates

- `just notices`: the first sandboxed attempt reached the UI notice generator but could not resolve the npm registry; the identical rerun with registry access exited 0. It regenerated unrelated `parish/THIRD_PARTY_NOTICES.ui.md` content outside this issue, which was restored to exact HEAD and is absent from the diff.
- `just check` exited 0 at exact head, including agent-check, format, clippy, Cargo tests, doc-path checks, and UI check/lint/format gates.
- `just verify`: the first restricted-sandbox attempt stopped before clippy could invoke `rustc` because `sccache` was denied access to the external toolchain/cache; the identical rerun outside that filesystem sandbox exited 0, including the deterministic game-harness walkthrough.
- After restoring generated artifacts, `git status --short` is clean and the PR remains a two-file bench-site-only diff.

No paid or model evaluation was run; this is a static benchmark-results site dependency proof.

### Judge

# Judge — #1724

The dependency diff is bounded to the two requested presentation packages and Svelte's direct transitive compiler dependency. Astro 7 and its Svelte integration remain fixed. A clean frozen install, Astro diagnostics, and production build all pass. Direct loader output, every build-time data input, the complete route set, and visible generated content match before and after. Repository checks pass, and unrelated notice drift was restored rather than included.

Verdict: sufficient

Technical debt: clear

Acceptance criteria: met

<!-- /parish-proof-bundle:1724 -->
