### PR TITLE
test: freeze clock in mode-parity fixtures

### DIFF
--- a/parish/crates/parish-engine/AGENTS.md
+++ b/parish/crates/parish-engine/AGENTS.md
@@ -25,6 +25,7 @@ The crate ships both a library (`parish_engine`) and a binary (`parish-engine`).
 - **Script mode skips LLM init entirely.** `--script FILE` invokes `run_script_mode` in `src/testing.rs`, which uses `SimulatorClient` and never touches Ollama or any cloud provider.
 - **`#[deprecated]` `find_data_dir()` violates rule #9.** Marked deprecated in `src/main.rs` — new code must resolve runtime paths from explicit config on `AppState`, not `std::env::current_dir()`. Exists only until all paths are migrated to `saves_dir` / `log_app_name` on `App`.
 - **`real_loop.rs` and `shadow.rs` are harness-correctness infrastructure (#1159).** `real_loop.rs` routes harness input through the real `game_loop` path; `shadow.rs` canonicalizes event streams so the legacy router and real loop outputs can be compared semantically. Do not remove either module.
+- **Freeze the game clock in sequential mode-parity fixtures.** The default clock runs at 36x, so host load can advance nested gameplay timestamps between legacy and real-loop executions even after a snapshot restore. Construct parity fixtures through the paused-clock helper and keep a delay-based regression assertion.
 
 ## Module map
 

--- a/parish/crates/parish-engine/tests/mode_parity.rs
+++ b/parish/crates/parish-engine/tests/mode_parity.rs
@@ -96,6 +96,28 @@ fn first_word(s: &str) -> &str {
     s.split_whitespace().next().unwrap_or(s)
 }
 
+/// Mode-parity comparisons run two paths sequentially from one captured state.
+/// Freeze the accelerated game clock so host load cannot make nested gameplay
+/// timestamps differ merely because one path took longer to execute.
+fn parity_harness() -> GameTestHarness {
+    let mut harness = GameTestHarness::new();
+    harness.app.world.clock.pause();
+    harness
+}
+
+#[test]
+fn parity_harness_keeps_game_time_frozen_under_host_delay() {
+    let harness = parity_harness();
+    let frozen_at = harness.app.world.clock.now();
+
+    // The normal 36x clock advances by at least one game second over this
+    // interval. A paused parity fixture must stay exactly at its captured time.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    assert!(harness.app.world.clock.is_paused());
+    assert_eq!(harness.app.world.clock.now(), frozen_at);
+}
+
 fn isolate_one_speaker(harness: &mut GameTestHarness) -> (NpcId, String) {
     let player_location = harness.app.world.player_location;
     let speaker_id = harness
@@ -185,7 +207,7 @@ fn isolate_one_unintroduced_speaker(harness: &mut GameTestHarness) -> (NpcId, St
 
 #[test]
 fn dialogue_turn_publishes_identical_event_across_legacy_and_real_loop() {
-    let mut h = GameTestHarness::new();
+    let mut h = parity_harness();
     let (_speaker_id, speaker_name) = isolate_one_speaker(&mut h);
 
     let input = format!("talk to {speaker_name} about the harvest");
@@ -227,7 +249,7 @@ fn dialogue_turn_publishes_identical_event_across_legacy_and_real_loop() {
 
 #[test]
 fn unique_first_name_and_occupation_reveals_identity_across_turn_modes() {
-    let mut legacy_harness = GameTestHarness::new();
+    let mut legacy_harness = parity_harness();
     let (legacy_id, speaker_name, occupation) =
         isolate_one_unintroduced_speaker(&mut legacy_harness);
     let first_name = first_word(&speaker_name);
@@ -253,7 +275,7 @@ fn unique_first_name_and_occupation_reveals_identity_across_turn_modes() {
         "legacy harness route must commit the identity transition"
     );
 
-    let mut real_harness = GameTestHarness::new();
+    let mut real_harness = parity_harness();
     let (real_id, real_name, real_occupation) = isolate_one_unintroduced_speaker(&mut real_harness);
     assert_eq!(
         (real_name, real_occupation),
@@ -269,7 +291,7 @@ fn unique_first_name_and_occupation_reveals_identity_across_turn_modes() {
 
 #[test]
 fn rejected_anachronistic_candidate_has_zero_effects_across_modes() {
-    let mut harness = GameTestHarness::new();
+    let mut harness = parity_harness();
     let (_speaker_id, speaker_name) = isolate_one_speaker(&mut harness);
     let input = "I'll take the work. What would you have me do first?".to_string();
     let response = serde_json::json!({
@@ -314,7 +336,7 @@ fn rejected_anachronistic_candidate_has_zero_effects_across_modes() {
 
 #[test]
 fn authored_landmark_rejection_has_zero_effects_across_modes() {
-    let mut harness = GameTestHarness::new();
+    let mut harness = parity_harness();
     let (speaker_id, speaker_name) = isolate_one_speaker(&mut harness);
     let kilteevan = harness
         .app
@@ -376,7 +398,7 @@ fn authored_landmark_rejection_has_zero_effects_across_modes() {
 
 #[test]
 fn incomplete_multifacet_reply_has_zero_effects_across_modes() {
-    let mut harness = GameTestHarness::new();
+    let mut harness = parity_harness();
     let (_speaker_id, speaker_name) = isolate_one_speaker(&mut harness);
     // Peig is a known authored parish person even when not co-located.
     let request =
@@ -418,9 +440,9 @@ fn incomplete_multifacet_reply_has_zero_effects_across_modes() {
 
 #[test]
 fn typed_unknown_person_followup_has_legacy_real_loop_parity() {
-    let mut legacy_harness = GameTestHarness::new();
+    let mut legacy_harness = parity_harness();
     let (legacy_id, legacy_speaker) = isolate_one_speaker(&mut legacy_harness);
-    let mut real_harness = GameTestHarness::new();
+    let mut real_harness = parity_harness();
     let (real_id, real_speaker) = isolate_one_speaker(&mut real_harness);
     assert_eq!(legacy_speaker, real_speaker);
 
@@ -480,7 +502,7 @@ fn typed_unknown_person_followup_has_legacy_real_loop_parity() {
 
 #[test]
 fn grounded_task_assignment_is_identical_in_legacy_and_real_loops() {
-    let mut harness = GameTestHarness::new();
+    let mut harness = parity_harness();
     let (speaker_id, speaker_name) = isolate_one_speaker(&mut harness);
     let input = "I'll take the work. What would you have me do first?".to_string();
     let response = serde_json::json!({
@@ -542,7 +564,7 @@ fn grounded_task_assignment_is_identical_in_legacy_and_real_loops() {
 
 #[test]
 fn grounded_work_referral_rejection_has_zero_effects_across_modes() {
-    let mut harness = GameTestHarness::new();
+    let mut harness = parity_harness();
     let (_speaker_id, speaker_name) = isolate_one_speaker(&mut harness);
     let input = "Good morning. I'm Eilis Byrne, newly arrived and looking for honest work. Is there anyone needing a hand today?";
     let response = serde_json::json!({
@@ -620,7 +642,7 @@ fn parity_comparison_catches_a_dropped_dialogue_event() {
 fn potato_patch_action_progresses_identically_in_legacy_and_real_loops() {
     const ACTION: &str = "I take up a spade, break the clods in the potato patch, and plant the seed as Siobhan instructed.";
 
-    let mut harness = GameTestHarness::new();
+    let mut harness = parity_harness();
     let location = harness.app.world.player_location;
     let assigned_at = harness.app.world.clock.now();
     let task_id = harness


### PR DESCRIPTION
## Summary

- construct every sequential mode-parity fixture through a paused-clock helper
- add a 50 ms regression assertion that would advance the normal 36x game clock
- record the deterministic-fixture rule in the parish-engine agent guidance

## Five Whys

**Problem:** `just verify` intermittently fails two mode-parity tests because nested `PlayerTask` times differ by one in-game second between the legacy and real-loop paths.

1. **Why do the equality assertions fail?** The legacy path records `assigned_at` or `started_at` at `08:00:00`, while the restored real-loop path sometimes records `08:00:01`.
2. **Why can restored paths observe different game times?** `GameSnapshot::restore` recreates a running `GameClock`, so each sequential path continues advancing from the captured time.
3. **Why is a short host delay visible as a whole game second?** The default clock runs at 36x; about 28 ms of real time becomes one in-game second before `GameClock::now()` truncates to integer seconds.
4. **Why does this surface under the full gate but not every focused run?** Build/test contention can push the mock-backed real-loop path across that 28 ms boundary while a faster legacy path remains below it.
5. **Why was the fixture vulnerable to host load?** The mode-parity suite constructed ordinary running-clock harnesses even though its contract is to compare two paths from identical deterministic state.

**Root cause:** the parity fixture did not encode frozen game time as a deterministic test precondition.

**Prevention conclusion:** the local `parish-engine/AGENTS.md` guidance lacked this test-specific invariant. This PR adds the rule: sequential parity fixtures use the paused-clock helper and retain a delay-based regression assertion. Production clock behavior and timestamp semantics remain unchanged.

## Verification

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/rundale-deps-python-bench.8SvXP4/parity-target PARISH_MODS_DIR="$PWD/mods" cargo test -p parish-engine --test mode_parity` — 11 passed
- worktree-isolated mode-parity binary repeated 50 times — 50 passed, 0 failed
- `CARGO_TARGET_DIR=/tmp/rundale-deps-python-bench.8SvXP4/parity-target PARISH_MODS_DIR="$PWD/mods" just check` — passed
- `CARGO_TARGET_DIR=/tmp/rundale-deps-python-bench.8SvXP4/parity-target PARISH_MODS_DIR="$PWD/mods" just verify` — passed

<!-- parish-proof-bundle:mode-parity-clock v=1 -->

## Proof: mode-parity-clock

### Acceptance criteria

# Acceptance criteria

1. Every sequential legacy-versus-real-loop comparison in `mode_parity.rs` uses one helper whose game clock is paused before either path runs.
2. The paused fixture retains exactly the same game time across a host delay long enough for the normal 36x clock to advance by at least one in-game second.
3. The task-assignment and task-progression parity cases exercise `execute_via_real_loop` and compare equal, including their nested `PlayerTask` timestamps.
4. The complete mode-parity integration binary passes 50 consecutive repetitions with no failures.

### Evidence

Evidence type: game-loop integration test

# Evidence

The integration suite drives the production game-loop boundary through `GameTestHarness::execute_via_real_loop`; only the inference provider is mocked. The legacy harness path and real-loop path start from the same snapshot.

Command:

```text
CARGO_TARGET_DIR=/tmp/rundale-deps-python-bench.8SvXP4/parity-target \
PARISH_MODS_DIR="$PWD/mods" \
cargo test -p parish-engine --test mode_parity
```

Observed result:

```text
running 11 tests
test parity_harness_keeps_game_time_frozen_under_host_delay ... ok
test grounded_task_assignment_is_identical_in_legacy_and_real_loops ... ok
test potato_patch_action_progresses_identically_in_legacy_and_real_loops ... ok
test result: ok. 11 passed; 0 failed
```

The worktree-isolated compiled integration binary was then invoked 50 consecutive times:

```text
mode-parity repetitions: 50 passed, 0 failed
```

### Judge

# Judge

Verdict: sufficient
Technical debt: clear
Acceptance criteria: met

- Criterion 1: met. All eleven parity fixtures are constructed through `parity_harness`; its sole direct `GameTestHarness::new()` call immediately pauses the clock.
- Criterion 2: met. `parity_harness_keeps_game_time_frozen_under_host_delay` waits 50 ms and asserts exact `DateTime` equality plus the paused state.
- Criterion 3: met. The full integration suite passed both task parity tests while exercising `execute_via_real_loop`.
- Criterion 4: met. The isolated integration binary completed 50 runs with zero failures.

The fix changes test determinism only. It does not normalize away gameplay timestamps or alter production clock behavior.

<!-- /parish-proof-bundle:mode-parity-clock -->
