### PR TITLE
docs: reorganize mobile reset guidance and import test plans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,185 +1,110 @@
-# Repository Guidelines — Rundale on the Parish Engine
+# Rundale Agent Guide
 
-`AGENTS.md` is the source of truth for repo guidelines. `CLAUDE.md` is a symlink to it, so any edit here is automatically visible to Claude Code as well.
+Rundale is the game. Parish is the Rust game engine.
+`CLAUDE.md` and `GEMINI.md` are symlinks to this file; keep that single source intact.
 
-**Before anything else, skim [LEARNINGS.md](LEARNINGS.md)** — brief
-bullet list of gotchas and surprising defaults that aren't obvious from
-reading code or git history. Append a bullet whenever you discover
-something a future agent would benefit from knowing. The
-`Stop--learnings-reminder` hook nudges you to revisit it on non-trivial
-sessions.
+## Start here
 
-Start with the detailed agent docs in [docs/agent/README.md](docs/agent/README.md):
+1. Skim [LEARNINGS.md](LEARNINGS.md) for relevant traps.
+2. Read the [product specification](docs/product-specs/README.md) for the task's milestone.
+3. Use [docs/agent/README.md](docs/agent/README.md) to select the engineering references
+   relevant to the files and behavior you will change.
+4. Read applicable directory-level instructions before editing.
 
-- [build-test.md](docs/agent/build-test.md) — cargo, harness, frontend, web, and Tauri commands
-- [architecture.md](docs/agent/architecture.md) — workspace layout and module ownership
-- [code-style.md](docs/agent/code-style.md) — Rust + Svelte conventions
-- [gotchas.md](docs/agent/gotchas.md) — Tokio, SQLite, Ollama, mode parity pitfalls
-- [git-workflow.md](docs/agent/git-workflow.md) — commits, tests, and PR standards
-- [agent-check.md](docs/agent/agent-check.md) — proof evidence and judge verdict gate
-- [skills.md](docs/agent/skills.md) — `/check`, `/parish-engine`, `/backlog`, etc.
-- [harness.md](docs/agent/harness.md) — one-page map of every sensor, skill, and gate (start here when something fails)
-- [codebase-map.md](docs/agent/codebase-map.md) — top-level directory index with per-area `CLAUDE.md` pointers
+Append a concise learning when you discover a reusable, non-obvious trap.
+The `Stop--learnings-reminder` hook nudges this review after non-trivial sessions.
+Do not load every reference for every task.
 
-**Rundale** is the game (Irish living world, 1820). **Parish** is the engine (Rust workspace + frontends).
+## Current product direction
 
-## Current project state (quick map)
+- Mobile-first text adventure, with iPhone as the primary client.
+- SwiftUI player UI: compact status header, transcript, native composer.
+- Parish Rust gameplay runs on device; local saves remain authoritative.
+- Production remote inference goes through Parish Endpoints. No provider credentials
+  or shared invocation secrets ship in the app.
+- Start with fixtures, then one location/one NPC, then the canonical three-location,
+  three-NPC world. Expand only after the applicable milestone gates pass.
+- Existing UI and content are reference material, not mobile feature-parity requirements.
 
-- Rust workspace: **24 crates** under `parish/crates/` — see [docs/agent/architecture.md](docs/agent/architecture.md) for the full table.
-  - Binaries: `parish-engine` (headless entry point — `--headless` / `--script FILE` / Tauri-launch; despite the name it is a thin binary, the engine is `parish-core` + leaf crates), `parish-server` (Axum HTTP/WS server, library + binary), `parish-tauri` (desktop), `parish-client` (binary `parish`, thin HTTP client — see [Ways to run Parish](README.md#ways-to-run-parish)), `parish-mcp`, `parish-scenario`, `parish-geo-tool`, `parish-npc-tool`.
-  - Composition: `parish-core` re-exports the leaf crates under stable namespaces.
-  - Leaf logic crates: `parish-chronicle`, `parish-config`, `parish-diagnostics`, `parish-editor`, `parish-inference`, `parish-input`, `parish-mod`, `parish-npc`, `parish-palette`, `parish-persistence`, `parish-providers`, `parish-setup`, `parish-types`, `parish-world`.
-  - These crates make up the **Parish** game engine.
-- Frontend: `parish/apps/ui/` (Svelte 5 + TypeScript)
-- Rundale game content: `mods/rundale/`
-- Test fixtures: `parish/testing/fixtures/`
-- Deploy artifacts: `deploy/`
-- Documentation hub: `docs/index.md`
+The specifications describe the target experience, not evidence that it is implemented.
+Do not restore legacy surfaces or content merely because the engine supports them.
 
-## Non-negotiable engineering rules
+## Sources of truth
 
-Rules marked **(enforced)** are checked mechanically by `cargo test` / CI — see `parish/crates/parish-core/tests/architecture_fitness.rs`. The rest are still convention.
+| Question                                                         | Read                                                                  |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Product scope, six milestones, acceptance and Definition of Done | [Product specs](docs/product-specs/README.md)                         |
+| Target mobile architecture and open integration decisions        | [Mobile architecture](docs/agent/mobile-architecture.md)              |
+| Existing engine layout and ownership                             | [Architecture](docs/agent/architecture.md)                            |
+| Build, tests, and available verification commands                | [Build/test](docs/agent/build-test.md)                                |
+| Detailed invariants, selected by affected subsystem              | [Engineering rules](docs/agent/engineering-rules.md)                  |
+| Debugging and known pitfalls                                     | [Gotchas](docs/agent/gotchas.md), [LEARNINGS.md](LEARNINGS.md)        |
+| Repository navigation                                            | [Codebase map](docs/agent/codebase-map.md), [docs hub](docs/index.md) |
 
-1. **Module ownership (enforced):** Shared logic belongs in a leaf crate; `parish-core` composes them. Never duplicate leaf-crate logic in `parish/crates/parish-engine/src/`. Orphaned source files (on disk but not declared as `mod`) are rejected. Crate map: [docs/agent/architecture.md](docs/agent/architecture.md).
-2. **Mode parity (partially enforced):** Tauri, headless CLI, and web server must share behavior. The fitness test forbids backend-agnostic crates from depending on `tauri` / `axum` / `tower*` / `wry` / `tao`. Wiring parity (every IPC handler called from every entry point) is still convention.
-3. **Tests with behavior changes:** Add/adjust tests for every behavior change.
-4. **Gameplay proof:** For gameplay features, run `/parish-engine prove <feature>` — unit tests alone are not sufficient.
-5. **No unexplained `#[allow]`:** Only with explicit justification.
-6. **Feature flags for new engine/gameplay features:** Gate with `config.flags.is_enabled("feature-name")`, default-on, document in the PR.
-7. **Keep README.md up to date:** feature list, repository structure, credits. Run `just notices` when dependencies change.
-8. **Five Whys before patching:** Diagnose bugs, regressions, and unexpected behavior with the `/five-whys` skill (or the method) to reach root cause first.
-9. **Resolve runtime paths from explicit config, not the cwd:** Resolve saves/mods/data dirs once at startup and store on `AppState` / `GlobalState`; never `current_dir()`, parent-walks, or marker-file searches from request handlers (#771). Resolver APIs, platform roots, and env overrides: [docs/agent/gotchas.md](docs/agent/gotchas.md).
-10. **Truthful test automation:** Anything named or scheduled as a test must execute the
-    production behavior it claims to cover, contain a machine-checkable oracle, and
-    propagate failures to its caller. Exploratory proof scripts belong outside regression
-    test directories. Every confirmed escaped bug gets a regression test at the lowest
-    production seam that would have caught it. Scheduled automation must be green,
-    explicitly paused with a tracking issue, or removed.
-11. **Scaling guardrails:** Any PR touching `AppState`, session persistence, real-time push, inference calls, identity lookups, mod loading, or request-ID tracing must be reviewed against the seam checklist in [docs/agent/scaling-rules.md](docs/agent/scaling-rules.md).
-12. **Cross-runtime orchestration belongs in `parish-core`:** Game-loop, IPC, and session handlers shared by the server, Tauri, and CLI entry points — including their constants, payload structs, and helpers — are defined once in a backend-agnostic crate, parameterized via traits (e.g. `EventEmitter`); entry-point crates are thin wiring. Never copy an orchestration body, constant, or payload struct into a second entry-point crate — the divergence is invisible at review time and silently produces security drift (#687, #696).
-13. **[REMOVED]**
-14. **Validate artifact content, not just the envelope:** A handler returning a produced artifact (screenshot, export, render, generated file) must verify real content before reporting success — a blank/degenerate result is an `Err`, never "nonzero bytes = success". Pattern: `reject_blank_capture` in `parish/crates/parish-tauri/src/commands/screenshot.rs` (#1301).
-15. **Dialogue prompts must ground the model in the actual world:** Every NPC system prompt includes a `PEOPLE YOU KNOW` and a `PLACES IN THIS PARISH` list with instructions to decline to confirm anyone or anywhere not on them. Enforcement: `build_enhanced_system_prompt_with_config` in `parish-npc/src/ticks/prompt.rs` (`location_names` must be `Some(...)` in production); test: `parish-core/tests/dialogue_prompt_anchor.rs`; flag `npc-dialogue-grounding`, default-on (#1394).
-16. **Cap external API payloads before sending:** Validate payload size client-side against the provider's documented limit (e.g. GitHub issue body ≤ 65536 chars) and truncate to ≤ 90% of it with a `[truncated N chars]` marker — never rely on the provider's 4xx. A test asserting `payload.len() <= budget` is required for every such code path (#1375).
-17. **Survey existing tooling before building any:** Check whether the repo already provides it — the `parish-harness` binary (built-in web server/dashboard), `justfile` recipes, `parish/scripts/**`, `.claude/skills/` — and run or extend the existing tool in place. Never hand-roll a throwaway duplicate.
-18. **Report only verification you actually ran:** Any claim that a test passed or a process ran must be backed by literal command output from the current session. State skips and failures explicitly — never estimate, extrapolate, or fabricate a result.
-19. **Production scope means end-to-end, not minimum arguable plumbing:** Rundale is a production-quality game, engine, and toolset. When an issue asks for a production pipeline/workflow/tool, implement the full stated workflow and proof path from source-of-truth inputs through generated/reviewed outputs and runtime integration. Do not downgrade scope to cached artifacts, manual intermediates, placeholders, or "assembly only" unless the issue explicitly says that is acceptable. If provider access, credentials, or product constraints block the true end-to-end workflow, mark the work incomplete/blocked instead of calling it done.
-20. **Character-art identity must be distinct across the cast:** Encode stable structured facial geometry separately from age, affect, hair/headwear topology, wardrobe, and props. Hair/headwear must expose machine-comparable front, rear, covering, and overall-silhouette families; reject missing, duplicate, or near-duplicate facial vectors and repeated hairstyle topology within relevant cohorts before generation. A pair matching itself is not enough: shared full-face style references must not become an identity prior for unrelated characters, and approval must compare each result against the full cast.
-21. **Persist billable external artifacts before validating them:** When an external API returns a non-deterministic generated artifact, write the raw bytes, content hash, provider request ID, and source provenance before content validation. Store each attempt immutably: a rejection must retain that raw artifact and link it from a failure receipt, and a retry must never overwrite an earlier paid response.
-22. **Validate generated art against the asset-specific visual contract:** File format, dimensions, and nonblank pixels are necessary but insufficient. Keep portrait, marker, scene, and UI-art prompts/references separate; encode machine-checkable composition and style signals where practical (for example bounds, fill, ink density, or palette), retain human review for semantic judgment, and test that a representative wrong-style artifact is rejected.
-23. **Character markers are character-only cutouts:** Make marker identity readable from face, hair/headwear, clothing, body shape, and stance. Reject held or carried objects, extra people, furniture, architecture, vegetation, scenery fragments, ground planes, and shadows unless an issue explicitly opts into contextual markers; worn clothing and headwear remain valid identity cues.
-24. **Commit generated files as transactions:** Finish every fallible preparation and handled-failure cleanup before the final source-snapshot comparison, then perform the same-filesystem rename immediately. Inject source mutation at the last cleanup seam and exercise competing snapshots across processes.
-25. **Launch portable Node tools without a shell:** Cross-platform Node automation must use `shell: false` and invoke JavaScript CLI entry points through `process.execPath`, never platform wrappers such as `.cmd`; execute the default path in tests with spaces in filesystem paths.
-26. **Keep shared-target artifacts worktree-coherent:** When a build script embeds worktree-local files, parallel test tooling that shares a Cargo target must key the build to those inputs and preserve and validate the resulting executable before releasing its coordination lock. Never launch the shared final binary after Cargo releases its own lock; use the Playwright managed-server helper as the reference (#1717).
-27. **Make managed-test lifecycles crash-safe on every platform:** Locks, candidates, and copied executables must have bounded startup recovery and mechanically tested platform policy. A fresh active-use lease is a capability: its heartbeat owner must fence and stop the child if ownership is lost, while a pruner must preserve lazily read artifacts and fail closed on malformed state. Retirement must atomically replace a stale lease with a tombstone, preserve its artifacts for another full grace, and reclaim only in a later pass. Test the real process-manager paths: POSIX group signals must leave the launcher alive to stop/wait the child and release ownership; Windows `taskkill /T /F` may skip hooks, so bounded expiry is the required fallback (#1717).
-28. **Preserve merged end-to-end contracts when extending or extracting a shared spec:** Retain every already-merged public-behavior assertion across API, IPC, gameplay, and UI surfaces, and add new coverage alongside it; bounded behavior must cover the cap boundary and overflow. A focused test for the new slice does not prove earlier consumer contracts still exist.
-29. **Audit player-facing interaction models, not only controls:** Before declaring a material visual UI change complete, run [the illustrated-notebook UX audit](.github/prompts/rundale-illustrated-notebook-ux-audit.prompt.md) against the live desktop and mobile surface. A label must lead to its ordinary semantic destination; persistent-object navigation (such as notebook tabs) renders in that object, visibly distinct controls have visibly distinct outcomes, and any deliberate overlay preserves the object’s visual and task continuity. Record the interaction model, screenshots/recording, findings, and semantic Playwright coverage. Functional tests that only assert that an overlay opened are insufficient.
-30. **Ground background simulation in canonical state (enforced):** LLM simulation prompts must carry each participant's exact current location and authored current activity. Every async result must retain immutable fingerprints plus a monotonic participant-lineage revision from the canonical snapshot used to generate it, then revalidate those anchors at the one public shared apply seam; stale, restored-branch, ABA, missing-anchor, and contradictory-known-location results must have zero side effects. Authored fallback schedules must be semantically valid in every season and day type where they can resolve; unscoped activity prose must remain season- and day-neutral (#1785, #1831).
-31. **Preserve live play signals and isolate replacement contexts:** The first viewport must visibly retain player input, narration, streamed NPC dialogue, location changes, and state-derived notebook content. Successful new-game/branch/reconnect replacement clears prior prompt, presentation, dedup, and retained-event state while preserving a lifetime-monotonic cursor; failure preserves the old context (#1774, #1778, #1782, #1783).
-32. **Player-visible gameplay status comes from authoritative state:** Consequential player actions must mutate canonical engine state, publish semantic events, survive save/load and journal recovery, and flow through shared IPC in every runtime. Local UI drafts and production placeholders must not masquerade as progression (#1781).
-33. **Validate semantic model output at the canonical apply seam:** Prompt contracts and deterministic guards must share canonical constants. Treat player-visible model dialogue as an effect: quarantine candidate tokens until the one canonical apply validator accepts or replaces them, and never pre-apply semantic guards or publish raw candidate text from a caller. Rejected text and metadata have zero memory, event, UI, or state effects. Schema-valid model fields and factual dialogue claims must not change or contradict identity, relationships, occupations, workplaces, locations, calendar facts, hints, recommendations, or other gameplay/UI metadata until cross-checked against authored world data and the final delivered dialogue. Explicit current-turn request facets must use one typed, ordered prompt/apply contract; if the final transformed dialogue omits a recognized facet, replace the whole response before effects. Multi-turn pronouns may carry an unresolved person/place only through a bounded typed conversation context and only while the referent is unambiguous (#1776, #1779, #1786, #1788–#1790, #1832, #1834, #1839–#1841).
-34. **Commit save/session identity before publishing a runtime:** Acquire a candidate save lock before any SQLite open, persist a complete candidate and atomic active-identity marker, then perform only infallible live-state publication. Cold restore/create must single-flight and recheck under one lifecycle gate; lock, marker, registry, or recovery failure must not fall back to another ledger, publish a session, or start workers.
-35. **Long-running HTTP harnesses must prove session and interaction continuity:** Reuse one authoritative server session across more requests than the configured admission cap, including local HTTP when production cookies are `Secure`, and reset/reacquire dialogue after terminal interactions so every counted sample actually reaches inference. A harness that silently creates sessions or counts post-farewell no-op commands invalidates soak/reliability evidence.
-36. **Promote local-inference presets only from passing production evidence:** A recommended model/backend/sampling/hardware profile requires a content-addressed promotion receipt from the frozen production-prompt holdout that passes dialogue and multiturn quality, hard-failure, parser-soak, guard-intervention, p95 latency/throughput, and memory-headroom gates. Development-split scores, preliminary leaderboard rows, hand-entered summaries, and average quality alone must never change a shipped recommendation.
-37. **Treat model termination as part of the response contract:** Streaming provider clients must reject every non-success finish reason (for example `length` / `MAX_TOKENS`) instead of parsing or displaying the partial body. Mandatory-reasoning profiles must budget and measure reasoning-token headroom separately from the player-visible response; a low effort label is not a token ceiling.
-38. **Separate qualification policy by serving topology:** Local promotion latency gates must not be reused for routed cloud models. A promotion receipt is valid only for the exact provider and API route measured; matching model identity through another gateway is not equivalent evidence. Cloud screening hard-gates structural validity, guard intervention, evidence completeness, and request reliability; latency and throughput rank qualified profiles unless a separately measured product SLO explicitly makes one a release gate.
-39. **Give judges the complete evidence needed by their rubric:** Any quality axis that depends on system-prompt facts—character identity, mood contract, known people, known places, or period rules—must receive those exact production facts in the judge bundle. Persist every paid judge attempt before validation, journal retries immutably, and trip a batch-wide circuit breaker on authentication, billing, quota, or rate-limit failures.
-40. **Cloud dialogue qualification requires independent judge families:** Never let a model family vote on itself. A promotable cloud profile needs at least two eligible judge families, uses the policy-defined consensus statistic, and routes split pass/fail votes or excessive score spread to an explicit adjudication state. Same-family judgments may remain visible as diagnostic evidence but cannot count toward promotion.
-41. **Bundle production rendering support assets:** Never ship required fonts, glyphs, sprites, or equivalent UI resources from demo or best-effort endpoints. Serve them from the frontend distribution unless an owned production SLA is documented, keep CSP origins minimal, and test both packaged integrity and browser requests/errors across every consuming surface.
-42. **Player-earned knowledge is durable state:** Introductions and other knowledge the player legitimately learns must survive save/load, branch restore, reconnect, cold server restore, Tauri restore, and headless restore. Only an explicit new-game/reset boundary may clear it. When adding durable knowledge, cover serialization plus every production restore lifecycle; compatibility repair may only infer facts from retained evidence that satisfies the same canonical apply guard.
+Versioned product specs govern the reset. Technical recommendations remain proposals
+until validated or recorded as decisions. Existing subsystem docs describe reusable
+implementation; historical roadmaps do not override current product requirements.
+Keep source provenance and requirement changes reviewable in the repository.
+
+## Core engineering invariants
+
+- Shared domain logic belongs in leaf crates; `parish-core` composes them and owns
+  shared application orchestration. Entry-point crates remain thin wiring.
+- Keep shared orchestration backend-agnostic. Preserve existing runtime contracts
+  when changing shared behavior; mobile scope does not require legacy UI parity.
+- Resolve runtime paths from explicit startup configuration, never cwd discovery.
+- Authoritative state changes pass through canonical validation and commit boundaries.
+  Model output and provisional text are not committed game facts.
+- Behavior changes require meaningful tests. Gameplay changes require production-path
+  proof, not unit tests alone.
+- Diagnose root causes before patching bugs; use Five Whys and existing tools.
+- Preserve applicable tests and invariants. Do not weaken a gate to make work pass
+  unless the task explicitly changes its underlying requirement and retains equivalent
+  or stronger coverage.
+- Report only verification actually run, with skips, failures, and unavailable gates
+  distinguished from passes.
+- Completion requires applicable acceptance criteria, Definition of Done, and Quality
+  Gate evidence. Never claim physical-iPhone validation unless it actually occurred.
+
+Read the [detailed rules](docs/agent/engineering-rules.md) before changing their
+associated subsystem, especially persistence, inference, concurrency, or UI state.
+Use the [mobile test plans](docs/test-plans/README.md) alongside the full milestone gates.
+
+## Agent workflow
+
+Follow the global Codex agent policy for model selection, delegation, independent
+adversarial review, autonomy, and usage efficiency. Keep that personal policy in
+`$CODEX_HOME/AGENTS.md`, not duplicated in this repository.
+
+Inspect existing tooling before creating new tools. Carry authorized work through
+implementation and relevant verification; distinguish a completed coding task from
+a milestone that still requires live integration or physical-device acceptance.
 
 ## Standard commands
 
-```sh
-just build         # cargo build (default member parish-engine)
-just run-client    # cargo run -p parish-client (thin HTTP client → running server)
-just run           # cargo tauri dev
-just run-headless
-just check         # fmt + clippy + tests
-just agent-check   # proof evidence + judge verdict gate
-just verify        # check + harness walkthrough
-
-just ui-test       # frontend unit tests
-just ui-e2e        # Playwright end-to-end tests
-just screenshots   # regenerate docs/screenshots/*.png
-```
-
-## Driving Parish via MCP (`parish-mcp`)
-
-`.mcp.json` at the repo root registers `parish-mcp` as a project-level MCP
-server. When you start a Claude Code session here, the tools below are
-available as `mcp__parish__*`:
-
-| Tool                       | Effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `parish_world_snapshot`    | Read clock, player location, weather, recent log.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| `parish_map`               | Read the location graph plus the player's position.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `parish_npcs_here`         | List NPCs co-located with the player.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `parish_engine_state`      | Read the canonical deterministic engine state for QA validation — `active_scene`, `clock`, `weather`, `player`, `npcs`, `grapevine`. Assert the UI against this after each interaction to detect UI-vs-engine drift (#1331).                                                                                                                                                                                                                                                                             |
-| `parish_save_state`        | Read save-file / branch metadata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| `parish_turn`              | Read recent canonical exchanges, the newest 20 unseen retained world events in chronological order, and current scene state. Pass its lifetime-monotonic `event_cursor` back as `since`; overflow drops the oldest unseen events and advances the cursor to the coherent current total.                                                                                                                                                                                                                  |
-| `parish_submit_input`      | Send player input — movement, action, dialogue, system commands. Optional `addressed_to` array scopes dialogue.                                                                                                                                                                                                                                                                                                                                                                                          |
-| `parish_new_game`          | Start a fresh game on a new save branch.                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `parish_save_game`         | Save the current branch.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `parish_load_branch`       | Load a branch by integer id.                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `parish_setup_status`      | Reads first-run setup state: `{implemented, complete, provider, model, base_url, has_api_key, has_env_key}`.                                                                                                                                                                                                                                                                                                                                                                                             |
-| `parish_setup_byok`        | Submits a BYOK provider config (`provider`, `api_key`, optional `base_url`/`model`). Persists to keychain + `parish.toml`, rebuilds the inference worker, emits `setup-done`.                                                                                                                                                                                                                                                                                                                            |
-| `parish_latest_screenshot` | Read metadata for the most recent player-triggered screenshot (`path`, `taken_at`, `size_bytes`). Capture is initiated by pressing F2 in the live desktop window.                                                                                                                                                                                                                                                                                                                                        |
-| `parish_file_bug`          | File a bug report (`title`, optional `description`/`context`). Bundles a live screenshot + recent logs + game state into a GitHub issue on the configured repo (`dmooney/rundale` by default) and returns the issue URL. Auto-appends a "black box" diagnostic payload — raw LLM prompt/response history, the `get_engine_state` snapshot, and the last raw user intent (#1331). In dry-run / no-token mode writes the composed report to disk (`created:false`, `bundle_path` set). For auto-QA agents. |
-| `tauri_invoke`             | Generic escape hatch — call any backend command (e.g. `editor_*`, `get_debug_snapshot`) by name.                                                                                                                                                                                                                                                                                                                                                                                                         |
-
-The MCP server is a _bridge_: it speaks HTTP to a running Parish backend on
-`127.0.0.1:3030`. **Before using any `mcp__parish__*` tool**, ensure a
-backend is up:
+These are existing repository commands, not proof of mobile milestone completion.
 
 ```sh
-# Headless web server (works in any sandbox; recommended in CI / on the web):
-bash parish/scripts/parish-mcp-backend.sh start    # spawn + wait for /api/health
-bash parish/scripts/parish-mcp-backend.sh status   # report pid + health
-bash parish/scripts/parish-mcp-backend.sh stop     # graceful shutdown
-
-# Desktop, when a display is available — drives the live window:
-cargo run -p parish-tauri -- --mcp-port 3030
+just build          # existing default engine build
+just check          # existing pre-commit quality gates
+just verify         # existing checks plus harness walkthrough
+just agent-check    # proof evidence and judge verdict gate
+just ui-test        # existing Svelte frontend tests
+just ui-e2e         # existing browser Playwright contracts
+bash parish/scripts/check-doc-paths.sh  # documentation links and paths
 ```
 
-If a tool call returns an MCP `isError: true` with `transport error: ...`,
-the backend isn't running — call `parish-mcp-backend.sh start` first.
+For gameplay changes, use `/parish-engine prove <feature>` on the affected production
+path. Read [build/test](docs/agent/build-test.md) for mobile verification requirements;
+the specified phase-selectable `./verify` must not be confused with `just verify`.
+Use [runtime driving](docs/agent/runtime-driving-reference.md) for existing MCP/CLI
+commands and [harness.md](docs/agent/harness.md) to diagnose gate failures.
 
-Two distinct things get called "MCP bridge" (#1366 §6) — be precise:
-the `parish-mcp` **crate** is the stdio MCP server that exposes the
-`mcp__parish__*` tools and forwards them over HTTP, while
-`parish-tauri/src/mcp_bridge.rs` is the **embedded HTTP listener** inside the
-desktop app that answers those forwarded calls when Tauri is the backend
-(the web server answers them natively). For deeper context on both see
-[parish/crates/parish-mcp/README.md](parish/crates/parish-mcp/README.md)
-and [parish/crates/parish-tauri/src/mcp_bridge.rs](parish/crates/parish-tauri/src/mcp_bridge.rs).
+## Changes and delivery
 
-## Driving Parish via the `parish` CLI client
-
-The `parish` binary (`parish-client` crate) is a thin synchronous HTTP client for a
-**running** Parish server. Calls `POST /api/command` and returns the full response in one
-round-trip — no WebSocket, no polling.
-
-```sh
-# Start the server first:
-bash parish/scripts/parish-mcp-backend.sh start     # port 3030
-# or: just web 3001                                  # port 3001
-
-# Drive it:
-parish [--server http://localhost:3001] "look"       # single-shot
-parish --script testing/fixtures/test_walkthrough.txt  # batch
-parish                                               # interactive REPL
-parish --json "go to the church" | jq .kind         # raw JSON
-
-# PARISH_SERVER env var sets the default URL:
-PARISH_SERVER=http://localhost:3001 parish "look"
-```
-
-Use `parish --script` for proof transcripts requiring real NPC inference.
-Use `just run-headless --script` for deterministic, fast harness-level testing.
-
-## Commit and PR expectations
-
-- Conventional commits: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`.
-- One logical change per commit.
-- PRs should explain behavior changes, link issues, list commands run, and include screenshots / updated Playwright baselines for visible UI changes.
+Use conventional commits and one logical change per commit. PRs explain changed
+behavior, link requirements/issues, and list actual verification and remaining gates.
+For visible changes include appropriate visual and interaction evidence.
+Follow [git workflow](docs/agent/git-workflow.md) and [proof requirements](docs/agent/agent-check.md).
+Keep the README, documentation, and canonical world sheet consistent with changes
+where applicable. Run `just notices` when dependencies change.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 An Irish Living World Text Adventure, set in 1820 rural Ireland; powered by the custom **Parish** engine. 1820 was chosen as it in the middle of the period after the [Acts of Union 1800](https://en.wikipedia.org/wiki/Acts_of_Union_1800) that brought Ireland into the United Kingdom of Great Britian and Ireland, and prior to the [Great Famine](<https://en.wikipedia.org/wiki/Great_Famine_(Ireland)>).
 
+## Current direction
+
+Rundale is resetting around a native iPhone text adventure: SwiftUI presents a
+status header, transcript, and composer; the Parish Rust runtime and authoritative
+saves live on device; remote inference goes through Parish Endpoints.
+The [product specifications](docs/product-specs/README.md) define the six gated
+milestones: first a fixture-only interaction prototype, then embedded gameplay
+in a tiny world.
+These requirements are not a claim that the mobile client is complete.
+
+## Existing engine and clients
+
+The capabilities, screenshots, and commands below describe the existing game,
+desktop/web clients, and developer tools retained as implementation reference.
+They do not define feature-parity requirements for the mobile reset.
+
 The player arrives as a newcomer to Kilteevan Village, about two miles south-east of Roscommon town in County Roscommon. The village and surrounding area is populated with numerous non-player characters. NPCs are driven by LLM inference. A cognitive level-of-detail (LOD) system simulates NPCs at varying fidelity based on proximity to the player. The geography is based on real early 19th century Ireland. The characters and establishments are fictional.
 
 [![Rundale](docs/screenshots/rundale.png)](docs/screenshots/rundale.png)
@@ -98,7 +114,7 @@ A four-tier simulation that scales hundreds of NPCs at varying fidelity based on
 - **Free-text dialogue** parsed by an LLM intent extractor (Move / Talk / Look / Examine / Interact), with a regex fallback.
 - **`@mention` targeting** to address a specific NPC in a crowded room.
 - **Slash-command surface** spanning save management, time control, provider config, debug, theming, and map switching — the same set works in the GUI, web, and CLI.
-- **Chat-first play screen** — the readable transcript, enriched command input, nearby people, language hints, map context, and status are available on the default desktop and mobile route.
+- **Chat-first play screen** — the readable transcript, enriched command input, nearby people, language hints, map context, and status are available on the existing desktop and responsive-web routes.
 - **Responsive illustrated context** — approved watercolor scene plates, NPC portraits, and a selected map icon render as ordinary responsive DOM images without a canvas renderer.
 - **Coordinated secondary surfaces** — Map, Save/Load, Debug, Mod, Bug Report, and shortcuts share one presentation-neutral coordinator with focus restoration and required-mod blocking.
 - **Streaming responses** rendered word-by-word in the visible transcript with smooth per-chunk timing.

--- a/docs/agent/AGENTS.md
+++ b/docs/agent/AGENTS.md
@@ -24,25 +24,14 @@ witness-scan                                        # catch AI partial-completio
 - **Scaling guardrails (rule #11)** are in [scaling-rules.md](scaling-rules.md). Every entry-point crate AGENTS.md links here — edits ripple across the workspace.
 - **[`act-local.md`](act-local.md)** is the source of truth for `.actrc` and the `act-*` justfile recipes.
 
-## Doc index
+## Documentation routing
 
-| File                                                 | Purpose                                                                   | Cross-references from                                                            |
-| ---------------------------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| [`README.md`](README.md)                             | Human-facing table of contents for this directory                         | root `AGENTS.md`, entry point                                                    |
-| [`build-test.md`](build-test.md)                     | Cargo, harness, frontend, web, and Tauri commands                         | `codebase-map.md`, root `AGENTS.md`, crate AGENTS.md files                       |
-| [`architecture.md`](architecture.md)                 | Workspace layout, crate dependency graph, module ownership                | `codebase-map.md`, `code-style.md`, design docs (`docs/design/overview.md`)      |
-| [`code-style.md`](code-style.md)                     | Rust + Svelte conventions, naming, formatting, dep rules                  | `architecture.md`, crate AGENTS.md files                                         |
-| [`gotchas.md`](gotchas.md)                           | Tokio, SQLite, Ollama, mode parity, platform pitfalls                     | root `AGENTS.md` rule block, `parish-engine/AGENTS.md`, every crate AGENTS.md    |
-| [`git-workflow.md`](git-workflow.md)                 | Commits, tests, PR standards, review expectations                         | root `AGENTS.md` commit section                                                  |
-| [`improvement-drain.md`](improvement-drain.md)       | Event-driven portfolio, readiness contract, WIP and authoritative linkage | `triage-vocabulary.md`, `.github/workflows/triage-audit.yml`, issue/PR templates |
-| [`witness.md`](witness.md)                           | Witness-style completion gates (AI partial-completion markers)            | `harness.md` witness row, `justfile` witness-scan recipe                         |
-| [`agent-check.md`](agent-check.md)                   | PR proof-evidence gate (rule #10), local and CI source modes              | root `AGENTS.md` rule #10, `harness.md`, `justfile`                              |
-| [`skills.md`](skills.md)                             | Agent slash commands (`/check`, `/parish-engine`, `/backlog`, ...)        | root `AGENTS.md` skill list, `harness.md` skills section, `.agents/skills/`      |
-| [`harness.md`](harness.md)                           | One-page map of every sensor, skill, gate — what fires when               | root `AGENTS.md`, `codebase-map.md`, `agent-check.md`, `skills.md`, `witness.md` |
-| [`act-local.md`](act-local.md)                       | Running CI workflows locally with `nektos/act`                            | `justfile` act-\* recipes, `.actrc`                                              |
-| [`idempotency.md`](idempotency.md)                   | `Idempotency-Key` header support (#619) on mutating routes                | `parish-server/AGENTS.md`, scaling review (#614–#622)                            |
-| [`scaling-rules.md`](scaling-rules.md)               | Scaling guardrails — per-session state, seam review checklist (rule #11)  | root `AGENTS.md` rule #11, `parish-core/AGENTS.md`, `parish-server/AGENTS.md`    |
-| [`repository-artifacts.md`](repository-artifacts.md) | Generated output, large-file, screenshot, art, and benchmark policy       | `harness.md`, repository artifact gate                                           |
-| [`codebase-map.md`](codebase-map.md)                 | Top-level directory index, Parish crate table, entry points               | root `AGENTS.md`, every AGENTS.md file across workspace                          |
-| [`triage-vocabulary.md`](triage-vocabulary.md)       | Canonical labels for issue triage (priorities + themes)                   | `.github/triage-labels.json`, `/backlog` skill                                   |
-| [`tracing.md`](tracing.md)                           | `tracing` / OpenTelemetry OTLP conventions (#621)                         | `parish-server/AGENTS.md`, scaling review                                        |
+Use [README.md](README.md) as the maintained index rather than duplicating its
+full inventory here. Current requirements live in [product specs](../product-specs/README.md).
+The [engineering rule index](engineering-rules.md) preserves the original rule
+numbers and routes to scoped references; root AGENTS.md is only the short map.
+
+When reorganizing docs, preserve requirement wording and provenance, repair
+relative links, and distinguish current requirements, proposed architecture,
+existing implementation, and historical product directions. Do not turn a
+requested future verification command into a claim that it exists or passed.

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -1,6 +1,25 @@
 # Agent Docs
 
-Quick reference for AI coding agents and human contributors working in this repo.
+Read the [current product specs](../product-specs/README.md) first for mobile reset
+scope and milestone gates. This directory maps implementation and engineering
+rules; read only the topics relevant to the task. Existing client/tool documents
+remain scoped references, not a mandate to restore old product features.
+
+| Task concern                                                   | Required reference                                           |
+| -------------------------------------------------------------- | ------------------------------------------------------------ |
+| Mobile architecture, Swift/Rust boundary, Endpoint integration | [mobile-architecture.md](mobile-architecture.md)             |
+| Universal rules and routing to specialized invariants          | [engineering-rules.md](engineering-rules.md)                 |
+| Existing runtime MCP/CLI commands                              | [runtime-driving-reference.md](runtime-driving-reference.md) |
+
+Model selection and orchestration policy belongs in the user's global
+`$CODEX_HOME/AGENTS.md`. It is not duplicated here. See the
+[official instruction hierarchy](https://learn.chatgpt.com/docs/agent-configuration/agents-md)
+for global and repository discovery behavior.
+
+The detailed references below describe existing implementation and tooling.
+
+For mobile acceptance cases, use the [Phase 1 and Phase 2 test plans](../test-plans/README.md)
+alongside the full product milestone requirements.
 
 | Topic                                                             | File                                                       |
 | ----------------------------------------------------------------- | ---------------------------------------------------------- |

--- a/docs/agent/architecture.md
+++ b/docs/agent/architecture.md
@@ -1,5 +1,9 @@
 # Architecture & Layout
 
+Scope: existing repository implementation. For the target iPhone runtime and
+Swift/Rust boundary, read [mobile-architecture.md](mobile-architecture.md).
+Existing crate availability does not establish mobile portability or product scope.
+
 See [docs/design/overview.md](../design/overview.md) for the full architecture and [docs/index.md](../index.md) for all documentation.
 
 **Rundale** is the Irish living world game. **Parish** is the Rust engine it runs on. The repository is a **Cargo workspace** — all engine crates live under `parish/crates/`, the game content lives under `mods/rundale/`, frontends under `parish/apps/`, test fixtures under `parish/testing/`, and deploy artifacts under `deploy/`.

--- a/docs/agent/build-test.md
+++ b/docs/agent/build-test.md
@@ -1,5 +1,31 @@
 # Build & Test
 
+## Mobile reset verification
+
+The [product specs](../product-specs/README.md) define the required mobile gates.
+The [Phase 1 and Phase 2 test plans](../test-plans/README.md) provide the companion
+case lists; they are test instructions, not completed verification reports.
+The technical vision requires a phase-selectable repository entry point such as
+`./verify --phase 1`, extended for Phase 2. At this reorganization (2026-09-07),
+this checkout has no root `./verify` or Swift/iOS project. These are implementation
+requirements, not commands this documentation change supplies or claims to pass.
+The existing `just verify` below runs the existing engine harness; it is not an
+equivalent iPhone acceptance gate.
+
+Phase 1 must report deterministic fixture/UI checks; Phase 2 adds portable Rust,
+persistence fault injection, binding contracts, device/simulator builds, and
+Endpoint protocol checks. Reports must distinguish pass, fail, skipped,
+unavailable, and human/device gates. Keep real-inference integration opt-in and
+separate from deterministic regression tests. Physical-iPhone interaction and
+VoiceOver judgment require recorded evidence, even when automated checks pass.
+
+## Existing engine and client commands
+
+These procedures remain applicable to the existing runtimes and tooling.
+Select checks for the changed surface; do not treat web viewport tests as native
+iPhone validation. For documentation changes, use the repository documentation
+path checker and the configured Prettier/Markdown lint tools on changed files.
+
 ## Cargo
 
 Most engine commands should be run from the `parish/` directory:
@@ -121,8 +147,9 @@ just ui-e2e-update
 ## Web server (browser testing)
 
 ```sh
-cd parish/apps/ui && npm run build && cd ../../..
-cargo run -p parish-server -- --port            # default port 3001
+(cd parish/apps/ui && npm run build)
+cd parish
+cargo run -p parish-server                     # default port 3001
 cargo run -p parish-server -- --port 8080
 ```
 

--- a/docs/agent/engineering-rules.md
+++ b/docs/agent/engineering-rules.md
@@ -1,0 +1,166 @@
+# Engineering Rules
+
+This is the canonical map for the numbered non-negotiable rules formerly
+listed in the repository root instructions. The stable rule number is part of
+each heading and each heading has an explicit anchor, so references remain
+unambiguous when the documents are rearranged. The complete rule text lives in
+exactly one topical file.
+
+Rules marked **(enforced)** are checked mechanically by `cargo test` / CI — see
+`parish/crates/parish-core/tests/architecture_fitness.rs`. The rest are still
+convention.
+
+## Canonical rule map
+
+| Rule | Canonical text                                                                         |
+| ---: | -------------------------------------------------------------------------------------- |
+|    1 | [Module ownership](#rule-1)                                                            |
+|    2 | [Mode parity](#rule-2)                                                                 |
+|    3 | [Tests with behavior changes](#rule-3)                                                 |
+|    4 | [Gameplay proof](#rule-4)                                                              |
+|    5 | [No unexplained `#[allow]`](#rule-5)                                                   |
+|    6 | [Feature flags](#rule-6)                                                               |
+|    7 | [README maintenance](#rule-7)                                                          |
+|    8 | [Five Whys](#rule-8)                                                                   |
+|    9 | [Runtime paths](persistence-and-session-rules.md#rule-9)                               |
+|   10 | [Truthful test automation](test-tooling-rules.md#rule-10)                              |
+|   11 | [Scaling guardrails](#rule-11)                                                         |
+|   12 | [Cross-runtime orchestration](#rule-12)                                                |
+|   13 | [[REMOVED]](#rule-13)                                                                  |
+|   14 | [Artifact content validation](generated-art-rules.md#rule-14)                          |
+|   15 | [Dialogue prompt grounding](inference-rules.md#rule-15)                                |
+|   16 | [External API payload caps](test-tooling-rules.md#rule-16)                             |
+|   17 | [Existing tooling](test-tooling-rules.md#rule-17)                                      |
+|   18 | [Truthful verification reporting](test-tooling-rules.md#rule-18)                       |
+|   19 | [Production scope](#rule-19)                                                           |
+|   20 | [Character-art identity](generated-art-rules.md#rule-20)                               |
+|   21 | [Billable artifact persistence](generated-art-rules.md#rule-21)                        |
+|   22 | [Generated-art visual contracts](generated-art-rules.md#rule-22)                       |
+|   23 | [Character markers](generated-art-rules.md#rule-23)                                    |
+|   24 | [Generated-file transactions](generated-art-rules.md#rule-24)                          |
+|   25 | [Portable Node tools](legacy-client-rules.md#rule-25)                                  |
+|   26 | [Shared-target artifacts](test-tooling-rules.md#rule-26)                               |
+|   27 | [Crash-safe managed tests](test-tooling-rules.md#rule-27)                              |
+|   28 | [Merged end-to-end contracts](test-tooling-rules.md#rule-28)                           |
+|   29 | [Player-facing interaction models](test-tooling-rules.md#rule-29)                      |
+|   30 | [Canonical background simulation](persistence-and-session-rules.md#rule-30)            |
+|   31 | [Live play signals and replacement contexts](persistence-and-session-rules.md#rule-31) |
+|   32 | [Authoritative gameplay status](persistence-and-session-rules.md#rule-32)              |
+|   33 | [Canonical semantic model apply](inference-rules.md#rule-33)                           |
+|   34 | [Save/session identity](persistence-and-session-rules.md#rule-34)                      |
+|   35 | [HTTP harness continuity](legacy-client-rules.md#rule-35)                              |
+|   36 | [Local-inference promotion](inference-rules.md#rule-36)                                |
+|   37 | [Model termination](inference-rules.md#rule-37)                                        |
+|   38 | [Serving-topology qualification](inference-rules.md#rule-38)                           |
+|   39 | [Judge evidence](inference-rules.md#rule-39)                                           |
+|   40 | [Independent judge families](inference-rules.md#rule-40)                               |
+|   41 | [Production rendering support assets](generated-art-rules.md#rule-41)                  |
+|   42 | [Durable player-earned knowledge](persistence-and-session-rules.md#rule-42)            |
+
+The specialized documents preserve the same invariants for the systems they
+cover. Their scope notes identify maintenance-only policies without weakening
+requirements that apply to every runtime or client.
+
+## General engineering rules
+
+<a id="rule-1"></a>
+
+## Rule 1 — **Module ownership (enforced):**
+
+Shared logic belongs in a leaf crate; `parish-core` composes them. Never
+duplicate leaf-crate logic in `parish/crates/parish-engine/src/`. Orphaned
+source files (on disk but not declared as `mod`) are rejected. Crate map:
+[docs/agent/architecture.md](architecture.md).
+
+<a id="rule-2"></a>
+
+## Rule 2 — **Mode parity (partially enforced):**
+
+Scope note: this parity requirement applies to shared behavior across
+maintained runtimes; it does not impose mobile legacy UI parity. Shared
+engine/API semantics and every applicable entry point remain covered.
+
+Tauri, headless CLI, and web server must share behavior. The fitness test
+forbids backend-agnostic crates from depending on `tauri` / `axum` / `tower*` /
+`wry` / `tao`. Wiring parity (every IPC handler called from every entry point)
+is still convention.
+
+<a id="rule-3"></a>
+
+## Rule 3 — **Tests with behavior changes:**
+
+Add/adjust tests for every behavior change.
+
+<a id="rule-4"></a>
+
+## Rule 4 — **Gameplay proof:**
+
+For gameplay features, run `/parish-engine prove <feature>` — unit tests alone
+are not sufficient.
+
+<a id="rule-5"></a>
+
+## Rule 5 — **No unexplained `#[allow]`:**
+
+Only with explicit justification.
+
+<a id="rule-6"></a>
+
+## Rule 6 — **Feature flags for new engine/gameplay features:**
+
+Gate with `config.flags.is_enabled("feature-name")`, default-on, document in
+the PR.
+
+<a id="rule-7"></a>
+
+## Rule 7 — **Keep README.md up to date:**
+
+feature list, repository structure, credits. Run `just notices` when
+dependencies change.
+
+<a id="rule-8"></a>
+
+## Rule 8 — **Five Whys before patching:**
+
+Diagnose bugs, regressions, and unexpected behavior with the `/five-whys`
+skill (or the method) to reach root cause first.
+
+<a id="rule-11"></a>
+
+## Rule 11 — **Scaling guardrails:**
+
+Any PR touching `AppState`, session persistence, real-time push, inference
+calls, identity lookups, mod loading, or request-ID tracing must be reviewed
+against the seam checklist in [docs/agent/scaling-rules.md](scaling-rules.md).
+
+<a id="rule-12"></a>
+
+## Rule 12 — **Cross-runtime orchestration belongs in `parish-core`:**
+
+Game-loop, IPC, and session handlers shared by the server, Tauri, and CLI
+entry points — including their constants, payload structs, and helpers — are
+defined once in a backend-agnostic crate, parameterized via traits (e.g.
+`EventEmitter`); entry-point crates are thin wiring. Never copy an orchestration
+body, constant, or payload struct into a second entry-point crate — the
+divergence is invisible at review time and silently produces security drift
+(#687, #696).
+
+<a id="rule-13"></a>
+
+## Rule 13 — **[REMOVED]**
+
+This number is intentionally retained as a traceability marker for the rule
+that was removed from the original numbered block.
+
+<a id="rule-19"></a>
+
+## Rule 19 — **Production scope means end-to-end, not minimum arguable plumbing:**
+
+Rundale is a production-quality game, engine, and toolset. When an issue asks
+for a production pipeline/workflow/tool, implement the full stated workflow
+and proof path from source-of-truth inputs through generated/reviewed outputs
+and runtime integration. Do not downgrade scope to cached artifacts, manual
+intermediates, placeholders, or "assembly only" unless the issue explicitly
+says that is acceptable. If provider access, credentials, or product
+constraints block the true end-to-end workflow, mark the work incomplete/blocked
+instead of calling it done.

--- a/docs/agent/generated-art-rules.md
+++ b/docs/agent/generated-art-rules.md
@@ -1,0 +1,81 @@
+# Generated Art and Rendering Rules
+
+Rules 20, 22, and 23 are specialized to the existing generated character-art
+pipeline. When maintaining that pipeline, they apply in full; they do not turn
+mobile feature work into an art-generation requirement. Rules 14, 21, 24, and
+41 apply whenever the corresponding artifact, generated-file, or production
+rendering-support behavior exists, including future mobile surfaces. They are
+cross-cutting requirements and are not waived by the character-art scope. See
+[engineering-rules.md](engineering-rules.md) for the complete numbered map.
+
+<a id="rule-14"></a>
+
+## Rule 14 — **Validate artifact content, not just the envelope:**
+
+A handler returning a produced artifact (screenshot, export, render, generated
+file) must verify real content before reporting success — a blank/degenerate
+result is an `Err`, never "nonzero bytes = success". Pattern:
+`reject_blank_capture` in
+`parish/crates/parish-tauri/src/commands/screenshot.rs` (#1301).
+
+<a id="rule-20"></a>
+
+## Rule 20 — **Character-art identity must be distinct across the cast:**
+
+Encode stable structured facial geometry separately from age, affect,
+hair/headwear topology, wardrobe, and props. Hair/headwear must expose
+machine-comparable front, rear, covering, and overall-silhouette families;
+reject missing, duplicate, or near-duplicate facial vectors and repeated
+hairstyle topology within relevant cohorts before generation. A pair matching
+itself is not enough: shared full-face style references must not become an
+identity prior for unrelated characters, and approval must compare each result
+against the full cast.
+
+<a id="rule-21"></a>
+
+## Rule 21 — **Persist billable external artifacts before validating them:**
+
+When an external API returns a non-deterministic generated artifact, write the
+raw bytes, content hash, provider request ID, and source provenance before
+content validation. Store each attempt immutably: a rejection must retain that
+raw artifact and link it from a failure receipt, and a retry must never
+overwrite an earlier paid response.
+
+<a id="rule-22"></a>
+
+## Rule 22 — **Validate generated art against the asset-specific visual contract:**
+
+File format, dimensions, and nonblank pixels are necessary but insufficient.
+Keep portrait, marker, scene, and UI-art prompts/references separate; encode
+machine-checkable composition and style signals where practical (for example
+bounds, fill, ink density, or palette), retain human review for semantic
+judgment, and test that a representative wrong-style artifact is rejected.
+
+<a id="rule-23"></a>
+
+## Rule 23 — **Character markers are character-only cutouts:**
+
+Make marker identity readable from face, hair/headwear, clothing, body shape,
+and stance. Reject held or carried objects, extra people, furniture,
+architecture, vegetation, scenery fragments, ground planes, and shadows unless
+an issue explicitly opts into contextual markers; worn clothing and headwear
+remain valid identity cues.
+
+<a id="rule-24"></a>
+
+## Rule 24 — **Commit generated files as transactions:**
+
+Finish every fallible preparation and handled-failure cleanup before the final
+source-snapshot comparison, then perform the same-filesystem rename
+immediately. Inject source mutation at the last cleanup seam and exercise
+competing snapshots across processes.
+
+<a id="rule-41"></a>
+
+## Rule 41 — **Bundle production rendering support assets:**
+
+Never ship required fonts, glyphs, sprites, or equivalent UI resources from
+demo or best-effort endpoints. Serve them from the frontend distribution
+unless an owned production SLA is documented, keep CSP origins minimal, and
+test both packaged integrity and browser requests/errors across every
+consuming surface.

--- a/docs/agent/git-workflow.md
+++ b/docs/agent/git-workflow.md
@@ -15,7 +15,7 @@ just verify    # check + harness walkthrough
 
 ## Engineering standards
 
-- All new code must have accompanying unit tests.
+- Behavior changes require appropriate tests of observable behavior and failure cases.
 - The Rust coverage ratchet must pass (`just coverage-check`). Raise the ratchet floor as coverage-recovery work lands; the long-term target is **90%**.
 - No `#[allow]` without a justifying comment.
 - When creating PRs, make sure the PR content makes it into a design doc.
@@ -60,7 +60,12 @@ nightly schedule, and manual dispatch. Until a merge queue is available,
 dispatch it explicitly for high-risk PR heads and let the post-merge run catch
 any remaining integration failure.
 
-Replacing the shipped default UI surface is one logical contract migration:
+Replacing the existing Svelte default UI surface is one logical contract migration:
 the same pull request must migrate or explicitly retire every canonical E2E
 assertion for the prior surface, and the complete `just ui-e2e` suite must pass.
 A focused smoke test does not satisfy this gate by itself.
+
+The separate native mobile reset does not require Svelte feature parity. It follows
+the [current product specifications](../product-specs/README.md); preserve existing
+shared-engine contracts and do not silently retire tests of maintained surfaces.
+Mobile interaction evidence includes the required physical-iPhone gates.

--- a/docs/agent/improvement-drain.md
+++ b/docs/agent/improvement-drain.md
@@ -2,14 +2,18 @@
 
 This repository manages improvement work by queue state and evidence gates, not
 calendar estimates. GitHub issue [#1684](https://github.com/dmooney/Rundale/issues/1684)
-is the bootstrap record for the current portfolio reset.
+is the bootstrap record for the earlier portfolio workflow.
+The [mobile product specs](../product-specs/README.md) now govern product scope
+and milestone sequencing; this document governs an explicitly invoked backlog
+workflow, not automatic authorization to expand the mobile product.
 
 ## Sources of truth
 
 1. GitHub Issues are executable work records.
 2. An active epic owns each funded initiative's outcome and child work.
-3. The [roadmap](../requirements/roadmap.md) records product strategy and
-   capability status; it is not an implementation queue.
+3. The [product specs](../product-specs/README.md) govern current strategy.
+   The [earlier roadmap](../requirements/roadmap.md) preserves existing capability
+   status; neither is an implementation queue.
 4. `TODO.md` files are discovery ledgers. A validated item must link to an open
    issue before it can be scheduled.
 5. Audit reports are dated evidence. A newer reconciliation must mark the old

--- a/docs/agent/inference-rules.md
+++ b/docs/agent/inference-rules.md
@@ -1,0 +1,94 @@
+# Inference Rules
+
+These rules govern prompt grounding, model output application, provider
+termination, and qualification evidence. See [engineering-rules.md](engineering-rules.md)
+for the complete numbered map.
+
+Rule 36 is a specialized maintenance policy for the existing local-inference
+promotion and setup systems. It is not a requirement for mobile feature work.
+When a local preset is promoted, the complete rule applies; this scope note
+does not waive the cross-cutting inference, state, or evidence rules.
+
+<a id="rule-15"></a>
+
+## Rule 15 — **Dialogue prompts must ground the model in the actual world:**
+
+Every NPC system prompt includes a `PEOPLE YOU KNOW` and a `PLACES IN THIS
+PARISH` list with instructions to decline to confirm anyone or anywhere not on
+them. Enforcement: `build_enhanced_system_prompt_with_config` in
+`parish-npc/src/ticks/prompt.rs` (`location_names` must be `Some(...)` in
+production); test: `parish-core/tests/dialogue_prompt_anchor.rs`; flag
+`npc-dialogue-grounding`, default-on (#1394).
+
+<a id="rule-33"></a>
+
+## Rule 33 — **Validate semantic model output at the canonical apply seam:**
+
+Prompt contracts and deterministic guards must share canonical constants. Treat
+player-visible model dialogue as an effect: quarantine candidate tokens until
+the one canonical apply validator accepts or replaces them, and never
+pre-apply semantic guards or publish raw candidate text from a caller. Rejected
+text and metadata have zero memory, event, UI, or state effects. Schema-valid
+model fields and factual dialogue claims must not change or contradict
+identity, relationships, occupations, workplaces, locations, calendar facts,
+hints, recommendations, or other gameplay/UI metadata until cross-checked
+against authored world data and the final delivered dialogue. Explicit
+current-turn request facets must use one typed, ordered prompt/apply contract;
+if the final transformed dialogue omits a recognized facet, replace the whole
+response before effects. Multi-turn pronouns may carry an unresolved person/place
+only through a bounded typed conversation context and only while the referent
+is unambiguous (#1776, #1779, #1786, #1788–#1790, #1832, #1834, #1839–#1841).
+
+<a id="rule-36"></a>
+
+## Rule 36 — **Promote local-inference presets only from passing production evidence:**
+
+A recommended model/backend/sampling/hardware profile requires a
+content-addressed promotion receipt from the frozen production-prompt holdout
+that passes dialogue and multiturn quality, hard-failure, parser-soak,
+guard-intervention, p95 latency/throughput, and memory-headroom gates.
+Development-split scores, preliminary leaderboard rows, hand-entered
+summaries, and average quality alone must never change a shipped
+recommendation.
+
+<a id="rule-37"></a>
+
+## Rule 37 — **Treat model termination as part of the response contract:**
+
+Streaming provider clients must reject every non-success finish reason (for
+example `length` / `MAX_TOKENS`) instead of parsing or displaying the partial
+body. Mandatory-reasoning profiles must budget and measure reasoning-token
+headroom separately from the player-visible response; a low effort label is
+not a token ceiling.
+
+<a id="rule-38"></a>
+
+## Rule 38 — **Separate qualification policy by serving topology:**
+
+Local promotion latency gates must not be reused for routed cloud models. A
+promotion receipt is valid only for the exact provider and API route measured;
+matching model identity through another gateway is not equivalent evidence.
+Cloud screening hard-gates structural validity, guard intervention, evidence
+completeness, and request reliability; latency and throughput rank qualified
+profiles unless a separately measured product SLO explicitly makes one a
+release gate.
+
+<a id="rule-39"></a>
+
+## Rule 39 — **Give judges the complete evidence needed by their rubric:**
+
+Any quality axis that depends on system-prompt facts—character identity, mood
+contract, known people, known places, or period rules—must receive those exact
+production facts in the judge bundle. Persist every paid judge attempt before
+validation, journal retries immutably, and trip a batch-wide circuit breaker on
+authentication, billing, quota, or rate-limit failures.
+
+<a id="rule-40"></a>
+
+## Rule 40 — **Cloud dialogue qualification requires independent judge families:**
+
+Never let a model family vote on itself. A promotable cloud profile needs at
+least two eligible judge families, uses the policy-defined consensus statistic,
+and routes split pass/fail votes or excessive score spread to an explicit
+adjudication state. Same-family judgments may remain visible as diagnostic
+evidence but cannot count toward promotion.

--- a/docs/agent/legacy-client-rules.md
+++ b/docs/agent/legacy-client-rules.md
@@ -1,0 +1,30 @@
+# Legacy Client and HTTP Harness Rules
+
+This file groups rules for the existing portable Node and HTTP client-harness
+surface. They apply when maintaining those systems and do not impose a legacy
+client implementation on mobile feature work. If a new tool uses portable Node
+automation or an HTTP harness, the original conditions below still apply;
+shared engineering, persistence, inference, and evidence contracts remain
+mandatory for every client.
+
+See [engineering-rules.md](engineering-rules.md) for the complete numbered
+map.
+
+<a id="rule-25"></a>
+
+## Rule 25 — **Launch portable Node tools without a shell:**
+
+Cross-platform Node automation must use `shell: false` and invoke JavaScript
+CLI entry points through `process.execPath`, never platform wrappers such as
+`.cmd`; execute the default path in tests with spaces in filesystem paths.
+
+<a id="rule-35"></a>
+
+## Rule 35 — **Long-running HTTP harnesses must prove session and interaction continuity:**
+
+Reuse one authoritative server session across more requests than the
+configured admission cap, including local HTTP when production cookies are
+`Secure`, and reset/reacquire dialogue after terminal interactions so every
+counted sample actually reaches inference. A harness that silently creates
+sessions or counts post-farewell no-op commands invalidates soak/reliability
+evidence.

--- a/docs/agent/mobile-architecture.md
+++ b/docs/agent/mobile-architecture.md
@@ -1,0 +1,40 @@
+# Mobile architecture map
+
+> Status: Orientation note · Updated: 2026-09-07 · [Product specs](../product-specs/README.md)
+
+This note maps the proposed mobile reset onto the repository that exists today. The two imported specs in [product-specs](../product-specs/README.md) remain the source of product requirements; this file is a short implementation orientation and makes no completion claim.
+
+Read the [technical vision](../product-specs/software-technical-vision.md) for the full
+proposal and [existing architecture](architecture.md) for crate ownership. Start at
+vision sections 5–7 for FFI, requests, and persistence; sections 8–10 for native UI,
+bindings, and Endpoints; sections 11–14 for simulation, recovery, and phase evidence.
+The [build/test guide](build-test.md) distinguishes available commands from required
+future mobile verification.
+
+## Proposed mobile direction
+
+The Product & Technical Specification defines a native iPhone experience: SwiftUI owns the compact status header, transcript, and composer; the authoritative Parish gameplay runtime is embedded on-device; local saves remain authoritative; and production remote inference goes through Parish Endpoints. The Software Technical Vision turns that into proposed boundaries: semantic events and read-only projections cross a small Swift/Rust interface, Rust owns intent, simulation, validation, and commit ordering, and an iOS platform adapter owns lifecycle and transport mechanics without moving game authority into SwiftUI or the Endpoint.
+
+## Existing repository shape
+
+- Shared game behavior is composed through parish-core and its leaf crates under parish/crates/, including world, input, NPC, inference, persistence, and type layers. parish-engine is a thin headless/CLI entry point, not a second copy of the engine.
+- The current player-facing frontend is the Svelte 5 application under parish/apps/ui/. parish-tauri hosts the desktop application; parish-server provides the Axum HTTP/WebSocket server; parish-client is a thin HTTP client. Existing ADRs and design notes describe those desktop/web modes.
+- No native SwiftUI iOS client, Swift/Rust binding package, or embedded iOS runtime is present in the current repository tree. Those are proposed work for the reset and need a deliberate portability boundary around the reusable Rust crates.
+- Existing local inference and desktop setup paths include provider/process/server concerns that the proposed iOS runtime must not inherit accidentally. Reuse is a repository-audit decision, not an assumption made from this map.
+
+## Boundary map
+
+| Reset concern          | Technical vision proposal                                                                                                         | Existing repository analogue                                                             | Work implied by the reset                                                                      |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Presentation           | SwiftUI transcript/composer and a presentation reducer over semantic events                                                       | Svelte play surface and Tauri/web IPC projections                                        | Define a versioned mobile semantic event/read-model contract and build the native shell        |
+| Game authority         | One embedded Rust runtime owns mutable world state and the commit lane                                                            | Shared parish-core plus leaf crates already centralize game behavior across entry points | Audit portable dependencies and expose a small Swift-facing boundary without duplicating rules |
+| Persistence            | One local transactional boundary for accepted requests, world state, and committed transcript history                             | Existing parish-persistence and branch/save lifecycles                                   | Verify iOS storage/file-protection behavior, migrations, draft recovery, and request atomicity |
+| Inference              | On-device Rust orchestrates role-specific requests; Parish Endpoints owns provider execution, credentials, routing, and streaming | Current provider/inference paths serve desktop, server, and local/cloud configurations   | Add the mobile Endpoint adapter and prove the exact request/result/cancellation contract       |
+| Mobile services        | Swift-side lifecycle, credential access, native networking, and safe-area/accessibility integration                               | Current Tauri/Svelte lifecycle and web/server transport surfaces                         | Keep platform glue behind narrow interfaces and preserve fixture/headless testability          |
+| Content and simulation | Versioned authored definitions separate from mutable instance state; tiny world first                                             | Existing parish-world, parish-npc, mods, and canonical world data                        | Reconcile the three-location/three-NPC fixture and retain it as a regression oracle            |
+
+## Phase 2 capability gap
+
+The product requires a real Parish Endpoint path for authenticated mobile-safe inference with incremental streaming during Phase 2. The technical vision notes that the Endpoint architecture documents exclude streaming from the original MVP and describe client-safe authentication as planned. This is an unverified deployment capability: repository or architecture documents do not prove that the deployed service supports the required mobile authentication, incremental stream delivery, validated terminal result, cancellation, or request correlation.
+
+Before Phase 2 acceptance, resolve the gap with an explicit versioned Endpoint capability agreement and live integration evidence through the deployed path. Keep deterministic Endpoint doubles and protocol fixtures as the normal regression oracle. Direct model-provider calls from the iOS app, embedded provider credentials, or a bypassing Rundale game server would violate the product boundary.

--- a/docs/agent/persistence-and-session-rules.md
+++ b/docs/agent/persistence-and-session-rules.md
@@ -1,0 +1,67 @@
+# Persistence and Session Rules
+
+These rules cover canonical state, save/session lifecycle, restore behavior,
+and continuity across runtimes. Stable numbers are retained from the root rule
+block. See [engineering-rules.md](engineering-rules.md) for the complete map.
+
+<a id="rule-9"></a>
+
+## Rule 9 — **Resolve runtime paths from explicit config, not the cwd:**
+
+Resolve saves/mods/data dirs once at startup and store on `AppState` /
+`GlobalState`; never `current_dir()`, parent-walks, or marker-file searches
+from request handlers (#771). Resolver APIs, platform roots, and env overrides:
+[docs/agent/gotchas.md](gotchas.md).
+
+<a id="rule-30"></a>
+
+## Rule 30 — **Ground background simulation in canonical state (enforced):**
+
+LLM simulation prompts must carry each participant's exact current location and
+authored current activity. Every async result must retain immutable fingerprints
+plus a monotonic participant-lineage revision from the canonical snapshot used
+to generate it, then revalidate those anchors at the one public shared apply
+seam; stale, restored-branch, ABA, missing-anchor, and
+contradictory-known-location results must have zero side effects. Authored fallback schedules must
+be semantically valid in every season and day type where they can resolve;
+unscoped activity prose must remain season- and day-neutral (#1785, #1831).
+
+<a id="rule-31"></a>
+
+## Rule 31 — **Preserve live play signals and isolate replacement contexts:**
+
+The first viewport must visibly retain player input, narration, streamed NPC
+dialogue, location changes, and state-derived notebook content. Successful
+new-game/branch/reconnect replacement clears prior prompt, presentation,
+dedup, and retained-event state while preserving a lifetime-monotonic cursor;
+failure preserves the old context (#1774, #1778, #1782, #1783).
+
+<a id="rule-32"></a>
+
+## Rule 32 — **Player-visible gameplay status comes from authoritative state:**
+
+Consequential player actions must mutate canonical engine state, publish
+semantic events, survive save/load and journal recovery, and flow through
+shared IPC in every runtime. Local UI drafts and production placeholders must
+not masquerade as progression (#1781).
+
+<a id="rule-34"></a>
+
+## Rule 34 — **Commit save/session identity before publishing a runtime:**
+
+Acquire a candidate save lock before any SQLite open, persist a complete
+candidate and atomic active-identity marker, then perform only infallible
+live-state publication. Cold restore/create must single-flight and recheck
+under one lifecycle gate; lock, marker, registry, or recovery failure must not
+fall back to another ledger, publish a session, or start workers.
+
+<a id="rule-42"></a>
+
+## Rule 42 — **Player-earned knowledge is durable state:**
+
+Introductions and other knowledge the player legitimately learns must survive
+save/load, branch restore, reconnect, cold server restore, Tauri restore, and
+headless restore. Only an explicit new-game/reset boundary may clear it. When
+adding durable knowledge, cover serialization plus every production restore
+lifecycle; compatibility repair may only infer facts from retained evidence
+that satisfies the same canonical apply guard.

--- a/docs/agent/runtime-driving-reference.md
+++ b/docs/agent/runtime-driving-reference.md
@@ -1,0 +1,82 @@
+# Existing runtime command reference
+
+Scope: the existing desktop, server, and CLI runtimes. These commands do not
+prove on-device iOS execution. For the mobile reset, use the
+[product specifications](../product-specs/README.md) and their phase gates.
+For desktop visual QA, also read [the live-game guide](driving-the-game-via-mcp.md).
+The server is suitable for server/API proof when configured with the required
+inference provider; simulator output is not real-inference evidence.
+
+## Driving Parish via MCP (`parish-mcp`)
+
+`.mcp.json` at the repo root registers `parish-mcp` as a project-level MCP
+server. When you start a Claude Code session here, the tools below are
+available as `mcp__parish__*`:
+
+| Tool                       | Effect                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `parish_world_snapshot`    | Read clock, player location, weather, recent log.                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `parish_map`               | Read the location graph plus the player's position.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `parish_npcs_here`         | List NPCs co-located with the player.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `parish_engine_state`      | Read the canonical deterministic engine state for QA validation — `active_scene`, `clock`, `weather`, `player`, `npcs`, `grapevine`. Assert the UI against this after each interaction to detect UI-vs-engine drift (#1331).                                                                                                                                                                                                                                                                             |
+| `parish_save_state`        | Read save-file / branch metadata.                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `parish_turn`              | Read recent canonical exchanges, the newest 20 unseen retained world events in chronological order, and current scene state. Pass its lifetime-monotonic `event_cursor` back as `since`; overflow drops the oldest unseen events and advances the cursor to the coherent current total.                                                                                                                                                                                                                  |
+| `parish_submit_input`      | Send player input — movement, action, dialogue, system commands. Optional `addressed_to` array scopes dialogue.                                                                                                                                                                                                                                                                                                                                                                                          |
+| `parish_new_game`          | Start a fresh game on a new save branch.                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `parish_save_game`         | Save the current branch.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `parish_load_branch`       | Load a branch by integer id.                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `parish_setup_status`      | Reads first-run setup state: `{implemented, complete, provider, model, base_url, has_api_key, has_env_key}`.                                                                                                                                                                                                                                                                                                                                                                                             |
+| `parish_setup_byok`        | Submits a BYOK provider config (`provider`, `api_key`, optional `base_url`/`model`). Persists to keychain + `parish.toml`, rebuilds the inference worker, emits `setup-done`.                                                                                                                                                                                                                                                                                                                            |
+| `parish_latest_screenshot` | Read metadata for the most recent player-triggered screenshot (`path`, `taken_at`, `size_bytes`). Capture is initiated by pressing F2 in the live desktop window.                                                                                                                                                                                                                                                                                                                                        |
+| `parish_file_bug`          | File a bug report (`title`, optional `description`/`context`). Bundles a live screenshot + recent logs + game state into a GitHub issue on the configured repo (`dmooney/rundale` by default) and returns the issue URL. Auto-appends a "black box" diagnostic payload — raw LLM prompt/response history, the `get_engine_state` snapshot, and the last raw user intent (#1331). In dry-run / no-token mode writes the composed report to disk (`created:false`, `bundle_path` set). For auto-QA agents. |
+| `tauri_invoke`             | Generic escape hatch — call any backend command (e.g. `editor_*`, `get_debug_snapshot`) by name.                                                                                                                                                                                                                                                                                                                                                                                                         |
+
+The MCP server is a _bridge_: it speaks HTTP to a running Parish backend on
+`127.0.0.1:3030`. **Before using any `mcp__parish__*` tool**, ensure a
+backend is up:
+
+```sh
+# Headless web server (works in any sandbox; recommended in CI / on the web):
+bash parish/scripts/parish-mcp-backend.sh start    # spawn + wait for /api/health
+bash parish/scripts/parish-mcp-backend.sh status   # report pid + health
+bash parish/scripts/parish-mcp-backend.sh stop     # graceful shutdown
+
+# Desktop, when a display is available — drives the live window:
+cargo run -p parish-tauri -- --mcp-port 3030
+```
+
+If a tool call returns an MCP `isError: true` with `transport error: ...`,
+the backend isn't running — call `parish-mcp-backend.sh start` first.
+
+Two distinct things get called "MCP bridge" (#1366 §6) — be precise:
+the `parish-mcp` **crate** is the stdio MCP server that exposes the
+`mcp__parish__*` tools and forwards them over HTTP, while
+`parish-tauri/src/mcp_bridge.rs` is the **embedded HTTP listener** inside the
+desktop app that answers those forwarded calls when Tauri is the backend
+(the web server answers them natively). For deeper context on both see
+[parish/crates/parish-mcp/README.md](../../parish/crates/parish-mcp/README.md)
+and [parish/crates/parish-tauri/src/mcp_bridge.rs](../../parish/crates/parish-tauri/src/mcp_bridge.rs).
+
+## Driving Parish via the `parish` CLI client
+
+The `parish` binary (`parish-client` crate) is a thin synchronous HTTP client for a
+**running** Parish server. Calls `POST /api/command` and returns the full response in one
+round-trip — no WebSocket, no polling.
+
+```sh
+# Start the server first:
+bash parish/scripts/parish-mcp-backend.sh start     # port 3030
+# or: just web 3001                                  # port 3001
+
+# Drive it:
+parish [--server http://localhost:3001] "look"       # single-shot
+parish --script testing/fixtures/test_walkthrough.txt  # batch
+parish                                               # interactive REPL
+parish --json "go to the church" | jq .kind         # raw JSON
+
+# PARISH_SERVER env var sets the default URL:
+PARISH_SERVER=http://localhost:3001 parish "look"
+```
+
+Use `parish --script` for proof transcripts requiring real NPC inference.
+Use `just run-headless --script` for deterministic, fast harness-level testing.

--- a/docs/agent/test-tooling-rules.md
+++ b/docs/agent/test-tooling-rules.md
@@ -1,0 +1,100 @@
+# Test and Tooling Rules
+
+These rules cover truthful automation, tool reuse, verification reporting,
+managed test processes, preserved end-to-end contracts, and player-facing UX
+audits. See [engineering-rules.md](engineering-rules.md) for the complete
+numbered map.
+
+<a id="rule-10"></a>
+
+## Rule 10 — **Truthful test automation:**
+
+Anything named or scheduled as a test must execute the production behavior it
+claims to cover, contain a machine-checkable oracle, and propagate failures to
+its caller. Exploratory proof scripts belong outside regression test
+directories. Every confirmed escaped bug gets a regression test at the lowest
+production seam that would have caught it. Scheduled automation must be green,
+explicitly paused with a tracking issue, or removed.
+
+<a id="rule-16"></a>
+
+## Rule 16 — **Cap external API payloads before sending:**
+
+Validate payload size client-side against the provider's documented limit (e.g.
+GitHub issue body ≤ 65536 chars) and truncate to ≤ 90% of it with a
+`[truncated N chars]` marker — never rely on the provider's 4xx. A test
+asserting `payload.len() <= budget` is required for every such code path
+(#1375).
+
+<a id="rule-17"></a>
+
+## Rule 17 — **Survey existing tooling before building any:**
+
+Check whether the repo already provides it — the `parish-harness` binary
+(built-in web server/dashboard), `justfile` recipes, `parish/scripts/**`,
+`.claude/skills/` — and run or extend the existing tool in place. Never
+hand-roll a throwaway duplicate.
+
+<a id="rule-18"></a>
+
+## Rule 18 — **Report only verification you actually ran:**
+
+Any claim that a test passed or a process ran must be backed by literal command
+output from the current session. State skips and failures explicitly — never
+estimate, extrapolate, or fabricate a result.
+
+<a id="rule-26"></a>
+
+## Rule 26 — **Keep shared-target artifacts worktree-coherent:**
+
+When a build script embeds worktree-local files, parallel test tooling that
+shares a Cargo target must key the build to those inputs and preserve and
+validate the resulting executable before releasing its coordination lock.
+Never launch the shared final binary after Cargo releases its own lock; use the
+Playwright managed-server helper as the reference (#1717).
+
+<a id="rule-27"></a>
+
+## Rule 27 — **Make managed-test lifecycles crash-safe on every platform:**
+
+Locks, candidates, and copied executables must have bounded startup recovery
+and mechanically tested platform policy. A fresh active-use lease is a
+capability: its heartbeat owner must fence and stop the child if ownership is
+lost, while a pruner must preserve lazily read artifacts and fail closed on
+malformed state. Retirement must atomically replace a stale lease with a
+tombstone, preserve its artifacts for another full grace, and reclaim only in a
+later pass. Test the real process-manager paths: POSIX group signals must leave
+the launcher alive to stop/wait the child and release ownership; Windows
+`taskkill /T /F` may skip hooks, so bounded expiry is the required fallback
+(#1717).
+
+<a id="rule-28"></a>
+
+## Rule 28 — **Preserve merged end-to-end contracts when extending or extracting a shared spec:**
+
+Retain every already-merged public-behavior assertion across API, IPC,
+gameplay, and UI surfaces, and add new coverage alongside it; bounded behavior
+must cover the cap boundary and overflow. A focused test for the new slice does
+not prove earlier consumer contracts still exist.
+
+<a id="rule-29"></a>
+
+## Rule 29 — **Audit player-facing interaction models, not only controls:**
+
+Scope note: the illustrated-notebook audit applies to the existing web/Tauri
+surface. Mobile feature work follows its product physical-iPhone UX gates and
+does not restore the notebook object; this note does not weaken semantic
+interaction contracts for a mobile surface. In the preserved rule text below,
+“desktop and mobile surface” means the existing web/Tauri client at desktop and
+mobile viewport sizes, not the native SwiftUI client. Its native-iPhone
+interaction audit is defined by the [product specifications](../product-specs/README.md).
+
+Before declaring a material visual UI change complete, run [the
+illustrated-notebook UX audit](../../.github/prompts/rundale-illustrated-notebook-ux-audit.prompt.md)
+against the live desktop and mobile surface. A label must lead to its ordinary
+semantic destination; persistent-object navigation (such as notebook tabs)
+renders in that object, visibly distinct controls have visibly distinct
+outcomes, and any deliberate overlay preserves the object’s visual and task
+continuity. Record the interaction model, screenshots/recording, findings, and
+semantic Playwright coverage. Functional tests that only assert that an overlay
+opened are insufficient.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,21 +9,26 @@ subcollections keep their own indexes so large evidence corpora stay navigable.
 
 ## Project status
 
-Rundale ships features across many subsystems in parallel rather than along a
-single linear phase. The authoritative status view is the **feature-status
-matrix** in the [Roadmap](requirements/roadmap.md).
+The current product direction is the **native iPhone text-adventure reset**.
+Start with the [versioned product specifications](product-specs/README.md) for
+scope, the six milestones, acceptance criteria, and the Quality Gate. The
+[mobile architecture guide](agent/mobile-architecture.md) maps the proposed
+technical direction and decisions that still need evidence.
 
-Quick orientation: the core simulation (world graph, time/weather, cognitive
-LOD tiers 1–4, NPC memory/gossip, branching persistence, natural-language
-input), the Tauri + Svelte desktop GUI, the web server, per-category + cloud +
-MLX inference, the Parish Designer editor, and the rundale-bench harness are all
-shipped. Active design work centres on world expansion, the save/load UI,
-mythology hooks, and dialogue-quality evals.
+Existing engine, Tauri/Svelte, web, tooling, and content documentation remains
+useful implementation reference. The [earlier feature matrix](requirements/roadmap.md)
+records that work; it is not the mobile roadmap or evidence of mobile completion.
+No mobile milestone is certified by this documentation reorganization.
+
+The [Phase 1 and Phase 2 test plans](test-plans/README.md) provide companion cases
+for interaction and embedded-runtime verification; they do not record test results.
 
 ## How docs are organised
 
 | Folder           | Contains                                                        | Status vocabulary                |
 | ---------------- | --------------------------------------------------------------- | -------------------------------- |
+| `product-specs/` | Current mobile requirements and proposed technical vision       | Requirements · Proposed          |
+| `agent/`         | Task routing, scoped invariants, build and proof procedures     | Engineering guidance             |
 | `design/`        | Durable subsystem reference — how a shipped/extant system works | Implemented · Partial            |
 | `design/ideas/`  | Brainstorms, RFCs, speculative proposals                        | Brainstorm · Proposed            |
 | `plans/`         | Active implementation plans                                     | In progress · Proposed · Planned |
@@ -67,13 +72,14 @@ Every design/plan doc carries a `> Status: …` header. See
 
 ## Visual client and graphics research
 
-The visual work has three related but distinct tracks. The active default client
-is the semantic chat-first shell with responsive DOM art. The retired Pixi
-notebook, Diorama, and Godot documents remain historical or exploratory records.
+The existing desktop/web visual work has three related but distinct tracks.
+Its default implementation is the semantic chat-first shell with responsive DOM
+art; it is reference material for the native reset. The retired Pixi notebook,
+Diorama, and Godot documents remain historical or exploratory records.
 
 | Need                                                                  | Start here                                                                         | Follow with                                                           |
 | --------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| Default visual play surface                                           | [Chat-first stabilization contract](../parish/apps/ui/CHAT_FIRST_STABILIZATION.md) | [GUI features](features.md#chat-first-illustrated-viewport)           |
+| Existing desktop/web play surface                                     | [Chat-first stabilization contract](../parish/apps/ui/CHAT_FIRST_STABILIZATION.md) | [GUI features](features.md#chat-first-illustrated-viewport)           |
 | Concept art, exterior pipeline, interiors, portraits, or map evidence | [Graphics V2 research index](graphics-v2/README.md)                                | Its task-oriented links and scoped guidance                           |
 | Runtime-composed visual scene system                                  | [Interactive Parish Diorama RFC](design/ideas/parish-diorama.md)                   | [Diorama implementation plan](plans/parish-diorama-implementation.md) |
 | Separate Godot presentation client                                    | [Godot-Based Rundale plan](design/godot-parish-game-plan.md)                       | Treat as an exploratory alternative client                            |

--- a/docs/product-specs/README.md
+++ b/docs/product-specs/README.md
@@ -1,0 +1,27 @@
+# Product specifications
+
+This directory contains the local, versioned working copies of the two product documents that define the mobile reset. They are authoritative working specs for repository changes after review; the native Google Docs remain the recorded source snapshots and provenance.
+
+Changes to these specs go through normal versioned repository review. The technical vision is subordinate to the Product & Technical Specification: its mechanisms and defaults are proposals to validate where the product spec leaves an implementation choice, and it cannot waive or replace a product requirement.
+
+These files record source text and proposed direction. They make no claim that a milestone, integration, deployment capability, or acceptance gate is complete.
+
+The source bundle also contained the global Rundale agent instructions, modified 2026-09-06 17:46:48.912 UTC ([Google Doc](https://docs.google.com/document/d/1Ixa4S1A9yfVhxpoE8AL-DFXt_ppLZG2QXOB_JOxkb4o/edit)). That document is global personal policy governed by the global AGENTS.md; it is intentionally not duplicated as a product spec here.
+
+Editorial import note: references in the imported technical vision to the native Product & Technical Specification resolve within this repository to the versioned [Product & Technical Specification](product-technical-spec.md). The original native documents remain source provenance.
+
+## Documents
+
+- [Product & Technical Specification](product-technical-spec.md) — governing player experience, reset scope, requirements, milestones, quality gate, and success definition.
+- [Software Technical Vision](software-technical-vision.md) — proposed architecture and delivery guidance subordinate to the product specification.
+
+The companion [Phase 1 and Phase 2 test plans](../test-plans/README.md) preserve
+the imported test cases. They supplement these requirements and do not constitute
+execution evidence or replace the complete milestone gates.
+
+## Imported source provenance
+
+| Local document                    | Imported on | Source modified (UTC)       | Native source                                                                                      |
+| --------------------------------- | ----------- | --------------------------- | -------------------------------------------------------------------------------------------------- |
+| Product & Technical Specification | 2026-09-07  | 2026-09-06 17:26:47.997 UTC | [Google Doc](https://docs.google.com/document/d/1Py5MWE9pqwNYk5gkx094ofmSf4fwSk12Dt7hfRp2VPk/edit) |
+| Software Technical Vision         | 2026-09-07  | 2026-09-05 19:00:44.701 UTC | [Google Doc](https://docs.google.com/document/d/12sxakaxkUCLX6qallEXui0N7cTtSv6Sels4gFXbXnPk/edit) |

--- a/docs/product-specs/product-technical-spec.md
+++ b/docs/product-specs/product-technical-spec.md
@@ -1,0 +1,854 @@
+# Rundale Mobile Text Adventure — Product & Technical Specification
+
+## 1. Purpose
+
+Rundale will reset its player experience around a mobile-first, pure-text adventure. The new client should feel less like a conventional game UI and more like a polished coding harness applied to an interactive living world: a persistent transcript, a powerful text composer, clear interpretation of player intent, streaming responses, and dependable recovery.
+
+This is a deliberate product reset. Existing Parish engine capabilities remain available, but the new player experience will not attempt feature parity with the current UI or content set. Features and content will be reintroduced only after the smaller experience is stable, understandable, testable, and pleasant to use.
+
+## 2. Product Principles
+
+### 2.1 The transcript is the game
+
+The primary interface is a chronological living transcript containing player commands, narration, NPC dialogue, movement, deterministic game output, errors, and other meaningful events.
+
+Secondary game state should be expressed through text wherever practical rather than permanent panels.
+
+### 2.2 Mobile first
+
+The primary target is iPhone. The design assumes that typing on a phone is a normal, comfortable interaction rather than something to minimize.
+
+The experience must prioritize:
+
+- excellent keyboard behavior;
+- stable scrolling while content streams;
+- readable typography;
+- fast one-handed interaction;
+- draft preservation;
+- app lifecycle recovery;
+- Dynamic Type;
+- VoiceOver;
+- native light and dark appearance.
+
+### 2.3 Harness behavior, not terminal aesthetics
+
+Rundale should borrow interaction patterns from modern coding harnesses:
+
+- explicit command submission;
+- visible interpretation of requests;
+- streaming output;
+- clear activity state;
+- stop;
+- retry;
+- editable command history;
+- deterministic slash commands;
+- strong error recovery.
+
+It should not imitate a literal terminal. The visual style should be literary and restrained.
+
+### 2.4 Local-first gameplay
+
+The authoritative game runtime lives on the device.
+
+A gameplay action that does not inherently require LLM inference must not require a network connection.
+
+The network is used for:
+
+1. remote LLM inference; and
+2. optional future cloud save synchronization.
+
+Local saves remain authoritative even if cloud synchronization is later added.
+
+### 2.5 Grow only from proven foundations
+
+The new UI and Rundale content begin deliberately small. No feature or content expansion should occur merely because the engine already supports it.
+
+Each addition must have:
+
+- a clear player need;
+- explicit acceptance criteria;
+- automated tests where practical;
+- physical-device validation where appropriate;
+- evidence that existing behavior remains reliable.
+
+## 3. Scope of the Reset
+
+The reset covers both:
+
+1. the player-facing UI; and
+2. the initial Rundale world/NPC data.
+
+The existing Parish simulation engine is retained and adapted for portable on-device use.
+
+The existing Rundale content and frontend remain reference material. They do not define compatibility requirements for the new experience.
+
+## 4. Initial Player Experience
+
+### 4.1 Primary screen
+
+The first version has only three persistent regions.
+
+**Compact status header**
+**Displays:**
+
+- current location;
+- time of day;
+- weather.
+
+Tapping the header may reveal a concise deterministic summary of the current location, nearby people, and exits.
+
+**Transcript**
+
+A single vertically scrolling history containing all meaningful play.
+
+**Example:**
+
+```text
+KILTEEVAN VILLAGE
+
+Rain has darkened the road through the village.
+Smoke hangs low above the cottages. Peig Hannigan
+stands beneath the letter-office awning.
+
+PEIG HANNIGAN
+
+“You’ll find no dry road west today.”
+
+> ask Peig who came through the village last night
+
+ ↳ Talking to Peig Hannigan about last night’s travellers
+
+PEIG HANNIGAN
+
+“Two men passed before dawn. Neither stopped to
+give a name.”
+```
+
+**Composer**
+
+A multiline native text input anchored above the iOS keyboard.
+
+**Initial supporting controls:**
+
+- Send;
+- Stop while a request is active;
+- @ NPC targeting/completion;
+- / command completion;
+- command history.
+
+There is no permanent bottom tab bar in the initial design.
+
+### 4.2 Typography
+
+The visual identity should come primarily from typography and spacing.
+
+**Recommended direction:**
+
+- literary serif for narration and dialogue;
+- clean sans-serif for labels and controls;
+- restrained monospace treatment for player commands and deterministic system output;
+- warm, clean light appearance;
+- native dark appearance;
+- generous readable spacing.
+
+**Avoid:**
+
+- fake parchment;
+- decorative borders;
+- chat bubbles;
+- card-heavy layouts;
+- terminal-green aesthetics;
+- unnecessary ornament.
+
+### 4.3 Scene transitions
+
+Location changes are represented as strong transcript landmarks.
+
+```text
+────────────────────────────
+THE OLD STONE BRIDGE
+Late morning · Rain easing
+────────────────────────────
+```
+
+The transcript itself should communicate geography and progress without requiring a graphical map.
+
+## 5. Input Model
+
+### 5.1 Natural language is primary
+
+Players should be able to type ordinary instructions:
+
+```text
+ask Peig about the old church
+walk over to the bridge
+tell Michael what Peig told me
+```
+
+### 5.2 Interpretation receipts
+
+After submission, the client immediately displays the engine's interpretation when useful:
+
+```text
+> head over to Michael’s place
+
+ ↳ Walking to Mícheál Connolly’s cottage
+```
+
+This makes natural-language interpretation observable instead of silently hiding mistakes.
+
+### 5.3 Ambiguity
+
+If an action cannot be resolved confidently, the game asks rather than guessing.
+
+**Example:**
+
+```text
+I’m not sure which Connolly you mean.
+
+[ Mícheál Connolly ]   [ Róisín Connolly ]
+```
+
+Temporary choice controls are appropriate for genuine ambiguity.
+
+### 5.4 Slash commands
+
+Slash commands provide deterministic access to game information and advanced actions.
+
+**Initial set:**
+
+```text
+/look
+/people
+/exits
+/help
+```
+
+**Possible later additions:**
+
+```text
+/journal
+/inventory
+/status
+/history
+/undo
+```
+
+Typing / opens completion immediately above the keyboard.
+
+### 5.5 NPC targeting
+
+Typing @ opens completion for relevant nearby NPCs. NPC names in the transcript may also be tappable to insert an appropriate reference into the composer.
+
+## 6. Request Lifecycle
+
+Every submitted request has a clear lifecycle:
+
+1. Player submits text.
+2. A PlayerCommand event is committed.
+3. Parish interprets the command.
+4. An interpretation receipt is emitted if appropriate.
+5. If clarification is required, execution stops pending player choice.
+6. Deterministic work executes locally.
+7. If inference is required, Parish makes a remote inference request.
+8. Output streams into the transcript.
+9. State changes are committed atomically.
+10. A completion event marks the request finished and eligible for persistence/synchronization.
+
+Interrupted or failed requests must not leave partially committed world state.
+
+## 7. Stop, Retry, and History
+
+The client must support:
+
+- stopping an active streaming response;
+- retrying a failed request;
+- preserving the original request when retrying;
+- tapping a previous player command to copy it into the composer;
+- editing and resubmitting copied commands;
+- preserving unsent drafts across backgrounding and relaunch.
+
+Retry semantics must be explicit so that retrying cannot accidentally duplicate an already committed gameplay action.
+
+## 8. Transcript Behavior
+
+Transcript correctness is a core product feature.
+
+Requirements:
+
+- streaming text must not cause visible scroll instability;
+- if the player is at the bottom, new output follows naturally;
+- if the player has scrolled upward, streaming must not pull them back to the bottom;
+- new content while reading history produces a clear “New text” affordance;
+- transcript restoration preserves sensible position;
+- events must never duplicate after reconnect/relaunch;
+- partial streaming content must be distinguishable internally from committed final content.
+
+## 9. Minimal Semantic Event Protocol
+
+SwiftUI should not consume arbitrary internal Parish structures. Parish exposes a small, presentation-oriented semantic event protocol.
+
+**Initial event kinds should include concepts equivalent to:**
+
+```text
+SceneChanged
+PlayerCommand
+CommandInterpreted
+Narration
+NpcDialogue
+ActionResult
+ClarificationRequired
+Progress
+Error
+ResponseCompleted
+```
+
+**Each event should carry only the fields needed by the presentation layer, such as:**
+
+```text
+event_id
+request_id
+game_time
+kind
+content
+speaker
+state
+```
+
+Exact serialization and FFI representation are implementation decisions, but event identity and request correlation are required.
+
+The protocol must support:
+
+- replay;
+- deduplication;
+- streaming;
+- reconnect/restoration;
+- deterministic UI fixtures;
+- testing the Swift UI without live inference.
+
+## 10. iOS Architecture
+
+### 10.1 Native client
+
+The new primary client is implemented in SwiftUI.
+
+Reasons include direct control over:
+
+- keyboard and focus;
+- scrolling;
+- Dynamic Type;
+- VoiceOver;
+- safe areas;
+- app lifecycle;
+- background/foreground transitions;
+- native persistence;
+- haptics;
+- platform conventions.
+
+### 10.2 Embedded Parish runtime
+
+Parish runs on-device as compiled Rust code exposed to Swift through a deliberately small FFI boundary.
+
+**Conceptual API:**
+
+```text
+start_game()
+resume_game()
+submit(text)
+respond_to_clarification(choice)
+cancel(request)
+snapshot()
+```
+
+The Swift layer should not manipulate internal NPC, world, inference, or persistence structures directly.
+
+### 10.3 Portable runtime boundary
+
+The iOS build should include only Parish components required for gameplay.
+
+Desktop/server infrastructure must not become accidental dependencies of the portable runtime.
+
+**Examples of capabilities to keep outside the iOS runtime unless specifically needed:**
+
+- Tauri;
+- Axum server;
+- desktop process launching;
+- local model management;
+- desktop diagnostics;
+- web authentication;
+- browser-specific code;
+- developer-only tooling.
+
+This portability boundary should improve the architecture of Parish generally.
+
+## 11. Inference Architecture
+
+Inference is the primary remote runtime dependency.
+
+Parish remains responsible for deciding:
+
+- whether inference is necessary;
+- which inference role is required;
+- prompt construction;
+- structured-output validation;
+- timeout/retry policy;
+- interpretation of the response;
+- resulting state changes.
+
+SwiftUI should not contain game-specific LLM orchestration.
+
+All production remote inference from the Rundale mobile client must be performed through Parish Endpoints. The iOS application must not communicate directly with model-provider APIs or contain provider credentials. Parish Endpoints are responsible for securely holding provider credentials and providing the authenticated remote inference boundary.
+
+The on-device Parish runtime remains responsible for game-specific inference orchestration and authoritative game state. It prepares the inference request and sends only the context needed for that inference role to the Parish Endpoint. The Parish Endpoint handles the remote provider call, including provider/model routing and streaming the response back to the device. The Endpoint does not become authoritative for the game world or require the complete save state.
+
+On-device LLM inference is explicitly out of scope for the initial reset.
+
+## 12. Persistence
+
+### 12.1 Local authoritative save
+
+The game saves locally and resumes immediately.
+
+The player should not normally need to think about saving.
+
+Requirements:
+
+- autosave after completed state-changing actions;
+- safe recovery after app termination;
+- no partially applied request state;
+- durable transcript/event identity;
+- preservation of unsent composer drafts;
+- schema/version migration strategy.
+
+### 12.2 Cloud synchronization
+
+Cloud saves are optional future functionality.
+
+If introduced, cloud storage synchronizes/replicates local saves. It does not turn the remote service into the runtime authority.
+
+Conflict handling and multi-device branching are later design problems and should not complicate the first implementation.
+
+### 12.3 Branching
+
+Parish's existing branching capability may remain underneath the system, but the initial player UI should not expose a save DAG.
+
+A future /undo or alternate-timeline feature may use branching internally without requiring players to understand the implementation.
+
+## 13. Minimal Rundale World
+
+The content reset begins with a world small enough for a developer or tester to understand completely.
+
+Initial target:
+
+- 3 locations;
+- 3 NPCs;
+- 3 explicitly authored NPC relationships;
+- 1 shared fact capable of becoming gossip;
+- 1 simple player task;
+- 1 weather-sensitive behavior;
+- 1 simple scheduled movement per NPC per day.
+
+No expansion occurs until this world behaves reliably.
+
+### 13.1 Example topology
+
+Kilteevan Village
+
+├── Letter Office
+
+└── Connolly Cottage
+
+Every connection is explicit and easy to reason about.
+
+### 13.2 NPC definition
+
+Each initial NPC needs only:
+
+- identity;
+- home;
+- occupation/role;
+- concise personality;
+- relationships to the other initial NPCs;
+- simple schedule;
+- explicitly authored starting knowledge.
+
+Avoid elaborate biographies until they serve proven gameplay.
+
+### 13.3 Content exclusions
+
+The initial world does not require:
+
+- large family trees;
+- dozens of NPCs;
+- sprawling geography;
+- festivals;
+- mythology systems;
+- complicated seasonal schedules;
+- extensive lore;
+- large inventories;
+- numerous concurrent quests;
+- generated background facts.
+
+Existing content can later be selectively reintroduced after the foundation is proven.
+
+## 14. Canonical World Sheet
+
+During early development, maintain a concise human-readable representation of the entire test world.
+
+**Example:**
+
+```text
+KILTEEVAN VILLAGE
+ exits: Letter Office, Connolly Cottage
+ present at 08:00: Peig
+
+LETTER OFFICE
+ exits: Kilteevan Village
+ occupant: Peig
+
+CONNOLLY COTTAGE
+ exits: Kilteevan Village
+ residents: Mícheál, Róisín
+
+PEIG
+ home: Letter Office
+ morning: Letter Office
+ knows: Mícheál, Róisín
+
+MÍCHEÁL
+ home: Connolly Cottage
+ morning: fields
+ afternoon: village
+
+RÓISÍN
+ home: Connolly Cottage
+ morning: cottage
+ afternoon: village
+```
+
+The sheet is a development oracle. Unexpected contradiction between authoritative game state and the sheet indicates either a bug or an intentional change that requires the sheet to be updated.
+
+## 15. Initial Non-Requirements
+
+The following existing or proposed capabilities do not define the new UI and should not be restored merely for feature parity:
+
+- AI-generated scene art;
+- NPC portraits;
+- graphical world/map view;
+- MapLibre player UI;
+- NPC sidebar;
+- emoji reactions;
+- save DAG UI;
+- Parish Designer;
+- player-facing debug panels;
+- inference-provider configuration UI;
+- multiple custom visual themes;
+- demo/auto-player mode;
+- bug-report UI;
+- rich secondary dashboards;
+- broad command completion;
+- desktop feature parity.
+
+These systems may remain in the repository and may be reconsidered individually later.
+
+## 16. Definition of Done
+
+A milestone is Done only when:
+
+• every applicable requirement in its checklist is satisfied;
+
+• its Exit Criteria can be demonstrated;
+
+• relevant automated tests pass;
+
+• no known defect violates the Quality Gate;
+
+• changes affecting mobile interaction have been exercised on a physical iPhone;
+
+• persistence and recovery behavior introduced or affected by the milestone has been verified; and
+
+• documentation and the canonical world sheet reflect the implemented behavior where applicable.
+
+Passing tests alone does not establish Done. A milestone must produce the observable player experience described by its Exit Criteria.
+
+## 17. Incremental Delivery Plan
+
+Each milestone is intentionally narrow. The checklist describes required outcomes and observable behavior, not a prescribed internal implementation. A milestone is complete only when all applicable requirements are satisfied and the resulting build is stable enough to serve as the foundation for the next milestone.
+
+Milestone 1 — Static native interaction prototype
+
+Build a SwiftUI prototype using fixture data only. The purpose is to establish the fundamental iPhone reading-and-typing experience before integrating Parish.
+
+**Requirements checklist**
+
+- The app launches directly into the primary play screen without onboarding, configuration, or secondary navigation being required.
+- The screen contains only the compact status header, transcript, and composer as persistent gameplay regions.
+- The transcript clearly distinguishes narration, NPC dialogue, player commands, deterministic/system output, and scene transitions without relying on chat bubbles.
+- The composer uses normal iOS text-entry behavior and remains correctly positioned when the software keyboard appears, changes size, or is dismissed.
+- The composer supports multiline input without making short commands cumbersome.
+- Sending text immediately produces a visible player-command entry in the transcript.
+- Fixture responses can stream incrementally so the real streaming experience can be evaluated before backend integration.
+- An active fixture response can be stopped from the primary screen.
+- Long transcripts remain readable and responsive.
+- When the player is following the newest content, streaming output remains naturally visible.
+- When the player scrolls upward to read history, incoming output does not force the transcript back to the bottom.
+- When new content arrives while the player is reading earlier history, the UI provides a clear way to return to the newest content.
+- Previous player commands can be recalled into the composer and edited.
+- @ and / affordances can be exercised with fixture completion data without requiring a real game engine.
+- The layout works in portrait on supported iPhone screen sizes, including small screens.
+- The interface respects iPhone safe areas.
+- Light and dark appearances are both usable and intentional.
+- Dynamic Type remains usable through accessibility text sizes without hiding essential controls or making the composer unusable.
+- Core transcript and composer interactions are usable with VoiceOver.
+- Basic focus behavior is predictable when entering text, submitting, stopping, scrolling, and returning to the composer.
+- The prototype uses no live LLM and no Parish runtime; all behavior needed for this milestone is reproducible from fixtures.
+- No graphical map, portrait, scene art, tab bar, NPC sidebar, save UI, debug UI, or other legacy player surface is introduced.
+
+**Exit criteria**
+
+A tester can spend several minutes reading, typing, submitting, stopping, recalling commands, and navigating a long simulated transcript on a physical iPhone without encountering keyboard, scrolling, readability, or accessibility problems serious enough to undermine the basic interaction model.
+
+Milestone 2 — Embedded Rust vertical slice
+
+Establish the Swift/Rust boundary and make the prototype into a tiny real game. This milestone deliberately supports only one location and one NPC.
+
+**Requirements checklist**
+
+- Parish gameplay code runs locally on the iPhone rather than through a remote Parish game server.
+- SwiftUI communicates with Parish through a small, presentation-oriented boundary rather than depending directly on internal engine structures.
+- The iOS gameplay runtime does not require Tauri, the web server, desktop process management, local-model launching, or other desktop-only facilities.
+- A new game can be created locally.
+- An existing local game can be resumed.
+- The initial world contains exactly one playable location and one interactive NPC for this milestone.
+- /look returns authoritative local game information through the same transcript event path used by the UI.
+- The player can address the NPC using ordinary free text.
+- The game makes its interpretation of the player's request visible when doing so helps the player understand what will happen.
+- A real remote inference request through a Parish Endpoint can produce an NPC response.
+- NPC output streams into the transcript.
+- The player can stop an active inference-backed response.
+- Stopping a response leaves the game in a coherent, resumable state.
+- A failed inference request produces a comprehensible player-facing error without corrupting the session.
+- Failed requests can be retried without unintentionally applying the same game action twice.
+- Gameplay that does not inherently require inference works without network access.
+- Provider credentials or other long-lived secrets are not embedded in the shipped application; production inference reaches model providers only through Parish Endpoints.
+- Completed state-changing actions are persisted locally.
+- Force-quitting after a completed action and relaunching restores the correct game state.
+- An interrupted request cannot leave partially committed authoritative world state.
+- Transcript events have durable identities sufficient to prevent duplicate display after restoration.
+- Request-related events can be correlated so the UI can associate a command, its interpretation, streaming response, errors, and completion.
+- The same semantic event fixtures used for UI testing can represent real Parish output.
+- The one-location/one-NPC game can be played without exposing engine configuration, provider selection, debugging tools, or other developer infrastructure.
+
+**Exit criteria**
+
+On a physical iPhone, a tester can launch or resume the game, inspect the location, converse repeatedly with one NPC using real inference, stop or retry requests, quit the app, relaunch it, and continue from correct local state. This should already feel like a small but genuine text game rather than an engine demonstration.
+
+Milestone 3 — Tiny world navigation
+
+Expand to the complete canonical three-location/three-NPC test world. The purpose is to prove spatial state, NPC presence, schedules, and natural-language navigation while the entire world remains understandable by one person.
+
+**Requirements checklist**
+
+- The canonical test world contains exactly three locations and three NPCs at the start of this milestone.
+- Every location and connection is explicitly represented in the canonical world sheet.
+- Every NPC has an explicitly authored home, simple role/occupation, concise personality, starting knowledge, relationships, and schedule needed by this milestone.
+- /people reports who is actually present at the player's current location.
+- /exits reports the authoritative destinations currently reachable from the player's location.
+- /look, /people, and /exits work without network access.
+- The player can travel using deterministic commands or ordinary natural-language phrasing.
+- A successful move updates authoritative player location exactly once.
+- A move creates a clear scene transition in the transcript.
+- After travel, the status header and subsequent transcript output agree about the current location.
+- NPC presence agrees with authoritative NPC location rather than being invented by generated prose.
+- NPC scheduled movement can change who is present as game time advances.
+- The player cannot converse normally with an NPC who is not actually available for that interaction.
+- When a natural-language destination or NPC reference is confidently resolved, the game shows an understandable interpretation receipt where useful.
+- When a materially ambiguous destination or NPC reference cannot be resolved confidently, the game asks the player to choose rather than guessing.
+- Clarification does not execute the underlying action until the player resolves the ambiguity.
+- Choosing a clarification continues the original request without requiring the player to retype it.
+- Travel, presence, and schedule state survive save/resume.
+- The entire world can be inspected against the canonical world sheet during testing.
+- Unexpected contradictions between the canonical sheet and authoritative runtime state are treated as defects unless the sheet is intentionally updated.
+- No additional locations or NPCs are added merely to make the world feel fuller.
+
+**Exit criteria**
+
+A tester can understand the entire world, move among all three locations, find each NPC where expected, observe at least one scheduled movement, converse only with available NPCs, resolve ambiguous requests, and quit/resume without spatial or presence inconsistencies.
+
+Milestone 4 — Mobile reliability
+
+Stop feature growth and harden the existing game as a native mobile application. No new gameplay breadth is required in this milestone.
+
+**Requirements checklist**
+
+- The current game survives normal app backgrounding and foregrounding without losing committed state.
+- An unsent composer draft survives backgrounding and restoration.
+- An unsent composer draft survives ordinary app termination/relaunch where iOS restoration is reasonably expected.
+- Backgrounding during an inference request has defined, tested behavior and never silently duplicates the request.
+- Returning after an interrupted or completed background inference leaves the transcript and authoritative world state consistent.
+- Loss of connectivity before an inference request produces a recoverable state.
+- Loss of connectivity during an inference request produces a recoverable state.
+- Restoring connectivity allows the player to continue without restarting the game.
+- Retry behavior clearly distinguishes retrying an uncommitted request from repeating an already completed player action.
+- Reconnection or restoration does not duplicate transcript events.
+- Reconnection or restoration does not duplicate authoritative game actions.
+- Force-quitting at representative points in the request lifecycle cannot corrupt the save.
+- Long transcripts remain responsive over a realistic play session.
+- Streaming remains scroll-stable in long transcripts.
+- Reading earlier history remains possible while new output is streaming.
+- The newest-content affordance remains understandable and reliable.
+- Keyboard presentation, dismissal, rotation where supported, dictation, and common iOS text-entry behavior do not break the composer.
+- Incoming interruptions such as app switching do not lose submitted or unsent text.
+- The app remains usable at supported Dynamic Type sizes, including accessibility sizes.
+- The core game loop remains usable with VoiceOver.
+- Interactive elements have sensible accessibility labels and focus order.
+- Error messages tell the player what happened and what they can do next without exposing irrelevant implementation details.
+- A 20-minute physical-device play session can be completed without needing a secondary screen for normal gameplay.
+- Reliability testing covers at least one small-screen supported iPhone and the primary development/test iPhone.
+- No new map, art, inventory, quest, save-management, or other major gameplay UI is added during this hardening milestone.
+
+**Exit criteria**
+
+The existing tiny game behaves like a dependable iPhone application under realistic lifecycle, connectivity, accessibility, keyboard, scrolling, and failure conditions. Known defects that can lose, duplicate, corrupt, or substantially confuse player actions block progression to the next milestone.
+
+Milestone 5 — Living-world proof
+
+Add only enough simulation to demonstrate Rundale's central living-world premise inside the tiny canonical world.
+
+**Requirements checklist**
+
+- Exactly one initial authored fact is designated as the first gossip case.
+- The fact has a known starting source so testers can determine who should and should not know it initially.
+- A player interaction can cause an NPC to remember one meaningful fact about the player or conversation.
+- That memory persists across save/resume.
+- A later interaction can demonstrate that the NPC's response is informed by the persisted memory.
+- The chosen gossip fact can propagate through one intended NPC-to-NPC path.
+- Before propagation, an NPC who should not know the gossip does not behave as though they know it.
+- After propagation, the newly informed NPC can demonstrate knowledge of it through normal play.
+- Gossip state is authoritative game state rather than inferred solely from generated prose.
+- One NPC can assign one simple, concrete task to the player.
+- The task has an authoritative state that can distinguish at least assignment, progress where applicable, and completion.
+- The task state survives save/resume.
+- Completing the task through the intended world action is reflected in later NPC interaction.
+- One NPC has one clearly defined weather-dependent behavior.
+- Changing to the relevant weather condition causes the expected behavior in authoritative state.
+- One NPC has one scheduled movement that can be observed by the player through location/presence changes.
+- The scheduled movement remains consistent with /people, conversation availability, and save/resume.
+- The five living-world proofs—memory, gossip, task, weather behavior, and scheduled movement—can each be reproduced without adding extra NPCs or locations.
+- Generated dialogue is constrained by authoritative state sufficiently that it does not casually contradict who is present, what has happened, or what an NPC knows.
+- Failures in one living-world mechanism are diagnosable within the tiny world rather than hidden by large amounts of content.
+- The canonical world sheet is extended only with the facts needed to describe these behaviors and remains concise enough for a tester to understand as a whole.
+
+**Exit criteria**
+
+A tester can deliberately demonstrate all five living-world behaviors in the three-location/three-NPC world and explain why each observed outcome occurred. Save/resume and repeated tests produce coherent authoritative state, and generated dialogue does not obscure whether the underlying mechanisms worked.
+
+Milestone 6 — Controlled expansion
+
+Only after the previous milestones are stable may Rundale begin growing beyond the canonical tiny world. Expansion is incremental rather than a return to the previous content scale.
+
+**Requirements checklist**
+
+- The tiny canonical world remains available as a deterministic regression fixture even after production content expands.
+- New player-facing capabilities are proposed in terms of a concrete player need or gameplay outcome rather than existing-engine feature availability.
+- Every proposed capability has explicit acceptance criteria before implementation begins.
+- Every proposed capability identifies how it will be tested before implementation begins.
+- Content additions are introduced in small enough batches that testers can still reason about new relationships, locations, schedules, and knowledge changes.
+- NPC count is increased gradually rather than restoring the previous population wholesale.
+- Location count is increased gradually rather than restoring the previous world graph wholesale.
+- Existing NPCs or locations are reintroduced only after their data is reviewed against the new content model and current gameplay needs.
+- Legacy UI features are not restored merely because corresponding engine support exists.
+- Legacy content is not assumed correct merely because it previously shipped.
+- A graphical map is considered only if demonstrated player needs cannot be served well by the text-first location/exits experience.
+- Art and portraits are considered optional enhancements rather than prerequisites for atmosphere or comprehension.
+- New secondary screens are added only when the transcript/composer model is demonstrably inadequate for the required interaction.
+- Every expansion preserves offline operation for gameplay that does not inherently require inference.
+- Every expansion preserves local authoritative save behavior.
+- Every expansion preserves transcript stability, request atomicity, and duplicate prevention.
+- Physical-iPhone validation remains required for changes affecting core interaction.
+- Accessibility remains part of acceptance rather than deferred polish.
+- A feature or content batch that makes the current experience materially less reliable or understandable is fixed or reverted before further expansion.
+- The project may intentionally remain text-only indefinitely; graphical feature parity is not an end-state requirement.
+
+**Definition of Done for each expansion increment**
+
+There is no single feature-count target for this milestone. Each expansion increment is Done only when its explicit acceptance criteria and planned tests pass, all applicable project-wide Definition of Done requirements are satisfied, and the increment leaves Rundale more useful or expressive without sacrificing the reliability, comprehensibility, mobile usability, and text-first identity established by the earlier milestones.
+
+## 18. Quality Gate
+
+Before adding a new player-facing capability, the current build must satisfy the relevant portions of this baseline:
+
+- keyboard never obscures active input or critical response content;
+- no submitted command is lost;
+- no command is executed twice unintentionally;
+- transcript does not jump while the player reads earlier content;
+- streaming can be stopped safely;
+- failed inference leaves coherent game state;
+- relaunch restores the correct story state;
+- unsent drafts survive normal lifecycle transitions;
+- player can determine current location;
+- player can determine who is present;
+- player can determine what action the game interpreted;
+- every persistent visible control has a clear purpose;
+- basic play remains usable with VoiceOver and large Dynamic Type;
+- a normal 20-minute play session does not require navigating secondary screens.
+
+Passing unit tests alone is insufficient for interaction changes. Mobile UX changes require validation on a physical iPhone before being considered complete.
+
+## 19. Testing Strategy
+
+The reset should favor small, deterministic fixtures.
+
+Swift UI tests
+
+Use fixture event streams to test:
+
+- rendering;
+- streaming;
+- scrolling;
+- error states;
+- clarification;
+- restoration;
+- accessibility.
+
+No live LLM should be necessary for UI regression tests.
+
+Parish runtime tests
+
+Use the tiny canonical world to test:
+
+- movement;
+- presence;
+- schedules;
+- memory;
+- gossip;
+- task progression;
+- persistence;
+- request atomicity;
+- event ordering.
+
+Integration tests
+
+Exercise Swift-facing Parish APIs with deterministic/mock inference.
+
+Live inference tests
+
+Keep a small, intentional set of tests proving the real inference path. Do not make routine UI correctness depend on nondeterministic external models.
+
+## 20. Definition of Success
+
+The reset succeeds when Rundale can be handed to someone on an iPhone with minimal explanation and the player can:
+
+1. understand where they are;
+2. understand who is around them;
+3. type naturally;
+4. understand what the game thought they meant;
+5. converse with a believable NPC;
+6. move through the tiny world;
+7. observe that NPCs remember and act;
+8. leave the app and return without losing their place;
+9. continue playing without needing graphical interfaces or secondary dashboards.
+
+The first objective is not breadth. It is to make a tiny Rundale experience feel exceptionally reliable and natural.
+
+Only then should the world grow.

--- a/docs/product-specs/software-technical-vision.md
+++ b/docs/product-specs/software-technical-vision.md
@@ -1,0 +1,621 @@
+# Rundale Mobile — Software Technical Vision
+
+Architecture for the text-first reset and all six delivery phases
+
+> Status: Proposed technical direction, version 1.1. Scope: Native iPhone client, embedded Parish Engine, Rundale content, and the integration contract with Parish Endpoints. This is a companion to the current Product & Technical Specification, not a replacement for its requirements or a claim that any milestone is complete.
+
+Editorial import note: references to the native Product & Technical Specification, including [P1], resolve within this repository to the versioned [Product & Technical Specification](product-technical-spec.md). The native document remains source provenance; this note does not change the imported source text or its proposed status.
+
+## 1. Technical north star
+
+Rundale should become a small, dependable local application that can grow into a richer living world without changing who owns the game. SwiftUI provides the reading-and-typing experience. The embedded Rust Parish Engine interprets commands, enforces rules, advances simulated time, manages NPC state, and commits saves. Parish Endpoints supplies remote inference. The network never becomes the authority for location, knowledge, tasks, or story history. [P1]
+
+The important investment is not an elaborate framework. It is a few durable boundaries: intent versus execution, proposed output versus committed facts, authored content versus mutable saves, presentation events versus engine internals, and remote computation versus local authority. These boundaries must exist in the tiny implementation even when only one NPC and one location are enabled.
+
+The first prototype should therefore be deliberately narrow but structurally representative. A fixture response and a real Parish response should pass through the same presentation contract. A one-NPC conversation should use the same request identity, cancellation, persistence, and validation rules that will later protect gossip and tasks. The three-location world should be ordinary validated content, not a special engine mode built around three hard-coded objects.
+
+The desired end state remains a text adventure. Supporting more NPCs, richer memory, optional undo, or eventual save synchronization must not require a new player interface. Conversely, keeping future options open does not authorize building those features early. The project can remain text-only indefinitely. [P1]
+
+Architectural success test: adding a new world behavior should normally require a bounded engine/content change, relevant tests, and perhaps an additional semantic event—not a rewrite of the composer, the storage ownership model, or the Endpoint integration.
+
+## 2. Authority, assumptions, and source alignment
+
+### 2.1 What this document treats as fixed
+
+The current native Google Docs specification is the governing product source. It requires SwiftUI on iPhone, on-device Rust gameplay, authoritative local saves, remote inference exclusively through Parish Endpoints, and the six existing delivery milestones. It deliberately resets both frontend and world/NPC data while retaining useful Parish Engine capabilities. Existing graphical interfaces and old content do not define compatibility obligations. [P1]
+
+This vision makes additional technical recommendations. Where the product spec does not choose a mechanism, recommendations below are defaults to validate, not retroactively approved product requirements. No individual class hierarchy, exact database table inventory, or comprehensive internal API is prescribed.
+
+This is a target architecture, not a repository audit. Before modifying the engine, inspect the current repository to identify reusable implementations and actual portability constraints. Do not assume a capability is absent merely because it is not described here, or correct merely because it exists.
+
+### 2.2 A cross-project dependency that must be resolved
+
+The Rundale spec requires streaming NPC output through Parish Endpoints during Phase 2. The separate Parish Endpoints architecture currently excludes streaming from its original MVP. It also describes client-safe OIDC/JWT invocation as planned, while allowing owner-only dogfood work to precede that capability. Those are document-level integration gaps; they are not evidence of the deployed service's actual feature set. [P1, P2]
+
+Rundale therefore needs a small, explicit Endpoint capability agreement before Phase 2 can be accepted: a versioned inference contract, authenticated mobile-safe invocation, incremental response delivery, a validated terminal result, bounded failure/cancellation behavior, and request correlation. Implement missing capabilities in the generic Parish Endpoints product rather than bypassing it with direct provider calls or inventing a Rundale game server.
+
+This document does not change either source document. The integration owner should reconcile their requirements when implementation work begins. Marketplace features, billing systems, and a broad Endpoint platform expansion are not prerequisites for this narrow integration.
+
+### 2.3 Assumptions selected for the reset
+
+The recommended early runtime is single-player and single-writer, with one state-changing player request active at a time. Game time advances through accepted gameplay outcomes rather than real-world waiting. The world does not continue simulating while the phone is suspended. Initial content ships with the app. Cloud saves, a graphical map, a save-branch interface, and on-device inference are not required.
+
+These assumptions reduce concurrency and lifecycle ambiguity without making the domain model depend on an iPhone screen or a single NPC. Revisit them only through an explicit design decision with migration and test consequences.
+
+## 3. Decisions to establish early—and what to leave replaceable
+
+| Area                      | Initial direction                                                                       | Future option preserved                                                        |
+| ------------------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Player experience         | SwiftUI shell; transcript, compact status header, native composer                       | Replace a difficult scrolling/text component without replacing game logic      |
+| Game authority            | One embedded Rust runtime owns mutable world state                                      | Other clients can reuse the engine without duplicating rules                   |
+| UI contract               | Versioned semantic events and read-only projections                                     | Richer behaviors and optional secondary views without leaking engine internals |
+| Request execution         | Durable command receipt; staged outcome; one atomic world commit                        | Safe retry, future undo, and reliable long-running inference                   |
+| Local storage             | Prefer one transactional SQLite-backed save boundary, subject to existing-engine review | Migrations, paging, consistent export, and later synchronization               |
+| Foreign-function boundary | Small owned-value interface; evaluate generated Swift bindings before choosing          | Change binding tooling without changing the game contract                      |
+| Networking                | Parish Endpoint adapter behind a narrow transport capability                            | Provider changes and endpoint evolution without provider SDKs in the client    |
+| Time and randomness       | Explicit game clock and persisted/versioned randomness state                            | Reproducible schedules, controlled catch-up, and deterministic tests           |
+| Content                   | Stable entity IDs; immutable content definitions; separate mutable state                | New content packs and save-compatible expansion                                |
+| NPC cognition             | Structured knowledge/provenance; model output is a proposal                             | Gossip, memory, and tasks without transcript-driven state inference            |
+| Testing                   | Shared semantic fixtures, headless engine tests, real iPhone gates                      | Implementation changes without relying on live models for correctness          |
+| Deployment                | Reproducible iOS builds; immutable Endpoint versions with recorded resolution           | Safe rollback and diagnosis across independently deployed components           |
+
+Do not build a plugin marketplace, distributed simulation, generic workflow engine, entity-component framework, vector database, CRDT layer, or arbitrary scripting system merely to preserve optionality. Prefer a specific extension point at a known boundary over speculative infrastructure.
+
+## 4. System boundaries and ownership
+
+### 4.1 Logical components
+
+These are responsibility boundaries, not a requirement to create a separate package or class for each row.
+
+| Component                  | Owns                                                                                                | Must not own                                                   |
+| -------------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| iOS presentation           | Transcript rendering, composer, focus, scrolling, accessibility, transient UI state                 | World rules, NPC memory, provider routing, save-state mutation |
+| iOS platform services      | App lifecycle, native networking, credential access, sandbox paths, OS integration                  | Game-specific prompt selection or adjudication                 |
+| Parish application runtime | Request lifecycle, intent resolution, validation, orchestration, commit ordering                    | UIKit/SwiftUI layout and provider secrets                      |
+| Parish simulation          | Locations, presence, time, schedules, weather, relationships, knowledge, tasks                      | HTTP, view identity, or app navigation                         |
+| Local persistence boundary | Durable requests, committed world state, transcript records, migration/export                       | Inferring state from prose or making network calls             |
+| Rundale content            | Authored definitions, initial conditions, bounded rules and fixtures                                | Mutable player progress or hidden per-device state             |
+| Parish Endpoints           | Authorized inference execution, provider credentials/routing, published behavior versions, metering | Authoritative game state or autonomous changes to the save     |
+
+The client-to-engine dependency points inward. Platform capabilities are injected through narrow interfaces where the engine needs them. The simulation must be testable without SwiftUI, a network connection, or a model provider. The iOS renderer must be testable without compiling or launching Parish.
+
+### 4.2 Keep three representations separate
+
+Authoritative domain state says what is true in the game: where someone is, what they know, whether a task is complete, and what game time it is.
+
+Interaction history records what the player submitted and what was presented, including interrupted attempts. A failed command belongs in interaction history even when it changed no world state.
+
+Presentation state says which transcript entries are loaded, which row is streaming, where the player is reading, and what is in the draft composer. It may be rebuilt from durable records, but it is not the save itself.
+
+These representations may share IDs and a storage transaction without becoming the same data structure. Rendering an old scene heading must never move the player. Loading a transcript must never replay a command against the current world. Trimming an inference context must never delete an NPC's authoritative memory.
+
+### 4.3 Portable engine boundary
+
+Keep Tauri, Axum hosting, desktop process control, local-model launching, web authentication infrastructure, and developer tools outside the iOS gameplay dependency graph. Prefer explicit build targets or feature separation over importing a desktop runtime and hoping unused paths never execute. Retain established desktop behavior where practical without making desktop feature parity a condition of the mobile reset. [P1]
+
+A headless host for tests and diagnostics can use the same portable engine. It is a development tool, not a second implementation of the game or a requirement for a player-facing debug screen.
+
+## 5. Stable contracts across the Swift/Rust boundary
+
+### 5.1 An application-facing contract, not an engine mirror
+
+The boundary needs capabilities to create/resume a local session, submit player intent, answer a clarification, stop a request, retrieve a consistent view of current state, page through transcript history, and receive correlated events. Exact function names and serialization are implementation choices.
+
+The contract should transfer owned values or well-defined opaque handles. It must define lifetimes, disposal, error propagation, callback threading, cancellation, and maximum payload sizes. Swift must not hold mutable pointers into an NPC graph or call arbitrary engine internals to populate a screen.
+
+Expose semantic commands and queries, not a generic “execute Rust function” mechanism. For example, completion asks for currently relevant entity references; it does not fetch every internal NPC object. A location summary carries player-visible facts, not hidden NPC knowledge.
+
+### 5.2 Identity and versioning
+
+Use stable identifiers independently of display names and array positions. The earliest real save should distinguish a game/session identity, content version, state revision, logical request ID, execution attempt ID, transcript item ID, and committed event ordering. A future branch/checkpoint must be referencable without renumbering historical identities.
+
+A logical request is the player's intended submission. An attempt is one execution effort for that request. A transcript item is a visible unit such as a command or an NPC response. Multiple stream updates modify one item; they are not separate dialogue messages. A committed state revision identifies the exact world against which an outcome was validated.
+
+Version the presentation contract, save format, content schema, and Endpoint input/output contract separately. Their release cycles differ. A provider/model name is not a substitute for an inference contract version. Unknown mandatory behavior should produce a controlled compatibility error; an unknown optional presentation decoration may degrade to a safe text fallback.
+
+### 5.3 Semantic events and projections
+
+Start with the concepts in the product spec: scene change, player command, interpretation receipt, narration, NPC dialogue, action result, clarification, progress, error, and response completion. Keep terminal success, cancellation, interruption, and failure distinguishable even if represented by a shared event envelope. [P1]
+
+Events need sufficient context to identify their request/attempt, speaker or location when relevant, logical order, provisional/committed status, and resulting state revision where applicable. Hidden state is not carried merely because the engine knows it. Use bounded structured metadata for entity references and interaction choices rather than encoding clickable semantics into arbitrary Markdown.
+
+A read model for the current header, nearby people, and exits must come from one consistent state revision. Update it together with, or immediately after, the corresponding committed action. Never compute it by scanning the last generated paragraph.
+
+### 5.4 Gap-free restoration and bounded delivery
+
+The runtime must support a consistent snapshot plus an event cursor, or an equivalent subscription handshake that cannot miss a commit between “read current state” and “start listening.” Repeated delivery of the same committed record must be harmless.
+
+Do not persist every token as a permanent transcript event. Maintain a bounded provisional stream buffer with per-attempt sequencing and a final durable item. Chunk boundaries must not split or corrupt Unicode. Coalesce UI updates, but do not discard terminal transitions or state-changing records under backpressure.
+
+Full token-level stream resumption is not required initially. Restoring the committed transcript and showing a clearly interrupted provisional attempt is sufficient. Preserve the identifiers needed to add stronger recovery later without pretending a network stream is a durable event log.
+
+## 6. Runtime execution, atomicity, and cancellation
+
+### 6.1 One authority, one commit lane
+
+Use a serialized execution context for authoritative mutations. Expensive inference and transport run asynchronously outside that context; their results return as candidates associated with an expected state revision. Do not hold a database transaction or engine lock open while waiting for a remote model.
+
+Initially, allow one active state-changing player request. The player can continue composing while it runs. Read-only inspection may operate on the last committed snapshot, provided it cannot advance time or mutate the pending turn. Do not introduce parallel NPC agents or concurrent player turns in order to make a tiny game feel sophisticated.
+
+The logical single-writer rule does not require all work to run on the UI thread. Swift presentation updates belong on the appropriate UI isolation context; storage, parsing, validation, simulation work, and FFI operations that can block must not stall typing or scrolling.
+
+### 6.2 Two durable boundaries
+
+Acceptance boundary: record the logical request, original text, relevant targeting references, base state revision, and its accepted status. The player-command transcript item becomes durable here. Clear the composer only after acceptance, and use the same submission ID to reconcile a crash or duplicate acknowledgment.
+
+Gameplay commit boundary: after interpretation, inference where required, and validation, commit the resulting domain changes, final authoritative transcript records, request terminal outcome, and new state revision together. This is the point at which the game has actually changed.
+
+The accepted command may therefore survive a failed turn. That is not a partial world commit; it is an accurate record of an attempted action. A successful UI completion indicator must follow the durable gameplay commit, not precede it. Optional cloud upload happens later and cannot delay local completion.
+
+### 6.3 Recommended request state machine
+
+A request moves through accepted, interpreting, possibly awaiting clarification, executing or awaiting inference, validating, and then a terminal outcome. Internal state names are not mandated, but the legal transitions and their persistence meaning must be testable.
+
+Terminality is per attempt, except that a successful gameplay commit permanently settles the logical request. Retrying an uncommitted request creates an explicit new attempt; it does not erase or rewrite the previous attempt’s terminal record. Only the currently authorized attempt can become the logical request’s committed outcome.
+
+Clarification preserves the original intent and identifies bounded choices. Selecting a choice continues that request rather than creating an unrelated command. On resume, revalidate the choice against the saved state. A stale target or changed precondition must not silently redirect an action to a different NPC.
+
+Before commit, the engine checks the expected revision, entity existence, presence, permitted actions, task preconditions, output bounds, and the request's cancellation/terminal state. A response from an obsolete attempt cannot win merely because it arrives last.
+
+### 6.4 Stop and retry semantics
+
+Stop is a request to cancel uncommitted work, not a general rollback feature. It should immediately change visible activity state, propagate cancellation through the runtime and transport, and prevent a late result from committing. The runtime serializes the final cancel-versus-commit decision.
+
+If commit has already won, the action stays committed and the UI reports completion. Do not pretend that a late Stop undid the world. Future undo is a separate operation with a separate checkpoint/branch policy.
+
+A retry of a failed, uncommitted action retains its logical request identity and original player intent, but receives a new attempt identity. A network retry of the same remote invocation should retain the same remote idempotency key and request fingerprint where the Endpoint contract supports it. A deliberate new model generation is a new remote invocation/attempt, not a fabricated replay of the old one.
+
+After subsequent gameplay has changed the base state, the old request cannot simply commit against its old assumptions. Revalidate and obtain a new interpretation as necessary, or offer an explicit new submission. Copying a completed command into the composer is always a new player action when sent.
+
+### 6.5 Failure cases that define the design
+
+| Interruption point                                | Required result                                                                                                           |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Before durable acceptance                         | Keep recoverable draft text; do not claim the command was accepted                                                        |
+| After acceptance, before gameplay commit          | Restore the command as pending/interrupted; world remains at its last committed revision                                  |
+| During incremental model output                   | Preserve or discard the provisional excerpt according to a documented UI policy; never promote it to memory or task state |
+| While committing                                  | Recover either the complete old state or complete new state, never a mixture                                              |
+| After commit, before UI acknowledgment            | Restore the committed result and deduplicate delivery; do not execute again                                               |
+| Endpoint completed but client lost the connection | Recover the same result when supported, otherwise report interruption; local commit protection remains authoritative      |
+| Stop races a final response                       | Exactly one local terminal decision wins; late callbacks cannot mutate the session                                        |
+| Save write fails or disk is full                  | Preserve the last valid save and expose a recoverable error; never show an unsaved action as durably completed            |
+
+The achievable promise is at-most-once committed local effects for a logical request, backed by durable deduplication. Do not promise exactly-once execution or exactly-once billing across an unreliable network and a remote provider. Endpoint idempotency reduces duplicate work but cannot repair incorrect local commit semantics. [P2]
+
+## 7. Persistence, history, migrations, and future saves
+
+### 7.1 Storage recommendation
+
+Prefer a single transactional SQLite-backed persistence boundary owned by the Parish runtime for requests, authoritative world state, and committed transcript history. A consistent transactional store makes the gameplay commit boundary practical; SQLite documents atomic transaction behavior and recovery mechanisms. This recommendation still requires verification of the chosen binding, journal configuration, durability settings, and iOS file behavior. [T4]
+
+First inspect existing Parish persistence and branching. Reuse it if it satisfies these boundaries and works on-device. Do not add a second authoritative database because SQLite appears in this document. If replacement is necessary, identify the missing property and migrate deliberately rather than maintaining two save systems indefinitely.
+
+Avoid making SwiftData/Core Data the authoritative game model while Rust maintains a separate mutable copy. Avoid a single ever-growing JSON save rewritten for every token, or an append-only prose file from which game state must be guessed. Simple JSON remains appropriate for test fixtures, content exchange, or an export format; it is not a substitute for defined transaction semantics.
+
+### 7.2 Durable records and projections
+
+Persist enough to restore accepted commands, terminal request outcomes, state revisions, final transcript items, content/schema versions, game time, and any randomness state required for future deterministic progression. Knowledge, task state, schedule position, and weather are domain data, not incidental text fields in a dialogue log.
+
+A materialized current state plus a durable interaction/commit history is sufficient. Full event sourcing from the first prototype is not required. Historical reconstruction must use recorded outcomes or checkpoints, not rerun past prompts against a current model. Generated dialogue is nondeterministic; saved output is the historical fact that it was shown.
+
+Keep full interaction history separate from the bounded window loaded by the UI and the much smaller context selected for inference. Paging is a read operation, not an excuse to remove old committed turns. Introduce compaction or archival only with an explicit retention policy that preserves required history and future checkpoint references.
+
+### 7.3 Draft and viewport restoration
+
+Treat the draft as durable player input with its own lightweight persistence policy. Save it independently of gameplay completion, including selection/targeting information needed to restore an intelligible command. Flush at safe lifecycle boundaries and use a short debounced write policy during editing; do not rely exclusively on a termination callback.
+
+During submission, associate the outgoing draft with its request ID until the accepted receipt is durable. A crash after acceptance but before clearing the local draft must not show two accepted commands or trigger resubmission. Restore the appropriate empty/new draft while leaving the accepted command in history.
+
+Restore reading position using a stable transcript item anchor and an offset or equivalent logical position. Raw pixel offsets alone are fragile when font size or device geometry changes. Preserve the difference between following new output and deliberately reading history.
+
+### 7.4 Migration and content compatibility
+
+Give save-format changes explicit, ordered migrations. Test them using real prior-format fixtures. Preserve the original valid save until the migrated copy has been validated and adopted; failed migration must not quietly create a fresh game over the player's data. A newer unsupported save must produce a clear compatibility error.
+
+Content updates are a separate problem from database schema changes. A save should identify the content definition version or fingerprint it depends on. Renaming a location should not change its stable ID. Removing or changing an entity referenced by a save requires a content migration, a pinned old content version, or an explicitly incompatible new-game path—not best-effort guessing.
+
+Resetting legacy frontend/content does not imply that every existing pre-reset save needs migration. Decide legacy-save compatibility explicitly before distributing the first mobile save format. Once players have relied on mobile saves, preservation becomes an ongoing engineering obligation.
+
+### 7.5 Future checkpoints, undo, and cloud synchronization
+
+Preserve checkpoint identity and ancestry where existing engine support already exists, or leave a small explicit place for them in save metadata. Do not expose a save DAG or build a general branching UI in early phases. Future undo should select or create a valid alternate state lineage; deleting the last transcript paragraph is not undo.
+
+Optional synchronization should transfer consistent, versioned save snapshots or logical change packages, never an actively mutating database file. SQLite's backup facilities provide a consistent snapshot approach; in WAL mode, committed data may still reside outside the main database file, so copying that file alone is not an acceptable export protocol. [T5, T6]
+
+A future sync adapter needs save identity, checkpoint/state revision, content version, format version, integrity metadata, and a clear point-in-time boundary. Add only inexpensive identity/version metadata now. Defer synchronization queues, conflict UI, and transport selection until cloud saves are authorized.
+
+For divergent offline progress, the safe default is separate branches or an explicit choice of a complete history—not last-write-wins merging of individual NPC locations, memories, or tasks. The cloud remains a replica. Loss of connectivity, expired cloud credentials, or service downtime must not prevent local launch or local gameplay.
+
+## 8. Native presentation without simulation leakage
+
+### 8.1 A thin but capable SwiftUI client
+
+Use SwiftUI for the application structure and primary screen. Keep a replaceable rendering/composer boundary so a native UIKit-backed text or scrolling component can be introduced if measured behavior demands it. That is an implementation detail inside a SwiftUI application, not permission to rebuild gameplay in a web view.
+
+A presentation reducer or equivalent state transformation consumes semantic events and consistent read models. It must be usable with fixtures in Phase 1 and the real engine in Phase 2. Do not spread ad hoc engine subscriptions, network callbacks, and derived world state across individual views.
+
+The only persistent gameplay regions remain the compact status header, transcript, and composer. Temporary completion, clarification, retry, and “New text” controls belong to those interactions. Optional later features first use text queries or contextual presentation; a permanent tab bar is not the assumed destination. [P1]
+
+### 8.2 Transcript rendering and streaming
+
+Give each visible transcript item stable identity. Incremental output updates an existing provisional item rather than repeatedly replacing the entire transcript collection. Separate immutable history from the small active tail so long sessions do not cause full-history layout work on every token.
+
+Follow new output only while the player is intentionally following the bottom. Once the user scrolls upward, retain their anchor and offer a “New text” affordance. Account for changes in keyboard height and Dynamic Type without treating every geometry update as a command to scroll to the end.
+
+The renderer needs explicit styles for player intent, interpretation receipts, NPC speech, narration, deterministic facts, scene transitions, errors, and interrupted output. Typography and spacing communicate these roles; the underlying distinction must not depend on font choice or color. Do not parse provider-specific response syntax in the view layer.
+
+Partial output is visibly part of an active attempt. If it is canceled or rejected, mark it as incomplete/not applied, or replace it with a clear interrupted-state representation while retaining the command. Never silently turn an unfinished NPC promise into canonical memory. Persist final accepted wording so restoration does not regenerate a different past.
+
+### 8.3 Composer and completion
+
+Maintain native multiline editing, selection, dictation, input-method composition, copy/paste, predictable focus, and normal keyboard behavior. Do not clear an unaccepted command. Do not discard text typed while the previous request is still completing.
+
+Slash-command help and completion should derive from the same capability registry used by the runtime, with a fixture equivalent in Phase 1. Initial commands remain /look, /people, /exits, and /help; expose only implemented behavior. When deterministic travel is introduced in Phase 3, choose and document its discoverable syntax rather than depending on an LLM to make movement possible offline.
+
+NPC completion passes an entity reference plus a display label. The engine remains responsible for availability and final resolution. A name tapped in old history may refer to someone no longer present; insertion into the composer is not authorization to converse remotely. Handle accents, aliases, duplicate names, and ordinary natural phrasing without using labels as primary keys.
+
+### 8.4 Accessibility is a contract property
+
+Preserve semantic speaker labels, scene headings, action availability, and error meaning for VoiceOver. Do not announce every streaming token or unexpectedly move accessibility focus. Prefer coherent announcements at message or status boundaries, with the full transcript still navigable.
+
+Dynamic Type must not hide Send/Stop, break completion, or make the draft unusable. Light/dark appearance and contrast must work without changing semantics. Physical-device validation starts in Phase 1 and continues throughout development; Phase 4 expands the reliability matrix rather than introducing accessibility for the first time. [P1]
+
+## 9. Rust integration, concurrency, and platform services
+
+### 9.1 Prove the actual iOS build path early
+
+The Rust toolchain documents separate ARM64 device and ARM64 simulator targets. Build and link the real portable engine for both; a macOS test build is not evidence of iOS compatibility. Verify native dependencies, target configuration, symbol export, linking, signing, and startup on a physical iPhone. [T1]
+
+Prefer a reproducibly generated XCFramework or equivalent supported binary integration with separately built device and simulator variants. Apple supports distributing XCFramework binaries through Swift packages. This is a packaging choice, not a requirement to publish an independent SDK. Keep generated bindings and the Rust binary from the same build revision. [T2]
+
+Choose a minimum iOS version and supported physical-device set during Phase 1 based on required interactions and actual test access. Do not derive the application's minimum version from the lowest version a Rust target can theoretically compile for. Pin the Xcode, Swift, Rust, and binding-tool versions used by CI.
+
+### 9.2 Binding strategy
+
+Evaluate UniFFI as the preferred starting candidate for generated Swift bindings, but make the decision through a small integration spike. Its documentation describes Swift type/error mappings and also notes Swift concurrency limitations that must be checked against the selected toolchain. Treat successful code generation as the beginning of validation, not the end. [T3]
+
+The spike must exercise asynchronous completion, cancellation, errors, Unicode, repeated session creation/disposal, large but bounded event batches, and callback delivery under the intended isolation model. A minimal C ABI is an acceptable fallback if generated bindings add unacceptable constraints. Do not spread whichever choice wins throughout gameplay and UI code.
+
+Never allow a Rust panic to unwind unsafely across a foreign boundary. Use fallible operations for recoverable conditions, establish explicit panic handling at the boundary where supported, and rely on durable recovery if an unrecoverable failure terminates the process. Do not claim arbitrary internal corruption is recoverable merely because an error can be caught.
+
+### 9.3 Transport ownership
+
+The engine owns inference decisions and the logical request/response contract. An iOS platform adapter may own HTTP streaming, lifecycle cancellation, TLS handling, and credential retrieval. URLSession exposes incremental asynchronous byte delivery suitable for consuming a framed response. Keeping these platform mechanics in Swift does not move game orchestration out of Rust. [T7]
+
+If an existing Rust transport is retained, apply the same separation and prove its iOS cancellation/lifecycle behavior. Do not add both a Rust provider SDK path and a Swift provider SDK path. The production destination remains Parish Endpoints either way.
+
+Use one documented concurrency model. Avoid a task/thread per NPC, synchronous callback chains into SwiftUI, and several independent async runtimes created accidentally by dependencies. Bound queues and make session shutdown cancel and drain outstanding callbacks before releasing associated state.
+
+## 10. Parish Endpoints: the required remote contract
+
+### 10.1 Responsibility split
+
+The on-device engine decides whether inference is needed, the inference role, which context is permitted, the game-specific interpretation of output, and whether resulting changes may commit. It constructs the logical prompt/context for that role. Parish Endpoints owns the provider call, credentials, provider/model routing, and the remote execution boundary. [P1]
+
+Published Endpoint definitions may hold reusable private instructions and provider-formatting templates, but must not independently redefine game rules or receive an entire save merely for convenience. Define the split once: the engine supplies authoritative role-specific facts and constraints; the Endpoint applies a versioned inference definition. Avoid contradictory copies of the same rule in client code, client prompt text, and Endpoint templates.
+
+Start with one real Rundale Endpoint integration in Phase 2. Later roles such as interpretation or memory extraction may use additional published definitions or a bounded role contract. Do not create a generic mobile-accessible “arbitrary prompt to any model” proxy that defeats server-side authorization and cost controls.
+
+### 10.2 Minimum request and result semantics
+
+The agreement needs an input/output contract version, published Endpoint version or compatible alias policy, logical request/attempt correlation, bounded input context, output limits, and cancellation/deadline behavior. The engine retains the base world revision locally; include only an opaque correlation value remotely when needed, not an assumption that the Endpoint can validate the world.
+
+A successful final response includes validated role output, resolved Endpoint version, and sufficient invocation metadata for diagnosis. Provider/model identification and usage metadata belong in diagnostics where available, not in gameplay prose. Immutable Endpoint versions and deployment aliases already appear in the Parish architecture; record the resolved version so an alias change does not erase reproducibility. [P2]
+
+Initial release behavior should prefer a pinned compatible Endpoint version or a rigorously compatibility-tested alias. Retrying one invocation must not silently resolve to a new behavior version. Rollback of provider/prompt behavior must not require rewriting player saves.
+
+### 10.3 Streaming is not final validation
+
+Use a documented framed stream that separates progress and text deltas from the final validated result and terminal error. SSE or another bounded HTTP streaming format can work; the semantic contract matters more than the wire syntax. Test it through the actual hosting/proxy path, including buffering and disconnect behavior.
+
+Stream only renderable text and safe progress information. Do not expose raw partial JSON as game narration or execute partially received structured actions. The terminal result is the sole candidate for gameplay validation. The Endpoint's schema validation does not replace the engine's checks of presence, knowledge, task preconditions, or permitted state transitions.
+
+Specify how output limits, malformed frames, missing terminal frames, duplicate frames, validation failure after partial text, and provider interruptions are represented. Automatic model repair/retry must not splice output from two different attempts into one apparently continuous NPC statement. Once text has streamed, a restarted attempt must be distinguishable.
+
+Before Phase 2 acceptance, demonstrate real incremental delivery through Parish Endpoints. Simulating a typewriter effect after receiving a complete response does not prove the required streaming integration.
+
+### 10.4 Authentication and secret handling
+
+No provider credential or reusable shared Parish invocation key may be embedded in a distributed iOS binary, resource file, or remotely fetched public configuration. Storing a shared secret in Keychain after shipping it inside the app does not make that original distribution safe. [P1, P2]
+
+The documented direction for client-safe Parish invocation is trusted-issuer token validation. For an interactive native login, use a standards-based public-client flow with an external authorization agent and Authorization Code + PKCE. Send an access token intended for the Endpoint audience; do not substitute an arbitrary identity token for API authorization. Validate issuer, signature, audience, expiry, and authorization claims server-side. [P2, T8]
+
+Store acquired tokens in appropriate platform credential storage and keep them out of save exports, logs, fixtures, and source control. The exact identity provider and token acquisition experience are decisions to close before a distributed inference-enabled build. Owner-only development provisioning may be separate, but no secret-bearing development path may leak into a shipped app.
+
+Local launch, local saves, deterministic inspection, and local navigation must not depend on successful authentication. The initial screen still opens directly into play. Any required remote authorization should be scoped to accessing inference rather than becoming a new requirement for a local game server or an always-online startup sequence.
+
+### 10.5 Retries, quotas, and cost controls
+
+Set finite time, context, output, and retry budgets. Distinguish a transport retry from a new inference attempt; prevent retries at the client, Endpoint, and provider-adapter layers from multiplying independently. The Endpoint owns provider-level policy within an agreed overall limit; the engine owns whether the gameplay request is retried.
+
+Persist correlation and remote idempotency information before starting the call when recovery depends on it. The Parish architecture contemplates bounded result reuse by idempotency key and request fingerprint, but does not guarantee it exists. Do not design Phase 2 around unverified result lookup, stream resumption, or remote cancellation features. Where unavailable, interruption must still leave a coherent local game. [P2]
+
+Enforce per-principal authorization, rate limits, concurrency limits, and output ceilings at Parish Endpoints. Client limits improve UX but are not an abuse boundary. Cancellation may stop local work before a provider stops billing; measure canceled/failed usage rather than promising cost-free Stop.
+
+Avoid whole-world and whole-transcript prompts. Build context from the current scene, the addressed NPC's permitted knowledge, relevant relationships and memories, a bounded recent exchange, and the current action. Cache only when the role, content, Endpoint version, and relevant state/context fingerprint make reuse valid. Stale cached dialogue must never revive obsolete world facts.
+
+## 11. World content, time, and living-world behavior
+
+### 11.1 Separate definitions from instances
+
+Represent locations, NPC identities, relationships, allowed connections, schedules, authored facts, and task definitions as versioned content. Mutable position, acquired knowledge, task progress, and player-specific memories belong to a game instance. The content loader establishes initial state; loading a save must not rerun initialization and overwrite progress.
+
+Use stable IDs and explicit references. Validate uniqueness, referenced entity existence, navigable graph connections, schedule destinations, task dependencies, and knowledge sources before starting a game. Give authors useful errors that identify the content record and violated rule. The exact source format can follow existing well-supported tooling; an elaborate content DSL is unnecessary.
+
+Phase 2's one-location/one-NPC world and Phase 3's three-location/three-NPC world should both use this model. Small data sets are test fixtures, not hard-coded cardinality assumptions in the simulation or UI. Keep the canonical tiny world available after production content grows.
+
+### 11.2 The canonical world sheet is an oracle, not another database
+
+Maintain the concise human-readable world sheet required by the product spec. It should explain expected initial state and the intended transitions that tests demonstrate. A generated factual listing from the content bundle can help keep IDs and locations synchronized, but expected outcomes also need independent review; deriving both the implementation and every assertion from the same erroneous source proves little.
+
+Finalize actual canonical content before Phase 3. The specification's illustrative sheet mentions “fields” outside its example three-node topology and gives Peig potentially inconsistent initial/morning placement. Treat these as examples to reconcile, not authorization to add an unplanned fourth location or accept contradictory presence. Document exactly three locations, three NPCs, three authored relationships, starting knowledge, and the intended schedule/weather precedence. [P1]
+
+Do not expand biographies, family trees, geography, lore, or quests to make the fixture feel realistic. Each initial content record must help prove a specific behavior.
+
+### 11.3 Explicit game time
+
+Use a simulation clock distinct from wall-clock time and network timeout clocks. Recommended initial policy: observation/help does not advance game time; completed gameplay actions advance it according to explicit local rules; failed or canceled uncommitted actions do not. Reading, typing, waiting for inference, and background suspension do not make NPCs leave or trigger unseen gossip.
+
+Persist game time, schedule progress, and the randomness state or recorded random outcomes needed for reproducibility. Use stable tie-breaking for simultaneous scheduled events. Avoid dependence on hash iteration order or platform-local time zones. A seed alone is not sufficient for historical replay across changes to algorithms or content; keep versions and committed outcomes/checkpoints.
+
+Choose a consistent turn ordering. A practical default is to validate the action against its start state, apply the accepted outcome, advance game time, then process due scheduled/weather transitions in a documented order before publishing the next current-state projection. Dialogue describes the interaction at its defined time; subsequent departure or weather changes appear as separate ordered consequences.
+
+Long actions and multi-step travel may later require intermediate simulation boundaries. They should extend explicit action/time semantics rather than introduce an unrelated wall-clock loop. Do not implement continuous background simulation now to reserve that possibility.
+
+### 11.4 Schedules and weather
+
+Use one deterministic scheduling mechanism, not a timer or async agent per NPC. An NPC's presence is a query over authoritative state; schedules and weather rules change that state through normal validated transitions. Weather is simulated game data, not a new external weather-service dependency.
+
+Define precedence when a scheduled destination conflicts with a weather-dependent behavior. For example, a shelter rule may override a routine destination under the authored condition. Whichever rule is selected must be visible in the canonical sheet and reproducible without a model call.
+
+Phase 3 establishes simple scheduled movement, including the initial per-NPC schedules. Phase 5 adds or demonstrates the specific living-world proof cases; it is not an excuse to defer basic time/presence consistency until then.
+
+### 11.5 Memory, knowledge, and gossip
+
+Distinguish world facts, NPC beliefs/knowledge, statements made by the player, and text the player has seen. A statement such as “the bridge is closed” is not automatically true because it appeared in conversation. Record source, acquisition event/time, relevant participants, and whether a proposition is authored truth, observation, or a reported claim.
+
+For the first gossip case, use an authored fact ID with a known source and a single intended propagation path. Before propagation, the receiving NPC lacks that knowledge. After the legitimate transition, the knowledge record includes provenance. Test the absence as carefully as the presence; showing an NPC knows something is insufficient if every NPC knew it from the start.
+
+A remembered interaction is a committed domain record linked to a completed request. Interrupted or rejected output must not be remembered as a completed conversation. Summaries and retrieval indexes are derived aids; they must not replace the only authoritative record of what was learned or permit an NPC to recall another branch's future.
+
+Construct prompts from the addressed NPC's permitted perspective. Do not send the complete omniscient world state or the player's entire transcript to every NPC and ask the model to ignore what it should not know. Relationship-specific willingness to share a fact is separate from possession of the fact.
+
+### 11.6 Tasks and generated behavior
+
+The first task has an authored definition and authoritative states for assignment, relevant progress, and completion. The engine checks completion against world actions and preconditions. A model's statement that a task is complete does not complete it.
+
+LLM output may propose a bounded memory addition, dialogue act, or permitted game action, but the engine validates it against an allowlist and current state. Never accept generated database operations, arbitrary code, unrestricted entity creation, or implicit changes hidden inside prose.
+
+Use deterministic text for exact facts where practical, and grounded generation for expression. Structured validation cannot guarantee that every natural-language sentence is semantically correct. Measure dialogue grounding separately, reject known contradictory structured claims, and make regressions visible rather than treating successful JSON parsing as proof of believable behavior.
+
+## 12. iOS lifecycle, recovery, and operating limits
+
+### 12.1 Suspend safely rather than depend on running forever
+
+Apple documents finite background execution opportunities and expiration handling. Ordinary streaming data tasks are not a guarantee of continued execution after suspension; URLSession background support does not turn an active conversational stream into a permanently running process. [T9]
+
+The recommended initial policy is to stop beginning new inference when the app backgrounds, finish only bounded critical persistence work when the OS permits, and interrupt an uncommitted active turn safely. On return, show the saved outcome or an explicit interrupted request with retry. A later ability to recover a completed remote result can improve this without changing local commit rules.
+
+Do not rely on a final lifecycle callback to save everything. Persist each accepted request and completed state-changing action at its defined boundary. Background execution is an optimization for orderly cleanup, never the sole mechanism preventing save loss.
+
+### 12.2 Storage and credential unavailability
+
+Test locked-device/file-protection conditions, insufficient storage, corrupt or unsupported saves, interrupted migrations, and expired credentials. An inability to open a protected file is not evidence that there is no save. An inference-authentication failure is not a reason to discard a local session.
+
+Choose file protection and credential accessibility deliberately with the lifecycle policy, keeping tokens separate from game saves. Logs must not include bearer tokens, provider credentials, or raw player conversations by default. Any diagnostic export containing text requires deliberate user/developer action and an explicit retention policy; it is not an always-on telemetry feature.
+
+### 12.3 Performance and cost budgets
+
+Set initial measurable budgets during Phase 1 and calibrate them on supported devices. Suggested starting targets—not measured claims—are immediate visible submission/Stop feedback within roughly 100 ms, ordinary local query/commit completion within roughly 250 ms for the tiny world, and responsive typing/scrolling while incremental output arrives. Measure durable acceptance separately from optimistic visual feedback.
+
+Use synthetic long histories, for example 10,000 to 50,000 transcript items, to expose full-history rendering and unbounded loading early. These are stress fixtures, not a promise of a particular production retention limit. Track memory, launch/resume latency, event-buffer growth, storage growth, and time spent on the main thread; choose device-specific acceptance budgets before Phase 4 sign-off.
+
+Inference first-token and completion latency are external measurements, not guarantees controlled solely by the client. Record them along with input/output usage, retries, and canceled attempts. Phase 6 may introduce priority-based cognition or lower-detail simulation for distant NPCs, but first prove a measured cost/performance problem. Reduce unnecessary inference before adding infrastructure.
+
+## 13. Testing, diagnostics, and release discipline
+
+### 13.1 A layered test system
+
+Pure engine tests validate movement, presence, game time, schedules, weather, knowledge, tasks, and deterministic outcome rules using an injected clock/randomness source and a tiny world.
+
+Request/persistence tests inject failures around acceptance, inference completion, validation, commit, migration, and recovery. Assert that authoritative effects occur at most once and that every visible completed action has durable backing.
+
+Contract tests check Swift/Rust value compatibility, event ordering, snapshot/cursor behavior, bounded buffers, and Endpoint schemas. The same semantic fixtures must drive the Phase 1 renderer and the Phase 2 integration tests.
+
+UI tests and physical-device checks exercise keyboard/focus, history recall, completion, scrolling while streaming, safe areas, Dynamic Type, VoiceOver, relaunch, and interruptions. Simulator results complement but do not replace the physical-iPhone gates in the product spec. [P1]
+
+Live inference evaluations are a small separate suite for connectivity, real streaming, actual authorization, output validity, grounding, and model behavior. They cannot be the sole regression tests for save safety or UI correctness.
+
+### 13.2 Cross-phase invariant suite
+
+Maintain durable fixtures for these properties: duplicate delivery does not duplicate a command or effect; a stopped obsolete attempt cannot commit; a final success is restorable after immediate termination; an unknown save version is not silently reset; header and world presence agree; clarification does not act early; the same local world operations work offline; an NPC cannot gain knowledge from a failed turn; task completion follows authoritative actions; replay never calls a provider; unsupported Endpoint output cannot mutate the save; and content changes do not silently retarget stable IDs.
+
+Add generated/property-based request sequences where useful, especially for interleavings of retry, Stop, resume, and duplicate messages. Fault injection should target deterministic boundaries, not depend only on manually timing force-quits.
+
+A test must assert domain state, not only that a plausible sentence appeared. Likewise, a state assertion alone does not establish that the mobile interaction was understandable. Keep these two kinds of acceptance evidence separate.
+
+### 13.3 Diagnostics without a debug-first product
+
+Use structured diagnostic events correlated by session, logical request, attempt, Endpoint invocation, and state revision. Record durations, terminal status, validation reasons, version identifiers, and resource/cost metrics. Keep developer traces separate from player-visible transcript events.
+
+Provide headless inspection of current state and the canonical world sheet for developers. Capture enough information to reproduce a fault using mock inference or a recorded validated result. Do not require a player-facing diagnostics panel, provider settings screen, or manual log review for normal play.
+
+### 13.4 Build and deployment controls
+
+Use reproducible builds with lockfiles and pinned toolchains. Continuous integration should include headless Rust tests, content validation, contract fixtures, a clean iOS simulator build/test run, and a real iOS device-target build. Physical-device acceptance remains a recorded human/test-device gate rather than an automated claim without evidence.
+
+Keep the iOS app, portable engine, content bundle, and published Endpoint behavior identifiable in each release. Test compatibility before promoting an Endpoint alias. Record the actual resolved version for live invocations. Do not change model behavior, save format, and content semantics simultaneously without a migration/rollback plan that can isolate the cause of a regression.
+
+Keep signing credentials and service secrets out of source and build artifacts. Owner-only development and distributed/TestFlight builds must have explicit credential and environment policies. Do not make an unsigned simulator success the release gate for native integration.
+
+## 14. All-phase technical delivery vision
+
+The six phases below retain the scope and order of the product spec. Each phase adds the architecture needed for its own acceptance and establishes the minimum durable boundary needed by later work. They are not six opportunities to rebuild the application. All existing product checklists remain applicable. [P1]
+
+### Phase 1 — Static native interaction prototype
+
+Player outcome. A fixture-only SwiftUI screen proves the reading-and-typing interaction on a physical iPhone: header, transcript, composer, streaming, Stop, history recall, temporary completion, and accessibility. There is no live LLM and no embedded Parish runtime in the delivered prototype.
+
+Technical work now. Define the first semantic event/projection contract and stable visible-item identity. Build a renderer/presentation state layer that accepts a fixture session through the same boundary the real session will later implement. Include fixtures for command interpretation, clarification, failed response, interrupted partial output, scene transition, restoration, and long history—not only a successful NPC greeting.
+
+Establish composer state ownership, acceptance-versus-optimistic-display semantics, scroll-follow behavior, and accessibility structure. Prove the behavior at large text sizes and on a small supported screen. Choose the initial iOS/toolchain/device test baseline and establish repeatable builds. A saved fixture/draft demonstration may exercise restoration without introducing engine persistence.
+
+Automated verification foundation. Phase 1 must establish a repository-level verification entry point that a coding agent can run without interpretation, preferably ./verify with a phase selector such as ./verify --phase 1. The exact implementation may be a small script or task runner, but the command is the stable developer/agent contract. It must build the relevant targets, run all deterministic Phase 1 tests, return a nonzero exit status on any required failure, and emit both a concise human summary and machine-readable results such as JSON plus JUnit-compatible output. The report must identify passed, failed, skipped, unavailable, and not-automatable gates separately; a missing simulator or other infrastructure problem must never be reported as a passing test.
+
+The Phase 1 automated suite should exercise the presentation contract with deterministic semantic fixtures rather than bespoke UI mocks. It should include XCTest/XCUITest or equivalent automation for submission and composer clearing only after acceptance, multiline editing, history recall, command/NPC completion, Send/Stop state changes, clarification selection, interrupted and failed responses, restoration of a saved draft/fixture session, scroll-follow versus reading history, the “New text” affordance, long-history behavior, Dynamic Type configurations, accessibility identifiers/semantics, and repeated deterministic stream chunks including Unicode boundaries. Use controllable clocks, fixture stream schedules, and explicit failure/cancellation triggers so race-sensitive behavior can be reproduced without sleeps or manual timing. Screenshot or visual-diff tests may supplement these checks but must not be the sole assertion of interaction correctness.
+
+Agent completion rule. A coding task that affects Phase 1 is not complete until the applicable automated verification command passes. Codex or another coding agent may add tests as part of implementation, but it may not make a task pass by deleting, skipping, quarantining, weakening, broadening tolerances in, or rewriting an existing test, fixture, invariant, performance threshold, or acceptance check unless the task explicitly changes the requirement that the check represents. Legitimate test changes must state the requirement change and preserve equivalent or stronger coverage. Physical-device usability, VoiceOver judgment, and other explicitly human/real-device acceptance gates remain separate; automation should prepare a reproducible checklist/report for them but must not mark them passed without recorded evidence.
+
+Protect later phases. Do not use one giant attributed string or a flat array of anonymous text messages as the only model. Do not bake NPC names, locations, provider response shapes, or future task logic into views. The fixture adapter may simulate outcomes, but it must not become a second game engine.
+
+Deliberately deferred. Rust integration, real inference, production save storage, simulation, full NPC content, cloud synchronization, maps, portraits, secondary navigation, and legacy feature parity.
+
+Exit evidence. The product's physical-device interaction gate passes; fixture playback is deterministic; new output does not steal scroll position; canceled/error states are intelligible; and replacing the fixture session with a real adapter does not require redesigning the presentation model. Any hard native text/scrolling limitation is resolved before engine complexity obscures it.
+
+### Phase 2 — Embedded Rust vertical slice
+
+Player outcome. Exactly one location and one interactive NPC form a real local game. The player can start/resume, inspect with /look, converse through a real Parish Endpoint, stop/retry, quit, and continue from correct local state.
+
+Technical work now. Inspect the existing Parish code and isolate the smallest portable runtime without rewriting unrelated engine systems. Complete the Swift/Rust binding and device/simulator build spike. Establish one mutation authority, accepted-request persistence, atomic outcome commit, durable transcript IDs, and the distinction between logical request and execution attempt.
+
+Implement one real Endpoint role with versioned inputs/outputs, authentic incremental streaming, bounded context, error handling, and safe credential acquisition. Resolve the Parish streaming/authentication dependency; do not bypass it. Implement the preferred transactional save path or document why an existing mechanism provides equivalent guarantees. Establish content/save versioning even though the data set is tiny.
+
+Protect later phases. The first NPC already has a stable identity and an authored definition separate from mutable state. The engine API is not “send message to the only NPC.” The turn model can stage a future memory/task update without changing the UI contract. A successful completed turn persists before completion is reported. One-request deduplication is a real guarantee, not an assumption about users pressing Send only once.
+
+Deliberately deferred. Additional NPCs/locations, broad natural-language action coverage, gossip/task gameplay, cloud saves, continuous simulation, multiple simultaneous turns, and a generalized Endpoint platform roadmap.
+
+Automated verification. Extend the Phase 1 verification entry point so a coding agent can run the complete deterministic Phase 2 suite with one command, preferably ./verify --phase 2 with ./verify remaining the repository-wide superset. The command must build the portable Rust engine for test, run headless engine and persistence tests, run Swift/Rust binding contract tests, build the iOS device and simulator artifacts, run simulator XCTest/XCUITest suites, validate content and Endpoint schemas, and produce both a concise human summary and machine-readable results such as JSON plus JUnit-compatible output. A nonzero exit status must mean the automated gate failed; partial execution, skipped required suites, unavailable dependencies, and infrastructure failures must be represented distinctly rather than reported as success.
+
+Phase 2 fault automation. Provide deterministic injection points around durable acceptance, inference start, each stream stage, validation, gameplay commit, persistence, callback delivery, cancellation, and restoration. Automated cases must cover duplicate submissions/events, Stop racing the terminal response, a late obsolete callback, disconnect during streaming, malformed or truncated stream frames, validation failure after provisional text, force-termination after acceptance but before commit, force-termination immediately after commit but before UI acknowledgment, storage/write failure, failed migration fixtures when applicable, and retry after interruption. Assertions must inspect authoritative domain state and durable records, not merely the visible transcript, and must prove that an accepted/committed logical request produces at most one committed effect.
+
+Inference testing must be split. The default verification gate uses deterministic Endpoint doubles, recorded validated results, and protocol fixtures so correctness does not depend on network availability, provider nondeterminism, latency, or model quality. A separate opt-in live-integration suite exercises real Parish authentication, real incremental streaming through the deployed path, schema compatibility, cancellation behavior available from the service, and basic grounding/output validity. Live inference may block the explicit Phase 2 integration acceptance gate when required by the product spec, but it must not replace deterministic regression coverage or become the oracle for persistence and game-state correctness.
+
+Agent completion rule. Codex or another coding agent may use the verification output as its primary completion contract, but it may not make a task pass by deleting, skipping, quarantining, weakening, broadening tolerances in, or rewriting an existing test, fixture, invariant, fault case, performance threshold, or acceptance check unless the task itself explicitly changes the underlying requirement. Any legitimate test change must accompany the production change, state which requirement changed, and preserve equivalent or stronger coverage. The verification report must identify skipped tests and distinguish agent-executable checks from physical-device or qualitative gates that remain unverified.
+
+Exit evidence. A physical device proves real local runtime execution and real Parish streaming. Tests cover Stop/final-result races, storage failure, force-quit after commit, interruption before commit, retry without duplicate effects, and /look without network. Shipping artifacts contain no provider/shared invocation secrets. The fixture renderer still works unchanged.
+
+### Phase 3 — Tiny world navigation
+
+Player outcome. Exactly three locations and three NPCs make geography, presence, schedules, and ambiguous references understandable. /look, /people, and /exits use local truth; deterministic and ordinary natural-language travel work through the same validated action path.
+
+Technical work now. Finalize the canonical content bundle and world sheet, including three authored relationships, initial knowledge, explicit connections, and simple schedules. Validate every reference and reject the illustrative inconsistencies rather than inheriting them. Introduce explicit action time, stable schedule ordering, presence checks, and graph-based movement.
+
+Resolve natural-language actions into a bounded local intent model. Deterministic commands bypass inference; unfamiliar natural phrasing may use the approved inference boundary, but cannot invent destinations or people. Show interpretation receipts when useful. Persist clarification requests and correlate selected choices with the original command. Revalidate availability at execution.
+
+Protect later phases. Movement, scheduled transitions, and future weather/task effects use the same commit lane. The current header and location transcript landmark reflect the same committed outcome. IDs—not names or screen positions—identify actors and destinations. The world loader handles a small graph as data instead of exposing a three-room special case.
+
+Deliberately deferred. More content, a graphical map, distant-NPC conversation, elaborate schedules, automatic offline time catch-up, and an unconstrained natural-language planner.
+
+Exit evidence. All three places and NPCs can be accounted for against the sheet. At least one scheduled movement is observed; unavailable NPC interaction is rejected coherently; ambiguous commands wait for clarification; and movement/presence/schedule state survive resume. Offline deterministic traversal covers the complete tiny graph. An attempted move never updates location twice.
+
+### Phase 4 — Mobile reliability
+
+Player outcome. The existing tiny game behaves dependably through app switching, disconnection, large transcripts, accessibility settings, and relaunch. Gameplay breadth is frozen.
+
+Technical work now. Expand lifecycle and fault-injection tests around every durable boundary. Close the exact policy for background inference, expired credentials, file protection, interrupted migration, disk pressure, and uncommitted stream restoration. Test event deduplication and snapshot/subscription reconciliation rather than only ordinary launch/resume.
+
+Measure rendering, bounded loading, main-thread work, save latency, and memory growth on the supported devices. Make long-history paging and current-tail updates predictable. Harden dictation, keyboard resizing/dismissal, focus restoration, scroll anchors, and VoiceOver announcements. Make retry errors distinguish a failed uncommitted request from repeating a successful action.
+
+Protect later phases. Freeze a documented minimum mobile save compatibility policy and preserve prior-format fixtures. Establish repeatable diagnostics that can explain lost/duplicate-looking requests without exposing secrets. Keep inference and storage failure independent: loss of remote service must not make local data inaccessible.
+
+Deliberately deferred. New task systems, maps, art, inventory breadth, save-management UI, additional NPCs, cloud sync, and speculative optimizations that do not address measured problems.
+
+Exit evidence. The specified 20-minute physical-device session passes on the primary test iPhone and a small supported iPhone. Representative crashes at acceptance, streaming, validation, and commit recover correctly. Long-history/accessibility tests meet the chosen budgets. No unresolved defect that loses, duplicates, corrupts, or materially misrepresents player actions is accepted as a later-phase cleanup item.
+
+### Phase 5 — Living-world proof
+
+Player outcome. Within the same three-location/three-NPC world, the player can deliberately demonstrate persistent memory, one gossip propagation, one simple task, one weather-dependent behavior, and scheduled movement.
+
+Technical work now. Add the minimum structured domain records and transitions for those proof cases. Give the gossip fact a known initial source and a single intended transmission path. Persist the first meaningful player/conversation memory with provenance. Keep authored truth distinct from NPC knowledge and player claims. Constrain prompts to each NPC's permitted perspective.
+
+Implement authoritative task assignment/progress/completion and weather behavior through existing action, time, and commit rules. Record explainable causes: the interaction that created a memory, the contact that carried gossip, the action that fulfilled a task, or the weather condition that redirected movement. Extend the canonical sheet and independent tests with those exact cases.
+
+Protect later phases. Knowledge is not a bag of unstructured transcript snippets. Tasks are not inferred from dialogue wording. NPC scheduling is not a new autonomous network loop. The same identity, atomicity, save, UI, and Endpoint boundaries from Phase 2 remain in use. Rejected generation cannot mutate any of these systems.
+
+Deliberately deferred. Large memory retrieval infrastructure, vector databases, many quests, elaborate social simulation, free-form generated world facts, extra locations/NPCs, and a new UI dashboard for every mechanism.
+
+Exit evidence. Each proof can be reproduced from a known starting fixture and explained by authoritative state. Test both “should know” and “must not yet know.” Repeat after save/resume. Canceling a conversation does not grant knowledge or complete a task. Generated dialogue demonstrates the mechanisms without becoming the only evidence that they worked.
+
+### Phase 6 — Controlled expansion
+
+Player outcome. Each accepted increment makes the text adventure more expressive while preserving comprehensibility and mobile reliability. There is no required destination population, feature count, or graphical interface.
+
+Technical work now. Keep the tiny world as a permanent regression fixture. Add content in reviewed, versioned batches with explicit expected effects on graph size, schedules, knowledge, and inference cost. Introduce capability-specific schema and contract extensions only when the feature is approved. Run migration, offline, accessibility, and fault tests for every increment.
+
+When measured scale requires it, prioritize player-relevant work, index local history/knowledge, schedule bounded NPC cognition, and reduce expensive inference for low-salience activity. Every asynchronous result still passes through the single authoritative commit lane with revision/precondition checks. Performance work must not grant hidden knowledge or change outcomes merely because an NPC was not currently visible.
+
+Options intentionally preserved. Textual journal/status/inventory views can query domain state; undo can use checkpoints; optional cloud sync can move consistent save packages; a future client can reuse the semantic engine boundary. A map or illustration remains optional and must consume the same world projections rather than creating a competing state model. These are possible extensions, not Phase 6 commitments.
+
+Protect earlier work. Do not restore old UI/content wholesale. Do not treat a new screen as the default answer to every feature. Do not merge divergent cloud histories automatically at the individual-field level. Do not allow a provider/prompt update to reinterpret old saves or regenerate established dialogue.
+
+Exit evidence for each increment. Acceptance criteria and tests are written before implementation; the change has a bounded migration/rollback plan; the canonical tiny-world suite remains green; physical-device checks cover affected interactions; and measured reliability, accessibility, and cost remain acceptable. Fix or revert an increment that materially weakens these properties before starting the next one.
+
+## 15. Decision register: deadlines and revisit triggers
+
+Use lightweight architecture decision records for consequential choices. Each should state the decision, alternatives actually considered, evidence, migration consequences, and the event that would justify revisiting it. Do not turn every implementation detail into a governance artifact.
+
+| Decision                                                     | Close by                                         | Recommended direction / revisit trigger                                                                                                        |
+| ------------------------------------------------------------ | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Supported iOS/device baseline                                | Phase 1 acceptance                               | Choose based on required interactions and physical test access; revisit when an actual platform capability justifies dropping support          |
+| Transcript/composer implementation                           | Phase 1 acceptance                               | SwiftUI first with isolated native fallback; revisit only for demonstrated input, scrolling, or accessibility limitations                      |
+| Swift/Rust bindings and packaging                            | Early Phase 2                                    | Prove generated bindings and device/simulator binaries; fall back to a narrow C ABI if the selected toolchain exposes unacceptable limitations |
+| Save storage and migration boundary                          | Before Phase 2 real saves                        | Reuse sound Parish persistence or prefer one transactional SQLite boundary; no parallel authoritative stores                                   |
+| Endpoint streaming and mobile authentication                 | Before Phase 2 acceptance                        | Agree and test actual capabilities; missing support is an integration blocker, not permission for direct provider calls                        |
+| Inference result/stream contract                             | Before Phase 2 acceptance                        | Distinguish provisional text from validated final output and bound retries; revisit for a concrete new inference role                          |
+| Action time and schedule precedence                          | Before Phase 3 acceptance                        | Local action-driven time with deterministic ordering; revisit before long actions or concurrent simulation                                     |
+| Canonical content and ID policy                              | Before Phase 3 acceptance                        | Finalize exact tiny-world definitions and stable IDs; changes require content-version handling                                                 |
+| Background/interruption and save support policy              | Before Phase 4 acceptance                        | Safe interruption and durable local recovery; improve remote result recovery only when the Endpoint supports it                                |
+| Knowledge provenance and task transitions                    | Before Phase 5 implementation                    | Model truth, belief, claim, and progress explicitly; do not begin with prose-only state that later needs reinterpretation                      |
+| Cloud sync, undo UI, richer retrieval, NPC cognition scaling | Only after the corresponding feature is approved | Preserve identities and boundaries now; choose mechanisms when requirements and measured constraints are real                                  |
+
+These decisions should be made at the last responsible point, not all in the first coding session. The early obligation is to avoid representations that make the later choice expensive or impossible.
+
+## 16. Repository evolution and implementation handoff
+
+### 16.1 Preserve useful work without inheriting the old product
+
+At the start of engine integration, inventory existing simulation, persistence, branching, inference, content loading, and diagnostics. Classify each as reusable, adaptable, or outside the mobile runtime. Verify behavior with targeted tests before deciding to replace it.
+
+Extract or expose the portable gameplay boundary incrementally. Keep old frontend/content as reference material or a separately buildable legacy target where that is inexpensive. Do not couple the mobile milestone to deleting every old system, migrating every legacy save, or achieving a perfect repository layout. Conversely, do not let legacy dependencies dictate the new UI or silently become the mobile runtime.
+
+The iOS app and engine should evolve in coordinated changes with versioned contracts. Parish Endpoints remains a separate product/deployable; use a documented client contract and test fixtures rather than shared database access or a dependency on its private internal implementation. [P2]
+
+### 16.2 What an implementation agent should receive
+
+For each phase, provide the current product requirements, this technical vision, the relevant decision records, the canonical fixtures/content, and the explicit acceptance evidence required for that phase. Implementation tasks should identify the boundary being changed, the permitted scope, the failure cases to test, and the migration implications.
+
+An agent may choose ordinary internal types, helper functions, package layout, and libraries within these boundaries. It may not silently relax local authority, skip physical-device evidence, embed secrets, convert provisional text into state, or restore out-of-scope legacy features. A green unit-test run is not permission to mark a physical-device requirement complete.
+
+Keep mock/fixture execution available throughout development. When a new behavior cannot be exercised without a live provider, treat that as a testability problem to resolve before adding more content. When an integration requires a missing Parish Endpoint capability, create a bounded dependency task instead of working around the agreed architecture.
+
+### 16.3 Definition of architectural readiness
+
+The foundation is ready for controlled growth when a developer can explain, for any visible turn: what the player submitted, what the engine interpreted, which state revision it used, whether inference was called, which attempt produced output, which facts changed, why they were valid, where they were committed, and how the same result is restored after termination.
+
+That explanation should come from code boundaries and recorded state—not from reading a model's prose and guessing what must have happened. The player need not see this machinery. Its purpose is to make the simple transcript/composer experience dependable as the world becomes richer.
+
+## 17. Source references
+
+Project sources establish requirements and prior architectural direction. External references substantiate platform capabilities and constraints, not unmeasured claims about Rundale's implementation. All other architectural choices in this document are proposals with the deadlines and validation gates described above.
+
+[P1] Product requirements. Rundale Mobile Text Adventure — Product & Technical Specification, current native Google Docs copy in Projects/Rundale. Primary source for all six phases, the mobile reset, local authority, and the Parish Endpoints requirement. Rundale Mobile Text Adventure — Product & Technical Specification
+
+[P2] Endpoint platform direction. Parish Endpoints — Software Architecture, in Projects/Parish. Relevant sections include product boundary, original MVP non-goals, immutable versions/deployment aliases, idempotency, and client-safe end-user authentication. This is an architecture source, not proof of deployed capabilities. Parish Endpoints - Software Architecture
+
+[T1] Rust iOS target support. The rustc book, Apple iOS targets. Device/simulator targets, SDK requirements, and build/test distinctions. Official reference (doc.rust-lang.org)
+
+[T2] Apple binary packaging. Apple Developer Documentation, Distributing binary frameworks as Swift packages. XCFramework integration and the platform scope of packaged binaries. Official reference (developer.apple.com)
+
+[T3] Swift/Rust binding support. Mozilla UniFFI user guide, Swift Bindings. Type/error mappings and documented Swift concurrency caveats. Official reference (mozilla.github.io)
+
+[T4] Transaction durability. SQLite, Atomic Commit in SQLite. Atomic transaction behavior, recovery, and the assumptions on which durability depends. Official reference (sqlite.org)
+
+[T5] Consistent save snapshots. SQLite, Online Backup API. Consistent database backup rather than copying a live file ad hoc. Official reference (sqlite.org)
+
+[T6] WAL and save export. SQLite, Write-Ahead Logging. Journal behavior and implications for copying a database. Official reference (sqlite.org)
+
+[T7] Incremental native transport. Apple Developer Documentation, URLSession bytes(for:delegate:). Asynchronous response-byte delivery. Official reference (developer.apple.com)
+
+[T8] Native-app authorization. IETF RFC 8252, OAuth 2.0 for Native Apps. External authorization agents, public-client treatment, and PKCE. Official reference (www.rfc-editor.org)
+
+[T9] Background execution limits. Apple Developer Documentation, Choosing Background Strategies for Your App; URLSessionTask. Finite execution opportunities, expiration handling, and the distinction between ordinary data tasks and background sessions. Official reference (developer.apple.com) and Official reference (developer.apple.com)

--- a/docs/requirements/roadmap.md
+++ b/docs/requirements/roadmap.md
@@ -4,11 +4,10 @@
 >
 > Last updated: 2026-07-14
 
-This is the authoritative status view for Rundale + the Parish engine. The
-project no longer tracks a single linear phase pointer — it ships features
-across many subsystems in parallel. The **feature-status matrix** below is the
-source of truth; the historical linear phases are preserved at the bottom for
-provenance.
+This is the **pre-reset feature-status reference** for the existing engine and
+clients. The [mobile product specifications](../product-specs/README.md) now
+govern product direction and the six reset milestones. Entries below preserve
+historical status claims; they do not establish mobile implementation or acceptance.
 
 ## Portfolio tracking
 

--- a/docs/test-plans/README.md
+++ b/docs/test-plans/README.md
@@ -1,0 +1,25 @@
+# Mobile test plans
+
+These versioned test plans complement the [mobile product specifications](../product-specs/README.md).
+They preserve the imported cases and their original numbering. Changes go through
+repository review, with source provenance retained in each plan.
+
+| Phase | Test plan                                   | Scope                                                                                          |
+| ----- | ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| 1     | [Phase 1 test cases](phase-1-test-cases.md) | Fixture-only transcript/composer interaction, streaming, keyboard, accessibility, and UI scope |
+| 2     | [Phase 2 test cases](phase-2-test-cases.md) | Embedded Rust, one location/one NPC, inference, cancellation/retry, and local recovery         |
+
+These are test instructions, not execution reports or evidence that a milestone
+has passed. Record actual results separately, including the build/device or fixture
+used, evidence, failures, and gates that were not run or could not be automated.
+
+The plans do not replace the product's complete milestone checklists, Definition
+of Done, or Quality Gate, or the technical vision's verification requirements.
+Read the cases together with those contracts: composer clearing follows durable
+acceptance, and production remote inference uses Parish Endpoints. The shorter
+case wording does not waive those requirements.
+
+Use [build/test](../agent/build-test.md) to distinguish existing commands from
+the required mobile verification entry point. Deterministic regression checks,
+opt-in real-inference integration, and physical-iPhone acceptance remain separate;
+passing one does not establish the others.

--- a/docs/test-plans/phase-1-test-cases.md
+++ b/docs/test-plans/phase-1-test-cases.md
@@ -1,0 +1,137 @@
+# Rundale Phase 1 Test Cases
+
+> Imported on: 2026-09-07
+> Source modified (UTC): 2026-09-05 00:49:08.755 UTC
+> Google source: [Google Doc](https://docs.google.com/document/d/1heQa_bGCw00Rcyn1joz8w9PgPpkfwpv5eBfvEpcYYKw/edit)
+>
+> Note: This test plan is source-derived planning material and is not execution evidence.
+
+These cases validate Phase 1 of the mobile-first pure-text player experience. They focus on the transcript/composer interaction model, streaming behavior, command affordances, accessibility, and the intentionally narrow UI scope defined by the product specification.
+
+## 1. Launch state
+
+- Launch the app fresh.
+- Verify the primary play screen appears immediately.
+- Verify only the header, transcript, and composer are persistently visible.
+
+## 2. Basic command submission
+
+- Type “look around”.
+- Submit.
+- Verify the player command appears immediately in the transcript.
+- Verify the composer clears or returns to the expected ready state.
+
+## 3. Multiline composer
+
+- Enter a 3–4 line command.
+- Verify the composer expands without covering the transcript excessively.
+- Submit and verify formatting is preserved sensibly.
+
+## 4. Keyboard behavior
+
+- Open the keyboard, dismiss it, and reopen it.
+- Move between text entry and transcript scrolling.
+- Verify the composer remains visible and correctly positioned.
+- Verify no transcript content becomes unreachable.
+
+## 5. Streaming response
+
+- Trigger a fixture that streams for 10–20 seconds.
+- Verify text appears incrementally.
+- Verify the layout does not jump or flicker excessively.
+
+## 6. Stop
+
+- Start a long streaming fixture.
+- Stop it partway through.
+- Verify streaming ends promptly.
+- Verify partial output remains coherent.
+- Verify the composer becomes usable again.
+
+## 7. Auto-follow while at bottom
+
+- Stay at the newest transcript position.
+- Start streaming.
+- Verify newest content remains naturally visible as output arrives.
+
+## 8. Read history while streaming
+
+- Start streaming.
+- Scroll several screens upward.
+- Verify incoming text does not force the view back to the bottom.
+
+## 9. New-content indicator
+
+- While scrolled up, allow more output to arrive.
+- Verify the UI signals that newer content exists.
+- Activate that affordance.
+- Verify it returns cleanly to the newest content.
+
+## 10. Long transcript
+
+- Load a fixture with hundreds or thousands of transcript events.
+- Scroll rapidly up and down.
+- Verify interaction remains responsive with no obvious rendering stalls.
+
+## 11. Transcript type differentiation
+
+- Show narration, NPC dialogue, player commands, deterministic/system output, errors, and scene transitions together.
+- Verify a tester can distinguish them without chat bubbles or permanent side panels.
+
+## 12. Command history
+
+- Submit several commands.
+- Recall an earlier command.
+- Edit it.
+- Resubmit it.
+- Verify the original transcript entry remains unchanged and the edited version becomes a new command.
+
+## 13. @ completion
+
+- Type “@”.
+- Verify fixture NPC completions appear.
+- Select one.
+- Verify insertion into the composer is predictable and editable.
+
+## 14. / completion
+
+- Type “/”.
+- Verify fixture slash-command completions appear.
+- Select one and execute it.
+- Verify deterministic-style output appears correctly in the transcript.
+
+## 15. Draft preservation during interruption
+
+- Type a substantial unsent command.
+- Background the app briefly.
+- Return.
+- Verify the draft remains intact.
+
+## 16. Light/dark mode
+
+- Switch system appearance while the app is open.
+- Verify transcript hierarchy, composer, focus state, and controls remain legible and usable.
+
+## 17. Dynamic Type
+
+- Test default, large, and accessibility text sizes.
+- Verify essential controls remain reachable.
+- Verify the composer remains usable.
+- Verify the transcript does not become structurally broken.
+
+## 18. VoiceOver
+
+- Navigate through the header, transcript entries, composer, Stop control, and newest-content control.
+- Verify labels are meaningful and focus order is logical.
+
+## 19. Small-screen iPhone
+
+- Test on the smallest supported iPhone screen class.
+- Open the keyboard.
+- Enter multiline text.
+- Stream output.
+- Verify the app remains usable rather than cramped or obstructed.
+
+## 20. Forbidden-UI regression
+
+- Verify no graphical map, portrait panel, tab bar, NPC sidebar, save screen, debug panel, or other legacy player UI has been introduced.

--- a/docs/test-plans/phase-2-test-cases.md
+++ b/docs/test-plans/phase-2-test-cases.md
@@ -1,0 +1,149 @@
+# Rundale Phase 2 Test Cases
+
+> Imported on: 2026-09-07
+> Source modified (UTC): 2026-09-05 15:55:27.928 UTC
+> Google source: [Google Doc](https://docs.google.com/document/d/1Fsw8hSp13XZT_F9uMOdwAWyFTslBV_G03cmX2W6-G7A/edit)
+>
+> Note: This test plan is source-derived planning material and is not execution evidence.
+
+These cases validate Phase 2: the embedded Rust vertical slice. They focus on proving that Parish runs locally on iPhone, that the SwiftUI client communicates through a narrow presentation-oriented boundary, that one real NPC conversation works through remote inference, and that state, errors, cancellation, retry, and local persistence behave correctly.
+
+## 1. Create a new local game
+
+- Launch the Phase 2 build with no existing save.
+- Start a new game.
+- Verify the game initializes locally on the device.
+- Verify the player enters the single Phase 2 location with the single Phase 2 NPC available.
+
+## 2. Resume an existing local game
+
+- Create a game and perform at least one completed action.
+- Terminate and relaunch the app.
+- Resume the game.
+- Verify the same authoritative game state is restored without requiring a remote Parish server.
+
+## 3. Parish runtime is on-device
+
+- Disable access to any remote Parish game server while leaving the app otherwise functional.
+- Launch or resume the game.
+- Run a deterministic action such as /look.
+- Verify it succeeds locally.
+
+## 4. No desktop-only runtime dependency
+
+- Build and run the iOS gameplay target.
+- Verify normal gameplay does not require Tauri, an Axum game server, desktop process spawning, local-model launching, desktop diagnostics, or browser-only infrastructure.
+
+## 5. /look is authoritative and local
+
+- Disconnect the device from the network.
+- Run /look.
+- Verify the command succeeds.
+- Verify the returned location information comes through the same transcript event path used by the player UI.
+
+## 6. Basic free-text NPC conversation
+
+- Restore network connectivity.
+- Enter a natural-language message directed at the single NPC.
+- Verify the request is accepted and produces a real NPC response through remote inference.
+- Verify the response appears in the transcript rather than a secondary UI.
+
+## 7. Interpretation receipt
+
+- Submit a free-text request whose meaning is clear enough to interpret.
+- Verify the game displays an understandable interpretation receipt when useful.
+- Verify the receipt corresponds to the action Parish actually executes.
+
+## 8. Real streaming response
+
+- Submit a request that produces a nontrivial NPC response.
+- Verify output appears incrementally as it is received.
+- Verify the transcript remains usable while the response streams.
+- Verify completion is clearly distinguishable from partial output.
+
+## 9. Stop active inference
+
+- Start a long inference-backed NPC response.
+- Stop it before completion.
+- Verify output stops promptly.
+- Verify the app returns to a usable input state.
+- Verify the game remains coherent and resumable.
+
+## 10. Stop does not partially commit world state
+
+- Trigger an inference-backed request that would cause a state change only on successful completion.
+- Stop the request before completion.
+- Inspect or exercise the resulting game state.
+- Verify no partial authoritative state change was committed.
+
+## 11. Inference failure handling
+
+- Force the inference request to fail, for example through a controlled mock failure or unavailable endpoint.
+- Verify the player sees a comprehensible error.
+- Verify the transcript remains intact.
+- Verify the current game session remains usable.
+- Verify no authoritative state corruption occurs.
+
+## 12. Retry failed inference
+
+- Cause an inference-backed request to fail before completion.
+- Use Retry.
+- Verify the original player request is preserved.
+- Verify the retry can complete successfully.
+- Verify only one successful gameplay action is ultimately committed.
+
+## 13. Retry cannot duplicate a completed action
+
+- Complete a state-changing request successfully.
+- Attempt the failure/retry path or equivalent duplicate-delivery condition for the same request identity.
+- Verify the already committed action is not applied a second time.
+- Verify duplicate transcript completion is also prevented.
+
+## 14. Offline deterministic gameplay
+
+- Disconnect the device from the network.
+- Exercise every Phase 2 action that does not inherently require inference.
+- Verify each works normally.
+- Attempt an NPC interaction that does require inference.
+- Verify only the inference-dependent portion fails or waits for connectivity rather than making the entire game unusable.
+
+## 15. No long-lived provider secret in the app
+
+- Inspect the built app configuration and normal runtime setup used for Phase 2 inference.
+- Verify no long-lived OpenAI, Google, or other provider credential is embedded in the shipped application bundle or exposed through ordinary client configuration.
+
+## 16. Completed action persists locally
+
+- Perform a state-changing action and allow it to complete.
+- Force-quit the app immediately afterward.
+- Relaunch and resume.
+- Verify the completed state change is present.
+- Verify the corresponding transcript events are restored consistently.
+
+## 17. Interrupted request is not restored as completed
+
+- Start a state-changing inference-backed request.
+- Interrupt the app before the request completes or commits.
+- Relaunch and resume.
+- Verify the world does not reflect a partially completed action.
+- Verify the transcript clearly represents the interrupted state rather than falsely showing successful completion.
+
+## 18. Event identity prevents duplicate restoration
+
+- Create a session with several commands and responses.
+- Terminate and relaunch repeatedly.
+- Verify previously persisted transcript events appear exactly once.
+- Verify restoring the session does not append duplicates of commands, responses, errors, or completion events.
+
+## 19. Request correlation remains correct
+
+- Submit multiple requests sequentially, including at least one streamed response and one failed or stopped response.
+- Verify each command, interpretation receipt, streamed output, error/stop state, and completion state remains associated with the correct request.
+- Verify content from one request never appears attached to another.
+
+## 20. Phase 2 scope regression
+
+- Play through the entire Phase 2 vertical slice.
+- Verify the experience remains limited to one location and one NPC.
+- Verify no map, portrait system, provider-configuration screen, debug surface, save DAG, legacy sidebar, or other nonessential player UI has been introduced.
+- Verify the result already feels like a small playable text game rather than a technology demo.


### PR DESCRIPTION
Reorganize Rundale's documentation around the native iPhone text-adventure reset. The root agent guide becomes a short map; all 42 existing engineering rules retain their text and stable IDs in scoped references. Existing desktop/web documentation remains implementation reference rather than mobile feature-parity requirements.

Import the full product specification, proposed technical vision, and Phase 1/2 test plans as versioned Markdown with source provenance. Update navigation and distinguish required future mobile verification from currently available engine checks and actual acceptance evidence. The existing global agent policy stays separate.

Validation: source-preservation checks cover all 42 rules, both full specifications, and all 40 test cases; Prettier, Markdown lint, documentation links, the documentation-only proof gate, repository artifact policy, and staged whitespace checks passed. No runtime code changed. Gameplay tests and physical-device checks were not run for this documentation-only change.

The user explicitly requested landing this documentation change without waiting for CI.
