### PR TITLE
chore: disable Gemini review workflow

### DIFF
--- a/.github/scripts/gemini-review-disabled.test.cjs
+++ b/.github/scripts/gemini-review-disabled.test.cjs
@@ -1,0 +1,21 @@
+const assert = require("node:assert/strict");
+const { existsSync } = require("node:fs");
+const { join } = require("node:path");
+const test = require("node:test");
+
+const workflows = join(process.cwd(), ".github", "workflows");
+
+test("Gemini review workflows remain disabled", () => {
+  for (const name of ["gemini-dispatch", "gemini-review"]) {
+    assert.equal(
+      existsSync(join(workflows, `${name}.yml`)),
+      false,
+      `${name}.yml would reactivate the Gemini review integration`,
+    );
+    assert.equal(
+      existsSync(join(workflows, `${name}.yml.disabled`)),
+      true,
+      `${name}.yml.disabled should retain the paused workflow source`,
+    );
+  }
+});

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -32,7 +32,7 @@ just act-pr         # simulate the pull_request fast lane
 - **Rust toolchain is pinned to 1.95.0** in `full-ci.yml` and `release.yml`. Bump in a dedicated PR alongside any lint fixes.
 - **No YAML anchors** — setup steps (checkout, toolchain, cache, native deps) are inlined per job.
 - **`concurrency: cancel-in-progress: true`** on most workflows; `release.yml` sets `cancel-in-progress: false` (releases must not be cancelled).
-- **Secrets:** `GITHUB_TOKEN` (all), `GEMINI_API_KEY`/`GOOGLE_API_KEY`/`APP_PRIVATE_KEY` (Gemini review), `OPENROUTER_API_KEY` (inference eval, via `secrets: inherit`). Add new secrets to repo-level GitHub secrets and the consuming job's `env:` block.
+- **Secrets:** `GITHUB_TOKEN` (all), `OPENROUTER_API_KEY` (inference eval, via `secrets: inherit`). The disabled Gemini sources retain references to `GEMINI_API_KEY`/`GOOGLE_API_KEY`/`APP_PRIVATE_KEY` for a future re-enable. Add new secrets to repo-level GitHub secrets and the consuming job's `env:` block.
 - **`concurrency: pages`** in `publish-bench-site.yml` — do not rename without checking the `deploy-pages` action's concurrency expectations.
 - **`act` does not reproduce GitHub-side concerns** — concurrency groups, branch protections, required-check status, and `permissions:` are server-side only. See `docs/agent/act-local.md` for caveats.
 
@@ -52,17 +52,11 @@ just act-pr         # simulate the pull_request fast lane
 - **Jobs:** rust-quality-gate (fmt+clippy+tests), rust-coverage-ratchet (cargo-llvm-cov floor 60.8%), rust-multi-channel (stable+beta), game-harness (fixture sweep + parish-client smoke), ui-quality (svelte-check+lint+format+build+vitest), ui-e2e (Playwright), and `Full CI gate`.
 - **Concurrency:** `full-ci-${{ github.workflow }}-${{ github.ref }}`, cancel-in-progress.
 
-### `gemini-dispatch.yml` — Gemini review dispatch
+### `gemini-dispatch.yml.disabled` + `gemini-review.yml.disabled` — paused Gemini review
 
-- **Triggers:** PR opened, PR review submitted, PR review comment, issue comment.
-- Routes to `gemini-review.yml` via `workflow_call`. Dispatches only for non-fork PRs or `@gemini-cli` mentions from OWNER/MEMBER/COLLABORATOR users. Uses GitHub App identity token.
-- **Permissions:** `issues: write`, `pull-requests: write`.
-
-### `gemini-review.yml` — Gemini code review
-
-- **Trigger:** `workflow_call` from `gemini-dispatch.yml`.
-- Runs `google-github-actions/run-gemini-cli` with GCP workload identity federation, MCP server for GitHub tools, and code-review extension.
-- **Timeout:** 7 minutes.
+- **Status:** disabled on 2026-08-09 after the provider rejected reviews because prepaid credits were depleted. The non-YAML extension keeps both workflows out of GitHub Actions entirely, so PRs receive neither a Gemini check nor failure comments.
+- The former dispatcher handled PR opens and authorized `@gemini-cli /review` requests; the reusable workflow ran `google-github-actions/run-gemini-cli` with the GitHub MCP integration.
+- To re-enable it, restore both `.yml` filenames together, confirm provider billing, and run `actionlint` on both files before merging.
 
 ### `audit.yml` — Security audit (cargo-audit)
 

--- a/.github/workflows/gemini-dispatch.yml.disabled
+++ b/.github/workflows/gemini-dispatch.yml.disabled
@@ -1,5 +1,9 @@
 name: "🔀 Gemini Dispatch"
 
+# Disabled 2026-08-09. GitHub Actions ignores files without a .yml/.yaml
+# extension. Rename this file and gemini-review.yml.disabled together to
+# re-enable the integration.
+
 on:
   pull_request_review_comment:
     types:

--- a/.github/workflows/gemini-review.yml.disabled
+++ b/.github/workflows/gemini-review.yml.disabled
@@ -1,5 +1,9 @@
 name: "🔎 Gemini Review"
 
+# Disabled 2026-08-09. GitHub Actions ignores files without a .yml/.yaml
+# extension. Rename this file and gemini-dispatch.yml.disabled together to
+# re-enable the integration.
+
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
## Summary

- move the Gemini dispatcher and reusable review workflow out of GitHub Actions active YAML discovery
- retain both workflow sources with `.disabled` suffixes for deliberate re-enablement
- add a policy test preventing accidental reactivation
- document the paused integration and re-enable procedure

## Why

Gemini PR review is exhausting prepaid provider credits and leaving failed checks plus failure comments without producing review feedback. Disabling both workflows removes the unreliable PR signal until billing and the integration are intentionally restored.

## Impact

New pull requests will no longer receive automatic Gemini reviews. Authorized `@gemini-cli /review` requests are also disabled. Other CI, security scans, and the independent agent proof gate are unchanged.

## Validation

- `node --test .github/scripts/*.test.cjs` (48 passed)
- `npm run format:check`
- `npm run lint:md`
- `./parish/scripts/check-doc-paths.sh`
- `git diff --check`