### PR TITLE
test(ui): budget notebook art promotion integration

### DIFF
--- a/parish/apps/ui/scripts/notebook-person-art-promotion-build.integration.test.mjs
+++ b/parish/apps/ui/scripts/notebook-person-art-promotion-build.integration.test.mjs
@@ -548,6 +548,7 @@ test('production refuses an alternate input catalog even when its bytes match ca
 	);
 });
 
+// Production freshness invokes Cargo with its own five-minute timeout.
 test('promotes a complete approved production release that builds without its candidate store', async () => {
 	const fixture = await createProductionFixture();
 	const releaseRoot = join(fixture.root, 'approved', 'v1');
@@ -653,7 +654,7 @@ test('promotes a complete approved production release that builds without its ca
 	assert.equal(entries.length, 24);
 	assert.equal(new Set(assetPaths).size, 48);
 	assert.equal(new Set(assetHashes).size, 48);
-}, 30_000);
+}, 360_000);
 
 test('production promotion rejects stale canonical catalogs and source mutations', async () => {
 	const fixture = await createProductionFixture();

--- a/parish/apps/ui/scripts/notebook-person-art-promotion-build.integration.test.mjs
+++ b/parish/apps/ui/scripts/notebook-person-art-promotion-build.integration.test.mjs
@@ -653,7 +653,7 @@ test('promotes a complete approved production release that builds without its ca
 	assert.equal(entries.length, 24);
 	assert.equal(new Set(assetPaths).size, 48);
 	assert.equal(new Set(assetHashes).size, 48);
-});
+}, 30_000);
 
 test('production promotion rejects stale canonical catalogs and source mutations', async () => {
 	const fixture = await createProductionFixture();


### PR DESCRIPTION
## Summary

- give the production notebook-person-art promotion/build integration a documented six-minute timeout
- preserve all functional assertions and Vitest defaults for every other test
- let the production freshness command's existing five-minute Cargo timeout report first
- restore main-branch Full CI after the post-#1749 UI-quality regression

## Root cause

Full CI run `29551373100`, job `87794411130`, passed 900 of 901 UI tests before this production-shaped integration exceeded Vitest's generic 5-second default. An initial 30-second correction was then exercised by exact-head Full CI run `29552254950`, job `87797147528`; it reached 30,057 ms while the other 900 tests passed. The integration invokes a cold Cargo freshness/build subprocess whose own bounded timeout is five minutes, so the wrapper test must outlive that ceiling.

## Risk

Standard and narrowly bounded. Only this one test receives a six-minute ceiling; production code and assertions are untouched. The subprocess retains its stricter five-minute failure bound, and all ordinary tests keep Vitest's default timeout.

## Verification

- targeted integration: 1 passed (1.09 seconds)
- complete UI suite: 70 files, 901 tests passed
- `just agent-check`: passed
- `just check`: passed
- exact-head 30-second Full CI trial: reproduced timeout at 30,057 ms with 900/901 passing

Fixes #1750

<!-- parish-proof-bundle:1750 v=1 -->

## Proof: 1750

### Acceptance criteria

## Acceptance criteria

1. The production notebook-person-art promotion/build integration has an explicit bounded timeout that outlives its real Cargo subprocess's five-minute ceiling.
2. The test's production promotion, provenance, artifact, uniqueness, and runtime-build assertions remain unchanged.
3. The targeted production promotion/build integration passes.
4. The complete UI test suite passes without regressions.

## Proof method

- Inspect the one-file diff to confirm only the documented per-test timeout changed.
- Run the targeted Vitest integration test against the exact branch head.
- Run the complete Vitest suite against the exact branch head.

### Evidence

Evidence type: gameplay transcript

## Scope

Issue #1750 repairs the main-branch UI quality regression observed in Full CI run `29551373100`, job `87794411130`. The failed test completed 900 of 901 tests before this production-shaped integration exceeded Vitest's generic 5-second default under CI contention.

An initial 30-second bound was also exercised by exact-head Full CI run `29552254950`, job `87797147528`: the same test reached 30,057 ms while the other 900 tests passed. That result established that the outer test must outlive the production freshness command's existing five-minute subprocess ceiling rather than use a unit-test-scale estimate.

## Evidence mapping

1. The diff adds a documented six-minute timeout for `promotes a complete approved production release that builds without its candidate store`, one minute beyond the production freshness subprocess's existing five-minute ceiling.
2. No assertion or production implementation changed; the diff adds only the timeout rationale and argument.
3. `transcript.txt` records the targeted integration passing in 1.09 seconds.
4. `transcript.txt` records all 70 UI test files and all 901 tests passing.

## Interpretation

The six-minute ceiling is bounded and specific to the production-shaped test that invokes a real Cargo freshness check. It lets the implementation's existing five-minute subprocess timeout report a meaningful failure before Vitest aborts the wrapper test. Ordinary tests retain Vitest's default timeout. The successful targeted and full-suite runs exercise all existing assertions unchanged; the exact-head CI failure at 30 seconds validates the timeout relationship under cold-runner contention.

### Transcript

```text
$ SCCACHE_DISABLE=1 CARGO_TARGET_DIR=/private/tmp/rundale-1749-timeout-target rtk proxy ./node_modules/.bin/vitest run scripts/notebook-person-art-promotion-build.integration.test.mjs -t 'promotes a complete approved production release that builds without its candidate store' --reporter=verbose

 RUN  v4.1.9 /private/tmp/rundale-1749-timeout/parish/apps/ui

 ✓ scripts/notebook-person-art-promotion-build.integration.test.mjs > promotes a complete approved production release that builds without its candidate store 1090ms

 Test Files  1 passed (1)
      Tests  1 passed | 3 skipped (4)
   Start at  23:27:46
   Duration  1.23s (transform 32ms, setup 25ms, import 36ms, tests 1.09s, environment 0ms)

$ SCCACHE_DISABLE=1 CARGO_TARGET_DIR=/private/tmp/rundale-1749-timeout-target rtk proxy ./node_modules/.bin/vitest run

 RUN  v4.1.9 /private/tmp/rundale-1749-timeout/parish/apps/ui

 Test Files  70 passed (70)
      Tests  901 passed (901)
   Start at  23:27:54
   Duration  17.23s (transform 25.39s, setup 5.18s, import 34.74s, tests 9.33s, environment 25.21s)
```

### Judge

## Judge review

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

The one-file diff preserves every functional assertion and adds only a documented six-minute timeout to the production-shaped integration whose real Cargo subprocess exceeded Vitest's generic CI budget. This outer ceiling intentionally outlives the subprocess's existing five-minute timeout. Exact-head Full CI demonstrated that a 30-second estimate was still insufficient under cold-runner contention, timing out at 30,057 ms with the other 900 tests passing. The corrected targeted test passed in 1.09 seconds locally and the complete suite passed 901 of 901 tests. The timeout remains finite, applies to no other test, and does not suppress or retry failures.

Criterion review:

1. Met: the affected integration has a finite six-minute workload-specific ceiling that permits its five-minute Cargo timeout to fire first.
2. Met: diff inspection shows no assertion or implementation change.
3. Met: the targeted test passes with its real Cargo freshness subprocess.
4. Met: the complete UI suite passes all 901 tests.

### Artifacts

- `transcript.txt` (full transcript)

<!-- /parish-proof-bundle:1750 -->